### PR TITLE
fix: resume approved terminal writer projections

### DIFF
--- a/apps/web/lib/mcp-task-completed-approval-resume.test.ts
+++ b/apps/web/lib/mcp-task-completed-approval-resume.test.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import { expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  findTaskRun: vi.fn(),
+  findCurrentTaskRun: vi.fn(),
+  findEnvelope: vi.fn(),
+  findToolExecution: vi.fn(),
+  updateTaskRun: vi.fn(),
+  reserveTaskRun: vi.fn(),
+}));
+const autonomous = vi.hoisted(() => ({ executeTool: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findFirst: (...args: unknown[]) => db.findTaskRun(...args),
+      findUnique: (...args: unknown[]) => db.findCurrentTaskRun(...args),
+      update: (...args: unknown[]) => db.updateTaskRun(...args),
+      updateMany: (...args: unknown[]) => db.reserveTaskRun(...args),
+    },
+    coworkerActionEnvelope: {
+      findFirst: (...args: unknown[]) => db.findEnvelope(...args),
+    },
+    toolExecution: {
+      findFirst: (...args: unknown[]) => db.findToolExecution(...args),
+    },
+  },
+}));
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  executeAutonomousWorkTool: (...args: unknown[]) => autonomous.executeTool(...args),
+}));
+
+import { submitRemoteCoworkerTask } from "./mcp-task-submit";
+
+it("consumes an approved exact-bound writer from a historically completed TaskRun", async () => {
+  const taskRunId = "TR-MCP-OBJECTIVE-MAPPING";
+  const params = {
+    agentId: "AGT-WS-BUILD",
+    routeContext: "/build/work/WC-923105A2",
+    title: "Objective mapping for BI-BFBF1BBB",
+    objective: "Record the exact objective mapping.",
+    prompt: "Read the bound design and record the objective mapping.",
+    idempotencyKey: "initiative-readiness:BI-BFBF1BBB:objective-mapping:head",
+    riskClass: "bounded-write" as const,
+    authorityScope: [
+      "backlog-item:BI-BFBF1BBB",
+      "tool:read_source_at_version",
+      "tool:record_initiative_evidence",
+    ],
+    initiativeReviewBinding: {
+      writerToolName: "record_initiative_evidence",
+      itemId: "BI-BFBF1BBB",
+      gate: "objective-mapping" as const,
+      expectedCurrentBaselineId: "baseline-bi-bfbf1bbb",
+      artifactRef: {
+        kind: "repo-blob-at-commit" as const,
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        commitSha: "0fbf03cc4794b89dcd845bc6a867df6fed311bad",
+        path: "docs/superpowers/specs/2026-07-06-bi-work-location-claim-at-start-design.md",
+        providerBlobId: "5e71fb539b174a583ad2f480cebc1a7146d69dd7",
+      },
+    },
+  };
+  const requestDigest = createHash("sha256").update(JSON.stringify({
+    agentId: params.agentId,
+    routeContext: params.routeContext,
+    title: params.title,
+    objective: params.objective,
+    prompt: params.prompt,
+    riskClass: params.riskClass,
+    authorityScope: [...params.authorityScope].sort(),
+    collaborationKind: null,
+    initiativeReviewBinding: params.initiativeReviewBinding,
+  })).digest("hex");
+  const updatedAt = new Date("2026-09-03T23:00:00.000Z");
+  db.findTaskRun.mockResolvedValue({
+    id: "task-internal",
+    taskRunId,
+    userId: "user-1",
+    threadId: "thread-objective-mapping",
+    contextId: "thread-objective-mapping",
+    status: "completed",
+    progressPayload: { summary: "Approval required.", requiresApproval: true },
+    a2aMetadata: { requestDigest, idempotencyKey: params.idempotencyKey, apiTokenId: "PAT-A" },
+    lastHeartbeatAt: updatedAt,
+    completedAt: updatedAt,
+    updatedAt,
+  });
+  db.findEnvelope.mockResolvedValue({
+    id: "ENV-OBJECTIVE-MAPPING",
+    threadId: "thread-objective-mapping",
+    manifestActionId: "record_initiative_evidence",
+  });
+  db.findToolExecution.mockResolvedValue({
+    parameters: {
+      backlogItemId: "BI-BFBF1BBB",
+      operation: "objective-mapping",
+      decision: "pass",
+      _takAlignment: { verdict: "aligned" },
+    },
+  });
+  db.reserveTaskRun.mockResolvedValue({ count: 1 });
+  db.updateTaskRun.mockResolvedValue({});
+  db.findCurrentTaskRun.mockResolvedValue({ status: "working" });
+  autonomous.executeTool.mockResolvedValue({
+    success: true,
+    message: "Objective mapping recorded.",
+    entityId: "initiative-mapping-receipt",
+  });
+
+  const outcome = await submitRemoteCoworkerTask({
+    token: { tokenId: "PAT-A", userId: "user-1", capability: "write", source: "pat" },
+    userContext: { platformRole: "developer", isSuperuser: false },
+    params,
+  });
+
+  expect(db.reserveTaskRun).toHaveBeenCalledWith({
+    where: { taskRunId, status: "completed", updatedAt },
+    data: {
+      completedAt: null,
+      progressPayload: expect.objectContaining({ approvalResumeReserved: true }),
+    },
+  });
+  expect(autonomous.executeTool).toHaveBeenCalledWith(expect.objectContaining({
+    toolName: "record_initiative_evidence",
+    taskRunId,
+    args: {
+      backlogItemId: "BI-BFBF1BBB",
+      operation: "objective-mapping",
+      decision: "pass",
+    },
+  }));
+  expect(outcome).toMatchObject({
+    kind: "result",
+    result: {
+      taskRunId,
+      status: "completed",
+      idempotentReplay: true,
+      resumedFromApproval: true,
+      entityId: "initiative-mapping-receipt",
+    },
+  });
+});

--- a/apps/web/lib/mcp-task-execution.test.ts
+++ b/apps/web/lib/mcp-task-execution.test.ts
@@ -26,6 +26,9 @@ vi.mock("@/lib/tak/autonomous-work-run", () => ({
   resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
 }));
 vi.mock("@/lib/tak/task-records", () => ({ createTaskMessage: vi.fn() }));
+vi.mock("./mcp/external-approval-location-lookup", () => ({
+  withTaskRunApprovalLocation: vi.fn(async (value: unknown) => value),
+}));
 
 import { executeRemoteTaskAttempt, remoteTaskConversation } from "./mcp-task-execution";
 
@@ -117,6 +120,59 @@ describe("remote task terminal-writer postcondition", () => {
         executedToolCount: 2,
       },
     });
+  });
+
+  it("parks an approval-required terminal writer even when the tool did not project TaskRun state", async () => {
+    autonomous.execute.mockResolvedValue({
+      content: "The objective mapping is ready for exact approval.",
+      executedTools: [{
+        name: writerToolName,
+        args: { operation: "objective-mapping" },
+        result: {
+          success: false,
+          error: "approval_required",
+          message: "Approval is required.",
+          data: { envelopeId: "ENV-OBJECTIVE-MAPPING" },
+        },
+      }],
+    });
+
+    const outcome = await executeRemoteTaskAttempt({
+      run: { id: "run-internal", taskRunId: "TR-MCP-APPROVAL-PROJECTION", contextId: "thread-1" },
+      threadId: "thread-1",
+      token: { tokenId: "PAT-WRITER-APPROVAL", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      parsed,
+      idempotentReplay: true,
+      resumeKind: "terminal-writer",
+      capacityAttempt: 1,
+      terminalWriterAttempt: 2,
+    });
+
+    expect(db.updateTaskRun).toHaveBeenCalledWith({
+      where: { taskRunId: "TR-MCP-APPROVAL-PROJECTION" },
+      data: expect.objectContaining({
+        status: "input-required",
+        completedAt: null,
+        progressPayload: expect.objectContaining({
+          requiresApproval: true,
+          approvalEnvelopeId: "ENV-OBJECTIVE-MAPPING",
+        }),
+      }),
+    });
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        taskRunId: "TR-MCP-APPROVAL-PROJECTION",
+        status: "input-required",
+        idempotentReplay: true,
+        resumedFromTerminalWriterWait: true,
+        requiresApproval: true,
+      },
+    });
+    expect(db.updateTaskRun).not.toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: "completed" }),
+    }));
   });
 });
 

--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -43,6 +43,15 @@ function remoteTaskContent(text: string) {
   return [{ type: "text", text }];
 }
 
+function approvalRequiredEnvelopeId(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const result = value as Record<string, unknown>;
+  if (result["success"] !== false || result["error"] !== "approval_required") return null;
+  const data = result["data"];
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  return optionalString((data as Record<string, unknown>)["envelopeId"]);
+}
+
 export function remoteTaskConversation(input: {
   systemPrompt: string;
   prompt: string;
@@ -192,7 +201,7 @@ export async function executeRemoteTaskAttempt(input: {
       ? null
       : await prisma.taskRun.findUnique({
           where: { taskRunId: run.taskRunId },
-          select: { status: true },
+          select: { status: true, progressPayload: true },
         });
     // The loop is not trusted to self-report a missing writer: main enforces this
     // at the completion boundary (#4925, #4930) so a review cannot pass without
@@ -202,6 +211,12 @@ export async function executeRemoteTaskAttempt(input: {
       ? (result.executedTools ?? []).some((tool) => tool.name === terminalToolPolicy.writerToolName)
         || result.proposal?.name === terminalToolPolicy.writerToolName
       : false;
+    const terminalWriterApprovalEnvelopeId = terminalToolPolicy
+      ? (result.executedTools ?? [])
+          .filter((tool) => tool.name === terminalToolPolicy.writerToolName)
+          .map((tool) => approvalRequiredEnvelopeId(tool.result))
+          .find((envelopeId): envelopeId is string => envelopeId !== null) ?? null
+      : null;
     const terminalWriterMissing = terminalToolPolicy !== null && !terminalWriterWasAttempted;
     // BI-8B8731EE: a resource wait is NOT a writer-contract failure, and this
     // branch would otherwise swallow it. `terminalWriterMissing` is true for any
@@ -210,6 +225,42 @@ export async function executeRemoteTaskAttempt(input: {
     // unreachable and every deferral was reported as a missing receipt writer.
     // Let the resource wait win; it resumes on the same TaskRun either way.
     const resourceWaitOwnsThisTurn = preInferenceResourceWait(result) !== null;
+    if (terminalWriterApprovalEnvelopeId && terminalToolPolicy) {
+      const priorProgress = currentRun?.progressPayload
+        && typeof currentRun.progressPayload === "object"
+        && !Array.isArray(currentRun.progressPayload)
+        ? currentRun.progressPayload as Record<string, unknown>
+        : {};
+      await prisma.taskRun.update({
+        where: { taskRunId: run.taskRunId },
+        data: {
+          status: "input-required",
+          completedAt: null,
+          progressPayload: {
+            ...priorProgress,
+            summary: result.content,
+            riskClass: parsed.riskClass,
+            executedToolCount: result.executedTools?.length ?? 0,
+            requiresApproval: true,
+            approvalEnvelopeId: terminalWriterApprovalEnvelopeId,
+            ...resumedFlag,
+          },
+        },
+      });
+      return {
+        kind: "result",
+        result: await withTaskRunApprovalLocation({
+          taskRunId: run.taskRunId,
+          status: "input-required",
+          idempotentReplay: input.idempotentReplay,
+          ...resumedFlag,
+          requiresApproval: true,
+          content: remoteTaskContent(result.content),
+          executedToolCount: result.executedTools?.length ?? 0,
+          isError: false,
+        }, { taskRunId: run.taskRunId, callerUserId: token.userId }),
+      };
+    }
     if (
       !resourceWaitOwnsThisTurn
       && (result.failure?.kind === "terminal-writer-missing" || terminalWriterMissing)

--- a/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  findUnique: vi.fn(),
+  findModelConfig: vi.fn(),
+  findEnvelope: vi.fn(),
+  findToolExecution: vi.fn(),
+  findToolExecutions: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+}));
+const autonomous = vi.hoisted(() => ({
+  execute: vi.fn(),
+  executeTool: vi.fn(),
+  resolveAgent: vi.fn(),
+  resolveTools: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findFirst: (...args: unknown[]) => db.findFirst(...args),
+      findUnique: (...args: unknown[]) => db.findUnique(...args),
+      update: (...args: unknown[]) => db.update(...args),
+      updateMany: (...args: unknown[]) => db.updateMany(...args),
+    },
+    coworkerActionEnvelope: {
+      findFirst: (...args: unknown[]) => db.findEnvelope(...args),
+    },
+    toolExecution: {
+      findFirst: (...args: unknown[]) => db.findToolExecution(...args),
+      findMany: (...args: unknown[]) => db.findToolExecutions(...args),
+    },
+    agentModelConfig: {
+      findUnique: (...args: unknown[]) => db.findModelConfig(...args),
+    },
+  },
+}));
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: vi.fn(),
+  executeAutonomousAgenticLoop: (...args: unknown[]) => autonomous.execute(...args),
+  executeAutonomousWorkTool: (...args: unknown[]) => autonomous.executeTool(...args),
+  resolveAutonomousWorkAgent: (...args: unknown[]) => autonomous.resolveAgent(...args),
+  resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
+}));
+vi.mock("@/lib/tak/task-records", () => ({ createTaskMessage: vi.fn() }));
+vi.mock("./mcp-task-submit-approval-recovery", () => ({
+  recoverStaleApprovalOnReplay: vi.fn(async () => null),
+  resumeApprovedRemoteTask: vi.fn(async () => null),
+}));
+
+import { remoteTaskRequestDigest } from "./mcp-task-capacity-contract";
+import { submitRemoteCoworkerTask } from "./mcp-task-submit";
+
+const params = {
+  agentId: "AGT-WS-BUILD",
+  routeContext: "/platform/build",
+  title: "Independent research review",
+  objective: "Review the immutable source and record research evidence.",
+  prompt: "Read the exact source and record the governed evidence.",
+  idempotencyKey: "terminal-writer-crossed-stale-threshold",
+  riskClass: "bounded-write" as const,
+  authorityScope: [
+    "backlog-item:BI-E2B632D2",
+    "tool:read_source_at_version",
+    "tool:record_initiative_evidence",
+  ],
+  collaborationKind: "handoff" as const,
+  initiativeReviewBinding: {
+    writerToolName: "record_initiative_evidence",
+    itemId: "BI-E2B632D2",
+    gate: "research" as const,
+    artifactRef: {
+      kind: "repo-blob-at-commit" as const,
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      commitSha: "4100d18ad75cc29602f8857db0de2901f185effb",
+      path: "apps/web/lib/mcp-task-submit.ts",
+      providerBlobId: "f05787443eb00b0c22f22f7c7bc683cd81cfaf49",
+    },
+  },
+};
+
+const readerExecution = {
+  id: "reader-1",
+  toolName: "read_source_at_version",
+  parameters: {
+    repositoryFullName: params.initiativeReviewBinding.artifactRef.repositoryFullName,
+    path: params.initiativeReviewBinding.artifactRef.path,
+    version: params.initiativeReviewBinding.artifactRef.commitSha,
+    expectedBlobId: params.initiativeReviewBinding.artifactRef.providerBlobId,
+    startLine: 1,
+    maxChars: 3_200,
+  },
+  result: {},
+  success: true,
+  createdAt: new Date("2026-09-01T04:11:43.124Z"),
+};
+
+describe("reaper-stalled terminal writer resumption", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const updatedAt = new Date("2026-09-01T04:17:00.140Z");
+    db.findFirst.mockResolvedValue({
+      id: "task-internal",
+      taskRunId: "TR-MCP-REAPER-STALLED",
+      userId: "user-1",
+      threadId: "thread-external",
+      contextId: "thread-external",
+      status: "stalled",
+      lastHeartbeatAt: new Date("2026-09-01T04:16:32.587Z"),
+      completedAt: updatedAt,
+      updatedAt,
+      progressPayload: {
+        terminalWriterWait: {
+          schemaVersion: 1,
+          kind: "missing-terminal-writer",
+          writerToolName: "record_initiative_evidence",
+          resumeMode: "same-taskrun",
+          attempt: 1,
+          observedAt: "2026-09-01T04:12:32.612Z",
+          dispatchContract: "required-tool-call",
+        },
+      },
+      a2aMetadata: {
+        requestDigest: remoteTaskRequestDigest(params),
+        idempotencyKey: params.idempotencyKey,
+        initiativeReviewBinding: params.initiativeReviewBinding,
+      },
+    });
+    db.findEnvelope.mockResolvedValue(null);
+    db.findToolExecution.mockResolvedValue(null);
+    db.findToolExecutions.mockResolvedValue([readerExecution]);
+    db.findModelConfig.mockResolvedValue({
+      minimumTier: "strong",
+      budgetClass: "quality_first",
+      pinnedProviderId: "local",
+      pinnedModelId: "review-model",
+    });
+    db.update.mockResolvedValue({});
+    db.updateMany.mockResolvedValue({ count: 1 });
+    db.findUnique.mockResolvedValue({ status: "working" });
+    autonomous.resolveAgent.mockResolvedValue({
+      agentId: "build-specialist",
+      displayName: "Build Lead",
+      systemPrompt: "Review the immutable source.",
+      sensitivity: "internal",
+    });
+    autonomous.resolveTools.mockResolvedValue({
+      tools: [],
+      toolsForProvider: [],
+      deferredTools: [],
+    });
+    autonomous.execute.mockResolvedValue({
+      content: "The governed local inference provider is still at capacity.",
+      executedTools: [],
+      failure: { kind: "capacity", message: "No local inference slot is available." },
+    });
+  });
+
+  it("reserves and resumes the same exact-bound TaskRun after a reaper stall", async () => {
+    const outcome = await submitRemoteCoworkerTask({
+      token: {
+        tokenId: "token-research",
+        userId: "user-1",
+        capability: "write",
+        source: "pat",
+      },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).toHaveBeenCalledWith({
+      where: {
+        taskRunId: "TR-MCP-REAPER-STALLED",
+        status: "stalled",
+        updatedAt: new Date("2026-09-01T04:17:00.140Z"),
+      },
+      data: {
+        status: "working",
+        lastHeartbeatAt: expect.any(Date),
+        completedAt: null,
+        progressPayload: expect.objectContaining({
+          terminalWriterWait: expect.objectContaining({ attempt: 2 }),
+          resumeReservedAt: expect.any(String),
+        }),
+      },
+    });
+    expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
+      taskRunId: "TR-MCP-REAPER-STALLED",
+      threadId: "thread-external",
+      terminalToolPolicy: expect.objectContaining({
+        terminalPhase: "writer-only",
+        persistedEvidenceAvailable: true,
+      }),
+    }));
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        taskRunId: "TR-MCP-REAPER-STALLED",
+        idempotentReplay: true,
+        resumedFromTerminalWriterWait: true,
+      },
+    });
+  });
+});

--- a/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-stalled-terminal-writer.test.ts
@@ -97,37 +97,45 @@ const readerExecution = {
   createdAt: new Date("2026-09-01T04:11:43.124Z"),
 };
 
+const updatedAt = new Date("2026-09-01T04:17:00.140Z");
+const terminalWriterWait = {
+  schemaVersion: 1,
+  kind: "missing-terminal-writer",
+  writerToolName: "record_initiative_evidence",
+  resumeMode: "same-taskrun",
+  attempt: 1,
+  observedAt: "2026-09-01T04:12:32.612Z",
+  dispatchContract: "required-tool-call",
+};
+
+function existingRun(
+  status: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: "task-internal",
+    taskRunId: "TR-MCP-REAPER-STALLED",
+    userId: "user-1",
+    threadId: "thread-external",
+    contextId: "thread-external",
+    status,
+    lastHeartbeatAt: new Date("2026-09-01T04:16:32.587Z"),
+    completedAt: updatedAt,
+    updatedAt,
+    progressPayload: { terminalWriterWait },
+    a2aMetadata: {
+      requestDigest: remoteTaskRequestDigest(params),
+      idempotencyKey: params.idempotencyKey,
+      initiativeReviewBinding: params.initiativeReviewBinding,
+    },
+    ...overrides,
+  };
+}
+
 describe("reaper-stalled terminal writer resumption", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    const updatedAt = new Date("2026-09-01T04:17:00.140Z");
-    db.findFirst.mockResolvedValue({
-      id: "task-internal",
-      taskRunId: "TR-MCP-REAPER-STALLED",
-      userId: "user-1",
-      threadId: "thread-external",
-      contextId: "thread-external",
-      status: "stalled",
-      lastHeartbeatAt: new Date("2026-09-01T04:16:32.587Z"),
-      completedAt: updatedAt,
-      updatedAt,
-      progressPayload: {
-        terminalWriterWait: {
-          schemaVersion: 1,
-          kind: "missing-terminal-writer",
-          writerToolName: "record_initiative_evidence",
-          resumeMode: "same-taskrun",
-          attempt: 1,
-          observedAt: "2026-09-01T04:12:32.612Z",
-          dispatchContract: "required-tool-call",
-        },
-      },
-      a2aMetadata: {
-        requestDigest: remoteTaskRequestDigest(params),
-        idempotencyKey: params.idempotencyKey,
-        initiativeReviewBinding: params.initiativeReviewBinding,
-      },
-    });
+    db.findFirst.mockResolvedValue(existingRun("stalled"));
     db.findEnvelope.mockResolvedValue(null);
     db.findToolExecution.mockResolvedValue(null);
     db.findToolExecutions.mockResolvedValue([readerExecution]);
@@ -150,6 +158,22 @@ describe("reaper-stalled terminal writer resumption", () => {
       tools: [],
       toolsForProvider: [],
       deferredTools: [],
+    });
+    autonomous.executeTool.mockResolvedValue({
+      success: true,
+      message: "Read exact source.",
+      data: {
+        repositoryFullName: params.initiativeReviewBinding.artifactRef.repositoryFullName,
+        path: params.initiativeReviewBinding.artifactRef.path,
+        version: params.initiativeReviewBinding.artifactRef.commitSha,
+        blobId: params.initiativeReviewBinding.artifactRef.providerBlobId,
+        content: "export async function submitRemoteCoworkerTask() {}",
+        startLine: 1,
+        endLine: 1,
+        totalLines: 1,
+        hasMore: false,
+        nextCursor: null,
+      },
     });
     autonomous.execute.mockResolvedValue({
       content: "The governed local inference provider is still at capacity.",
@@ -200,6 +224,109 @@ describe("reaper-stalled terminal writer resumption", () => {
         taskRunId: "TR-MCP-REAPER-STALLED",
         idempotentReplay: true,
         resumedFromTerminalWriterWait: true,
+      },
+    });
+  });
+
+  it("resumes a failed exact-bound wait after a rejected non-proposal writer", async () => {
+    db.findFirst.mockResolvedValue(existingRun("failed"));
+    db.findToolExecution.mockImplementation(async (query: { where?: { success?: unknown } }) => (
+      query.where?.success === true
+        ? null
+        : {
+            id: "writer-rejected",
+            success: false,
+            result: { success: false, error: "OBJECTIVE_BASELINE_CONFLICT" },
+          }
+    ));
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        taskRunId: "TR-MCP-REAPER-STALLED",
+        status: "failed",
+        updatedAt,
+      },
+    }));
+    expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
+      taskRunId: "TR-MCP-REAPER-STALLED",
+      terminalToolPolicy: expect.objectContaining({ terminalPhase: "writer-only" }),
+    }));
+  });
+
+  it.each(["stalled", "failed"])("does not reopen a generic %s TaskRun", async (status) => {
+    db.findFirst.mockResolvedValue(existingRun(status, {
+      progressPayload: { summary: "Ordinary terminal task." },
+    }));
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen a wait whose writer binding changed", async () => {
+    db.findFirst.mockResolvedValue(existingRun("stalled", {
+      progressPayload: {
+        terminalWriterWait: {
+          ...terminalWriterWait,
+          writerToolName: "record_initiative_design_review",
+        },
+      },
+    }));
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen after a successful writer", async () => {
+    db.findToolExecution.mockResolvedValue({ id: "writer-success", success: true, result: {} });
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen a wait at the existing attempt ceiling", async () => {
+    db.findFirst.mockResolvedValue(existingRun("stalled", {
+      progressPayload: {
+        terminalWriterWait: { ...terminalWriterWait, attempt: 3 },
+      },
+    }));
+
+    const outcome = await submitRemoteCoworkerTask({
+      token: { tokenId: "token-research", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params,
+    });
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        resumable: false,
+        waitReason: "terminal-writer-retry-exhausted",
       },
     });
   });

--- a/apps/web/lib/mcp-task-submit-approval-recovery.ts
+++ b/apps/web/lib/mcp-task-submit-approval-recovery.ts
@@ -56,7 +56,9 @@ export async function resumeApprovedRemoteTask(input: {
   userContext: UserContext;
   parsed: RemoteTaskSubmitParams;
 }): Promise<RemoteTaskSubmitOutcome | null> {
-  if (input.existing.status !== "input-required") return null;
+  const recoveringCompletedProjection = input.existing.status === "completed";
+  if (input.existing.status !== "input-required" && !recoveringCompletedProjection) return null;
+  if (recoveringCompletedProjection && !input.parsed.initiativeReviewBinding) return null;
 
   const envelope = await prisma.coworkerActionEnvelope.findFirst({
     where: {
@@ -69,6 +71,10 @@ export async function resumeApprovedRemoteTask(input: {
     select: { id: true, threadId: true, manifestActionId: true },
   }) as ApprovedRemoteTaskEnvelope | null;
   if (!envelope) return null;
+  if (
+    recoveringCompletedProjection
+    && envelope.manifestActionId !== input.parsed.initiativeReviewBinding?.writerToolName
+  ) return null;
 
   const proposedExecution = await prisma.toolExecution.findFirst({
     where: {
@@ -86,10 +92,11 @@ export async function resumeApprovedRemoteTask(input: {
   const reservation = await prisma.taskRun.updateMany({
     where: {
       taskRunId: input.existing.taskRunId,
-      status: "input-required",
+      status: input.existing.status,
       updatedAt: input.existing.updatedAt,
     },
     data: {
+      ...(recoveringCompletedProjection ? { completedAt: null } : {}),
       progressPayload: {
         ...(input.existing.progressPayload && typeof input.existing.progressPayload === "object"
           && !Array.isArray(input.existing.progressPayload)

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -504,7 +504,7 @@ export async function submitRemoteCoworkerTask(input: {
     ) return replay;
     if (
       storedRequestDigest(existing) === requestDigest
-      && existing.status === "input-required"
+      && (existing.status === "input-required" || (existing.status === "completed" && terminalToolPolicy))
     ) {
       const resumed = await resumeApprovedRemoteTask({
         existing,

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -277,9 +277,11 @@ async function reserveTerminalWriterReplay(input: {
   if (recoverTerminalWriterEscalation(input.existing.progressPayload)) return null;
 
   const existingWait = parseTerminalWriterWait(input.existing.progressPayload);
-  const isProjectedWait = input.existing.status === "input-required" && existingWait !== null;
+  const isProjectedWait = existingWait !== null
+    && ["input-required", "stalled", "failed"].includes(input.existing.status);
   const isRecoverableCompletedExit = input.existing.status === "completed" && !existingWait;
   if (!isProjectedWait && !isRecoverableCompletedExit) return null;
+  if (existingWait && existingWait.writerToolName !== input.terminalToolPolicy.writerToolName) return null;
 
   const [readerExecutions, successfulWriter, writerAttempt] = await Promise.all([
     persistedTerminalReaderExecutions(input.existing.taskRunId),
@@ -308,17 +310,22 @@ async function reserveTerminalWriterReplay(input: {
     const proposalEnvelopeId = writerAttempt.success === false
       ? approvalEnvelopeIdFromWriterAttempt(writerAttempt.result)
       : null;
-    if (!proposalEnvelopeId) return null;
-    const declinedProposalEnvelope = await prisma.coworkerActionEnvelope.findFirst({
-      where: {
-        id: proposalEnvelopeId,
-        taskRunId: input.existing.taskRunId,
-        manifestActionId: input.terminalToolPolicy.writerToolName,
-        status: "declined",
-      },
-      select: { id: true },
-    });
-    if (declinedProposalEnvelope?.id !== proposalEnvelopeId) return null;
+    if (proposalEnvelopeId) {
+      const declinedProposalEnvelope = await prisma.coworkerActionEnvelope.findFirst({
+        where: {
+          id: proposalEnvelopeId,
+          taskRunId: input.existing.taskRunId,
+          manifestActionId: input.terminalToolPolicy.writerToolName,
+          status: "declined",
+        },
+        select: { id: true },
+      });
+      if (declinedProposalEnvelope?.id !== proposalEnvelopeId) return null;
+    } else if (
+      writerAttempt.success !== false
+      || !existingWait
+      || !["stalled", "failed"].includes(input.existing.status)
+    ) return null;
   }
 
   const progress = input.existing.progressPayload && typeof input.existing.progressPayload === "object"

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -116,8 +116,7 @@ extends that contract; it does not replace or narrow the original safeguards.
   `OBJ-DE-005`, `OBJ-E2B-001`, `OBJ-E2B-002`, `OBJ-E2B-003`, and `OBJ-E2B-004`.
 - Contract refs: `immutable-source terminal-writer contract` and
   `exact-bound stalled and failed replay contract`.
-- Flow refs: `exact request replay -> compare-and-set reservation -> immutable
-  hydration -> writer-only turn -> governed approval or receipt`.
+- Flow refs: `writer-only turn`.
 - Verification refs: `AC-DE-001`, `AC-DE-002`, `AC-DE-003`, `AC-DE-004`,
   `AC-DE-005`, `AC-DE-006`, `AC-DE-007`, `AC-E2B-001`, `AC-E2B-002`,
   `AC-E2B-003`, `AC-E2B-004`, `AC-E2B-005`, and `AC-E2B-006`.

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -101,7 +101,7 @@ no schema changes.
 - Decision: atomic
 - Parent: `BI-E2B632D2`
 - Design baseline: `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`
-- Receipt: pending immutable plan registration
+- Receipt: `cmtmd9eri7nj001miwklshlsr`
 - Rationale: stalled/failed admission, reservation checks, regressions, and live
   same-TaskRun proof are one replay contract and have no independently useful
   shipping boundary.
@@ -127,3 +127,9 @@ extends that contract; it does not replace or narrow the original safeguards.
 - Live `BI-BFBF1BBB` replay reconfirmed the cached failed-but-resumable mismatch.
 - Graph impact resolved: six exact related test suites were returned for
   `apps/web/lib/mcp-task-submit.ts`.
+- Design baseline `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`, research
+  receipt `initiative-7f4fa9fe-8e08-49f5-bc84-edbcd66f1898`, and plan coverage
+  receipt `cmtmd9eri7nj001miwklshlsr` passed before production-code edits.
+- The focused RED failed because the marked stalled TaskRun made zero
+  compare-and-set reservation calls. After the eligibility correction, the new
+  seven-case regression and all six graph-linked suites pass: 54 tests total.

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -26,6 +26,12 @@ before any success claim, and `dpf-pr-with-dco` for handoff.
   projected as `resumable`; identical replay nevertheless returns the cached
   failure. Its earlier writer arguments were rejected after a prerequisite
   schema defect that is now fixed and deployed.
+- A later replay reached the bound writer and created approval envelope
+  `cmtmgbxy603kd01qid8kg6261`, but the executor persisted the TaskRun as
+  `completed` after receiving `approval_required`. Approval then could not be
+  consumed because replay admitted approved envelopes only from
+  `input-required`. This is the AC-E2B-003 completion-leakage case, not a new
+  approval model or backlog item.
 - The fix extends the existing reservation and terminal-writer attempt budget.
   It adds no TaskRun, writer, receipt, approval bypass, or alternate evidence
   path.
@@ -66,6 +72,15 @@ Change only `reserveTerminalWriterReplay` and its small parsing predicates in
   bounded writer-only turn, while preserving proposal-envelope recovery as the
   authority for actual pending approvals;
 - preserve ordinary TaskRun terminal semantics.
+
+The live acceptance path added one necessary continuation to this phase:
+
+- in `mcp-task-execution.ts`, project the bound writer's explicit
+  `approval_required` result as `input-required` even if the tool path did not
+  update TaskRun state;
+- in the existing approval-resume adapter, admit a historical `completed`
+  projection only for an exact initiative-review binding whose approved
+  envelope names the same writer; preserve generic completed-task finality.
 
 Update the governing design with the live evidence and exact eligibility rule.
 
@@ -134,3 +149,8 @@ extends that contract; it does not replace or narrow the original safeguards.
 - The focused RED failed because the marked stalled TaskRun made zero
   compare-and-set reservation calls. After the eligibility correction, the new
   seven-case regression and all six graph-linked suites pass: 54 tests total.
+- Live acceptance then exposed the approval projection dependency. Two new
+  regressions failed on the pre-fix tree: a fresh bound writer proposal was
+  persisted as `completed`, and the same-packet replay of an approved historical
+  projection executed no writer. Both pass after the bounded projection and
+  exact-completed recovery changes (22/22 focused tests).

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -100,10 +100,27 @@ no schema changes.
 
 - Decision: atomic
 - Parent: `BI-E2B632D2`
+- Design baseline: `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`
 - Receipt: pending immutable plan registration
 - Rationale: stalled/failed admission, reservation checks, regressions, and live
   same-TaskRun proof are one replay contract and have no independently useful
   shipping boundary.
+
+### Four-way traceability
+
+The atomic deliverable is bound to every objective and acceptance criterion in
+the approved immutable-source terminal-writer baseline. The replay correction
+extends that contract; it does not replace or narrow the original safeguards.
+
+- Requirement refs: `OBJ-DE-001`, `OBJ-DE-002`, `OBJ-DE-003`, `OBJ-DE-004`,
+  `OBJ-DE-005`, `OBJ-E2B-001`, `OBJ-E2B-002`, `OBJ-E2B-003`, and `OBJ-E2B-004`.
+- Contract refs: `immutable-source terminal-writer contract` and
+  `exact-bound stalled and failed replay contract`.
+- Flow refs: `exact request replay -> compare-and-set reservation -> immutable
+  hydration -> writer-only turn -> governed approval or receipt`.
+- Verification refs: `AC-DE-001`, `AC-DE-002`, `AC-DE-003`, `AC-DE-004`,
+  `AC-DE-005`, `AC-DE-006`, `AC-DE-007`, `AC-E2B-001`, `AC-E2B-002`,
+  `AC-E2B-003`, `AC-E2B-004`, `AC-E2B-005`, and `AC-E2B-006`.
 
 ## Progress evidence
 

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -1,0 +1,113 @@
+---
+status: active
+---
+
+# Exact-bound terminal-writer replay liveness plan
+
+**Backlog item:** `BI-E2B632D2`  
+**Workroom:** `WC-17F74F70`  
+**Design:** `docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md`
+
+**For agentic workers:** execute this plan one independently reviewable backlog
+item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate
+before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Observed state
+
+- The original reproduction is an exact-bound TaskRun reaped to `stalled` while
+  waiting in governed inference admission. Its request digest, artifact binding,
+  successful immutable reads, and `missing-terminal-writer` marker survived, but
+  `reserveTerminalWriterReplay` admits only `input-required` and one historical
+  `completed` route exit.
+- Canonical replay for `BI-BFBF1BBB` exposed the same contract mismatch at a
+  second terminal state. TaskRun `...7AF37EB34EF7` is `failed`, retains the exact
+  request and terminal-writer wait marker, has no successful writer, and is
+  projected as `resumable`; identical replay nevertheless returns the cached
+  failure. Its earlier writer arguments were rejected after a prerequisite
+  schema defect that is now fixed and deployed.
+- The fix extends the existing reservation and terminal-writer attempt budget.
+  It adds no TaskRun, writer, receipt, approval bypass, or alternate evidence
+  path.
+
+## Atomic deliverable
+
+This is one replay-contract correction: admit an exact marked `stalled` or
+`failed` terminal-writer wait to the existing compare-and-set reservation only
+when the request digest matches, the server reconstructs the same immutable
+review binding, no writer has succeeded, and the bounded attempt ceiling remains
+open. A failed non-proposal writer attempt is historical evidence, not an active
+approval; replay reruns only the bound writer turn on the same TaskRun.
+
+## Phase 1 — RED
+
+Add source-local regressions in
+`apps/web/lib/mcp-task-stalled-terminal-writer.test.ts` for:
+
+1. a reaper-stalled exact-bound wait returning the same TaskRun to writer-only
+   execution;
+2. a failed exact-bound wait after a rejected writer argument doing the same;
+3. unchanged refusal for a generic stalled/failed task, digest mismatch,
+   successful writer, and exhausted attempt budget.
+
+Run the new regression plus all six graph-linked `mcp-task-submit` suites. Keep
+the first failure as evidence before implementation.
+
+## Phase 2 — GREEN
+
+Change only `reserveTerminalWriterReplay` and its small parsing predicates in
+`apps/web/lib/mcp-task-submit.ts`:
+
+- recognize `stalled`/`failed` only when the persisted terminal-writer marker is
+  valid and matches the reconstructed writer;
+- retain request-digest, successful-writer, immutable hydration, approval, and
+  compare-and-set checks;
+- allow a prior non-successful, non-proposal writer attempt to trigger a new
+  bounded writer-only turn, while preserving proposal-envelope recovery as the
+  authority for actual pending approvals;
+- preserve ordinary TaskRun terminal semantics.
+
+Update the governing design with the live evidence and exact eligibility rule.
+
+## Phase 3 — gates and functional replay
+
+Run the new regression, all graph-linked suites, style guard, web production
+build, `pregate:preflight`, and the exact-tree `pregate`. Open a DCO-signed PR
+with the design and current code substrate named in Design grounding, verify it
+with `pnpm pr:health`, and merge through the queue.
+
+After canonical self-upgrade, replay the unchanged `BI-BFBF1BBB` recovery packet.
+Success requires the same TaskRun to execute the now-bound objective mapping,
+produce the governed acceptance evidence, and allow both its BI and Workroom to
+close. Then close this dependency BI and Workroom with the same live evidence.
+
+UX is not applicable because no UI changes. Migration is not applicable because
+no schema changes.
+
+## Risks and rollback
+
+- Risk: reopening an unrelated terminal task. Control: require the exact request
+  digest, immutable review policy, valid same-TaskRun marker, zero successful
+  writer, and compare-and-set reservation.
+- Risk: repeating a rejected judgment forever. Control: retain the existing
+  terminal-writer attempt counter and escalation ceiling.
+- Risk: bypassing a live approval. Control: proposal envelopes continue through
+  approval recovery; replay does not execute their stored arguments directly.
+- Rollback: revert the eligibility branch and regressions. No persisted schema or
+  evidence format changes.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-E2B632D2`
+- Receipt: pending immutable plan registration
+- Rationale: stalled/failed admission, reservation checks, regressions, and live
+  same-TaskRun proof are one replay contract and have no independently useful
+  shipping boundary.
+
+## Progress evidence
+
+- Workroom resumed and canonical path repaired on 2026-09-03.
+- Live `BI-BFBF1BBB` replay reconfirmed the cached failed-but-resumable mismatch.
+- Graph impact resolved: six exact related test suites were returned for
+  `apps/web/lib/mcp-task-submit.ts`.

--- a/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
+++ b/docs/superpowers/plans/2026-09-03-terminal-writer-replay-liveness.md
@@ -100,6 +100,7 @@ no schema changes.
 
 - Decision: atomic
 - Parent: `BI-E2B632D2`
+- Dependencies: none
 - Design baseline: `baseline-f49b4926-7e2b-4511-8cdb-0e2fb903637e`
 - Receipt: `cmtmd9eri7nj001miwklshlsr`
 - Rationale: stalled/failed admission, reservation checks, regressions, and live

--- a/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
+++ b/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
@@ -258,3 +258,46 @@ Live BI-FFBDDD96 research TaskRun `TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-799
 The remote-task executor is the final completion boundary for initiative reviews. When an immutable review binding creates a terminal-writer policy, the executor may persist ordinary completion only after the bound writer appears in the governed execution history or as the active bound proposal. Any other loop result—including duration, iteration, cancellation, route, circuit-breaker, or prose exits—is converted to the existing `input-required/missing-terminal-writer` projection on the same TaskRun. The conversion clears `completedAt`, preserves the request digest and immutable binding, records the bounded attempt, and creates no envelope, decision, mapping, or receipt.
 
 This is a postcondition, not a second inference policy. The agent loop still controls reader/writer surfaces and required tool choice; the executor independently prevents an incomplete result from escaping as completed. A genuine writer attempt retains existing approval and receipt handling, and non-review tasks remain unchanged.
+
+## Exact-bound stalled and failed replay liveness (BI-E2B632D2)
+
+Two live states expose the same false resumability promise. A Build Lead review
+was reaped to `stalled` while it remained in governed inference admission; a
+later objective-mapping review was left `failed` after an approved writer used
+an argument that a subsequently deployed binding repair now constrains. Both
+TaskRuns retain their request digest, immutable artifact binding, valid
+`missing-terminal-writer` marker, and zero successful writers. The replay read
+model reports both as resumable, but `reserveTerminalWriterReplay` admits neither
+state and returns the cached terminal result.
+
+- **OBJ-E2B-001:** Make every TaskRun projected as a resumable exact-bound
+  terminal-writer wait executable through the same TaskRun and request digest.
+- **OBJ-E2B-002:** Preserve the immutable review binding, writer identity,
+  evidence hydration, approval boundary, and receipt validators during replay.
+- **OBJ-E2B-003:** Keep ordinary stalled, failed, completed, and non-review
+  TaskRuns terminal; only an exact marked terminal-writer wait is eligible.
+- **OBJ-E2B-004:** Bound replay attempts and stop with the existing escalation
+  rather than retrying a rejected or unavailable writer forever.
+
+| Acceptance ID | Objectives | Acceptance criterion |
+| --- | --- | --- |
+| AC-E2B-001 | OBJ-E2B-001, OBJ-E2B-002 | An exact-bound reaper-stalled wait compare-and-sets the same TaskRun back to `working` and reaches the existing writer-only turn. |
+| AC-E2B-002 | OBJ-E2B-001, OBJ-E2B-002 | A failed exact-bound wait with a prior non-successful, non-proposal writer attempt may run a new bounded writer-only turn on the same TaskRun; no sibling identity is created. |
+| AC-E2B-003 | OBJ-E2B-002 | A live proposal or approval remains owned by approval recovery; replay neither executes stored arguments nor bypasses fresh exact approval. |
+| AC-E2B-004 | OBJ-E2B-003 | A generic stalled/failed run, changed request digest, changed writer binding, or successful writer remains unrecoverable through this path. |
+| AC-E2B-005 | OBJ-E2B-004 | The existing attempt ceiling applies to stalled and failed waits and produces the existing bounded escalation when exhausted. |
+| AC-E2B-006 | OBJ-E2B-001, OBJ-E2B-002, OBJ-E2B-003 | Canonical replay of the original objective-mapping packet records the governed mapping and allows its BI and Workroom to close. |
+
+### Ordered fix sequence
+
+1. Add regressions for the reaper-stalled wait, the corrected-prerequisite
+   failed wait, and the fail-closed exclusions above.
+2. Extend only the existing reservation eligibility and prior-attempt handling;
+   retain the request digest, immutable policy reconstruction, successful-writer
+   check, compare-and-set, hydration, approval, and receipt paths.
+3. Run the graph-linked TaskRun suites and build gates, publish through the merge
+   queue, self-upgrade canonically, then replay the unchanged original packet.
+
+This is an orchestration-liveness correction, not a second evidence or approval
+model. The prior failed attempts remain immutable audit history. Rollback is the
+single eligibility change and its tests; no schema or stored contract changes.

--- a/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
+++ b/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
@@ -301,3 +301,30 @@ state and returns the cached terminal result.
 This is an orchestration-liveness correction, not a second evidence or approval
 model. The prior failed attempts remain immutable audit history. Rollback is the
 single eligibility change and its tests; no schema or stored contract changes.
+
+### Approval projection is part of the same replay contract (2026-09-03)
+
+Canonical acceptance replay for BI-BFBF1BBB reached
+`record_initiative_evidence`, persisted proposal execution
+`cmtmgbxya03ke01qisordc4tb`, and created exact-bound envelope
+`cmtmgbxy603kd01qid8kg6261`. The tool result was
+`approval_required`, but the remote executor then overwrote the TaskRun as
+`completed`. After the envelope was approved, identical replay returned that
+cached completion and never executed the writer. The TaskRun therefore held an
+approved, unconsumed exact writer and no objective-mapping receipt.
+
+The executor must treat an `approval_required` result from the bound terminal
+writer as an explicit `input-required` projection even when the lower tool path
+did not mutate TaskRun state. It records the envelope id, clears `completedAt`,
+and returns the existing approval location. For already-persisted historical
+misprojections, replay may recover a `completed` TaskRun only when the current
+request digest matches, the server reconstructs an initiative-review terminal
+policy, an unexpired approved envelope belongs to that same TaskRun and user,
+and its action is the exact bound writer. The existing proposal execution
+remains the sole source of writer arguments. Generic completed tasks and writer
+mismatches remain terminal.
+
+This correction realizes AC-E2B-003 rather than weakening it: approval recovery
+continues to own live proposals, inference is not rerun, stored arguments are
+not synthesized, and the writer still passes through its ordinary authority and
+receipt validators.


### PR DESCRIPTION
## Summary

- keep an exact-bound terminal-writer proposal `input-required` when its governed tool returns `approval_required`
- resume an already-approved historical `completed` projection only when the immutable request and writer binding still match
- preserve ordinary completed-task finality, stored writer arguments, and the existing authority/receipt validators

## Why

The live BI-BFBF1BBB objective-mapping replay created an exact approval envelope, but the executor then marked its TaskRun complete. Approving the envelope could not resume it, so no objective-mapping receipt was written. This closes that completion leak without rerunning inference or adding another approval path.

## Design grounding

This extends the approved replay contract in `docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md`, specifically AC-E2B-003. The implementation reuses `executeRemoteTaskAttempt` in `apps/web/lib/mcp-task-execution.ts`, `resumeApprovedRemoteTask` in `apps/web/lib/mcp-task-submit-approval-recovery.ts`, and the existing idempotent replay ordering in `apps/web/lib/mcp-task-submit.ts`.

## Verification

- TDD: both regressions failed before the fix for the expected reasons
- affected Vitest suites: 62/62 passed
- focused extraction check: 23/23 passed
- style drift guard: passed
- `pnpm --filter web build`: passed, 148 routes
- preflight: 63 guards passed
- independent semantic review: passed, two review branches, zero findings
- exact-tree local CI: passed
- UX: not applicable; no UI changed
- migration: not applicable; no schema changed

Backlog: BI-E2B632D2

Local-CI-Evidence: cmtmgw1jk0fk401qin02yh7rs (fix/terminal-writer-replay-liveness@29b9a03667911a8d38a41c4dd4538b3687843881)
