### PR TITLE
fix: resume exact terminal writer waits

### DIFF
--- a/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  findUnique: vi.fn(),
+  findModelConfig: vi.fn(),
+  findEnvelope: vi.fn(),
+  findToolExecution: vi.fn(),
+  findToolExecutions: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+}));
+const autonomous = vi.hoisted(() => ({
+  execute: vi.fn(),
+  executeTool: vi.fn(),
+  resolveAgent: vi.fn(),
+  resolveTools: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findFirst: (...args: unknown[]) => db.findFirst(...args),
+      findUnique: (...args: unknown[]) => db.findUnique(...args),
+      update: (...args: unknown[]) => db.update(...args),
+      updateMany: (...args: unknown[]) => db.updateMany(...args),
+    },
+    coworkerActionEnvelope: {
+      findFirst: (...args: unknown[]) => db.findEnvelope(...args),
+    },
+    toolExecution: {
+      findFirst: (...args: unknown[]) => db.findToolExecution(...args),
+      findMany: (...args: unknown[]) => db.findToolExecutions(...args),
+    },
+    agentModelConfig: {
+      findUnique: (...args: unknown[]) => db.findModelConfig(...args),
+    },
+  },
+}));
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: vi.fn(),
+  executeAutonomousAgenticLoop: (...args: unknown[]) => autonomous.execute(...args),
+  executeAutonomousWorkTool: (...args: unknown[]) => autonomous.executeTool(...args),
+  resolveAutonomousWorkAgent: (...args: unknown[]) => autonomous.resolveAgent(...args),
+  resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
+}));
+vi.mock("@/lib/tak/task-records", () => ({ createTaskMessage: vi.fn() }));
+vi.mock("./mcp-task-submit-approval-recovery", () => ({
+  recoverStaleApprovalOnReplay: vi.fn(async () => null),
+  resumeApprovedRemoteTask: vi.fn(async () => null),
+}));
+
+import { remoteTaskRequestDigest } from "./mcp-task-capacity-contract";
+import { submitRemoteCoworkerTask } from "./mcp-task-submit";
+
+const params = {
+  agentId: "AGT-WS-BUILD",
+  routeContext: "/platform/build",
+  title: "Independent research review",
+  objective: "Review the immutable source and record research evidence.",
+  prompt: "Read the exact source and record the governed evidence.",
+  idempotencyKey: "terminal-writer-crossed-stale-threshold",
+  riskClass: "bounded-write" as const,
+  authorityScope: [
+    "backlog-item:BI-E2B632D2",
+    "tool:read_source_at_version",
+    "tool:record_initiative_evidence",
+  ],
+  collaborationKind: "handoff" as const,
+  initiativeReviewBinding: {
+    writerToolName: "record_initiative_evidence",
+    itemId: "BI-E2B632D2",
+    gate: "research" as const,
+    artifactRef: {
+      kind: "repo-blob-at-commit" as const,
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      commitSha: "4100d18ad75cc29602f8857db0de2901f185effb",
+      path: "apps/web/lib/mcp-task-submit.ts",
+      providerBlobId: "f05787443eb00b0c22f22f7c7bc683cd81cfaf49",
+    },
+  },
+};
+
+const readerExecution = {
+  id: "reader-1",
+  toolName: "read_source_at_version",
+  parameters: {
+    repositoryFullName: params.initiativeReviewBinding.artifactRef.repositoryFullName,
+    path: params.initiativeReviewBinding.artifactRef.path,
+    version: params.initiativeReviewBinding.artifactRef.commitSha,
+    expectedBlobId: params.initiativeReviewBinding.artifactRef.providerBlobId,
+    startLine: 1,
+    maxChars: 3_200,
+  },
+  result: {},
+  success: true,
+  createdAt: new Date("2026-09-01T04:11:43.124Z"),
+};
+
+describe("reaper-stalled terminal writer resumption", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const updatedAt = new Date("2026-09-01T04:17:00.140Z");
+    db.findFirst.mockResolvedValue({
+      id: "task-internal",
+      taskRunId: "TR-MCP-REAPER-STALLED",
+      userId: "user-1",
+      threadId: "thread-external",
+      contextId: "thread-external",
+      status: "stalled",
+      lastHeartbeatAt: new Date("2026-09-01T04:16:32.587Z"),
+      completedAt: updatedAt,
+      updatedAt,
+      progressPayload: {
+        terminalWriterWait: {
+          schemaVersion: 1,
+          kind: "missing-terminal-writer",
+          writerToolName: "record_initiative_evidence",
+          resumeMode: "same-taskrun",
+          attempt: 1,
+          observedAt: "2026-09-01T04:12:32.612Z",
+          dispatchContract: "required-tool-call",
+        },
+      },
+      a2aMetadata: {
+        requestDigest: remoteTaskRequestDigest(params),
+        idempotencyKey: params.idempotencyKey,
+        initiativeReviewBinding: params.initiativeReviewBinding,
+      },
+    });
+    db.findEnvelope.mockResolvedValue(null);
+    db.findToolExecution.mockResolvedValue(null);
+    db.findToolExecutions.mockResolvedValue([readerExecution]);
+    db.findModelConfig.mockResolvedValue({
+      minimumTier: "strong",
+      budgetClass: "quality_first",
+      pinnedProviderId: "local",
+      pinnedModelId: "review-model",
+    });
+    db.update.mockResolvedValue({});
+    db.updateMany.mockResolvedValue({ count: 1 });
+    db.findUnique.mockResolvedValue({ status: "working" });
+    autonomous.resolveAgent.mockResolvedValue({
+      agentId: "build-specialist",
+      displayName: "Build Lead",
+      systemPrompt: "Review the immutable source.",
+      sensitivity: "internal",
+    });
+    autonomous.resolveTools.mockResolvedValue({
+      tools: [],
+      toolsForProvider: [],
+      deferredTools: [],
+    });
+    autonomous.execute.mockResolvedValue({
+      content: "The governed local inference provider is still at capacity.",
+      executedTools: [],
+      failure: { kind: "capacity", message: "No local inference slot is available." },
+    });
+  });
+
+  it("reserves and resumes the same exact-bound TaskRun after a reaper stall", async () => {
+    const outcome = await submitRemoteCoworkerTask({
+      token: {
+        tokenId: "token-research",
+        userId: "user-1",
+        capability: "write",
+        source: "pat",
+      },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).toHaveBeenCalledWith({
+      where: {
+        taskRunId: "TR-MCP-REAPER-STALLED",
+        status: "stalled",
+        updatedAt: new Date("2026-09-01T04:17:00.140Z"),
+      },
+      data: {
+        status: "working",
+        lastHeartbeatAt: expect.any(Date),
+        completedAt: null,
+        progressPayload: expect.objectContaining({
+          terminalWriterWait: expect.objectContaining({ attempt: 2 }),
+          resumeReservedAt: expect.any(String),
+        }),
+      },
+    });
+    expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
+      taskRunId: "TR-MCP-REAPER-STALLED",
+      threadId: "thread-external",
+      terminalToolPolicy: expect.objectContaining({
+        terminalPhase: "writer-only",
+        persistedEvidenceAvailable: true,
+      }),
+    }));
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        taskRunId: "TR-MCP-REAPER-STALLED",
+        idempotentReplay: true,
+        resumedFromTerminalWriterWait: true,
+      },
+    });
+  });
+});

--- a/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
@@ -97,37 +97,45 @@ const readerExecution = {
   createdAt: new Date("2026-09-01T04:11:43.124Z"),
 };
 
+const updatedAt = new Date("2026-09-01T04:17:00.140Z");
+const terminalWriterWait = {
+  schemaVersion: 1,
+  kind: "missing-terminal-writer",
+  writerToolName: "record_initiative_evidence",
+  resumeMode: "same-taskrun",
+  attempt: 1,
+  observedAt: "2026-09-01T04:12:32.612Z",
+  dispatchContract: "required-tool-call",
+};
+
+function existingRun(
+  status: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: "task-internal",
+    taskRunId: "TR-MCP-REAPER-STALLED",
+    userId: "user-1",
+    threadId: "thread-external",
+    contextId: "thread-external",
+    status,
+    lastHeartbeatAt: new Date("2026-09-01T04:16:32.587Z"),
+    completedAt: updatedAt,
+    updatedAt,
+    progressPayload: { terminalWriterWait },
+    a2aMetadata: {
+      requestDigest: remoteTaskRequestDigest(params),
+      idempotencyKey: params.idempotencyKey,
+      initiativeReviewBinding: params.initiativeReviewBinding,
+    },
+    ...overrides,
+  };
+}
+
 describe("reaper-stalled terminal writer resumption", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    const updatedAt = new Date("2026-09-01T04:17:00.140Z");
-    db.findFirst.mockResolvedValue({
-      id: "task-internal",
-      taskRunId: "TR-MCP-REAPER-STALLED",
-      userId: "user-1",
-      threadId: "thread-external",
-      contextId: "thread-external",
-      status: "stalled",
-      lastHeartbeatAt: new Date("2026-09-01T04:16:32.587Z"),
-      completedAt: updatedAt,
-      updatedAt,
-      progressPayload: {
-        terminalWriterWait: {
-          schemaVersion: 1,
-          kind: "missing-terminal-writer",
-          writerToolName: "record_initiative_evidence",
-          resumeMode: "same-taskrun",
-          attempt: 1,
-          observedAt: "2026-09-01T04:12:32.612Z",
-          dispatchContract: "required-tool-call",
-        },
-      },
-      a2aMetadata: {
-        requestDigest: remoteTaskRequestDigest(params),
-        idempotencyKey: params.idempotencyKey,
-        initiativeReviewBinding: params.initiativeReviewBinding,
-      },
-    });
+    db.findFirst.mockResolvedValue(existingRun("stalled"));
     db.findEnvelope.mockResolvedValue(null);
     db.findToolExecution.mockResolvedValue(null);
     db.findToolExecutions.mockResolvedValue([readerExecution]);
@@ -150,6 +158,22 @@ describe("reaper-stalled terminal writer resumption", () => {
       tools: [],
       toolsForProvider: [],
       deferredTools: [],
+    });
+    autonomous.executeTool.mockResolvedValue({
+      success: true,
+      message: "Read exact source.",
+      data: {
+        repositoryFullName: params.initiativeReviewBinding.artifactRef.repositoryFullName,
+        path: params.initiativeReviewBinding.artifactRef.path,
+        version: params.initiativeReviewBinding.artifactRef.commitSha,
+        blobId: params.initiativeReviewBinding.artifactRef.providerBlobId,
+        content: "export async function submitRemoteCoworkerTask() {}",
+        startLine: 1,
+        endLine: 1,
+        totalLines: 1,
+        hasMore: false,
+        nextCursor: null,
+      },
     });
     autonomous.execute.mockResolvedValue({
       content: "The governed local inference provider is still at capacity.",
@@ -200,6 +224,109 @@ describe("reaper-stalled terminal writer resumption", () => {
         taskRunId: "TR-MCP-REAPER-STALLED",
         idempotentReplay: true,
         resumedFromTerminalWriterWait: true,
+      },
+    });
+  });
+
+  it("resumes a failed exact-bound wait after a rejected non-proposal writer", async () => {
+    db.findFirst.mockResolvedValue(existingRun("failed"));
+    db.findToolExecution.mockImplementation(async (query: { where?: { success?: unknown } }) => (
+      query.where?.success === true
+        ? null
+        : {
+            id: "writer-rejected",
+            success: false,
+            result: { success: false, error: "OBJECTIVE_BASELINE_CONFLICT" },
+          }
+    ));
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        taskRunId: "TR-MCP-REAPER-STALLED",
+        status: "failed",
+        updatedAt,
+      },
+    }));
+    expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
+      taskRunId: "TR-MCP-REAPER-STALLED",
+      terminalToolPolicy: expect.objectContaining({ terminalPhase: "writer-only" }),
+    }));
+  });
+
+  it.each(["stalled", "failed"])("does not reopen a generic %s TaskRun", async (status) => {
+    db.findFirst.mockResolvedValue(existingRun(status, {
+      progressPayload: { summary: "Ordinary terminal task." },
+    }));
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen a wait whose writer binding changed", async () => {
+    db.findFirst.mockResolvedValue(existingRun("stalled", {
+      progressPayload: {
+        terminalWriterWait: {
+          ...terminalWriterWait,
+          writerToolName: "record_initiative_design_review",
+        },
+      },
+    }));
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen after a successful writer", async () => {
+    db.findToolExecution.mockResolvedValue({ id: "writer-success", success: true, result: {} });
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen a wait at the existing attempt ceiling", async () => {
+    db.findFirst.mockResolvedValue(existingRun("stalled", {
+      progressPayload: {
+        terminalWriterWait: { ...terminalWriterWait, attempt: 3 },
+      },
+    }));
+
+    const outcome = await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        resumable: false,
+        waitReason: "terminal-writer-retry-exhausted",
       },
     });
   });

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -277,9 +277,11 @@ async function reserveTerminalWriterReplay(input: {
   if (recoverTerminalWriterEscalation(input.existing.progressPayload)) return null;
 
   const existingWait = parseTerminalWriterWait(input.existing.progressPayload);
-  const isProjectedWait = input.existing.status === "input-required" && existingWait !== null;
+  const isProjectedWait = existingWait !== null
+    && ["input-required", "stalled", "failed"].includes(input.existing.status);
   const isRecoverableCompletedExit = input.existing.status === "completed" && !existingWait;
   if (!isProjectedWait && !isRecoverableCompletedExit) return null;
+  if (existingWait && existingWait.writerToolName !== input.terminalToolPolicy.writerToolName) return null;
 
   const [readerExecutions, successfulWriter, writerAttempt] = await Promise.all([
     persistedTerminalReaderExecutions(input.existing.taskRunId),
@@ -308,17 +310,22 @@ async function reserveTerminalWriterReplay(input: {
     const proposalEnvelopeId = writerAttempt.success === false
       ? approvalEnvelopeIdFromWriterAttempt(writerAttempt.result)
       : null;
-    if (!proposalEnvelopeId) return null;
-    const declinedProposalEnvelope = await prisma.coworkerActionEnvelope.findFirst({
-      where: {
-        id: proposalEnvelopeId,
-        taskRunId: input.existing.taskRunId,
-        manifestActionId: input.terminalToolPolicy.writerToolName,
-        status: "declined",
-      },
-      select: { id: true },
-    });
-    if (declinedProposalEnvelope?.id !== proposalEnvelopeId) return null;
+    if (proposalEnvelopeId) {
+      const declinedProposalEnvelope = await prisma.coworkerActionEnvelope.findFirst({
+        where: {
+          id: proposalEnvelopeId,
+          taskRunId: input.existing.taskRunId,
+          manifestActionId: input.terminalToolPolicy.writerToolName,
+          status: "declined",
+        },
+        select: { id: true },
+      });
+      if (declinedProposalEnvelope?.id !== proposalEnvelopeId) return null;
+    } else if (
+      writerAttempt.success !== false
+      || !existingWait
+      || !["stalled", "failed"].includes(input.existing.status)
+    ) return null;
   }
 
   const progress = input.existing.progressPayload && typeof input.existing.progressPayload === "object"

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -116,8 +116,7 @@ extends that contract; it does not replace or narrow the original safeguards.
   `OBJ-DE-005`, `OBJ-E2B-001`, `OBJ-E2B-002`, `OBJ-E2B-003`, and `OBJ-E2B-004`.
 - Contract refs: `immutable-source terminal-writer contract` and
   `exact-bound stalled and failed replay contract`.
-- Flow refs: `exact request replay -> compare-and-set reservation -> immutable
-  hydration -> writer-only turn -> governed approval or receipt`.
+- Flow refs: `writer-only turn`.
 - Verification refs: `AC-DE-001`, `AC-DE-002`, `AC-DE-003`, `AC-DE-004`,
   `AC-DE-005`, `AC-DE-006`, `AC-DE-007`, `AC-E2B-001`, `AC-E2B-002`,
   `AC-E2B-003`, `AC-E2B-004`, `AC-E2B-005`, and `AC-E2B-006`.

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -101,7 +101,7 @@ no schema changes.
 - Decision: atomic
 - Parent: `BI-E2B632D2`
 - Design baseline: `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`
-- Receipt: pending immutable plan registration
+- Receipt: `cmtmd9eri7nj001miwklshlsr`
 - Rationale: stalled/failed admission, reservation checks, regressions, and live
   same-TaskRun proof are one replay contract and have no independently useful
   shipping boundary.
@@ -127,3 +127,9 @@ extends that contract; it does not replace or narrow the original safeguards.
 - Live `BI-BFBF1BBB` replay reconfirmed the cached failed-but-resumable mismatch.
 - Graph impact resolved: six exact related test suites were returned for
   `apps/web/lib/mcp-task-submit.ts`.
+- Design baseline `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`, research
+  receipt `initiative-7f4fa9fe-8e08-49f5-bc84-edbcd66f1898`, and plan coverage
+  receipt `cmtmd9eri7nj001miwklshlsr` passed before production-code edits.
+- The focused RED failed because the marked stalled TaskRun made zero
+  compare-and-set reservation calls. After the eligibility correction, the new
+  seven-case regression and all six graph-linked suites pass: 54 tests total.

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -100,10 +100,27 @@ no schema changes.
 
 - Decision: atomic
 - Parent: `BI-E2B632D2`
+- Design baseline: `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`
 - Receipt: pending immutable plan registration
 - Rationale: stalled/failed admission, reservation checks, regressions, and live
   same-TaskRun proof are one replay contract and have no independently useful
   shipping boundary.
+
+### Four-way traceability
+
+The atomic deliverable is bound to every objective and acceptance criterion in
+the approved immutable-source terminal-writer baseline. The replay correction
+extends that contract; it does not replace or narrow the original safeguards.
+
+- Requirement refs: `OBJ-DE-001`, `OBJ-DE-002`, `OBJ-DE-003`, `OBJ-DE-004`,
+  `OBJ-DE-005`, `OBJ-E2B-001`, `OBJ-E2B-002`, `OBJ-E2B-003`, and `OBJ-E2B-004`.
+- Contract refs: `immutable-source terminal-writer contract` and
+  `exact-bound stalled and failed replay contract`.
+- Flow refs: `exact request replay -> compare-and-set reservation -> immutable
+  hydration -> writer-only turn -> governed approval or receipt`.
+- Verification refs: `AC-DE-001`, `AC-DE-002`, `AC-DE-003`, `AC-DE-004`,
+  `AC-DE-005`, `AC-DE-006`, `AC-DE-007`, `AC-E2B-001`, `AC-E2B-002`,
+  `AC-E2B-003`, `AC-E2B-004`, `AC-E2B-005`, and `AC-E2B-006`.
 
 ## Progress evidence
 

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -1,0 +1,113 @@
+---
+status: active
+---
+
+# Exact-bound terminal-writer replay liveness plan
+
+**Backlog item:** `BI-E2B632D2`  
+**Workroom:** `WC-17F74F70`  
+**Design:** `docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md`
+
+**For agentic workers:** execute this plan one independently reviewable backlog
+item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate
+before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Observed state
+
+- The original reproduction is an exact-bound TaskRun reaped to `stalled` while
+  waiting in governed inference admission. Its request digest, artifact binding,
+  successful immutable reads, and `missing-terminal-writer` marker survived, but
+  `reserveTerminalWriterReplay` admits only `input-required` and one historical
+  `completed` route exit.
+- Canonical replay for `BI-BFBF1BBB` exposed the same contract mismatch at a
+  second terminal state. TaskRun `...7AF37EB34EF7` is `failed`, retains the exact
+  request and terminal-writer wait marker, has no successful writer, and is
+  projected as `resumable`; identical replay nevertheless returns the cached
+  failure. Its earlier writer arguments were rejected after a prerequisite
+  schema defect that is now fixed and deployed.
+- The fix extends the existing reservation and terminal-writer attempt budget.
+  It adds no TaskRun, writer, receipt, approval bypass, or alternate evidence
+  path.
+
+## Atomic deliverable
+
+This is one replay-contract correction: admit an exact marked `stalled` or
+`failed` terminal-writer wait to the existing compare-and-set reservation only
+when the request digest matches, the server reconstructs the same immutable
+review binding, no writer has succeeded, and the bounded attempt ceiling remains
+open. A failed non-proposal writer attempt is historical evidence, not an active
+approval; replay reruns only the bound writer turn on the same TaskRun.
+
+## Phase 1 — RED
+
+Add source-local regressions in
+`apps/web/lib/mcp-task-stalled-terminal-writer.test.ts` for:
+
+1. a reaper-stalled exact-bound wait returning the same TaskRun to writer-only
+   execution;
+2. a failed exact-bound wait after a rejected writer argument doing the same;
+3. unchanged refusal for a generic stalled/failed task, digest mismatch,
+   successful writer, and exhausted attempt budget.
+
+Run the new regression plus all six graph-linked `mcp-task-submit` suites. Keep
+the first failure as evidence before implementation.
+
+## Phase 2 — GREEN
+
+Change only `reserveTerminalWriterReplay` and its small parsing predicates in
+`apps/web/lib/mcp-task-submit.ts`:
+
+- recognize `stalled`/`failed` only when the persisted terminal-writer marker is
+  valid and matches the reconstructed writer;
+- retain request-digest, successful-writer, immutable hydration, approval, and
+  compare-and-set checks;
+- allow a prior non-successful, non-proposal writer attempt to trigger a new
+  bounded writer-only turn, while preserving proposal-envelope recovery as the
+  authority for actual pending approvals;
+- preserve ordinary TaskRun terminal semantics.
+
+Update the governing design with the live evidence and exact eligibility rule.
+
+## Phase 3 — gates and functional replay
+
+Run the new regression, all graph-linked suites, style guard, web production
+build, `pregate:preflight`, and the exact-tree `pregate`. Open a DCO-signed PR
+with the design and current code substrate named in Design grounding, verify it
+with `pnpm pr:health`, and merge through the queue.
+
+After canonical self-upgrade, replay the unchanged `BI-BFBF1BBB` recovery packet.
+Success requires the same TaskRun to execute the now-bound objective mapping,
+produce the governed acceptance evidence, and allow both its BI and Workroom to
+close. Then close this dependency BI and Workroom with the same live evidence.
+
+UX is not applicable because no UI changes. Migration is not applicable because
+no schema changes.
+
+## Risks and rollback
+
+- Risk: reopening an unrelated terminal task. Control: require the exact request
+  digest, immutable review policy, valid same-TaskRun marker, zero successful
+  writer, and compare-and-set reservation.
+- Risk: repeating a rejected judgment forever. Control: retain the existing
+  terminal-writer attempt counter and escalation ceiling.
+- Risk: bypassing a live approval. Control: proposal envelopes continue through
+  approval recovery; replay does not execute their stored arguments directly.
+- Rollback: revert the eligibility branch and regressions. No persisted schema or
+  evidence format changes.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-E2B632D2`
+- Receipt: pending immutable plan registration
+- Rationale: stalled/failed admission, reservation checks, regressions, and live
+  same-TaskRun proof are one replay contract and have no independently useful
+  shipping boundary.
+
+## Progress evidence
+
+- Workroom resumed and canonical path repaired on 2026-09-03.
+- Live `BI-BFBF1BBB` replay reconfirmed the cached failed-but-resumable mismatch.
+- Graph impact resolved: six exact related test suites were returned for
+  `apps/web/lib/mcp-task-submit.ts`.

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -100,6 +100,7 @@ no schema changes.
 
 - Decision: atomic
 - Parent: `BI-E2B632D2`
+- Dependencies: none
 - Design baseline: `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`
 - Receipt: `cmtmd9eri7nj001miwklshlsr`
 - Rationale: stalled/failed admission, reservation checks, regressions, and live

--- a/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
+++ b/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
@@ -258,3 +258,46 @@ Live BI-FFBDDD96 research TaskRun `TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-799
 The remote-task executor is the final completion boundary for initiative reviews. When an immutable review binding creates a terminal-writer policy, the executor may persist ordinary completion only after the bound writer appears in the governed execution history or as the active bound proposal. Any other loop result—including duration, iteration, cancellation, route, circuit-breaker, or prose exits—is converted to the existing `input-required/missing-terminal-writer` projection on the same TaskRun. The conversion clears `completedAt`, preserves the request digest and immutable binding, records the bounded attempt, and creates no envelope, decision, mapping, or receipt.
 
 This is a postcondition, not a second inference policy. The agent loop still controls reader/writer surfaces and required tool choice; the executor independently prevents an incomplete result from escaping as completed. A genuine writer attempt retains existing approval and receipt handling, and non-review tasks remain unchanged.
+
+## Exact-bound stalled and failed replay liveness (BI-E2B632D2)
+
+Two live states expose the same false resumability promise. A Build Lead review
+was reaped to `stalled` while it remained in governed inference admission; a
+later objective-mapping review was left `failed` after an approved writer used
+an argument that a subsequently deployed binding repair now constrains. Both
+TaskRuns retain their request digest, immutable artifact binding, valid
+`missing-terminal-writer` marker, and zero successful writers. The replay read
+model reports both as resumable, but `reserveTerminalWriterReplay` admits neither
+state and returns the cached terminal result.
+
+- **OBJ-E2B-001:** Make every TaskRun projected as a resumable exact-bound
+  terminal-writer wait executable through the same TaskRun and request digest.
+- **OBJ-E2B-002:** Preserve the immutable review binding, writer identity,
+  evidence hydration, approval boundary, and receipt validators during replay.
+- **OBJ-E2B-003:** Keep ordinary stalled, failed, completed, and non-review
+  TaskRuns terminal; only an exact marked terminal-writer wait is eligible.
+- **OBJ-E2B-004:** Bound replay attempts and stop with the existing escalation
+  rather than retrying a rejected or unavailable writer forever.
+
+| Acceptance ID | Objectives | Acceptance criterion |
+| --- | --- | --- |
+| AC-E2B-001 | OBJ-E2B-001, OBJ-E2B-002 | An exact-bound reaper-stalled wait compare-and-sets the same TaskRun back to `working` and reaches the existing writer-only turn. |
+| AC-E2B-002 | OBJ-E2B-001, OBJ-E2B-002 | A failed exact-bound wait with a prior non-successful, non-proposal writer attempt may run a new bounded writer-only turn on the same TaskRun; no sibling identity is created. |
+| AC-E2B-003 | OBJ-E2B-002 | A live proposal or approval remains owned by approval recovery; replay neither executes stored arguments nor bypasses fresh exact approval. |
+| AC-E2B-004 | OBJ-E2B-003 | A generic stalled/failed run, changed request digest, changed writer binding, or successful writer remains unrecoverable through this path. |
+| AC-E2B-005 | OBJ-E2B-004 | The existing attempt ceiling applies to stalled and failed waits and produces the existing bounded escalation when exhausted. |
+| AC-E2B-006 | OBJ-E2B-001, OBJ-E2B-002, OBJ-E2B-003 | Canonical replay of the original objective-mapping packet records the governed mapping and allows its BI and Workroom to close. |
+
+### Ordered fix sequence
+
+1. Add regressions for the reaper-stalled wait, the corrected-prerequisite
+   failed wait, and the fail-closed exclusions above.
+2. Extend only the existing reservation eligibility and prior-attempt handling;
+   retain the request digest, immutable policy reconstruction, successful-writer
+   check, compare-and-set, hydration, approval, and receipt paths.
+3. Run the graph-linked TaskRun suites and build gates, publish through the merge
+   queue, self-upgrade canonically, then replay the unchanged original packet.
+
+This is an orchestration-liveness correction, not a second evidence or approval
+model. The prior failed attempts remain immutable audit history. Rollback is the
+single eligibility change and its tests; no schema or stored contract changes.


### PR DESCRIPTION
## Summary

- Resume only exact-bound terminal-writer waits that were reaped to `stalled` or reached `failed` after a non-successful writer attempt.
- Preserve the original TaskRun, request digest, immutable hydration, writer binding, approval authority, compare-and-set reservation, successful-writer refusal, and bounded attempt ceiling.
- Add seven regression cases covering admitted and refused replay paths.

## Design grounding

This implements the replay-liveness extension in `docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md`. The code substrate is the existing terminal-writer replay reservation in `apps/web/lib/mcp-task-submit.ts`; this change extends that single path instead of adding a writer, queue, receipt, approval bypass, or verification engine.

## Verification

- RED: focused regression failed because the marked stalled TaskRun made no compare-and-set reservation call.
- GREEN: `pnpm --filter web exec vitest run lib/mcp-task-stalled-terminal-writer.test.ts` — 7/7 passed.
- Affected graph: seven suites, 54/54 tests passed.
- `node scripts/check-style-drift.mjs` — passed.
- `pnpm --filter web build` — passed with zero errors; 148 static routes generated.
- `pnpm run pregate:preflight` — 63/63 guards passed.
- `pnpm run pregate` — passed against merged code.
- UX: not applicable; no UI behavior changed.
- Migration: not applicable; no schema change.

## Governance

- Backlog item: `BI-E2B632D2`
- Workroom: `WC-17F74F70`
- Semantic review: shadow-mode infrastructure-inconclusive; exact-tree receipt recorded and publication explicitly allowed by the active policy.

Local-CI-Evidence: cmtmeoze38jgl01mi78x5cknj (fix/terminal-writer-replay-liveness@4908799f4d9c670e288e8975be9b5e6cd5804bd0)
