### PR TITLE
fix(readiness): preserve baseline artifact commit

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/terminal-recovery.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/terminal-recovery.test.ts
@@ -6,6 +6,7 @@ import { resolveTerminalInitiativeRecovery } from "./terminal-recovery";
 
 const baseSha = "1".repeat(40);
 const headSha = "2".repeat(40);
+const baselineCommitSha = "5".repeat(40);
 const decision: InitiativeReadinessDecision = {
   decisionId: "IRD-TERMINAL",
   policyVersion: "initiative-readiness.v2",
@@ -83,6 +84,7 @@ describe("terminal initiative recovery", () => {
       artifactRef: {
         kind: "repo-blob-at-commit",
         repositoryFullName: room.repositoryFullName,
+        commitSha: baselineCommitSha,
         path: "docs/superpowers/specs/pinned-design.md",
         providerBlobId: "4".repeat(40),
       },
@@ -93,6 +95,7 @@ describe("terminal initiative recovery", () => {
     expect(ports.resolveRecovery).toHaveBeenCalledWith(expect.objectContaining({
       canonicalArtifact: {
         resolved: true,
+        commitSha: baselineCommitSha,
         path: "docs/superpowers/specs/pinned-design.md",
         providerBlobId: "4".repeat(40),
       },

--- a/apps/web/lib/backlog/initiative-readiness/terminal-recovery.ts
+++ b/apps/web/lib/backlog/initiative-readiness/terminal-recovery.ts
@@ -46,6 +46,7 @@ type BaselinePayload = {
   artifactRef?: {
     kind: "repo-blob-at-commit";
     repositoryFullName: string;
+    commitSha: string;
     path: string;
     providerBlobId: string;
   };
@@ -87,11 +88,13 @@ function parseBaselinePayloads(payloads: unknown[]): BaselinePayload[] | null {
     const artifactRef = ref && typeof ref === "object" && !Array.isArray(ref)
       && (ref as Record<string, unknown>).kind === "repo-blob-at-commit"
       && typeof (ref as Record<string, unknown>).repositoryFullName === "string"
+      && typeof (ref as Record<string, unknown>).commitSha === "string"
       && typeof (ref as Record<string, unknown>).path === "string"
       && typeof (ref as Record<string, unknown>).providerBlobId === "string"
       ? {
         kind: "repo-blob-at-commit" as const,
         repositoryFullName: (ref as Record<string, unknown>).repositoryFullName as string,
+        commitSha: (ref as Record<string, unknown>).commitSha as string,
         path: (ref as Record<string, unknown>).path as string,
         providerBlobId: (ref as Record<string, unknown>).providerBlobId as string,
       }
@@ -200,7 +203,11 @@ export async function resolveTerminalInitiativeRecovery(args: {
 
   const baselineArtifact = baseline.artifactRef?.repositoryFullName.toLocaleLowerCase("en-US")
       === room.repositoryFullName.toLocaleLowerCase("en-US")
-    ? { path: baseline.artifactRef.path, providerBlobId: baseline.artifactRef.providerBlobId }
+    ? {
+      commitSha: baseline.artifactRef.commitSha,
+      path: baseline.artifactRef.path,
+      providerBlobId: baseline.artifactRef.providerBlobId,
+    }
     : null;
   const discovered = baselineArtifact ? null : await ports.discoverArtifact({
       repositoryFullName: room.repositoryFullName,

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -199,6 +199,28 @@ describe("initiative readiness recovery routing", () => {
       .toBe("IBL-7C41");
   });
 
+  it("binds the reader to the canonical artifact commit without changing the Workroom request key", async () => {
+    const artifactCommitSha = "a".repeat(40);
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([
+        grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+      ]) } },
+      dispatchContext,
+      canonicalArtifact: { ...canonicalArtifact, commitSha: artifactCommitSha },
+      expectedCurrentBaselineId: "IBL-7C41",
+    });
+
+    expect(recovery.reviewerRoutes[0]?.requestCoworker).toMatchObject({
+      requestKey: `initiative-readiness:BI-A45D744A:research:${dispatchContext.headSha}`,
+      initiativeReviewBinding: {
+        artifactRef: { commitSha: artifactCommitSha },
+      },
+    });
+    expect(recovery.reviewerRoutes[0]?.requestCoworker.objective).toContain(`at ${artifactCommitSha}`);
+  });
+
   it("escalates with the provider remedy instead of emitting a route no coworker can execute", async () => {
     const recovery = await resolveInitiativeReviewerRecovery({
       decision,

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -152,7 +152,9 @@ export type InitiativeRecoveryDispatchContext = {
  * a pure routing decision over evidence it is handed.
  */
 export type InitiativeRecoveryCanonicalArtifact =
-  | { resolved: true; path: string; providerBlobId: string }
+  // A retained baseline already owns its immutable commit. Newly discovered
+  // branch artifacts omit it and inherit the Workroom head below.
+  | { resolved: true; path: string; providerBlobId: string; commitSha?: string }
   | { resolved: false; nextAction: string };
 
 type ReviewerRouteDb = {
@@ -417,18 +419,19 @@ function requestCoworkerPacket(args: {
   dispatch: InitiativeRecoveryDispatchContext;
   independent: boolean;
   /** Null for a lane whose writer the binding contract does not cover. */
-  artifact: { path: string; providerBlobId: string } | null;
+  artifact: { path: string; providerBlobId: string; commitSha?: string } | null;
   expectedCurrentBaselineId: string | null;
 }) {
   const reviewConstraint = args.independent ? "independently " : "";
+  const reviewSha = args.artifact?.commitSha ?? args.dispatch.headSha;
   const mappingInstruction = args.gate === "objective-mapping"
     ? " Map every current OBJ-* and AC-* statement to post-baseline evidence and submit the proposal with record_initiative_evidence(operation='objective-mapping')."
     : "";
   const base = {
     targetAgent: args.targetAgentId,
-    objective: `For ${args.decision.subject.id} in ${args.dispatch.workroomId} on ${args.dispatch.repositoryFullName}#${args.dispatch.branchName} at ${args.dispatch.headSha}, ${reviewConstraint}address ${args.gate} using ${args.toolName}.${
+    objective: `For ${args.decision.subject.id} in ${args.dispatch.workroomId} on ${args.dispatch.repositoryFullName}#${args.dispatch.branchName} at Workroom head ${args.dispatch.headSha}, ${reviewConstraint}address ${args.gate} using ${args.toolName}.${
       args.artifact
-        ? ` Read ${args.artifact.path} at that commit with ${IMMUTABLE_READER_TOOL},`
+        ? ` Read ${args.artifact.path} at ${reviewSha} with ${IMMUTABLE_READER_TOOL},`
         : ""
     } record a governed receipt only when the gate passes.${mappingInstruction}`,
     questionPacketSummary: `${args.gate} for ${args.decision.subject.id} at ${args.dispatch.headSha.slice(0, 12)}`,
@@ -450,7 +453,7 @@ function requestCoworkerPacket(args: {
       artifactRef: {
         kind: "repo-blob-at-commit" as const,
         repositoryFullName: args.dispatch.repositoryFullName,
-        commitSha: args.dispatch.headSha,
+        commitSha: reviewSha,
         path: args.artifact.path,
         providerBlobId: args.artifact.providerBlobId,
       },


### PR DESCRIPTION
## Summary

Terminal completion recovery reused the approved baseline's path and blob ID but replaced its commit with the later Workroom head. The immutable reader rejected that mixed locator, so the acceptance reviewer could not record objective mapping. This change preserves the baseline commit while keeping the Workroom head as delivery and request identity.

## Changes

- Parse and retain `commitSha` from the current baseline artifact reference.
- Bind reader authority and reviewer instructions to that baseline commit.
- Keep the deterministic request key anchored to the Workroom head.
- Add regressions for a baseline commit that differs from the Workroom head.

## Test plan

- [x] Web typecheck passed.
- [x] Seven affected and downstream Vitest files passed, 35 tests total.
- [x] Style and token drift guard passed.
- [x] All 63 preflight guards passed.
- [x] Exact-tree local CI passed its exhaustive plan, including the production build.
- [ ] Post-merge functional replay on the canonical install; an unmerged branch cannot be verified there.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md` and `docs/superpowers/specs/2026-09-01-completion-readiness-recovery-design.md`.
- Current code substrate reviewed: `apps/web/lib/backlog/initiative-readiness/terminal-recovery.ts` and `apps/web/lib/tak/initiative-readiness-tool-grants.ts`.
- Source of truth: the current approved baseline's complete immutable `artifactRef`.
- Decision: preserve the baseline commit for artifact reads while retaining the Workroom head for the delivery context and deterministic request key.

## Documentation impact

No documentation change is needed. This restores the existing immutable-source contract and adds no operator-facing workflow, route, tool, or configuration.

## Related work

- Backlog item: `BI-EDC0DAF2`
- WWMD decision: repair the packet generator; no baseline workaround or supersession.

## Overlap sweep

No open pull request targets this recovery surface.

## Notes for the reviewer

No schema, migration, dependency, UI, or authorization-grant change is included.
