### PR TITLE
fix(pet-rescue): remove final commercial cockpit copy

### DIFF
--- a/apps/web/app/(shell)/finance/page.tsx
+++ b/apps/web/app/(shell)/finance/page.tsx
@@ -268,7 +268,7 @@ export default async function FinancePage() {
 
     return (
       <div>
-        {!setupStatus.isConfigured && <SetupBanner />}
+        {!setupStatus.isConfigured && <SetupBanner description={financeSurface.setupDescription} />}
 
         <FinanceTabNav labels={financeSurface.navigationLabels} />
 
@@ -770,14 +770,14 @@ export default async function FinancePage() {
   );
 }
 
-function SetupBanner() {
+function SetupBanner({ description }: { description?: string }) {
   return (
     <div className="mb-6 rounded-lg border border-[color-mix(in_srgb,var(--dpf-warning)_35%,var(--dpf-border))] bg-[color-mix(in_srgb,var(--dpf-warning)_10%,transparent)] p-4">
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm font-medium text-[var(--dpf-warning)]">Complete your financial setup</p>
           <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
-            Set up your finances based on your business type to get started with invoicing, expenses, and reporting.
+            {description ?? "Set up your finances based on your business type to get started with invoicing, expenses, and reporting."}
           </p>
         </div>
         <Link

--- a/apps/web/lib/finance/finance-surface.test.ts
+++ b/apps/web/lib/finance/finance-surface.test.ts
@@ -252,6 +252,8 @@ describe("pet-rescue finance surface", () => {
       recentAccountHeader: "Supporter or funder",
       recentEmpty: "No contributions yet.",
     });
+    expect(surface.setupDescription).toMatch(/donations|grants/i);
+    expect(surface.setupDescription).not.toMatch(/invoicing/i);
   });
 
   it("does not make every nonprofit inherit pet-rescue claims", () => {

--- a/apps/web/lib/finance/finance-surface.ts
+++ b/apps/web/lib/finance/finance-surface.ts
@@ -117,6 +117,7 @@ export type FinanceSurfaceModel = {
   navigationLabels: Record<"revenue" | "spend" | "close" | "configuration", string>;
   recentRecordsLabel: string;
   recentRecordsEmpty: string;
+  setupDescription?: string;
   /** Visible metric/table nouns when the persisted record type is an internal implementation detail. */
   metricCopy?: {
     outstandingSingular: string;
@@ -526,6 +527,7 @@ export function resolveFinanceSurface(
       },
       recentRecordsLabel: "Recent contributions",
       recentRecordsEmpty: "No contributions recorded yet. Record a donation, grant, or sponsorship to get started.",
+      setupDescription: "Set up donations, grants, care spending, and stewardship reporting for this rescue.",
       metricCopy: {
         outstandingSingular: "commitment",
         outstandingPlural: "commitments",

--- a/apps/web/lib/owner-first/context.ts
+++ b/apps/web/lib/owner-first/context.ts
@@ -20,10 +20,11 @@ export async function loadOwnerFirstContext(): Promise<OwnerFirstContext> {
     include: { archetype: { select: { category: true, archetypeId: true, name: true } } },
   });
   const category = config?.archetype?.category ?? null;
+  const archetypeId = config?.archetype?.archetypeId ?? null;
   return {
     archetypeCategory: category,
-    archetypeId: config?.archetype?.archetypeId ?? null,
+    archetypeId,
     archetypeName: config?.archetype?.name ?? null,
-    vocab: resolveOwnerVocabulary(category),
+    vocab: resolveOwnerVocabulary(category, archetypeId),
   };
 }

--- a/apps/web/lib/owner-first/domain-summary.test.ts
+++ b/apps/web/lib/owner-first/domain-summary.test.ts
@@ -10,6 +10,7 @@ import { resolveOwnerVocabulary } from "./vocabulary";
 
 const restaurant = resolveOwnerVocabulary("food-hospitality");
 const neutral = resolveOwnerVocabulary("retail-goods");
+const petRescue = resolveOwnerVocabulary("nonprofit-community", "pet-rescue");
 
 describe("buildCustomerOwnerSummary", () => {
   it("leads with guest follow-up in restaurant language and orders by urgency", () => {
@@ -68,6 +69,23 @@ describe("buildCustomerOwnerSummary", () => {
     );
     expect(summary.headline).toBe("Customer follow-up");
     expect(summary.subhead).toMatch(/customers/i);
+  });
+
+  it("keeps the pet-rescue follow-up band free of customer and CRM language", () => {
+    const summary = buildCustomerOwnerSummary(
+      {
+        pendingReservations: 0,
+        pendingOrders: 0,
+        newInquiries: 4,
+        unworkedEngagements: 0,
+        overdueInvoices: 0,
+        renewalsDueSoon: 0,
+      },
+      petRescue,
+    );
+    expect(summary.headline).toBe("Adoption follow-up");
+    expect(summary.subhead).not.toMatch(/customer|crm/i);
+    expect(summary.actions[0]?.title).toBe("4 new adoption enquiries to answer");
   });
 });
 

--- a/apps/web/lib/owner-first/domain-summary.ts
+++ b/apps/web/lib/owner-first/domain-summary.ts
@@ -132,9 +132,7 @@ export function buildCustomerOwnerSummary(
   return {
     domain: "customer",
     headline: vocab.guestFollowUpLabel,
-    subhead: vocab.isRestaurant
-      ? "Guests waiting on you — reservations, orders, and inquiries first."
-      : "Customers waiting on you first — the rest of your CRM is below.",
+    subhead: vocab.customerSummarySubhead,
     actions: orderActions(actions),
     clearMessage: `No ${vocab.guestsLabel} are waiting on a reply right now. New ${vocab.reservationsLabel} and ${vocab.inquiriesLabel} will appear here first.`,
   };

--- a/apps/web/lib/owner-first/vocabulary.test.ts
+++ b/apps/web/lib/owner-first/vocabulary.test.ts
@@ -30,4 +30,12 @@ describe("resolveOwnerVocabulary", () => {
     expect(v.isRestaurant).toBe(false);
     expect(v.category).toBeNull();
   });
+
+  it("uses adoption and community vocabulary for pet rescue", () => {
+    const v = resolveOwnerVocabulary("nonprofit-community", "pet-rescue");
+    expect(v.guestFollowUpLabel).toBe("Adoption follow-up");
+    expect(v.guestsLabel).toBe("people & partners");
+    expect(v.inquiriesLabel).toBe("adoption enquiries");
+    expect(v.customerSummarySubhead).not.toMatch(/customer|crm/i);
+  });
 });

--- a/apps/web/lib/owner-first/vocabulary.ts
+++ b/apps/web/lib/owner-first/vocabulary.ts
@@ -23,6 +23,7 @@ export type OwnerDomainVocabulary = {
   guestsLabel: string;
   /** Customer-domain daily work. */
   guestFollowUpLabel: string;
+  customerSummarySubhead: string;
   reservationsLabel: string;
   ordersLabel: string;
   inquiriesLabel: string;
@@ -41,6 +42,7 @@ const RESTAURANT_VOCABULARY: OwnerDomainVocabulary = {
   category: RESTAURANT_ARCHETYPE_CATEGORY,
   guestsLabel: "guests",
   guestFollowUpLabel: "Guest follow-up",
+  customerSummarySubhead: "Guests waiting on you — reservations, orders, and inquiries first.",
   reservationsLabel: "reservations",
   ordersLabel: "orders",
   inquiriesLabel: "inquiries",
@@ -57,6 +59,7 @@ const DEFAULT_VOCABULARY: OwnerDomainVocabulary = {
   category: null,
   guestsLabel: "customers",
   guestFollowUpLabel: "Customer follow-up",
+  customerSummarySubhead: "Customers waiting on you first — the rest of your CRM is below.",
   reservationsLabel: "bookings",
   ordersLabel: "orders",
   inquiriesLabel: "inquiries",
@@ -68,12 +71,35 @@ const DEFAULT_VOCABULARY: OwnerDomainVocabulary = {
   invoicesLabel: "invoices",
 };
 
+const PET_RESCUE_VOCABULARY: OwnerDomainVocabulary = {
+  isRestaurant: false,
+  category: "nonprofit-community",
+  guestsLabel: "people & partners",
+  guestFollowUpLabel: "Adoption follow-up",
+  customerSummarySubhead: "Adopters, foster families, volunteers, donors, and partners waiting on you first.",
+  reservationsLabel: "adoption visits",
+  ordersLabel: "supply requests",
+  inquiriesLabel: "adoption enquiries",
+  staffLabel: "team & volunteers",
+  serviceReadinessLabel: "Care readiness",
+  timesheetLabel: "team hours",
+  billsLabel: "care bills",
+  depositsLabel: "donations",
+  invoicesLabel: "commitments",
+};
+
 /**
  * Resolve the owner-first vocabulary for an archetype category. Restaurant/Venue
  * Portal installs (`food-hospitality`) get restaurant nouns; everything else
  * gets a neutral small-business default (still owner-first, just archetype-neutral).
  */
-export function resolveOwnerVocabulary(category: string | null | undefined): OwnerDomainVocabulary {
+export function resolveOwnerVocabulary(
+  category: string | null | undefined,
+  archetypeId?: string | null,
+): OwnerDomainVocabulary {
+  if (["pet-rescue", "animal-shelter"].includes((archetypeId ?? "").trim().toLowerCase())) {
+    return { ...PET_RESCUE_VOCABULARY, category: category ?? null };
+  }
   if ((category ?? "").trim().toLowerCase() === RESTAURANT_ARCHETYPE_CATEGORY) {
     return RESTAURANT_VOCABULARY;
   }

--- a/apps/web/lib/tak/agent-routing.test.ts
+++ b/apps/web/lib/tak/agent-routing.test.ts
@@ -122,6 +122,12 @@ describe("resolveAgentForRoute", () => {
     expect(result.skills.some((skill) => skill.label === "Retrieve billing portal costs")).toBe(true);
   });
 
+  it("describes the finance specialist without forcing commercial billing or tax language", () => {
+    const result = resolveAgentForRoute("/finance", superuser);
+    expect(result.agentDescription).toBe("Money in, money out, cash position, reporting, and execution control");
+    expect(result.agentDescription).not.toMatch(/recurring billing|tax remittance/i);
+  });
+
   it("returns canAssist=false when platformRole is null on gated route", () => {
     const result = resolveAgentForRoute("/portfolio", noRole);
     expect(result.agentId).toBe("portfolio-advisor");
@@ -280,7 +286,8 @@ describe("generateCannedResponse", () => {
     const response = generateCannedResponse("finance-agent", "/finance/settings/tax", "HR-000");
 
     expect(response).toContain("Finance Specialist");
-    expect(response).toContain("tax");
+    expect(response).toContain("cash position");
+    expect(response).not.toMatch(/recurring billing|tax remittance/i);
   });
 
   it("uses licensing-oriented canned copy for the licensing specialist", () => {

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -430,7 +430,7 @@ OPERATING RULES:
   "/finance": {
     agentId: "finance-agent",
     agentName: "Finance Specialist",
-    agentDescription: "Financial operations, recurring billing posture, tax remittance readiness, and execution control",
+    agentDescription: "Money in, money out, cash position, reporting, and execution control",
     capability: "view_finance",
     sensitivity: "confidential",
     systemPrompt: `You are the Finance Specialist.
@@ -1072,7 +1072,7 @@ const CANNED_RESPONSES: Record<string, CannedResponseSet> = {
   },
   "finance-agent": {
     default: [
-      "I'm the Finance Specialist. I can help you review finance setup, recurring billing posture, tax remittance readiness, and execution blockers like missing credentials or failed runs. You can also explore more actions in the skills menu above.",
+      "I'm the Finance Specialist. I can help you review money coming in, money going out, cash position, reporting, and execution blockers like missing credentials or failed runs. You can also explore more actions in the skills menu above.",
     ],
     restricted: [
       "I can help you understand the finance workspace, but changing setup or tax records requires finance permissions.",

--- a/docs/user-guide/customers/index.md
+++ b/docs/user-guide/customers/index.md
@@ -28,7 +28,9 @@ part of the rescue's normal operating model. **Add person or partner** still
 creates the canonical relationship record; it does not create a second kind of
 customer database. The shared rail, breadcrumbs, and Relationship Manager use
 the same rescue-facing language, so opening the coworker panel does not bring
-the suppressed commercial concepts back into view.
+the suppressed commercial concepts back into view. The daily attention band is
+**Adoption follow-up** and describes people and community relationships rather
+than customers or a CRM.
 
 ## The Customer Lifecycle
 

--- a/docs/user-guide/finance/index.md
+++ b/docs/user-guide/finance/index.md
@@ -17,6 +17,9 @@ permissions remain canonical; the archetype changes the operator vocabulary,
 not the accounting truth. Foreground totals therefore count **contributions**
 and **commitments**, and recent records identify the **supporter or funder**;
 the internal invoice record type remains available only as accounting detail.
+The setup prompt and Finance Specialist summary use the same funding,
+stewardship, cash-position, and reporting language instead of assuming a
+commercial invoicing or tax-remittance workflow.
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
## Outcome
Completes the live Pet Rescue cockpit vocabulary acceptance after #5026 exposed two residual foreground leaks.

- renders the daily relationship band as Adoption follow-up with adoption/community language
- gives the finance setup banner rescue-specific donations, grants, care-spending, and stewardship copy
- makes the Finance Specialist's visible summary neutral across archetypes instead of forcing recurring-billing/tax language
- preserves canonical CRM and accounting records and routes
- updates the customer and finance guides

## Verification
- RED: 4 intended assertions failed against origin/main
- GREEN: 113/113 focused tests
- pnpm --filter web typecheck
- pnpm check:module-size
- pnpm docs:index:check (696 pages)
- git diff --check
- commit-hook scoped typecheck and gitleaks
- pnpm dco:check

All protected GitHub checks and the merge queue remain mandatory.

## Design grounding
- Existing specs/plans reviewed: docs/architecture/archetypes/pet-rescue-operating-model.md and the BI-9C5A3787 vocabulary reach contract.
- Current code substrate reviewed: apps/web/lib/owner-first/vocabulary.ts, apps/web/lib/finance/finance-surface.ts, apps/web/lib/tak/agent-routing.ts, and apps/web/app/(shell)/finance/page.tsx.
- Source of truth: the installed StorefrontArchetype selects presentation vocabulary; canonical CRM and accounting records remain unchanged.
- Decision: extend the existing archetype-owned vocabulary and finance surface models rather than fork data or routes.

Design-Grounding-Decision: archetype-specific foreground copy with canonical shared records preserved
Docs-Impact-Decision: updated docs/user-guide/customers/index.md and docs/user-guide/finance/index.md for the changed foreground workflow