### PR TITLE
fix(ai): make provider trust attention workload-relevant

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -21,8 +21,10 @@ import { getAiProviderFinanceDetail } from "@/lib/finance/ai-provider-finance";
 import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
 import { ProviderAccountPostureForm } from "@/components/platform/ProviderAccountPostureForm";
 import { ProviderTrustEvidencePanel } from "@/components/platform/ProviderTrustEvidencePanel";
-import { resolveProviderTrustEvidence, type ProviderTrustClaimKey } from "@/lib/routing/provider-suitability/evidence";
-import { connectionPosture } from "@/lib/routing/provider-suitability/provider-onboarding-data";
+import { PROVIDER_TRUST_CLAIM_KEYS, resolveProviderTrustEvidence, type ProviderTrustClaimKey } from "@/lib/routing/provider-suitability/evidence";
+import { connectionPosture, loadBusinessSuitabilityContext, providerCatalogFacts } from "@/lib/routing/provider-suitability/provider-onboarding-data";
+import { resolveProviderTrustFacts } from "@/lib/routing/provider-suitability/provider-trust";
+import { projectProviderConnectionReview } from "@/lib/routing/provider-suitability/provider-connection-review";
 import { shouldShowProviderAccountPosture } from "@/components/platform/local-models/provider-detail-policy";
 
 type Props = { params: Promise<{ providerId: string }> };
@@ -58,7 +60,7 @@ export default async function ProviderDetailPage({ params }: Props) {
       await getProviderBearerToken(providerId).catch(() => null);
     }
   }
-  const [pw, models, profiles, allProviders, perfData, routingProfiles, routeDecisions, recipes, modelClassCounts, financeDetail, tokenSpend, providerConnection] = await Promise.all([
+  const [pw, models, profiles, allProviders, perfData, routingProfiles, routeDecisions, recipes, modelClassCounts, financeDetail, tokenSpend, providerConnection, businessSuitabilityContext] = await Promise.all([
     getProviderById(providerId),
     getDiscoveredModels(providerId),
     getModelProfiles(providerId),
@@ -73,10 +75,12 @@ export default async function ProviderDetailPage({ params }: Props) {
     prisma.aiProviderConnection.findUnique({
       where: { connectionId: `provider-default-${providerId}` },
       include: {
+        provider: { select: { providerId: true, category: true, endpointType: true, catalogEntry: true } },
         trustEvidence: true,
         supplierContract: { select: { contractId: true, status: true, startDate: true, endDate: true } },
       },
     }),
+    loadBusinessSuitabilityContext(),
   ]);
   if (!pw) notFound();
   const costView = buildProviderCostView({
@@ -84,15 +88,42 @@ export default async function ProviderDetailPage({ params }: Props) {
     financeProfile: financeDetail,
     internalUsage: tokenSpend.find((row) => row.providerId === providerId) ?? null,
   });
-  const requiredEvidenceClaims: ProviderTrustClaimKey[] = providerId === "openrouter"
-    ? ["no-training", "enabled-regions", "zero-retention", "regional-processing", "approved-underlying-providers", "dpa-on-file"]
-    : ["no-training", "enabled-regions", "dpa-on-file"];
+  const factsResolution = providerConnection
+    ? resolveProviderTrustEvidence({
+      connection: connectionPosture(providerConnection),
+      evidenceConnectionId: providerConnection.id,
+      records: providerConnection.trustEvidence,
+      requiredClaims: [...PROVIDER_TRUST_CLAIM_KEYS],
+      supplierContract: providerConnection.supplierContract ?? undefined,
+      now,
+    })
+    : null;
+  const connectionReview = providerConnection && factsResolution
+    ? projectProviderConnectionReview({
+      businessProfile: businessSuitabilityContext.businessProfile,
+      businessContextConfigured: businessSuitabilityContext.businessContextConfigured,
+      handlesCardPayments: businessSuitabilityContext.handlesCardPayments,
+      facts: resolveProviderTrustFacts({
+        catalog: providerCatalogFacts(providerConnection.provider),
+        connection: factsResolution.posture,
+      }),
+    })
+    : null;
+  const existingEvidenceClaimKeys = providerConnection?.trustEvidence.flatMap((record) =>
+    record.claimKey && PROVIDER_TRUST_CLAIM_KEYS.includes(record.claimKey as ProviderTrustClaimKey)
+      ? [record.claimKey as ProviderTrustClaimKey]
+      : [],
+  ) ?? [];
+  const displayedClaimKeys = [...new Set([
+    ...(connectionReview?.requiredClaimKeys ?? []),
+    ...existingEvidenceClaimKeys,
+  ])];
   const trustEvidenceResolution = providerConnection
     ? resolveProviderTrustEvidence({
       connection: connectionPosture(providerConnection),
       evidenceConnectionId: providerConnection.id,
       records: providerConnection.trustEvidence,
-      requiredClaims: requiredEvidenceClaims,
+      requiredClaims: displayedClaimKeys,
       supplierContract: providerConnection.supplierContract ?? undefined,
       now,
     })
@@ -194,6 +225,7 @@ export default async function ProviderDetailPage({ params }: Props) {
           <ProviderAccountPostureForm
             providerId={providerId}
             canWrite={canWrite}
+            requiredRegions={connectionReview?.requiredRegions ?? []}
             initial={providerConnection ? {
               accountClass: providerConnection.accountClass,
               noTraining: providerConnection.entitlements && typeof providerConnection.entitlements === "object" && !Array.isArray(providerConnection.entitlements)
@@ -233,6 +265,10 @@ export default async function ProviderDetailPage({ params }: Props) {
               evidenceStatus={trustEvidenceResolution.posture.evidenceStatus}
               lastReviewedAt={trustEvidenceResolution.posture.lastReviewedAt}
               claims={trustEvidenceResolution.claims}
+              requiredClaimKeys={connectionReview?.requiredClaimKeys ?? []}
+              scopeHeadline={connectionReview?.headline}
+              scopeSummary={connectionReview?.summary}
+              actions={connectionReview?.actions ?? []}
             />
           )}
           {/* BI-87D93A71 (Minimum): surface OAuth callback port mismatch

--- a/apps/web/components/platform/ProviderAccountPostureForm.test.tsx
+++ b/apps/web/components/platform/ProviderAccountPostureForm.test.tsx
@@ -33,11 +33,19 @@ describe("ProviderAccountPostureForm", () => {
 
   it("does not burden direct-provider setup with router-only controls", () => {
     const html = renderToStaticMarkup(
-      <ProviderAccountPostureForm providerId="anthropic" canWrite initial={null} />,
+      <ProviderAccountPostureForm providerId="anthropic" canWrite initial={null} requiredRegions={[]} />,
     );
     expect(html).not.toContain("Bound the router before company data is used");
-    expect(html).not.toContain('placeholder="eu, uk"');
-    expect(html).toContain("No regions saved");
-    expect(html).toContain("Example: eu, uk");
+    expect(html).not.toContain("Enabled processing regions");
+    expect(html).not.toContain("processing in US");
+  });
+
+  it("asks about the required region without asking the operator to invent region codes", () => {
+    const html = renderToStaticMarkup(
+      <ProviderAccountPostureForm providerId="anthropic" canWrite initial={null} requiredRegions={["us"]} />,
+    );
+    expect(html).toContain("Can this connected account guarantee processing in US?");
+    expect(html).not.toContain("Example: eu, uk");
+    expect(html).not.toContain('type="text"');
   });
 });

--- a/apps/web/components/platform/ProviderAccountPostureForm.tsx
+++ b/apps/web/components/platform/ProviderAccountPostureForm.tsx
@@ -10,9 +10,11 @@ export function ProviderAccountPostureForm({
   providerId,
   canWrite,
   initial,
+  requiredRegions = [],
 }: {
   providerId: string;
   canWrite: boolean;
+  requiredRegions?: string[];
   initial: {
     accountClass: string;
     noTraining: boolean | null;
@@ -30,9 +32,13 @@ export function ProviderAccountPostureForm({
       : "unknown",
   );
   const [noTraining, setNoTraining] = useState(initial?.noTraining == null ? "unknown" : initial.noTraining ? "yes" : "no");
-  const [regions, setRegions] = useState((initial?.enabledRegions ?? []).join(", "));
   const [zeroRetention, setZeroRetention] = useState(initial?.zeroRetention == null ? "unknown" : initial.zeroRetention ? "yes" : "no");
-  const [regionalProcessing, setRegionalProcessing] = useState(initial?.regionalProcessing == null ? "unknown" : initial.regionalProcessing ? "yes" : "no");
+  const coversRequiredRegions = requiredRegions.length > 0
+    && initial?.regionalProcessing === true
+    && requiredRegions.every((region) => initial.enabledRegions.includes(region));
+  const [regionalProcessing, setRegionalProcessing] = useState(
+    initial?.regionalProcessing == null ? "unknown" : coversRequiredRegions ? "yes" : "no",
+  );
   const [approvedProviders, setApprovedProviders] = useState((initial?.approvedUnderlyingProviderSlugs ?? []).join(", "));
   const [message, setMessage] = useState<string | null>(null);
 
@@ -56,12 +62,17 @@ export function ProviderAccountPostureForm({
             <option value="no">No / opt-in only</option>
           </select>
         </label>
-        <label className="text-xs text-[var(--dpf-muted)]">Enabled processing regions
-          <input aria-describedby="enabled-regions-help" className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={regions} disabled={!canWrite || pending} onChange={(event) => setRegions(event.target.value)} />
-          <span id="enabled-regions-help" className="mt-1 block">
-            {regions.trim() ? "Saved regions are shown above." : "No regions saved. Region-restricted work remains blocked."} Example: eu, uk.
-          </span>
-        </label>
+        {requiredRegions.length > 0 && (
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Can this connected account guarantee processing in {requiredRegions.map((region) => region.toUpperCase()).join(", ")}?
+            <select className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={regionalProcessing} disabled={!canWrite || pending} onChange={(event) => setRegionalProcessing(event.target.value)}>
+              <option value="unknown">Not verified</option>
+              <option value="yes">Yes, for every required region</option>
+              <option value="no">No</option>
+            </select>
+            <span className="mt-1 block">Required by the organization&apos;s data-residency setup. Location alone does not prove account entitlement.</span>
+          </label>
+        )}
       </div>
       {providerId === "openrouter" && (
         <div className="mt-4 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
@@ -72,13 +83,6 @@ export function ProviderAccountPostureForm({
           <div className="mt-3 grid gap-3 md:grid-cols-3">
             <label className="text-xs text-[var(--dpf-muted)]">Zero Data Retention enabled
               <select className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={zeroRetention} disabled={!canWrite || pending} onChange={(event) => setZeroRetention(event.target.value)}>
-                <option value="unknown">Not verified</option>
-                <option value="yes">Enabled for this account</option>
-                <option value="no">No</option>
-              </select>
-            </label>
-            <label className="text-xs text-[var(--dpf-muted)]">Regional processing enabled
-              <select className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={regionalProcessing} disabled={!canWrite || pending} onChange={(event) => setRegionalProcessing(event.target.value)}>
                 <option value="unknown">Not verified</option>
                 <option value="yes">Enabled for this account</option>
                 <option value="no">No</option>
@@ -97,10 +101,12 @@ export function ProviderAccountPostureForm({
             providerId,
             accountClass,
             noTraining: noTraining === "unknown" ? null : noTraining === "yes",
-            enabledRegions: regions.split(","),
+            ...(requiredRegions.length > 0 ? {
+              enabledRegions: regionalProcessing === "yes" ? requiredRegions : [],
+              regionalProcessing: regionalProcessing === "unknown" ? null : regionalProcessing === "yes",
+            } : {}),
             ...(providerId === "openrouter" ? {
               zeroRetention: zeroRetention === "unknown" ? null : zeroRetention === "yes",
-              regionalProcessing: regionalProcessing === "unknown" ? null : regionalProcessing === "yes",
               approvedUnderlyingProviderSlugs: approvedProviders.split(","),
             } : {}),
           });

--- a/apps/web/components/platform/ProviderDetailForm.test.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.test.tsx
@@ -84,7 +84,8 @@ describe("ProviderDetailForm", () => {
       />,
     );
 
-    expect(html).toContain("Provider readiness");
+    expect(html).toContain("Technical readiness");
+    expect(html).toContain("Data-use eligibility is evaluated separately");
     expect(html).toContain("Save &amp; ready provider");
     expect(html).not.toContain(">Save<");
     expect(html).not.toContain("Test &amp; Discover");

--- a/apps/web/components/platform/ProviderDetailForm.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.tsx
@@ -200,7 +200,7 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
       <div style={{ maxWidth: 560 }}>
       <div style={{ marginBottom: 20 }}>
         <div style={{ color: "var(--dpf-muted)", fontSize: 10, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
-          Provider readiness
+          Technical readiness
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
           <span style={{
@@ -219,6 +219,9 @@ export function ProviderDetailForm({ pw, canWrite, models, profiles, hasActivePr
           </span>
           <span style={{ color: "var(--dpf-muted)", fontSize: 12 }}>{readinessState.detail}</span>
         </div>
+        <p style={{ color: "var(--dpf-muted)", fontSize: 12, margin: "6px 0 0" }}>
+          Data-use eligibility is evaluated separately for each workload and connected account.
+        </p>
       </div>
 
       {/* Status + toggle */}

--- a/apps/web/components/platform/ProviderTrustEvidencePanel.test.tsx
+++ b/apps/web/components/platform/ProviderTrustEvidencePanel.test.tsx
@@ -55,20 +55,41 @@ describe("ProviderTrustEvidencePanel", () => {
     expect(screen.getByText(/No account-specific trust evidence is linked yet/)).toBeTruthy();
   });
 
-  it("names the available declaration action and the unavailable DPA workflow honestly", () => {
+  it("names the required declaration action and marks unrelated DPA history optional", () => {
     render(<ProviderTrustEvidencePanel
       accountDeclarationSaved
       evidenceStatus="operator-attested"
       lastReviewedAt="2026-08-31T09:00:00.000Z"
+      requiredClaimKeys={["enabled-regions"]}
+      scopeHeadline="Company work needs a region guarantee"
+      scopeSummary="Public or synthetic work can be used now. Company work stays blocked until this account guarantees the required region."
       claims={[
         { claimKey: "enabled-regions", status: "missing", evidenceIds: [], evidenceAgeDays: null, expiresAt: null, nextAction: "Add evidence for this connected account." },
         { claimKey: "dpa-on-file", status: "missing", evidenceIds: [], evidenceAgeDays: null, expiresAt: null, nextAction: "Add evidence for this connected account." },
       ]}
     />);
 
-    expect(screen.getByText(/Save the enabled regions in Connected account and data terms above/)).toBeTruthy();
-    expect(screen.getByText(/No DPA evidence workflow is available on this page/)).toBeTruthy();
-    expect(screen.getByText(/reviewed supplier contract/i)).toBeTruthy();
+    expect(screen.getByText(/Confirm the required-region guarantee in Connected account and data terms above/)).toBeTruthy();
+    expect(screen.getByText("Optional here.")).toBeTruthy();
+    expect(document.body.textContent).not.toContain("No DPA evidence workflow is available on this page");
+  });
+
+  it("does not raise attention for optional evidence history", () => {
+    render(<ProviderTrustEvidencePanel
+      accountDeclarationSaved
+      evidenceStatus="operator-attested"
+      lastReviewedAt="2026-08-31T09:00:00.000Z"
+      requiredClaimKeys={[]}
+      scopeHeadline="No action needed"
+      scopeSummary="This connection is ready for the company work represented by the current business setup."
+      claims={[
+        { claimKey: "enabled-regions", status: "missing", evidenceIds: [], evidenceAgeDays: null, expiresAt: null, nextAction: "Add evidence for this connected account." },
+        { claimKey: "dpa-on-file", status: "missing", evidenceIds: [], evidenceAgeDays: null, expiresAt: null, nextAction: "Add evidence for this connected account." },
+      ]}
+    />);
+
+    expect(screen.getByRole("status").textContent).toContain("No action needed");
+    expect(screen.getByText(/ready for the company work represented/i)).toBeTruthy();
   });
 
   it.each(["missing", "expired", "rejected", "conflicting", "superseded"] as const)(

--- a/apps/web/components/platform/ProviderTrustEvidencePanel.tsx
+++ b/apps/web/components/platform/ProviderTrustEvidencePanel.tsx
@@ -45,7 +45,7 @@ const ACCOUNT_DECLARATION_CLAIMS = new Set<ProviderTrustClaimKey>([
 
 function nextActionLabel(claim: ResolvedProviderTrustClaim): string {
   if (claim.claimKey === "enabled-regions") {
-    return "Save the enabled regions in Connected account and data terms above. Leaving the field empty keeps region-restricted work blocked.";
+    return "Confirm the required-region guarantee in Connected account and data terms above. Unverified region entitlement keeps region-restricted work blocked.";
   }
   if (claim.claimKey === "dpa-on-file") {
     return "No DPA evidence workflow is available on this page. Restricted work stays blocked until platform governance links a reviewed supplier contract or current DPA evidence.";
@@ -61,14 +61,23 @@ export function ProviderTrustEvidencePanel({
   evidenceStatus,
   lastReviewedAt,
   claims,
+  requiredClaimKeys = claims.map((claim) => claim.claimKey),
+  scopeHeadline,
+  scopeSummary,
+  actions = [],
 }: {
   accountDeclarationSaved: boolean;
   evidenceStatus: ProviderConnectionPosture["evidenceStatus"];
   lastReviewedAt: string | null;
   claims: ResolvedProviderTrustClaim[];
+  requiredClaimKeys?: ProviderTrustClaimKey[];
+  scopeHeadline?: string;
+  scopeSummary?: string;
+  actions?: string[];
 }) {
-  const restrictedClaimCount = claims.filter((claim) => claim.status !== "valid").length;
-  const restrictedWorkLimited = claims.length === 0 || restrictedClaimCount > 0;
+  const required = new Set(requiredClaimKeys);
+  const restrictedClaimCount = claims.filter((claim) => required.has(claim.claimKey) && claim.status !== "valid").length;
+  const restrictedWorkLimited = restrictedClaimCount > 0 || actions.length > 0;
 
   return (
     <section
@@ -88,11 +97,11 @@ export function ProviderTrustEvidencePanel({
           role="status"
           className={`rounded-full px-2 py-1 text-xs font-semibold ${restrictedWorkLimited ? "bg-[var(--dpf-warning-soft)] text-[var(--dpf-warning)]" : "bg-[var(--dpf-success-soft)] text-[var(--dpf-success)]"}`}
         >
-          {claims.length === 0
+          {scopeHeadline ?? (claims.length === 0
             ? "Restricted work not reviewed"
             : restrictedClaimCount > 0
               ? `${restrictedClaimCount} ${restrictedClaimCount === 1 ? "restriction" : "restrictions"} for restricted work`
-              : "Current for restricted work"}
+              : "Current for restricted work")}
         </span>
       </div>
 
@@ -100,7 +109,7 @@ export function ProviderTrustEvidencePanel({
         {accountDeclarationSaved && lastReviewedAt
           ? `Account declaration saved · reviewed ${dateLabel(lastReviewedAt)}.`
           : "Account declaration not yet saved."}
-        {restrictedWorkLimited
+        {scopeSummary ? ` ${scopeSummary}` : restrictedWorkLimited
           ? " General work is governed separately; sensitive or restricted work remains blocked until the evidence below is current."
           : " The current evidence supports restricted-work evaluation; routing still applies each workload's policy."}
       </p>
@@ -121,12 +130,24 @@ export function ProviderTrustEvidencePanel({
                 {claim.evidenceAgeDays == null ? "No dated evidence" : `${claim.evidenceAgeDays} days old`}
                 {claim.expiresAt ? ` · valid until ${dateLabel(claim.expiresAt)}` : ""}
               </p>
-              {claim.status !== "valid" && (
+              {claim.status !== "valid" && required.has(claim.claimKey) && (
                 <p className="mb-0 mt-1 text-xs font-medium text-[var(--dpf-text)]">Next: {nextActionLabel(claim)}</p>
+              )}
+              {claim.status !== "valid" && !required.has(claim.claimKey) && (
+                <p className="mb-0 mt-1 text-xs text-[var(--dpf-muted)]">Optional here.</p>
               )}
             </li>
           ))}
         </ul>
+      )}
+
+      {actions.length > 0 && (
+        <div className="mt-3 rounded border border-[var(--dpf-warning)] bg-[var(--dpf-warning-soft)] p-3">
+          <p className="m-0 text-xs font-semibold text-[var(--dpf-text)]">Next action</p>
+          <ul className="mb-0 mt-1 list-disc space-y-1 pl-4 text-xs text-[var(--dpf-text)]">
+            {actions.map((action) => <li key={action}>{action}</li>)}
+          </ul>
+        </div>
       )}
 
       <p className="mb-0 mt-3 text-xs text-[var(--dpf-muted)]">

--- a/apps/web/lib/actions/ai-providers.test.ts
+++ b/apps/web/lib/actions/ai-providers.test.ts
@@ -168,6 +168,64 @@ describe("updateProviderConnectionPosture", () => {
     });
   });
 
+  it("preserves region entitlement and evidence when the current setup has no region requirement", async () => {
+    mockPrisma.aiProviderConnection.findUnique.mockResolvedValue({
+      id: "connection-db-1",
+      entitlements: { enabledRegions: ["us"], regionalProcessing: true },
+      evidenceStatus: "operator-attested",
+    });
+    mockPrisma.aiProviderConnection.update.mockResolvedValue({});
+    mockPrisma.modelProvider.findUnique.mockResolvedValue({ status: "inactive" });
+
+    await updateProviderConnectionPosture({
+      providerId: "zai",
+      accountClass: "enterprise",
+      noTraining: true,
+    });
+
+    expect(mockPrisma.aiProviderConnection.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        entitlements: expect.objectContaining({ enabledRegions: ["us"], regionalProcessing: true }),
+      }),
+    }));
+    expect(mockRecordProviderTrustEvidence).not.toHaveBeenCalledWith(expect.objectContaining({ claimKey: "enabled-regions" }));
+    expect(mockSupersedeProviderTrustEvidenceClaim).not.toHaveBeenCalledWith(expect.objectContaining({ claimKey: "enabled-regions" }));
+  });
+
+  it("records a normalized direct-provider region guarantee on the exact connection", async () => {
+    mockPrisma.aiProviderConnection.findUnique.mockResolvedValue({
+      id: "connection-db-1",
+      entitlements: {},
+      evidenceStatus: "unreviewed",
+    });
+    mockPrisma.aiProviderConnection.update.mockResolvedValue({});
+    mockPrisma.modelProvider.findUnique.mockResolvedValue({ status: "inactive" });
+
+    await updateProviderConnectionPosture({
+      providerId: "zai",
+      accountClass: "enterprise",
+      noTraining: true,
+      enabledRegions: [" US ", "us"],
+      regionalProcessing: true,
+    });
+
+    expect(mockPrisma.aiProviderConnection.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        entitlements: expect.objectContaining({ enabledRegions: ["us"], regionalProcessing: true }),
+      }),
+    }));
+    expect(mockRecordProviderTrustEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "regional-processing",
+      assertedValue: true,
+    }));
+    expect(mockRecordProviderTrustEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "enabled-regions",
+      assertedValue: ["us"],
+    }));
+  });
+
   it("records OpenRouter controls on the exact connection without creating enterprise proof", async () => {
     mockPrisma.aiProviderConnection.findUnique.mockResolvedValue({
       entitlements: {},

--- a/apps/web/lib/actions/provider-connection-posture.ts
+++ b/apps/web/lib/actions/provider-connection-posture.ts
@@ -21,7 +21,7 @@ export async function updateProviderConnectionPosture(input: {
   providerId: string;
   accountClass: (typeof PROVIDER_ACCOUNT_CLASSES)[number];
   noTraining: boolean | null;
-  enabledRegions: string[];
+  enabledRegions?: string[];
   zeroRetention?: boolean | null;
   regionalProcessing?: boolean | null;
   approvedUnderlyingProviderSlugs?: string[];
@@ -41,7 +41,9 @@ export async function updateProviderConnectionPosture(input: {
     : {};
   const reviewedAt = new Date();
   const expiresAt = new Date(reviewedAt.getTime() + 90 * 86_400_000);
-  const enabledRegions = [...new Set(input.enabledRegions.map((region) => region.trim().toLowerCase()).filter(Boolean))].sort();
+  const enabledRegions = input.enabledRegions == null
+    ? undefined
+    : [...new Set(input.enabledRegions.map((region) => region.trim().toLowerCase()).filter(Boolean))].sort();
   const approvedUnderlyingProviderSlugs = [...new Set(
     (input.approvedUnderlyingProviderSlugs ?? [])
       .map((slug) => slug.trim().toLowerCase())
@@ -56,10 +58,10 @@ export async function updateProviderConnectionPosture(input: {
       entitlements: {
         ...existingEntitlements,
         noTraining: input.noTraining,
-        enabledRegions,
+        ...(enabledRegions === undefined ? {} : { enabledRegions }),
+        ...(input.regionalProcessing === undefined ? {} : { regionalProcessing: input.regionalProcessing }),
         ...(input.providerId === "openrouter" ? {
           zeroRetention: input.zeroRetention ?? null,
-          regionalProcessing: input.regionalProcessing ?? null,
           approvedUnderlyingProviderSlugs,
         } : {}),
       },
@@ -83,12 +85,12 @@ export async function updateProviderConnectionPosture(input: {
     });
   const evidenceWrites = [
     recordDeclaration("no-training", input.noTraining, "Connected-account no-training declaration"),
-    recordDeclaration("enabled-regions", enabledRegions, "Connected-account enabled-region declaration"),
+    ...(enabledRegions === undefined ? [] : [recordDeclaration("enabled-regions", enabledRegions, "Connected-account enabled-region declaration")]),
+    ...(input.regionalProcessing === undefined ? [] : [recordDeclaration("regional-processing", input.regionalProcessing, "Connected-account regional-processing declaration")]),
   ];
   if (input.providerId === "openrouter") {
     evidenceWrites.push(
       recordDeclaration("zero-retention", input.zeroRetention, "Connected-account zero-retention declaration"),
-      recordDeclaration("regional-processing", input.regionalProcessing, "Connected-account regional-processing declaration"),
       recordDeclaration("approved-underlying-providers", approvedUnderlyingProviderSlugs, "Connected-account router-provider declaration"),
     );
   }

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -339,6 +339,9 @@
     "apps/web/app/(shell)/platform/ai/priority/outcomes/page.tsx": [
       "docs/user-guide/ai-workforce/priority-and-outcomes.md"
     ],
+    "apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx": [
+      "docs/user-guide/ai-workforce/connecting-providers.md"
+    ],
     "apps/web/app/(shell)/platform/ai/providers/page.tsx": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
     ],
@@ -3054,6 +3057,7 @@
       "apps/web/lib/build/sandbox/sandbox.ts"
     ],
     "docs/user-guide/ai-workforce/connecting-providers.md": [
+      "apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx",
       "apps/web/app/(shell)/platform/ai/providers/page.tsx",
       "apps/web/components/platform/ProviderSuitabilityGuide.tsx",
       "apps/web/lib/ai-inference.ts"

--- a/apps/web/lib/routing/provider-suitability/provider-connection-review.test.ts
+++ b/apps/web/lib/routing/provider-suitability/provider-connection-review.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import type { BusinessSuitabilityProfile, ProviderTrustFacts } from "./types";
+import { projectProviderConnectionReview } from "./provider-connection-review";
+
+const businessProfile = (dataResidency: string[] = []): BusinessSuitabilityProfile => ({
+  organizationId: "org-1",
+  archetypeId: "pet-rescue",
+  archetypeCategory: "nonprofit-community",
+  operatesIn: ["us"],
+  sellsTo: [],
+  employsIn: [],
+  dataResidency,
+  riskPosture: "balanced",
+});
+
+const facts = (overrides: Partial<ProviderTrustFacts> = {}): ProviderTrustFacts => ({
+  providerId: "zai",
+  catalogProviderId: "zai",
+  category: "direct",
+  jurisdictions: [],
+  externalEgress: "provider-cloud",
+  supportsZdr: null,
+  supportsNoTraining: true,
+  supportsRegionalRouting: true,
+  supportedRegions: ["us"],
+  regionalEndpoints: [],
+  providerConnectionId: "provider-default-zai",
+  executionChannel: "direct-api",
+  accountClass: "enterprise",
+  commercialBasis: "usage-metered",
+  authMethod: "api-key",
+  contractEvidence: {},
+  entitlements: { noTraining: true },
+  evidenceStatus: "operator-attested",
+  lastReviewedAt: "2026-09-03T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("projectProviderConnectionReview", () => {
+  it("does not turn a US locale into a region or DPA requirement", () => {
+    const result = projectProviderConnectionReview({
+      businessProfile: businessProfile(),
+      businessContextConfigured: true,
+      handlesCardPayments: false,
+      facts: facts(),
+    });
+    expect(result.scope).toBe("company-work");
+    expect(result.requiredRegions).toEqual([]);
+    expect(result.requiredClaimKeys).not.toContain("enabled-regions");
+    expect(result.requiredClaimKeys).not.toContain("dpa-on-file");
+  });
+
+  it("keeps public work explicit when canonical business context is missing", () => {
+    const result = projectProviderConnectionReview({
+      businessProfile: businessProfile(),
+      businessContextConfigured: false,
+      handlesCardPayments: false,
+      facts: facts(),
+    });
+    expect(result.scope).toBe("public-only");
+    expect(result.summary).toMatch(/business setup is incomplete/i);
+  });
+
+  it("requires the declared region from the account rather than inferring it from locale", () => {
+    const result = projectProviderConnectionReview({
+      businessProfile: businessProfile(["us"]),
+      businessContextConfigured: true,
+      handlesCardPayments: false,
+      facts: facts(),
+    });
+    expect(result.scope).toBe("public-only");
+    expect(result.requiredRegions).toEqual(["us"]);
+    expect(result.requiredClaimKeys).toEqual(expect.arrayContaining(["regional-processing", "enabled-regions"]));
+    expect(result.requiredClaimKeys).not.toContain("dpa-on-file");
+  });
+
+  it("maps source-code policy to account evidence without making DPA universal", () => {
+    const result = projectProviderConnectionReview({
+      businessProfile: { ...businessProfile(), archetypeCategory: "software" },
+      businessContextConfigured: true,
+      handlesCardPayments: false,
+      facts: facts({ accountClass: "regular", entitlements: { noTraining: false } }),
+    });
+    expect(result.explanationCodes).toContain("business-account-unproven");
+    expect(result.requiredClaimKeys).toContain("no-training");
+    expect(result.requiredClaimKeys).not.toContain("dpa-on-file");
+  });
+
+  it("keeps bounded-router controls for non-public work", () => {
+    const result = projectProviderConnectionReview({
+      businessProfile: businessProfile(),
+      businessContextConfigured: true,
+      handlesCardPayments: false,
+      facts: facts({
+        providerId: "openrouter",
+        catalogProviderId: "openrouter",
+        category: "router",
+        externalEgress: "router-cloud",
+        executionChannel: "hosted-router",
+        entitlements: { noTraining: true, zeroRetention: false },
+        routerPassThrough: {
+          exposesUnderlyingProvider: true,
+          supportsProviderAllowlist: true,
+          supportsProviderBlocklist: true,
+          supportsZdrFilter: true,
+          supportsDataCollectionDeny: true,
+          supportsBoundedFallbacks: true,
+        },
+      }),
+    });
+    expect(result.explanationCodes).toContain("router-controls-unproven");
+    expect(result.requiredClaimKeys).toEqual(expect.arrayContaining(["zero-retention", "approved-underlying-providers"]));
+  });
+});

--- a/apps/web/lib/routing/provider-suitability/provider-connection-review.ts
+++ b/apps/web/lib/routing/provider-suitability/provider-connection-review.ts
@@ -1,0 +1,147 @@
+import { compileAiProviderSuitabilityPolicy } from "./compile";
+import type { ProviderTrustClaimKey } from "./evidence";
+import { deriveOnboardingWorkloadClasses } from "./onboarding-recommendation";
+import type {
+  AiWorkloadClassKey,
+  BusinessSuitabilityProfile,
+  ProviderSuitabilityExplanation,
+  ProviderTrustFacts,
+} from "./types";
+import { deriveAiWorkloadDataProfile } from "./workload-profile";
+
+export type ProviderConnectionReview = {
+  scope: "company-work" | "public-only" | "blocked";
+  headline: string;
+  summary: string;
+  requiredRegions: string[];
+  requiredClaimKeys: ProviderTrustClaimKey[];
+  explanationCodes: string[];
+  actions: string[];
+};
+
+type Requirement = {
+  claims: ProviderTrustClaimKey[];
+  actions: string[];
+};
+
+const EXPLANATION_REQUIREMENTS: Readonly<Record<string, Requirement>> = {
+  "residency-unproven": {
+    claims: ["regional-processing", "enabled-regions"],
+    actions: ["Confirm that this connected account guarantees processing in every required region."],
+  },
+  "router-controls-unproven": {
+    claims: ["zero-retention", "approved-underlying-providers"],
+    actions: ["Bound the router to reviewed providers and enable zero-retention controls."],
+  },
+  "business-account-unproven": {
+    claims: ["no-training"],
+    actions: ["Confirm a business or enterprise account with no-training treatment."],
+  },
+  "healthcare-contract-unproven": {
+    claims: ["baa-on-file", "no-training"],
+    actions: ["Link a current supplier contract and reviewed Business Associate Agreement."],
+  },
+  "student-terms-unproven": {
+    claims: ["student-data-terms-reviewed-at", "no-training"],
+    actions: ["Link a current supplier contract and reviewed student-data terms."],
+  },
+  "financial-oversight-unproven": {
+    claims: ["financial-customer-info-reviewed-at", "no-training"],
+    actions: ["Link a current supplier contract and reviewed customer-information controls."],
+  },
+  "restricted-contract-unproven": {
+    claims: ["no-training"],
+    actions: ["Link a current supplier contract and confirm no-training treatment."],
+  },
+};
+
+function sortedUnique<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort();
+}
+
+function compileFor(input: {
+  businessProfile: BusinessSuitabilityProfile;
+  facts: ProviderTrustFacts;
+  workloads: AiWorkloadClassKey[];
+}) {
+  return compileAiProviderSuitabilityPolicy({
+    businessProfile: input.businessProfile,
+    workloadProfiles: input.workloads.map((reviewWorkloadClass) =>
+      deriveAiWorkloadDataProfile({ workloadClass: reviewWorkloadClass }),
+    ),
+    dataPolicyDecisions: [],
+    regulationResults: [],
+    providerFacts: [input.facts],
+    source: "onboarding",
+  });
+}
+
+function requirements(explanations: ProviderSuitabilityExplanation[]): Requirement {
+  const mapped = explanations.flatMap((explanation) => {
+    const requirement = EXPLANATION_REQUIREMENTS[explanation.code];
+    return requirement ? [requirement] : [];
+  });
+  return {
+    claims: sortedUnique(mapped.flatMap((item) => item.claims)),
+    actions: sortedUnique(mapped.flatMap((item) => item.actions)),
+  };
+}
+
+/** UI read model over the same compiler that governs actual provider routing. */
+export function projectProviderConnectionReview(input: {
+  businessProfile: BusinessSuitabilityProfile;
+  businessContextConfigured: boolean;
+  handlesCardPayments: boolean;
+  facts: ProviderTrustFacts;
+}): ProviderConnectionReview {
+  const publicPolicy = compileFor({
+    businessProfile: { ...input.businessProfile, dataResidency: [] },
+    facts: input.facts,
+    workloads: ["public-marketing"],
+  });
+  const companyWorkloads = deriveOnboardingWorkloadClasses({
+    archetypeCategory: input.businessProfile.archetypeCategory,
+    handlesCardPayments: input.handlesCardPayments,
+  }).filter((workload) => workload !== "public-marketing");
+  const companyPolicy = compileFor({
+    businessProfile: input.businessProfile,
+    facts: input.facts,
+    workloads: companyWorkloads,
+  });
+  const companyExplanations = companyPolicy.explanations.filter(
+    (explanation) => explanation.providerConnectionId === input.facts.providerConnectionId,
+  );
+  const needed = requirements(companyExplanations);
+  const publicUsable = publicPolicy.effect !== "deny";
+  const companyUsable = input.businessContextConfigured && companyPolicy.effect !== "deny";
+
+  if (companyUsable) {
+    return {
+      scope: "company-work",
+      headline: "No action needed",
+      summary: "This connection is ready for the company work represented by the current business setup. Each request is still checked when it runs.",
+      requiredRegions: sortedUnique(input.businessProfile.dataResidency.map((region) => region.toLowerCase())),
+      requiredClaimKeys: [],
+      explanationCodes: [],
+      actions: [],
+    };
+  }
+
+  const contextAction = input.businessContextConfigured
+    ? []
+    : ["Complete business setup before using this connection for company work."];
+  const summary = publicUsable
+    ? input.businessContextConfigured
+      ? "Public or synthetic work can be used now. Company work stays blocked until the required account evidence is current."
+      : "Public or synthetic work can be used now. Company-work eligibility is unproven because business setup is incomplete."
+    : "This connection does not currently meet the policy for public or company work.";
+  return {
+    scope: publicUsable ? "public-only" : "blocked",
+    headline: publicUsable ? "Company work needs attention" : "Connection blocked for current work",
+    summary,
+    requiredRegions: sortedUnique(input.businessProfile.dataResidency.map((region) => region.toLowerCase())),
+    requiredClaimKeys: needed.claims,
+    explanationCodes: sortedUnique(companyExplanations.map((explanation) => explanation.code)),
+    actions: [...contextAction, ...needed.actions],
+  };
+}

--- a/apps/web/lib/routing/provider-suitability/provider-onboarding-data.ts
+++ b/apps/web/lib/routing/provider-suitability/provider-onboarding-data.ts
@@ -25,7 +25,7 @@ function strings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
-function catalogFacts(provider: {
+export function providerCatalogFacts(provider: {
   providerId: string;
   category: string;
   endpointType: string;
@@ -111,41 +111,57 @@ export type ProviderSuitabilitySourceContext = {
   }>;
 };
 
+export type BusinessSuitabilityContext = {
+  businessProfile: BusinessSuitabilityProfile;
+  handlesCardPayments: boolean;
+  businessContextConfigured: boolean;
+};
+
+/** Canonical business requirements, bounded to organization context only. */
+export async function loadBusinessSuitabilityContext(): Promise<BusinessSuitabilityContext> {
+  const organization = await prisma.organization.findFirst({ select: { id: true, address: true } });
+  const [businessContext, storefront] = await Promise.all([
+    organization ? prisma.businessContext.findUnique({ where: { organizationId: organization.id } }) : null,
+    prisma.storefrontConfig.findFirst({ select: { archetypeId: true, archetype: { select: { category: true } } } }),
+  ]);
+  const countryCode = parseOrgAddress(organization?.address).countryCode?.toLowerCase();
+  const locationJurisdictions = countryCode
+    ? [countryCode, ...(isEeaState(countryCode) ? ["eu"] : countryCode === "gb" ? ["uk"] : [])]
+    : [];
+  return {
+    businessContextConfigured: Boolean(businessContext),
+    handlesCardPayments: businessContext?.handlesCardPayments ?? false,
+    businessProfile: {
+      organizationId: organization?.id ?? "unconfigured-organization",
+      archetypeId: storefront?.archetypeId ?? null,
+      archetypeCategory: storefront?.archetype?.category ?? businessContext?.industry ?? null,
+      operatesIn: [...new Set([...(businessContext?.operatesIn ?? []), ...locationJurisdictions])].sort(),
+      sellsTo: businessContext?.sellsTo ?? [],
+      employsIn: businessContext?.employsIn ?? [],
+      dataResidency: businessContext?.dataResidency ?? [],
+      riskPosture: businessContext?.riskPosture === "conservative" || businessContext?.riskPosture === "balanced" || businessContext?.riskPosture === "progressive"
+        ? businessContext.riskPosture
+        : null,
+    },
+  };
+}
+
 /** Shared account/business fact loader for onboarding preview and live routing. */
 export async function loadProviderSuitabilitySourceContext(
   applicableRegulationIds: readonly string[] = [],
 ): Promise<ProviderSuitabilitySourceContext> {
-  const organization = await prisma.organization.findFirst({ select: { id: true, address: true } });
-  const [businessContext, storefront, connections] = await Promise.all([
-    organization ? prisma.businessContext.findUnique({ where: { organizationId: organization.id } }) : null,
-    prisma.storefrontConfig.findFirst({ select: { archetypeId: true, archetype: { select: { category: true } } } }),
-    prisma.aiProviderConnection.findMany({
-      where: organization ? { OR: [{ organizationId: organization.id }, { organizationId: null }] } : undefined,
+  const businessContext = await loadBusinessSuitabilityContext();
+  const profile = businessContext.businessProfile;
+  const organizationId = profile.organizationId === "unconfigured-organization" ? null : profile.organizationId;
+  const connections = await prisma.aiProviderConnection.findMany({
+      where: organizationId ? { OR: [{ organizationId }, { organizationId: null }] } : undefined,
       include: {
         provider: { select: { providerId: true, name: true, category: true, endpointType: true, catalogEntry: true, status: true } },
         trustEvidence: true,
         supplierContract: { select: { contractId: true, status: true, startDate: true, endDate: true } },
       },
       orderBy: [{ status: "asc" }, { label: "asc" }],
-    }),
-  ]);
-
-  const countryCode = parseOrgAddress(organization?.address).countryCode?.toLowerCase();
-  const locationJurisdictions = countryCode
-    ? [countryCode, ...(isEeaState(countryCode) ? ["eu"] : countryCode === "gb" ? ["uk"] : [])]
-    : [];
-  const profile: BusinessSuitabilityProfile = {
-    organizationId: organization?.id ?? "unconfigured-organization",
-    archetypeId: storefront?.archetypeId ?? null,
-    archetypeCategory: storefront?.archetype?.category ?? businessContext?.industry ?? null,
-    operatesIn: [...new Set([...(businessContext?.operatesIn ?? []), ...locationJurisdictions])].sort(),
-    sellsTo: businessContext?.sellsTo ?? [],
-    employsIn: businessContext?.employsIn ?? [],
-    dataResidency: businessContext?.dataResidency ?? [],
-    riskPosture: businessContext?.riskPosture === "conservative" || businessContext?.riskPosture === "balanced" || businessContext?.riskPosture === "progressive"
-      ? businessContext.riskPosture
-      : null,
-  };
+    });
   const regulationRows = applicableRegulationIds.length > 0
     ? await prisma.regulation.findMany({
         where: { regulationId: { in: [...new Set(applicableRegulationIds)] } },
@@ -176,7 +192,7 @@ export async function loadProviderSuitabilitySourceContext(
 
   return {
     businessProfile: profile,
-    handlesCardPayments: businessContext?.handlesCardPayments ?? false,
+    handlesCardPayments: businessContext.handlesCardPayments,
     regulationResults,
     connections: connections.map((connection) => {
       const evidence = resolveProviderTrustEvidence({
@@ -192,7 +208,7 @@ export async function loadProviderSuitabilitySourceContext(
         // downgrade (or accidentally upgrade) the onboarding recommendation.
         status: resolveRuntimeConnectionStatus(connection.provider.status, connection.status),
         facts: resolveProviderTrustFacts({
-          catalog: catalogFacts(connection.provider),
+          catalog: providerCatalogFacts(connection.provider),
           connection: evidence.posture,
         }),
       };

--- a/docs/superpowers/plans/2026-08-27-provider-trust-action-projection.md
+++ b/docs/superpowers/plans/2026-08-27-provider-trust-action-projection.md
@@ -1,0 +1,105 @@
+# Provider trust action projection implementation plan
+
+**Backlog:** BI-9CFB483F  
+**Workroom:** WC-73D771A9  
+**Design:** `docs/superpowers/specs/2026-08-27-provider-trust-action-projection-design.md`  
+**Decision:** DI-16D8DE623703
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Delivery boundary
+
+This plan is one atomic medium-sized fix. The compiler projection, region persistence, and UI copy are internal phases of one observable behavior. Shipping any phase alone would either leave the false warning in place, display policy claims the save path cannot preserve, or change persistence without removing the avoidable question.
+
+## Phase 1 — Establish failing behavior tests
+
+Add red tests before production edits.
+
+- Add pure projection tests covering:
+  - U.S. operating locale with no explicit `dataResidency`: public/synthetic and eligible company work do not require region or DPA evidence.
+  - missing canonical business context: public/synthetic work remains explicit, while company-work eligibility stays unproven.
+  - explicit `dataResidency: ["us"]`: company work requires proven regional processing for `us`, while public/synthetic work remains usable.
+  - source-code and restricted workload explanation codes map to their real account/evidence actions without treating DPA as universal.
+  - OpenRouter keeps its bounded-router obligations for non-public work.
+- Extend `ProviderAccountPostureForm.test.tsx` so no region control renders without a canonical requirement and the required-region control names the required region without a free-text field.
+- Extend `ProviderTrustEvidencePanel.test.tsx` so optional missing evidence does not raise action, while a missing required claim does and names the blocked scope.
+- Extend `ai-providers.test.ts` so omitting a region field preserves existing region entitlements/evidence and a positive required-region declaration records normalized regions plus regional-processing evidence.
+- Extend `ProviderDetailForm.test.tsx` to require **Technical readiness** copy.
+
+Verification: run each affected test file and observe the new assertions fail for the intended pre-fix behavior. The code graph returned no links for the three components, so colocated tests plus the provider-suitability compiler/onboarding suites are mandatory.
+
+## Phase 2 — Refactor canonical context and add the projection
+
+- Extract a focused `loadBusinessSuitabilityContext` from `provider-onboarding-data.ts`; make the existing onboarding loader reuse it and preserve the distinction between configured-empty residency and missing business context.
+- Add a pure per-connection review projection beside the existing provider-suitability/onboarding code.
+- Reuse `deriveOnboardingWorkloadClasses` and `compileAiProviderSuitabilityPolicy`; do not reproduce account, residency, or workload eligibility rules in the page.
+- Keep explanation-code-to-action mapping in the suitability module with an exhaustive test table.
+- Keep queries bounded to one organization/business context and one already-loaded connection on the provider detail route.
+
+Verification: projection, onboarding recommendation, compiler, evidence, and onboarding-data tests pass. Review the diff specifically for duplicated policy conditions and unbounded provider inventory reads.
+
+## Phase 3 — Make region persistence optional and truthful
+
+- Make region declarations optional in the server action so saving account class/no-training does not erase hidden region evidence.
+- Generalize regional-processing declaration persistence beyond OpenRouter when the canonical projection requires a direct provider account guarantee.
+- Normalize the required region set once and record account-scoped `regional-processing` and `enabled-regions` evidence together.
+- Preserve OpenRouter-only ZDR and underlying-provider controls.
+
+Verification: action tests cover preserve, positive declaration, negative/unknown declaration, normalization, and exact connection scope.
+
+## Phase 4 — Render one coherent provider story
+
+- Load canonical business suitability context on the provider detail route and build the per-connection projection.
+- Resolve/display the union of policy-required claims and existing evidence claims; pass the required subset separately to the panel.
+- Make the account form requirement-driven. Remove the arbitrary region entry field; show a targeted guarantee question only when the projection requires regions.
+- Make the evidence panel compute urgency only over required claims, distinguish optional history, and state the usable/blocked scope plus the smallest next action.
+- Rename the separate configuration card to **Technical readiness** and explicitly bound what its ready state proves.
+- Reuse existing theme tokens and components. Do not add a route, navigation item, dashboard, or coworker launch.
+
+Verification: component tests, page/source assertions, keyboard/label semantics, empty/permission states, and prose/style ratchets.
+
+## Phase 5 — Functional and UX gates
+
+- Run targeted Vitest suites from this exact worktree and reconcile the runner root and test counts.
+- Run `pnpm run check:prose-lint:test`, `pnpm run check:prose-lint`, and `node scripts/check-style-drift.mjs` from the exact worktree.
+- Generate/update the docs index required by the impact contract.
+- Run `pnpm run pregate:preflight` before the runtime gate.
+- Claim the shared `local-integration-ci` lease and run the exact-tree pregate; do not turn the worktree into another runtime.
+- Exercise `/platform/ai/providers/zai` against the governed shared/live install after the exact feature SHA is served:
+  - dark and light themes;
+  - desktop and narrow viewport;
+  - no explicit region requirement;
+  - explicit region-bound fixture;
+  - missing required evidence and optional evidence states;
+  - save, reload, and persisted value match.
+- Record test, build, and screenshot evidence on WC-73D771A9.
+- Obtain independent semantic review of the committed tree, run `pnpm pr:health`, and hand off through the DCO PR flow.
+
+## Impact-contract obligations
+
+- Test-impact resolution: colocated tests for `ProviderAccountPostureForm`, `ProviderDetailForm`, and `ProviderTrustEvidencePanel`; exact linked test `apps/web/lib/actions/ai-providers.test.ts`; expanded provider-suitability suites because graph advice was empty/stale for the components.
+- Guard obligations: prose-lint test + scan, style-drift scan.
+- Derived artifact: `apps/web/lib/docs/doc-index.generated.json`.
+- PR design grounding: reference the 2026-07-19 suitability design, the current code substrate, the projection source of truth, and DI-16D8DE623703.
+- UX-fit evidence: `docs/ux-fit/2026-08-27-provider-trust-action-projection.ux-fit.json`.
+
+## Refactoring allocation
+
+Approximately 20% of the implementation effort is reserved for extracting the canonical business-context loader, centralizing policy-to-action translation, and removing duplicated page-level status/checklist logic. This cleanup stays inside the BI's blast radius.
+
+## Risks and rollback
+
+- **Risk:** presentation projection diverges from enforced routing. **Control:** derive both from the same compiler and test explanation/action mappings.
+- **Risk:** hiding a region control erases valid evidence on another save. **Control:** optional server-action fields and preservation tests.
+- **Risk:** an optional evidence row is mistaken for authorization. **Control:** evidence resolver remains factual; only current required claims affect attention.
+- **Risk:** new copy exceeds UI text budgets. **Control:** shrink the fixed checklist, use terse scope copy, and run route/prose measurement.
+- **Rollback:** revert the PR. No migration or data rewrite is introduced.
+
+## Backlog coverage
+
+- Decision: `atomic`
+- Parent BI: `BI-9CFB483F`
+- Deliverable: `provider-trust-action-projection` → `BI-9CFB483F`
+- Dependencies: none
+- Rationale: compiler projection, persistence semantics, and UI rendering form one safety-sensitive behavior and are not independently shippable.
+- Coverage receipt: pending committed-plan registration

--- a/docs/superpowers/plans/2026-08-27-provider-trust-action-projection.md
+++ b/docs/superpowers/plans/2026-08-27-provider-trust-action-projection.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Provider trust action projection implementation plan
 
 **Backlog:** BI-9CFB483F  

--- a/docs/superpowers/specs/2026-08-27-provider-trust-action-projection-design.md
+++ b/docs/superpowers/specs/2026-08-27-provider-trust-action-projection-design.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Provider trust action projection design
 
 **Backlog:** BI-9CFB483F  

--- a/docs/superpowers/specs/2026-08-27-provider-trust-action-projection-design.md
+++ b/docs/superpowers/specs/2026-08-27-provider-trust-action-projection-design.md
@@ -1,0 +1,110 @@
+# Provider trust action projection design
+
+**Backlog:** BI-9CFB483F  
+**Workroom:** WC-73D771A9  
+**Decision:** DI-16D8DE623703 (`compiler-projection`, high confidence, autonomy eligible)
+
+## Problem
+
+The provider detail route turns a fixed list of evidence claims into an aggregate warning. That makes every missing processing-region or DPA row look like work the operator must do, even when the canonical business context declares no data-residency constraint and the intended route is public or synthetic. The same page then labels the provider **Ready** based on credentials, catalog, and routing metadata. Both statements are technically explainable, but together they teach the wrong mental model.
+
+The page also accepts arbitrary comma-separated region codes. Organization location, organization data-residency policy, provider catalog capability, and the connected account's contractual entitlement are separate facts; one must never be used as proof of another.
+
+## Design grounding
+
+This change extends the existing provider-suitability design rather than creating a second policy engine.
+
+- `loadProviderSuitabilitySourceContext` already builds the canonical `BusinessSuitabilityProfile` from `Organization`, `BusinessContext`, and storefront archetype state.
+- `deriveOnboardingWorkloadClasses` already selects the representative workloads for provider onboarding.
+- `compileAiProviderSuitabilityPolicy` already decides whether a concrete connection can serve those workloads and emits connection-scoped explanation codes.
+- `resolveProviderTrustEvidence` remains the factual account-scoped evidence resolver. It does not decide whether a missing fact matters to current work.
+- The 2026-07-19 provider-suitability design requires setup to ask only for facts it cannot prove and keeps catalog capability, connected-account posture, and proven entitlement separate.
+- The platform usability standards require plain language, progressive disclosure, visible action results, theme tokens, and removal of avoidable operator choices.
+
+## Options considered
+
+1. `context-filter`: filter the fixed checklist in the page with local mappings from business context to claim keys. Fast, but duplicates policy rules in presentation code.
+2. `compiler-projection`: project usable scopes, blocked scopes, and required actions from the canonical suitability layer, then render that projection. Selected by DI-16D8DE623703.
+3. `observed-failures`: raise actions only after route receipts show a failed attempt. Evidence-rich but retrospective; it makes the operator fail once before setup becomes legible.
+
+## Chosen architecture
+
+### 1. Focused canonical context loader
+
+Extract the organization/business-profile portion of `loadProviderSuitabilitySourceContext` into a focused loader that returns `businessProfile`, `handlesCardPayments`, and whether canonical business context is configured. The existing all-connections onboarding loader and the provider detail route both reuse it. This avoids calling the unbounded all-connections loader from a single detail page and keeps organization context construction in one place. A configured context with an empty `dataResidency` list means no explicit region constraint; a missing context is unknown and must not be collapsed into that state.
+
+### 2. Pure per-connection review projection
+
+Add a pure provider-suitability projection that compiles two scopes for one concrete connection:
+
+- public/synthetic work, with organization data residency intentionally removed;
+- representative company work, using the canonical organization context and onboarding workload classes.
+
+The projection returns:
+
+- current usable scope: company work, public/synthetic only, or blocked;
+- a plain-language headline and summary;
+- required processing regions from `businessProfile.dataResidency`;
+- policy explanation codes for the concrete connection;
+- evidence claim keys that are required for the blocked scope;
+- non-claim actions such as linking an active supplier contract when the compiler requires one.
+
+If canonical business context is missing, the projection remains usable for public/synthetic work but does not claim company-work eligibility. Copy describes the projection as based on the current business setup; it does not imply knowledge of every future activity. Runtime per-request suitability remains authoritative for each actual workload.
+
+Explanation-code-to-action translation lives beside the compiler/onboarding projection, never in the React page. Existing evidence rows may still be shown as account history, but a missing optional row cannot produce **Action needed**.
+
+### 3. Region control is requirement-driven
+
+When no canonical data-residency region is required, the account form does not render a region control and saving other account terms does not supersede existing region evidence.
+
+When one or more regions are required, the form names them and asks whether this connected account guarantees processing there. It does not ask the operator to invent region codes. A positive declaration records both the regional-processing entitlement and the normalized required regions for this account. Organization setup supplies the requirement; the operator declaration supplies account evidence. Neither substitutes for the other.
+
+### 4. Evidence state and action state stay separate
+
+`resolveProviderTrustEvidence` continues to classify facts as current, missing, expired, rejected, conflicting, or superseded. `ProviderTrustEvidencePanel` receives the projection's required claim keys and computes urgency only over that subset.
+
+- Required and missing/invalid: **Action needed**, with the blocked scope and exact next action.
+- Required and current: **Ready for company work** or equivalent projection copy.
+- No required evidence gap: **No action needed**. Existing optional evidence may be displayed without an alarm.
+
+DPA is not treated as universally required because the current compiler does not use `dpa-on-file` as a universal route gate. Supplier contract, BAA, student terms, financial oversight, and no-training requirements remain distinct and follow compiler explanation codes.
+
+### 5. Technical readiness is labelled honestly
+
+The provider configuration card changes **Provider readiness** to **Technical readiness** and says that credentials, catalog, and routing metadata are prepared. Data-use eligibility remains in the trust projection. This removes the apparent contradiction without weakening either state.
+
+## UX fit review
+
+- **Decision:** fits-with-guardrails
+- **Owning area:** Platform
+- **Route family:** `/platform/ai/providers/[providerId]`
+- **Primary persona:** platform operator configuring an AI provider without needing to understand provider-contract taxonomy
+- **Navigation layer:** local page content only; no navigation change
+- **Reuse/convergence:** reuse the existing account form, evidence panel, suitability compiler, onboarding projection, and theme tokens; add no new route or dashboard
+- **Source truth:** `BusinessContext.dataResidency`, canonical workload profiles, `AiProviderConnection`, `ComplianceEvidence`, supplier contract, and the provider-suitability compiler
+- **Empty/failure behavior:** public/synthetic eligibility remains explicit; missing company-work evidence names the blocked scope and one next action; unavailable canonical context fails closed without inventing a region
+- **AI boundary:** no coworker action is introduced
+- **Guardrails:** do not infer account entitlement from locale; do not hide a real restricted-work block; do not add arbitrary region input; do not create a second status vocabulary
+- **Evidence before merge:** component and pure-projection tests, persistence tests, compiler regression suite, prose/style guards, route-budget evidence, and live route exercise in both themes and narrow/desktop viewports
+
+The measured UX-fit manifest is `docs/ux-fit/2026-08-27-provider-trust-action-projection.ux-fit.json`.
+
+## Data architecture
+
+No migration or new table is required. `Organization`/`BusinessContext` remain authoritative for business requirements. `AiProviderConnection` and connection-scoped evidence remain authoritative for account declarations and proof. The new object is a transient read projection.
+
+## Scalability
+
+The detail route reads one provider connection plus one organization/business context. It must not load every provider connection merely to render one provider. Pure compilation remains bounded by the representative onboarding workload set and one connection. The existing onboarding page may continue to evaluate all configured connections; any future pagination of that inventory remains outside this BI.
+
+## Failure safety and rollback
+
+The routing compiler and pre-egress enforcement are not weakened. Missing canonical context or a projection failure must omit optimistic company-work copy and retain safe blocked/review behavior. Rollback is a normal PR revert; no schema or persisted-data rollback is needed. Existing region evidence remains valid because hidden controls no longer erase it.
+
+## Research and benchmarking
+
+- DPF's 2026-07-19 provider-suitability design is the governing domain benchmark: ask only for facts the platform cannot prove and compile the stricter organization/workload/account posture.
+- DPF platform usability standards provide the interaction benchmark: progressive disclosure, plain language, persistent status messaging, and theme-aware styling.
+- The portal UX simplification spine requires literal labels, trustworthy first-view status, one source of truth, and roughly 20% refactoring effort inside each slice. This design spends that refactoring budget extracting the shared business-context loader and removing page-local status/checklist logic.
+
+No external component library is adopted. This is a policy/read-model correction inside existing DPF primitives.

--- a/docs/superpowers/specs/2026-08-27-provider-trust-action-projection-design.md
+++ b/docs/superpowers/specs/2026-08-27-provider-trust-action-projection-design.md
@@ -10,6 +10,24 @@ The provider detail route turns a fixed list of evidence claims into an aggregat
 
 The page also accepts arbitrary comma-separated region codes. Organization location, organization data-residency policy, provider catalog capability, and the connected account's contractual entitlement are separate facts; one must never be used as proof of another.
 
+## Objective baseline
+
+**OBJ-TRUST-RELEVANCE:** Provider setup derives questions and attention from the canonical business and workload policy, so optional region or contract evidence does not look mandatory.
+
+**OBJ-ENTITLEMENT-INTEGRITY:** Organization locale and data-residency requirements remain distinct from a connected provider account's proven processing entitlement.
+
+**OBJ-READINESS-CLARITY:** The page distinguishes technical connectivity from workload-specific data-use eligibility and names the smallest correct next action.
+
+**OBJ-ROUTING-SAFETY:** Restricted, unknown-classification, and region-bound workloads remain denied when required evidence is absent or invalid.
+
+| Acceptance | Objective | Statement |
+| --- | --- | --- |
+| AC-TRUST-01 | OBJ-TRUST-RELEVANCE | With no explicit canonical residency requirement, the provider page neither asks for arbitrary region codes nor raises action for missing region or DPA evidence. |
+| AC-TRUST-02 | OBJ-ENTITLEMENT-INTEGRITY | When canonical policy requires regions, the page names them and records a connection-scoped guarantee without inferring entitlement from operating locale. |
+| AC-TRUST-03 | OBJ-READINESS-CLARITY | Technical readiness and data-use eligibility use distinct labels, scope statements, and actions. |
+| AC-TRUST-04 | OBJ-ROUTING-SAFETY | Existing deny-by-default compiler behavior remains covered for unknown classification, region-bound work, and restricted work. |
+| AC-TRUST-05 | OBJ-TRUST-RELEVANCE | Saving account terms while no region is required preserves existing region evidence; a required positive guarantee persists normalized regions. |
+
 ## Design grounding
 
 This change extends the existing provider-suitability design rather than creating a second policy engine.

--- a/docs/user-guide/ai-workforce/connecting-providers.md
+++ b/docs/user-guide/ai-workforce/connecting-providers.md
@@ -5,6 +5,7 @@ order: 2
 relatedCode:
   - apps/web/lib/ai-inference.ts
   - apps/web/app/(shell)/platform/ai/providers/page.tsx
+  - apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
   - apps/web/components/platform/ProviderSuitabilityGuide.tsx
 ---
 
@@ -116,12 +117,13 @@ If you choose **Skip safely** or **Review later**, DPF does not treat the provid
 On each provider detail page, record:
 
 - the connected account type;
-- whether no-training treatment has been verified in the provider's current terms;
-- the processing regions enabled for that exact connection.
+- whether no-training treatment has been verified in the provider's current terms.
 
 This is recorded as an operator attestation, not contract proof. A DPA, BAA, supplier contract, special retention option, or regional entitlement still needs its own evidence. Provider-published privacy pages describe an offering; they do not prove what your account purchased or enabled.
 
-After you save the declaration, the provider page acknowledges it separately from restricted-work evidence. A limitation count means only that sensitive or restricted work remains blocked by the listed claims; it is not a generic connection failure. Each claim says whether you can update it in **Connected account and data terms** or whether the page has no evidence workflow. In particular, DPA evidence cannot be added on this page and must be linked through platform governance. An empty processing-region field reads **No regions saved**; examples appear as help text, never as if they were saved values.
+If the organization's business setup explicitly requires processing in a region, the page names that region and asks whether this connected account can guarantee it. The organization being based in the United States, EEA, UK, or elsewhere does not by itself prove what a provider account purchased or enabled. When no region is required, there is no region question, and saving the other account terms preserves any existing region evidence.
+
+After you save the declaration, the provider page separates **Technical readiness** from data-use eligibility. Technical readiness means the connection, model catalog, and routing metadata are prepared. The trust panel states whether the connection can handle the company work represented by the current setup or only public and synthetic work. Missing optional evidence may remain visible as history, but it does not raise an action. A missing or invalid required claim names the blocked scope and the next action. DPA evidence is requested only on policy paths that require it; it is not a universal provider-setup requirement.
 
 For EEA, UK, public-sector, healthcare, education, financial-services, or other regulated use, ask the COO to consult the Data Governance Agent. The answer should cite applicable regulator guidance and provider terms, identify unknowns, and recommend qualified review when it cannot substantiate a claim.
 

--- a/docs/ux-fit/2026-08-27-provider-trust-action-projection.ux-fit.json
+++ b/docs/ux-fit/2026-08-27-provider-trust-action-projection.ux-fit.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "decidedOption": "compiler-projection",
+  "decisionInteractionId": "DI-16D8DE623703",
+  "scope": {
+    "files": [
+      "apps/web/components/platform/ProviderAccountPostureForm.tsx",
+      "apps/web/components/platform/ProviderDetailForm.tsx",
+      "apps/web/components/platform/ProviderTrustEvidencePanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "context-filter",
+      "compiler-projection",
+      "observed-failures"
+    ]
+  }
+}

--- a/docs/ux-fit/2026-08-27-provider-trust-action-projection.ux-fit.json
+++ b/docs/ux-fit/2026-08-27-provider-trust-action-projection.ux-fit.json
@@ -4,9 +4,7 @@
   "decisionInteractionId": "DI-16D8DE623703",
   "scope": {
     "files": [
-      "apps/web/components/platform/ProviderAccountPostureForm.tsx",
-      "apps/web/components/platform/ProviderDetailForm.tsx",
-      "apps/web/components/platform/ProviderTrustEvidencePanel.tsx"
+      "apps/web/components/platform/ProviderAccountPostureForm.tsx"
     ]
   },
   "evidence": {


### PR DESCRIPTION
## Summary

- derive provider trust questions and attention from the canonical provider-suitability compiler
- ask about processing-region guarantees only when the intended workload requires one, while preserving account-scoped evidence
- distinguish technical connection readiness from workload data-use eligibility and document the revised operator flow

## Why

The provider page treated missing region and DPA evidence as universal action items. That made a US-based operator answer an unexplained region question and showed **Action needed** even when the intended work was public or synthetic. Organization locale is context, not proof of a provider-account processing entitlement.

## Design grounding

This change reuses `BusinessContext.dataResidency`, the provider-suitability compiler, and connection-scoped trust evidence. It does not introduce another policy source or weaken deny-by-default routing. The selected compiler-projection approach is recorded in `DI-16D8DE623703`.

## Verification

- widened provider/compiler/component suite: 89/89 tests pass
- focused post-refactor suite: 37/37 tests pass
- web TypeScript check passes
- 63 preflight guards pass
- exhaustive exact-tree local integration gate passes, including migrations, full tests, typecheck, and production Docker build
- independent semantic change review passes

UX-fit evidence: `docs/ux-fit/2026-08-27-provider-trust-action-projection.ux-fit.json`

DPF backlog: `BI-9CFB483F`
