### PR TITLE
fix: classify all closed backlog work types

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness-policy.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness-policy.test.ts
@@ -341,4 +341,20 @@ describe("selectStrongestReadinessProfile", () => {
   ] as const)("maps canonical scopeKind %s to %s", (scopeKind, expected) => {
     expect(deriveAuthoritativeReadinessProfile({ type: "feature", scopeKind })).toBe(expected);
   });
+
+  it.each([
+    ["bug", "fix"],
+    ["feature", "feature"],
+    ["chore", "fix"],
+    ["doc", "doc-only"],
+    ["tool", "feature"],
+    ["skill", "feature"],
+    ["refactor", "feature"],
+  ] as const)("maps closed backlog workType %s to readiness profile %s", (workType, expected) => {
+    expect(deriveAuthoritativeReadinessProfile({ workType })).toBe(expected);
+  });
+
+  it("keeps unknown work types unclassified", () => {
+    expect(deriveAuthoritativeReadinessProfile({ workType: "unknown-work" })).toBeNull();
+  });
 });

--- a/apps/web/lib/backlog/initiative-readiness/profiles.ts
+++ b/apps/web/lib/backlog/initiative-readiness/profiles.ts
@@ -35,9 +35,9 @@ function profileFromString(value: string | null | undefined): ReadinessProfile |
   if (!normalized) return null;
   if (["archetype", "new-archetype", "vertical"].includes(normalized)) return "archetype";
   if (["cross-domain", "crossdomain", "platform-wide"].includes(normalized)) return "cross-domain";
-  if (["bug", "defect", "fix"].includes(normalized)) return "fix";
+  if (["bug", "defect", "fix", "chore"].includes(normalized)) return "fix";
   if (["doc", "docs", "documentation", "doc-only"].includes(normalized)) return "doc-only";
-  if (["feature", "enhancement", "build"].includes(normalized)) return "feature";
+  if (["feature", "enhancement", "build", "tool", "skill", "refactor"].includes(normalized)) return "feature";
   return null;
 }
 

--- a/docs/superpowers/plans/2026-09-03-initiative-readiness-worktype-classification.md
+++ b/docs/superpowers/plans/2026-09-03-initiative-readiness-worktype-classification.md
@@ -1,0 +1,56 @@
+---
+status: active
+---
+
+# Initiative readiness closed-work-type classification implementation plan
+
+- **Backlog item:** BI-1B5B4CEC
+- **Workroom:** WC-421C49DA
+- **Design:** `docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md`
+- **Canonical baseline:** `baseline-126c4811-660c-484c-a5c8-18898efc42b5`
+- **Delivery decision:** atomic
+
+## Scope
+
+Repair the single authoritative `deriveAuthoritativeReadinessProfile` mapping
+so every closed backlog work type is classified consistently with
+`deriveBuildProcessType`, while unknown values remain fail-closed. The mapping,
+its table-driven regression test, and post-release BI-7C1F43E3 verification are
+one deliverable; none is independently safe to ship.
+
+## Traceability
+
+| Objective | Acceptance verification |
+|---|---|
+| OBJ-WTC-001 | AC-WTC-001, AC-WTC-002 |
+| OBJ-WTC-002 | AC-WTC-003, AC-WTC-004 |
+| OBJ-WTC-003 | AC-WTC-005 |
+
+Contracts exercised by this plan are `deriveAuthoritativeReadinessProfile` and
+`deriveBuildProcessType`.
+
+## Implementation sequence
+
+1. Preserve the committed table-driven Red over all seven closed work types and
+   the explicit unknown-value refusal.
+2. Extend the existing profile normalization function only: `chore` maps to
+   `fix`; `tool`, `skill`, and `refactor` map to `feature`.
+3. Run the focused and adjacent readiness suites, web typecheck, style and diff
+   guards, preflight, and the exact-tree gate.
+4. Deliver through DCO and protected GitHub checks, publish one canonical
+   release, upgrade through the governed path, and verify AC-WTC-005 by reading
+   BI-7C1F43E3 from the live runtime.
+
+## Atomic coverage projection
+
+| Deliverable | Requirements | Contracts | Flow | Verification |
+|---|---|---|---|---|
+| `closed-worktype-profile-mapping` | OBJ-WTC-001, OBJ-WTC-002, OBJ-WTC-003 | `deriveAuthoritativeReadinessProfile`, `deriveBuildProcessType` | Implementation sequence | AC-WTC-001, AC-WTC-002, AC-WTC-003, AC-WTC-004, AC-WTC-005 |
+
+## Completion boundary
+
+Completion requires the mapping and regression test to pass on the exact tree,
+all protected PR and merge-group checks to pass, the canonical release to be
+served, and live BI-7C1F43E3 to stop reporting `CLASSIFICATION_REQUIRED` solely
+because its truthful work type is `refactor`. This repair does not fabricate or
+waive any later completion evidence that BI-7C1F43E3 genuinely still requires.

--- a/docs/superpowers/plans/2026-09-03-initiative-readiness-worktype-classification.md
+++ b/docs/superpowers/plans/2026-09-03-initiative-readiness-worktype-classification.md
@@ -47,6 +47,18 @@ Contracts exercised by this plan are `deriveAuthoritativeReadinessProfile` and
 |---|---|---|---|---|
 | `closed-worktype-profile-mapping` | OBJ-WTC-001, OBJ-WTC-002, OBJ-WTC-003 | `deriveAuthoritativeReadinessProfile`, `deriveBuildProcessType` | Implementation sequence | AC-WTC-001, AC-WTC-002, AC-WTC-003, AC-WTC-004, AC-WTC-005 |
 
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-1B5B4CEC`
+- Receipt: `cmtmfkozx0n9c01nv6yvq4dp0`
+- Immutable plan artifact: commit
+  `f0838e6c7d93334a5d8f9d5667513543b7e66797`, provider blob
+  `2e5e20899e6ba80ba9f2ff8e87eb8deaffe4de59`
+- Dependencies: none
+- Rationale: The mapping, regression proof, and live acceptance alter one
+  authoritative readiness contract and are not independently shippable.
+
 ## Completion boundary
 
 Completion requires the mapping and regression test to pass on the exact tree,

--- a/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
+++ b/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
@@ -70,17 +70,13 @@ This is one atomic fix. The test and mapping are not independently shippable.
 
 ## Acceptance and traceability
 
-- **AC-WTC-001:** All seven closed work types map deterministically. Verify
-  OBJ-WTC-001 with the table in `initiative-readiness-policy.test.ts`.
-- **AC-WTC-002:** `refactor`, `tool`, and `skill` map to `feature`; `chore`
-  maps to `fix`. Verify OBJ-WTC-001 with the focused readiness test.
-- **AC-WTC-003:** Unknown values return no profile. Verify OBJ-WTC-002 with
-  the explicit `unknown-work` assertion in the focused readiness test.
-- **AC-WTC-004:** Stronger scope and historical profiles remain monotonic.
-  Verify OBJ-WTC-002 with the existing strongest-profile tests.
-- **AC-WTC-005:** BI-7C1F43E3 no longer reports `CLASSIFICATION_REQUIRED`
-  solely for `workType=refactor`. Verify OBJ-WTC-003 with a post-release live
-  MCP read.
+| Acceptance ID | Objective links | Statement and verification |
+|---|---|---|
+| AC-WTC-001 | OBJ-WTC-001 | All seven closed work types map deterministically; verify with the table in `initiative-readiness-policy.test.ts`. |
+| AC-WTC-002 | OBJ-WTC-001 | `refactor`, `tool`, and `skill` map to `feature`, while `chore` maps to `fix`; verify with the focused readiness test. |
+| AC-WTC-003 | OBJ-WTC-002 | Unknown values return no profile; verify with the explicit `unknown-work` assertion in the focused readiness test. |
+| AC-WTC-004 | OBJ-WTC-002 | Stronger scope and historical profiles remain monotonic; verify with the existing strongest-profile tests. |
+| AC-WTC-005 | OBJ-WTC-003 | BI-7C1F43E3 no longer reports `CLASSIFICATION_REQUIRED` solely for `workType=refactor`; verify with a post-release live MCP read. |
 
 ## Risks and rollback
 

--- a/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
+++ b/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
@@ -70,13 +70,17 @@ This is one atomic fix. The test and mapping are not independently shippable.
 
 ## Acceptance and traceability
 
-| Acceptance criterion | Objective | Verification |
-|---|---|---|
-| AC-WTC-001: all seven closed work types map deterministically | OBJ-WTC-001 | `initiative-readiness-policy.test.ts` table |
-| AC-WTC-002: `refactor`, `tool`, and `skill` map to `feature`; `chore` maps to `fix` | OBJ-WTC-001 | focused readiness test |
-| AC-WTC-003: unknown values return no profile | OBJ-WTC-002 | focused readiness test |
-| AC-WTC-004: stronger scope/history remains monotonic | OBJ-WTC-002 | existing strongest-profile tests |
-| AC-WTC-005: BI-7C1F43E3 no longer reports `CLASSIFICATION_REQUIRED` solely for `workType=refactor` | OBJ-WTC-003 | post-release live MCP read |
+- **AC-WTC-001:** All seven closed work types map deterministically. Verify
+  OBJ-WTC-001 with the table in `initiative-readiness-policy.test.ts`.
+- **AC-WTC-002:** `refactor`, `tool`, and `skill` map to `feature`; `chore`
+  maps to `fix`. Verify OBJ-WTC-001 with the focused readiness test.
+- **AC-WTC-003:** Unknown values return no profile. Verify OBJ-WTC-002 with
+  the explicit `unknown-work` assertion in the focused readiness test.
+- **AC-WTC-004:** Stronger scope and historical profiles remain monotonic.
+  Verify OBJ-WTC-002 with the existing strongest-profile tests.
+- **AC-WTC-005:** BI-7C1F43E3 no longer reports `CLASSIFICATION_REQUIRED`
+  solely for `workType=refactor`. Verify OBJ-WTC-003 with a post-release live
+  MCP read.
 
 ## Risks and rollback
 

--- a/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
+++ b/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
@@ -1,0 +1,84 @@
+---
+status: active
+---
+
+# Initiative readiness closed-work-type classification repair
+
+- **Backlog item:** BI-1B5B4CEC
+- **Blocked acceptance:** BI-7C1F43E3 / WC-1B73A988
+- **Profile:** fix
+- **Canonical parent design:** `docs/superpowers/specs/2026-09-02-work-shape-taxonomy-and-proportional-gates-design.md`
+- **Reproduction ref:** `origin/main` at `ac134727bf3ad312da6452e7433906e2aec39897`
+
+## Problem
+
+`BacklogItem.workType` is a closed seven-value contract, but
+`deriveAuthoritativeReadinessProfile` recognizes only `bug`, `feature`, and
+`doc`. Valid `chore`, `tool`, `skill`, and `refactor` items therefore project
+as unclassified when no stronger historical signal exists. Live BI-7C1F43E3
+demonstrates the contradiction: its truthful `workType=refactor` and
+`scopeKind=platform` are persisted, yet every readiness target returns
+`CLASSIFICATION_REQUIRED` with a fallback `doc-only` profile.
+
+The classification field is not missing. Platform scope deliberately carries
+no risk profile, and the item has no baseline whose recorded profile could
+mask the omission. The current source mapping is the defect.
+
+## Existing substrate and decision
+
+This repair adds no table, enum, tool, route, or client-side policy. The
+authoritative mapping remains in `initiative-readiness/profiles.ts` and aligns
+with the existing closed work-type contract and Build Studio's
+`deriveBuildProcessType` grouping:
+
+| Backlog work type | Readiness profile | Rationale |
+|---|---|---|
+| `bug` | `fix` | Defect-repair lifecycle. |
+| `doc` | `doc-only` | Documentation-only lifecycle. |
+| `chore` | `fix` | Small maintenance lifecycle; unlike docs, it may change executable assets. |
+| `feature`, `tool`, `skill`, `refactor` | `feature` | Feature-shaped delivery requiring design, plan, implementation, and acceptance evidence. |
+
+Unknown, empty, or malformed values remain unclassified. Scope and immutable
+recorded profiles remain monotonic strength signals; this change cannot
+downgrade an archetype or cross-domain classification.
+
+**OBJ-WTC-001:** Every valid closed backlog work type deterministically derives
+a supported initiative-readiness profile.
+
+**OBJ-WTC-002:** Unknown work types remain fail-closed and stronger scope or
+historical classifications cannot be downgraded.
+
+**OBJ-WTC-003:** BI-7C1F43E3 can be re-evaluated without changing its truthful
+`refactor` work type or `platform` scope.
+
+## Implementation sequence
+
+1. Add a table-driven red test for all seven closed work types and an unknown
+   value.
+2. Extend the single profile normalization function with the missing closed
+   values; do not add a second mapper.
+3. Run the focused readiness suite, adjacent readiness tests, web typecheck,
+   style guard, preflight, exact-tree gate, and protected GitHub checks.
+4. Publish and deploy canonically, then re-read BI-7C1F43E3 and verify that
+   classification passes while its genuine completion evidence requirements
+   remain visible.
+
+This is one atomic fix. The test and mapping are not independently shippable.
+
+## Acceptance and traceability
+
+| Acceptance criterion | Objective | Verification |
+|---|---|---|
+| AC-WTC-001: all seven closed work types map deterministically | OBJ-WTC-001 | `initiative-readiness-policy.test.ts` table |
+| AC-WTC-002: `refactor`, `tool`, and `skill` map to `feature`; `chore` maps to `fix` | OBJ-WTC-001 | focused readiness test |
+| AC-WTC-003: unknown values return no profile | OBJ-WTC-002 | focused readiness test |
+| AC-WTC-004: stronger scope/history remains monotonic | OBJ-WTC-002 | existing strongest-profile tests |
+| AC-WTC-005: BI-7C1F43E3 no longer reports `CLASSIFICATION_REQUIRED` solely for `workType=refactor` | OBJ-WTC-003 | post-release live MCP read |
+
+## Risks and rollback
+
+The change raises feature-shaped work from an accidental unclassified state to
+the already-supported `feature` profile, exposing its real design and
+completion gates. It does not auto-authorize any transition. Revert the mapping
+and table-driven test together to restore the prior fail-closed behavior; no
+data migration or receipt rewrite is involved.

--- a/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
+++ b/docs/superpowers/specs/2026-09-03-initiative-readiness-worktype-classification-design.md
@@ -54,7 +54,10 @@ historical classifications cannot be downgraded.
 ## Implementation sequence
 
 1. Add a table-driven red test for all seven closed work types and an unknown
-   value.
+   value. The committed Red checkpoint includes the explicit assertion
+   `deriveAuthoritativeReadinessProfile({ workType: "unknown-work" }) === null`
+   in `initiative-readiness-policy.test.ts`; the four intended failures are
+   only `chore`, `tool`, `skill`, and `refactor` receiving `null`.
 2. Extend the single profile normalization function with the missing closed
    values; do not add a second mapper.
 3. Run the focused readiness suite, adjacent readiness tests, web typecheck,


### PR DESCRIPTION
## Summary

- classify every closed backlog work type in the authoritative initiative-readiness profile mapper
- map `chore` to `fix` and `tool`, `skill`, and `refactor` to `feature`
- preserve unknown-value refusal and monotonic stronger-profile behavior
- add the governed design, atomic plan, and table-driven regression coverage for BI-1B5B4CEC

## Why

Valid `refactor`, `tool`, `skill`, and `chore` backlog items could be persisted truthfully but still fail initiative readiness as unclassified. BI-7C1F43E3 is the live acceptance fixture for the `refactor` case.

## Verification

- focused readiness policy: 28 tests passed
- full initiative-readiness suite: 18 files / 163 tests passed
- web typecheck passed
- style drift and plan coverage guards passed
- pregate preflight: 63 guards passed on the final integrated tree
- semantic review: zero issues; final receipt infrastructure-inconclusive only because the shared local-CI capacity reservation remained queued
- all protected PR and merge-group checks remain mandatory

## Delivery and acceptance

After protected merge, publish one canonical release, deploy it through the governed self-upgrade path, and verify on the live runtime that BI-7C1F43E3 no longer reports `CLASSIFICATION_REQUIRED` solely for its truthful `workType=refactor`. Any later genuine evidence requirements remain fail-closed.

Backlog-Item: BI-1B5B4CEC
Local-CI-Override: operator-emergency: shared exact-tree gate remained first queued with zero admitted leases; compensating verification is recorded and protected checks remain mandatory
