### PR TITLE
fix(attention): align coworker briefing with owner queue

### DIFF
--- a/apps/web/lib/agent/opening-briefing-loader.test.ts
+++ b/apps/web/lib/agent/opening-briefing-loader.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AttentionItem, AttentionSource } from "@/lib/attention/types";
+
+const mocks = vi.hoisted(() => ({
+  loadAttentionItems: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@/lib/agent-routing", () => ({
+  resolveAgentForRoute: vi.fn(() => ({ agentId: "AGT-COO" })),
+}));
+vi.mock("@/lib/feature-flags", () => ({
+  isUnifiedCoworkerEnabled: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("@/lib/attention/aggregate", () => ({
+  loadAttentionItems: mocks.loadAttentionItems,
+  filterAttentionForAudience: vi.fn((items: AttentionItem[]) => items),
+}));
+
+import { loadOpeningBriefingPayload } from "./opening-briefing-loader";
+
+function item(source: AttentionSource, index: number): AttentionItem {
+  return {
+    id: `${source}:${index}`,
+    source,
+    title: `${source} item ${index}`,
+    context: "context",
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: {
+      timeToAct: "none",
+      residueReason: "policy-approval",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: "2026-09-03T12:00:00.000Z",
+    actions: [{ kind: "open-in-context", label: "Open", href: "/review" }],
+    deepLink: "/review",
+    audience: { operator: true },
+  };
+}
+
+describe("loadOpeningBriefingPayload", () => {
+  beforeEach(() => {
+    mocks.loadAttentionItems.mockReset();
+  });
+
+  it("stays silent when every visible item belongs to the digital team", async () => {
+    mocks.loadAttentionItems.mockResolvedValue({
+      items: Array.from({ length: 51 }, (_, index) => item("platform-health", index + 1)),
+      failedSources: [],
+    });
+
+    await expect(loadOpeningBriefingPayload({ id: "user-1" }, "/workspace")).resolves.toBeNull();
+  });
+
+  it("counts only genuine owner decisions in the opening briefing", async () => {
+    const ownerDecision = item("approval-outbound", 1);
+    ownerDecision.title = "Launch email awaits your approval";
+    ownerDecision.deepLink = "/customer/marketing";
+
+    mocks.loadAttentionItems.mockResolvedValue({
+      items: [
+        ownerDecision,
+        ...Array.from({ length: 50 }, (_, index) => item("platform-health", index + 1)),
+      ],
+      failedSources: [],
+    });
+
+    const result = await loadOpeningBriefingPayload({ id: "user-1" }, "/workspace");
+
+    expect(result?.agentId).toBe("AGT-COO");
+    expect(result?.content).toContain("Launch email awaits your approval");
+    expect(result?.content).not.toContain("more items");
+    expect(result?.content).not.toContain("platform-health item");
+  });
+});

--- a/apps/web/lib/agent/opening-briefing-loader.ts
+++ b/apps/web/lib/agent/opening-briefing-loader.ts
@@ -7,6 +7,7 @@ import { prisma } from "@dpf/db";
 import { resolveAgentForRoute } from "@/lib/agent-routing";
 import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { loadAttentionItems, filterAttentionForAudience } from "@/lib/attention/aggregate";
+import { buildOwnerAttentionProjection } from "@/lib/attention/owner-projection";
 import { composeOpeningBriefing, type OpeningBriefingPayload } from "./opening-briefing";
 
 /**
@@ -43,12 +44,17 @@ export async function loadOpeningBriefingPayload(
   });
   // V1 operator-view, matching /workspace/inbox; worker scoping is BI-AS-4.
   const visible = filterAttentionForAudience(items, { operator: true });
+  const projection = buildOwnerAttentionProjection(visible, {
+    fallbackLevel: "balanced",
+    nowMs: Date.now(),
+    audience: "operator",
+  });
 
   const briefing = composeOpeningBriefing({
     routeContext,
     // Platform default: the composer treats null as balanced.
     proactivityLevel: null,
-    items: visible,
+    items: projection.needsYouNow.map((entry) => entry.item),
   });
   return briefing ? { content: briefing.content, agentId: agent.agentId ?? null } : null;
 }

--- a/docs/superpowers/plans/2026-09-03-owner-attention-briefing-convergence.md
+++ b/docs/superpowers/plans/2026-09-03-owner-attention-briefing-convergence.md
@@ -1,0 +1,45 @@
+# Owner-attention briefing convergence plan
+
+| Field | Value |
+| --- | --- |
+| Backlog item | `BI-2C50F548` |
+| Workroom | `WC-7B7175A9` |
+| Design and research | [`2026-08-24-owner-attention-briefing-convergence-design.md`](../specs/2026-08-24-owner-attention-briefing-convergence-design.md) |
+| Delivery shape | Atomic fix |
+
+This file is the plan-coverage carrier for the fix. The reviewed design remains
+the source of truth for the problem, research, architecture, UX fit, and ordered
+fix sequence; this plan does not introduce a second design or delivery phase.
+
+## Atomic deliverable
+
+### `owner-briefing-projection-convergence`
+
+- Backlog: `BI-2C50F548`
+- Requirements: `OBJ-1`, `OBJ-2`, `OBJ-3`
+- Contract: `buildOwnerAttentionProjection` is the single owner-routing truth;
+  `loadOpeningBriefingPayload` passes only `needsYouNow` items to
+  `composeOpeningBriefing`.
+- Flow: follow the design's **Ordered fix sequence**—retain the observed failing
+  loader regression, change the one loader seam, prove zero-owner and genuine-
+  owner cases, then run the governed delivery gates.
+- Verification: `AC-1` through `AC-8`, including the focused briefing/projection
+  suites, source-local typecheck, style-drift guard, exact-tree pregate, and a
+  fresh-install browser exercise.
+- Dependencies: none.
+- Independently shippable: no. The regression test and loader change express
+  one behavior correction; shipping either alone would not deliver the outcome.
+
+## Implementation boundary
+
+Edit only the loader seam and its regression coverage. Do not add routes, data
+models, source-name filters, briefing-specific projections, or copy-only
+workarounds. Preserve the pure composer's existing behavior for genuine owner
+decisions and assertive room-scoped callers.
+
+## UX fit checkpoint
+
+The fix fits the existing Workspace route family and founder/operator persona.
+It removes false owner-review copy without adding controls, navigation, or UI
+primitives. Browser verification must show that team-held technical items stay
+out of the opening briefing while genuine owner decisions still surface.

--- a/docs/superpowers/plans/2026-09-03-owner-attention-briefing-convergence.md
+++ b/docs/superpowers/plans/2026-09-03-owner-attention-briefing-convergence.md
@@ -23,9 +23,10 @@ fix sequence; this plan does not introduce a second design or delivery phase.
 - Flow: follow the design's **Ordered fix sequence**—retain the observed failing
   loader regression, change the one loader seam, prove zero-owner and genuine-
   owner cases, then run the governed delivery gates.
-- Verification: `AC-1` through `AC-8`, including the focused briefing/projection
-  suites, source-local typecheck, style-drift guard, exact-tree pregate, and a
-  fresh-install browser exercise.
+- Verification: `AC-1`, `AC-2`, `AC-3`, `AC-4`, `AC-5`, `AC-6`, `AC-7`, and
+  `AC-8`, including the focused briefing/projection suites, source-local
+  typecheck, style-drift guard, exact-tree pregate, and a fresh-install browser
+  exercise.
 - Dependencies: none.
 - Independently shippable: no. The regression test and loader change express
   one behavior correction; shipping either alone would not deliver the outcome.

--- a/docs/superpowers/plans/2026-09-03-owner-attention-briefing-convergence.md
+++ b/docs/superpowers/plans/2026-09-03-owner-attention-briefing-convergence.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Owner-attention briefing convergence plan
 
 | Field | Value |

--- a/docs/superpowers/specs/2026-08-24-owner-attention-briefing-convergence-design.md
+++ b/docs/superpowers/specs/2026-08-24-owner-attention-briefing-convergence-design.md
@@ -74,12 +74,15 @@ The defect was reproduced on branch `fix/deliver-bi-2c50f548-owner-attention-bri
 - `apps/web/lib/agent/opening-briefing.ts:112-122` derives the overflow count from the raw array and labels it owner review work.
 - `apps/web/components/workspace-home/OperatorCockpit.tsx:101` uses `buildOwnerAttentionProjection`, ruling out the Workspace projection as the source of the contradiction.
 - `node node_modules/vitest/vitest.mjs run --root apps/web lib/agent/opening-briefing-loader.test.ts` failed two regression cases before the fix: 51 platform-health items produced “Most pressing” plus “50 more items,” and one genuine approval plus 50 platform-health items produced an inflated overflow count.
+- A reversible research spike then routed the same feed through `buildOwnerAttentionProjection`; `node node_modules/vitest/vitest.mjs run --root apps/web lib/agent/opening-briefing-loader.test.ts lib/agent/opening-briefing.test.ts lib/attention/owner-projection.test.ts` passed all 17 tests. The loader was restored to the pre-fix state after the run so implementation still begins only after readiness is granted.
 
 Candidate causes ruled out by execution and direct comparison:
 
 - The pure composer is not responsible for classifying ownership; its focused tests demonstrate it presents the array it receives.
 - The Workspace count is not dropping data accidentally; owner-projection tests classify `platform-health` into `custodian` and keep genuine approvals in `needsYouNow`.
 - Audience filtering alone is insufficient; the failing loader test keeps all fixtures operator-visible and still reproduces the exact contradiction.
+
+**Research gate conclusion: pass.** The defect is reproduced on a named current ref, the exact one-seam candidate fix turns the new regression from red to green without breaking the existing composer or projection suites, and the competing loader/composer/Workspace causes above were exercised rather than inferred.
 
 ## Ordered fix sequence
 

--- a/docs/superpowers/specs/2026-08-24-owner-attention-briefing-convergence-design.md
+++ b/docs/superpowers/specs/2026-08-24-owner-attention-briefing-convergence-design.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: active
 ---
 
 # Owner-attention briefing convergence
@@ -24,7 +24,7 @@ The briefing is deterministic, not model-generated. `loadOpeningBriefingPayload`
 
 **OBJ-2:** Keep proactive coworker copy concise and honest: genuine owner decisions may interrupt; custodian and weekly-digest work must never be relabelled as waiting for owner review.
 
-**OBJ-3:** Prove the fresh-install regression is closed without weakening genuine approval, escalation, or assertive all-clear behavior.
+**OBJ-3:** Prove the fresh-install regression is closed without weakening genuine approval or escalation behavior.
 
 ## Design grounding
 
@@ -48,17 +48,15 @@ No external protocol, dependency, schema, or industry-specific workflow is intro
 
 ### 1. Project once, then compose the briefing
 
-`loadOpeningBriefingPayload` will build `OwnerAttentionProjection` from the operator-visible attention items using the same fallback proactivity level, timestamp, and operator audience used by Workspace. It will pass only `projection.needsYouNow.map(entry => entry.item)` to the existing briefing composer.
+`loadOpeningBriefingPayload` will build `OwnerAttentionProjection` from the operator-visible attention items using the same `balanced` fallback, current timestamp, and `operator` audience used by Workspace. It will pass only `projection.needsYouNow.map(entry => entry.item)` to the existing briefing composer.
 
-This keeps `composeOpeningBriefing` focused on presentation and preserves its surface-local headline selection, quiet/balanced/assertive semantics, link rendering, and detail de-duplication. The loader owns routing because it already owns the read-model fan-out and user/proactivity context.
+This keeps `composeOpeningBriefing` focused on presentation and preserves its surface-local headline selection, link rendering, and detail de-duplication. The loader owns routing because it already owns the read-model fan-out and audience context.
 
-### 2. Preserve the assertive all-clear
+### 2. Follow the current unroomed-posture contract
 
-When raw attention exists but `needsYouNow` is empty:
+`BI-87C9C91C` removed identity-owned coworker proactivity. The interactive, unroomed opening briefing now uses the platform default (`balanced`), while outcome-specific proactive work takes its posture from a Workroom. This fix therefore does not recreate a per-coworker proactivity read or an assertive loader path.
 
-- `balanced` remains silent, because no owner decision exists.
-- `assertive` receives an empty owner-decision list and emits the existing deterministic all-clear.
-- Team-held work remains visible in the Workspace `DigitalTeamHandlingStrip`; the coworker does not repeat or dump it.
+When raw attention exists but `needsYouNow` is empty, the balanced opening briefing remains silent because no owner decision exists. Team-held work remains visible in the Workspace `DigitalTeamHandlingStrip`; the coworker does not repeat or dump it. The pure composer retains its assertive all-clear behavior for any future room-scoped caller, but that is outside this loader's current contract.
 
 ### 3. Bound the presentation by owner decisions
 
@@ -67,6 +65,31 @@ The “N more items are waiting for your review” line is retained only for gen
 ### 4. Regression-first verification
 
 Add loader-level tests that mock 51 raw attention items classified into custodian/digest lanes and assert the composer receives an empty owner list. Keep pure composer tests for genuine owner items. The test must fail on the current raw-array path before implementation.
+
+## Reproduction evidence on the current tree
+
+The defect was reproduced on branch `fix/deliver-bi-2c50f548-owner-attention-briefing-con` at commit `1b54416aa5befa72a4e85d2add3fbd0a8c1de215`:
+
+- `apps/web/lib/agent/opening-briefing-loader.ts:45-51` filters only by audience and passes all visible items to the composer.
+- `apps/web/lib/agent/opening-briefing.ts:112-122` derives the overflow count from the raw array and labels it owner review work.
+- `apps/web/components/workspace-home/OperatorCockpit.tsx:101` uses `buildOwnerAttentionProjection`, ruling out the Workspace projection as the source of the contradiction.
+- `node node_modules/vitest/vitest.mjs run --root apps/web lib/agent/opening-briefing-loader.test.ts` failed two regression cases before the fix: 51 platform-health items produced “Most pressing” plus “50 more items,” and one genuine approval plus 50 platform-health items produced an inflated overflow count.
+
+Candidate causes ruled out by execution and direct comparison:
+
+- The pure composer is not responsible for classifying ownership; its focused tests demonstrate it presents the array it receives.
+- The Workspace count is not dropping data accidentally; owner-projection tests classify `platform-health` into `custodian` and keep genuine approvals in `needsYouNow`.
+- Audience filtering alone is insufficient; the failing loader test keeps all fixtures operator-visible and still reproduces the exact contradiction.
+
+## Ordered fix sequence
+
+1. Add the loader-level 51-raw/0-owner regression and observe it fail with the exact false owner-review copy.
+2. Route the audience-filtered feed through `buildOwnerAttentionProjection` in `loadOpeningBriefingPayload`, then give the composer only `needsYouNow` items.
+3. Prove the negative case is silent and the positive case preserves one genuine owner decision without counting 50 team-held items.
+4. Run the focused attention/briefing suites, source-local typecheck, style-drift guard, preflight and governed exact-tree gate.
+5. Review the final diff for architecture, blast radius, and UX fit; then verify the fresh-install path on a governed nonproduction runtime before completion.
+
+This is deliberately atomic: the regression test and the one loader seam describe a single behavior change and neither is independently shippable. No schema, migration, route, adapter, or new projection is involved.
 
 ## UX fit review
 
@@ -77,7 +100,7 @@ Add loader-level tests that mock 51 raw attention items classified into custodia
 - Navigation layer: contextual coworker action only.
 - Reuse/convergence: `buildOwnerAttentionProjection`; no new status or count primitive.
 - Source truth: attention aggregate plus canonical owner-routing projection.
-- Empty/failure behavior: balanced stays silent at zero owner decisions; assertive gives an honest all-clear; existing failed-source disclosure remains owned by Workspace/inbox.
+- Empty/failure behavior: the unroomed balanced briefing stays silent at zero owner decisions; the pure composer keeps its existing assertive all-clear contract; failed-source disclosure remains owned by Workspace/inbox.
 - AI boundary: deterministic, read-only opening bubble; no prompt send or mutation.
 
 ## Data, security, compliance, and scale
@@ -106,7 +129,7 @@ Add loader-level tests that mock 51 raw attention items classified into custodia
 | AC-1 | OBJ-1 | With 51 raw custodian/digest items and zero `needsYouNow` entries, the coworker opening briefing does not claim any item is waiting for owner review and does not link to the Needs-you inbox as if it contains work. |
 | AC-2 | OBJ-1 | Workspace, `/workspace/inbox`, and the coworker briefing derive owner-review counts from `buildOwnerAttentionProjection`; no parallel classification or source-name filter is added. |
 | AC-3 | OBJ-2 | A balanced coworker stays silent when the owner projection is empty, even if the digital team is handling raw attention items. |
-| AC-4 | OBJ-2 | An assertive coworker gives the existing honest all-clear when the owner projection is empty. |
+| AC-4 | OBJ-2 | The loader follows the current unroomed platform-default posture and does not reintroduce identity-owned proactivity; the pure composer keeps its existing assertive all-clear test. |
 | AC-5 | OBJ-2 | Genuine owner decisions retain the most-pressing headline, overflow count, deep links, and surface-local preference. |
 | AC-6 | OBJ-2 | The opening bubble does not render an unbounded comma-separated list of technical coworker names through team-held attention. |
 | AC-7 | OBJ-3 | A regression test reproduces the 51-raw/0-owner contradiction and is observed failing before the fix and passing after it. |

--- a/docs/superpowers/specs/2026-08-24-owner-attention-briefing-convergence-design.md
+++ b/docs/superpowers/specs/2026-08-24-owner-attention-briefing-convergence-design.md
@@ -1,0 +1,113 @@
+---
+status: draft
+---
+
+# Owner-attention briefing convergence
+
+| Field | Value |
+| --- | --- |
+| Backlog item | `BI-2C50F548` |
+| Workroom | `WC-7B7175A9` |
+| Date | 2026-08-24 |
+| Profile | Fix |
+| Owning area | Workspace |
+
+## Problem
+
+On a fresh install, `/workspace` truthfully reports that zero decisions need the owner and that the digital team is handling 51 technical items. The adjacent coworker opening briefing reads the same raw attention feed but labels one item “Most pressing” and the other 50 “waiting for your review,” then links to an inbox with zero owner decisions. The contradictory hierarchy makes the primary Workspace question—“What needs me now?”—untrustworthy.
+
+The briefing is deterministic, not model-generated. `loadOpeningBriefingPayload` passes raw operator-visible `AttentionItem[]` to `composeOpeningBriefing`, while `OperatorCockpit` and `AttentionInbox` first call `buildOwnerAttentionProjection` and treat only `needsYouNow` as owner work. The defect is the missing shared projection at the coworker seam.
+
+## Objectives
+
+**OBJ-1:** Make the Workspace cockpit, full Needs-you inbox, and coworker opening briefing derive owner-review counts from the same canonical owner-attention projection.
+
+**OBJ-2:** Keep proactive coworker copy concise and honest: genuine owner decisions may interrupt; custodian and weekly-digest work must never be relabelled as waiting for owner review.
+
+**OBJ-3:** Prove the fresh-install regression is closed without weakening genuine approval, escalation, or assertive all-clear behavior.
+
+## Design grounding
+
+This design extends, rather than replaces:
+
+- [`2026-06-23-human-attention-surface-design.md`](2026-06-23-human-attention-surface-design.md): the Needs-you inbox is a projector over source-owned state; only human residue belongs in the owner queue; proactive surfacing may change presentation but not truth.
+- [`2026-05-26-portal-ux-simplification-spine.md`](../plans/2026-05-26-portal-ux-simplification-spine.md): `/workspace` must have one trustworthy answer to “what needs me now,” use honest fresh-install empty states, and reserve implementation effort for convergence/refactoring.
+- [`owner-projection.ts`](../../../apps/web/lib/attention/owner-projection.ts): canonical classification into `needsYouNow`, `weeklyDigest`, and `custodian`.
+- [`OperatorCockpit.tsx`](../../../apps/web/components/workspace-home/OperatorCockpit.tsx) and [`AttentionInbox.tsx`](../../../apps/web/components/attention/AttentionInbox.tsx): existing owner-facing consumers of that projection.
+- [`opening-briefing-loader.ts`](../../../apps/web/lib/agent/opening-briefing-loader.ts) and [`opening-briefing.ts`](../../../apps/web/lib/agent/opening-briefing.ts): deterministic ephemeral briefing seam and proactivity rules.
+
+No new route, model, attention source, status map, or UI primitive is introduced.
+
+## Research and benchmarking
+
+The relevant product and security pattern is already canonical in DPF's human-attention design: a human inbox contains only governed residue, while technical/custodian work remains with the digital team. The existing Workspace cockpit and inbox are the implemented benchmark. This fix adopts their projection contract and rejects a second page-local classification or copy-only patch because either would recreate drift.
+
+No external protocol, dependency, schema, or industry-specific workflow is introduced, so external standards research would add no design signal. The applicable internal standards are `architecture-over-shortcuts`, `single-source-of-truth`, `structural-verification-is-not-functional`, and the Workspace UX fit gate.
+
+## Proposed design
+
+### 1. Project once, then compose the briefing
+
+`loadOpeningBriefingPayload` will build `OwnerAttentionProjection` from the operator-visible attention items using the same fallback proactivity level, timestamp, and operator audience used by Workspace. It will pass only `projection.needsYouNow.map(entry => entry.item)` to the existing briefing composer.
+
+This keeps `composeOpeningBriefing` focused on presentation and preserves its surface-local headline selection, quiet/balanced/assertive semantics, link rendering, and detail de-duplication. The loader owns routing because it already owns the read-model fan-out and user/proactivity context.
+
+### 2. Preserve the assertive all-clear
+
+When raw attention exists but `needsYouNow` is empty:
+
+- `balanced` remains silent, because no owner decision exists.
+- `assertive` receives an empty owner-decision list and emits the existing deterministic all-clear.
+- Team-held work remains visible in the Workspace `DigitalTeamHandlingStrip`; the coworker does not repeat or dump it.
+
+### 3. Bound the presentation by owner decisions
+
+The “N more items are waiting for your review” line is retained only for genuine `needsYouNow` items. Because custodian/digest items never reach the composer, a long technical coworker-name list cannot occupy the opening bubble through this path.
+
+### 4. Regression-first verification
+
+Add loader-level tests that mock 51 raw attention items classified into custodian/digest lanes and assert the composer receives an empty owner list. Keep pure composer tests for genuine owner items. The test must fail on the current raw-array path before implementation.
+
+## UX fit review
+
+- Decision: `fits-with-guardrails`.
+- Owning area: Workspace.
+- Route family: `/workspace` and `/workspace/inbox`; no new route.
+- Primary persona: founder/operator on a fresh install.
+- Navigation layer: contextual coworker action only.
+- Reuse/convergence: `buildOwnerAttentionProjection`; no new status or count primitive.
+- Source truth: attention aggregate plus canonical owner-routing projection.
+- Empty/failure behavior: balanced stays silent at zero owner decisions; assertive gives an honest all-clear; existing failed-source disclosure remains owned by Workspace/inbox.
+- AI boundary: deterministic, read-only opening bubble; no prompt send or mutation.
+
+## Data, security, compliance, and scale
+
+- Data: no schema, persistence, retention, sensitivity, query, or migration change. The ephemeral briefing remains unpersisted.
+- Security: no authorization or action boundary changes. Audience filtering remains operator-scoped before projection.
+- Compliance: no new personal, regulated, customer, or business data is introduced.
+- Scale ceiling: classification remains O(N) over the already-loaded bounded attention feed. The change removes an unbounded presentation symptom without adding queries or fan-out.
+
+## Alternatives rejected
+
+1. **Copy-only change:** rename “waiting for your review” to “being handled.” Rejected because the briefing would still headline technical work and duplicate Workspace's custodian strip.
+2. **Filter by source names in the briefing:** rejected because source identity is not owner-routing truth and would drift as adapters are added.
+3. **Create a briefing-specific projection:** rejected as a second status map and a direct single-source-of-truth violation.
+
+## Risks and rollback
+
+- Risk: a genuine owner item is accidentally demoted by owner routing. Mitigation: retain owner-projection unit coverage and add a positive loader test for a genuine `needsYouNow` item.
+- Risk: surface-local selection changes because projection ordering differs from raw triage ordering. Mitigation: the projection preserves ordered entries within each lane; the composer retains its current surface-local choice.
+- Rollback: revert the loader projection call and associated tests. No data rollback is required.
+
+## Acceptance criteria
+
+| ID | Objective | Statement |
+| --- | --- | --- |
+| AC-1 | OBJ-1 | With 51 raw custodian/digest items and zero `needsYouNow` entries, the coworker opening briefing does not claim any item is waiting for owner review and does not link to the Needs-you inbox as if it contains work. |
+| AC-2 | OBJ-1 | Workspace, `/workspace/inbox`, and the coworker briefing derive owner-review counts from `buildOwnerAttentionProjection`; no parallel classification or source-name filter is added. |
+| AC-3 | OBJ-2 | A balanced coworker stays silent when the owner projection is empty, even if the digital team is handling raw attention items. |
+| AC-4 | OBJ-2 | An assertive coworker gives the existing honest all-clear when the owner projection is empty. |
+| AC-5 | OBJ-2 | Genuine owner decisions retain the most-pressing headline, overflow count, deep links, and surface-local preference. |
+| AC-6 | OBJ-2 | The opening bubble does not render an unbounded comma-separated list of technical coworker names through team-held attention. |
+| AC-7 | OBJ-3 | A regression test reproduces the 51-raw/0-owner contradiction and is observed failing before the fix and passing after it. |
+| AC-8 | OBJ-3 | Focused tests, source-local typecheck, the governed exact-tree integration gate, and fresh-install browser verification all pass before delivery is claimed. |


### PR DESCRIPTION
## Summary

Make the AI coworker's opening briefing use the same canonical owner-attention projection as Workspace and the Needs-you inbox. This prevents fresh installs from calling team-held technical work "waiting for your review" when the owner queue is empty.

## Changes

- Project operator-visible attention through `buildOwnerAttentionProjection` before composing the opening briefing.
- Add loader regressions for 51 team-held items and for one genuine approval mixed with 50 team-held items.
- Record the reviewed design and atomic delivery trace for `BI-2C50F548`.

## Test plan

- [ ] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] `pnpm --filter web typecheck`
  - [x] Targeted unit tests: `opening-briefing-loader.test.ts`, `opening-briefing.test.ts`, and `owner-projection.test.ts` (17/17)

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime** — pick one:
        - [ ] root local install (`http://localhost:3000`)
        - [x] governed shared nonprod env (lease id: `NPEL-94C277A85B`)
        - [ ] CI workflow run (link: ____)
  - [x] Evidence captured below (command + observed output, screenshot, MCP record id, etc.)

- [ ] **Verification-harness limitation acknowledged** (check if any worktree-side gate was skipped because the worktree is not a full runtime; do NOT classify this as a product defect — file a platform BI instead)

### Verification evidence

- TDD red: both new loader regressions failed on the raw-array path.
- TDD green: focused loader/composer/projection suite passed 17/17.
- `pnpm --filter web typecheck` passed.
- `node scripts/check-style-drift.mjs` passed.
- `pnpm run pregate:preflight` passed 63/63 guards.
- Exact-tree `pnpm run pregate` passed against current `main`, including full tests and production Docker build: evidence `cmtmhss520u6o01nv6f0sgn5q`, candidate `99fa74dfc654c8b1da39ef37163bca26724dd549`, base `c60eded91e2bfab5b2fd0299f3f0eedc83e6c2aa`.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`, or an allowed `Local-CI-Override` is documented below
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cmtmhss520u6o01nv6f0sgn5q (fix/deliver-bi-2c50f548-owner-attention-briefing-con@99fa74dfc654c8b1da39ef37163bca26724dd549)

## Related issues / Epic

Backlog: `BI-2C50F548`

## Epic / Backlog linkage (for multi-BI work)

Not applicable; this is one atomic backlog fix.

## Overlap sweep

Current-main changes during delivery affected governance and task-run files only. No changed path overlaps the loader, regression test, or this fix's design/plan documents.

## Notes for the reviewer

No schema, migration, route, authorization, dependency, or visual-style change. The pure briefing composer remains unchanged; the loader now supplies only genuine owner decisions.
