### PR TITLE
fix(governance): preserve external reviewer token scope

### DIFF
--- a/apps/web/lib/mcp-task-execution.test.ts
+++ b/apps/web/lib/mcp-task-execution.test.ts
@@ -120,6 +120,10 @@ describe("remote task terminal-writer postcondition", () => {
         executedToolCount: 2,
       },
     });
+    expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
+      apiTokenId: "PAT-WRITER-DURATION",
+      tokenScope: "write",
+    }));
   });
 
   it("parks an approval-required terminal writer even when the tool did not project TaskRun state", async () => {

--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -177,6 +177,7 @@ export async function executeRemoteTaskAttempt(input: {
       threadId: input.threadId,
       taskRunId: run.taskRunId,
       apiTokenId: token.tokenId,
+      tokenScope: token.capability,
       taskType: "external-mcp",
       agentDisplayName: optionalString(agent.displayName) ?? resolvedAgentId,
       ...(effortWarrant ? { effortWarrant } : {}),

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -1054,7 +1054,6 @@ describe("runAgenticLoop", () => {
       success: true,
       message: "Found files",
     });
-
     await runAgenticLoop({
       ...baseParams,
       taskRunId: "TR-SCHED-TESTRUN",
@@ -1097,13 +1096,14 @@ describe("runAgenticLoop", () => {
       ...baseParams,
       taskRunId: "TR-MCP-TESTRUN",
       apiTokenId: "tok_remote",
+      tokenScope: "write",
     });
-
     expect(governedExecuteTool).toHaveBeenCalledWith(
       expect.objectContaining({
         context: expect.objectContaining({
           taskRunId: "TR-MCP-TESTRUN",
           apiTokenId: "tok_remote",
+          tokenScope: "write",
         }),
       }),
     );

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -945,7 +945,6 @@ function truncateMessageContent(content: string, maxChars: number, label: string
   return `${content.slice(0, Math.max(0, maxChars - suffix.length))}${suffix}`;
 }
 
-
 function compactAgenticMessages(
   messages: ChatMessage[],
   maxContextTokens?: number | null,
@@ -1110,6 +1109,7 @@ export type RunAgenticLoopParams = {
    * call records the same token id in ToolExecution audit rows.
    */
   apiTokenId?: string | null;
+  tokenScope?: "read" | "write" | "admin";
   /**
    * Governed Hermes learning Slice 1: active coworker skill for this run.
    * When set, every governed tool call records the same skillId in
@@ -1139,7 +1139,6 @@ export type RunAgenticLoopParams = {
   enableExecutionPlan?: boolean;
   /** Bounded evidence-reader surface with a reserved governed writer step. */
   terminalToolPolicy?: TerminalToolPolicy;
-
 };
 
 export async function runAgenticLoop(params: RunAgenticLoopParams): Promise<AgenticResult> {
@@ -2520,6 +2519,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
             threadId,
             taskRunId: taskRunId ?? undefined,
             apiTokenId: apiTokenId ?? undefined,
+            tokenScope: params.tokenScope,
             skillId: tracker.activeSkillId ?? undefined,
             // In-portal coworker chat turns attach COWORKER_READ_BASELINE_GRANTS
             // to the tool surface (actions/agent-coworker.ts). Flag the turn so

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -716,12 +716,14 @@ describe("createAutonomousWorkRun", () => {
       threadId: "thread-1",
       taskRunId: "TR-MCP-ABCDEF12",
       apiTokenId: "tok_remote",
+      tokenScope: "write",
     });
 
     expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
       expect.objectContaining({
         taskRunId: "TR-MCP-ABCDEF12",
         apiTokenId: "tok_remote",
+        tokenScope: "write",
       }),
     );
   });

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -341,6 +341,7 @@ export async function executeAutonomousAgenticLoop(input: {
   featureBuildId?: string | null;
   modelRequirements?: Record<string, unknown>;
   apiTokenId?: string | null;
+  tokenScope?: "read" | "write" | "admin";
   /**
    * Governed Hermes learning Slice 1: when the user message invokes a specific
    * coworker skill (via the canonical `Use the <id> skill.` marker), the
@@ -487,6 +488,7 @@ export async function executeAutonomousAgenticLoop(input: {
         threadId: input.threadId,
         taskRunId: input.taskRunId,
         apiTokenId: input.apiTokenId,
+        tokenScope: input.tokenScope,
         taskType: input.taskType,
         effortWarrant: input.effortWarrant,
         terminalToolPolicy: input.terminalToolPolicy,

--- a/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
+++ b/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
@@ -458,6 +458,33 @@ numeric tier is only a default and cannot add a human proxy gate to the exact
 review boundary. Unbound calls, ordinary side effects, and the downstream
 principal-level author/reviewer collision check remain unchanged.
 
+### 2026-09-04 live-acceptance amendment: preserve token scope through execution
+
+After the tier-policy repair shipped, governed self-upgrade
+`SUR-071C4319` installed release
+`v2026.09.04-initiative-canonical-discovery-transport.1`. The installed image
+served byte identity `c9a729fe3a562a263d648de1474c2a28f6fd3328`, which is a
+descendant of release target `90c65d227b3b42cd688235147115d2d88fdc7a9b`.
+The external Workroom then created fresh independent reviewer TaskRun
+`TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-703AB1AD13D8` with the exact
+subject, writer, and immutable design locator. Dispatch required no approval.
+
+That TaskRun exposed the next bounded transport defect. The autonomous loop
+received the submitting token id but not its server-resolved capability. Its
+writer therefore reached the receipt repository with a reviewer and an allow
+decision, but with `tokenScope=null`, and failed closed with
+`AUTHORIZATION_DENIED`. Retrying model arguments cannot repair server-owned
+authentication context.
+
+The architecture decision is to carry the already-authenticated token
+capability alongside the token id from `executeRemoteTaskAttempt`, through the
+shared autonomous execution seam, into `governedExecuteTool`. The capability is
+never accepted from model output or coworker request arguments. Direct portal
+and non-MCP autonomous runs continue to omit it, while replay and terminal
+writer recovery retain their existing explicit token projection. This keeps
+the receipt repository's three-part requirement intact: independent reviewer,
+recorded authority decision, and authenticated write/admin token scope.
+
 ## Acceptance criteria traceability
 
 | BI acceptance criterion | Design coverage |


### PR DESCRIPTION
## Summary

- preserve the server-resolved MCP token capability through remote autonomous coworker execution
- pass that trusted scope into governed tool execution without accepting authority from model or request arguments
- document the live reviewer failure and the authorization-context architecture decision

## Root cause

The external reviewer task carried the authenticated token id into the autonomous loop but dropped its server-resolved capability. `record_initiative_design_review` therefore saw no authenticated authority scope and denied an otherwise authorized independent reviewer.

## Verification

- RED: 3 contract failures across `mcp-task-execution`, `autonomous-work-run`, and `agentic-loop`
- GREEN: 139/139 focused tests
- `pnpm --filter @dpf/web typecheck`
- module-size guard
- style-drift guard
- doc index freshness and doc links
- `git diff --check`
- guard-parity preflight: 63/63 clean
- independent semantic review: PASS, receipt `cmtmz6nr301bv01o4admfzu0m`, task `TR-GATE-4B72FB229F2785B56CA166A2`, 0 blocking findings

The full local sandbox gate was bypassed under the operator's explicit instruction because that gate is the defect being repaired.

Local-CI-Override: operator-emergency: operator directed bypass because the local gate is the defect under repair

## Live evidence

- governed upgrade before this descendant repair: `SUR-071C4319`
- served artifact SHA: `c9a729fe3a562a263d648de1474c2a28f6fd3328`
- independent reviewer task: `TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-703AB1AD13D8`
- exact live denial: authenticated reviewer authority and token scope required
- workroom: `WC-53AF759D`
- backlog item: `BI-6804F720`

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md`
- Current code substrate reviewed: `apps/web/lib/mcp-task-execution.ts`, `apps/web/lib/tak/autonomous-work-run.ts`, and `apps/web/lib/tak/agentic-loop.ts`
- Source of truth: the capability resolved by the server for the authenticated MCP token
- Decision: carry that capability alongside token identity through the existing execution seam; never accept authority from task content, model arguments, or caller-provided tool arguments

Docs-Impact-Decision: Internal authorization-context propagation only; no user-facing route, workflow instruction, or UI behavior changes.
