### PR TITLE
feat(federation): the join file is sufficient — portal-mediated organization membership, slice 1 (BI-4DD1E739)

### DIFF
--- a/apps/web/app/api/v1/federation/membership/sign/route.test.ts
+++ b/apps/web/app/api/v1/federation/membership/sign/route.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { mockAvailable, mockRelay, mockParse } = vi.hoisted(() => ({
+  mockAvailable: vi.fn(),
+  mockRelay: vi.fn(),
+  mockParse: vi.fn(),
+}));
+
+vi.mock("@/lib/federation/membership-relay", () => ({
+  membershipRelayAvailable: mockAvailable,
+  relayMembershipSign: mockRelay,
+  parseMembershipSignRequest: mockParse,
+}));
+
+import { POST } from "./route";
+
+const body = { spec: "dpf.membership-sign/1", csrPem: "-----BEGIN CERTIFICATE REQUEST-----\nAA==\n-----END CERTIFICATE REQUEST-----", enrollmentToken: "t", memberAddress: "http://192.168.0.200:3000" };
+
+function request(payload: unknown = body, headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://test/api/v1/federation/membership/sign", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: typeof payload === "string" ? payload : JSON.stringify(payload),
+  }) as NextRequest;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockAvailable.mockResolvedValue({ available: true, rootPem: "ROOT" });
+  mockParse.mockReturnValue(body);
+  mockRelay.mockResolvedValue({ accepted: true, certPem: "LEAF", chainPems: ["LEAF", "ROOT"], rootPem: "ROOT" });
+});
+
+describe("POST /api/v1/federation/membership/sign", () => {
+  it("is not there on an installation that is not the organization authority", async () => {
+    mockAvailable.mockResolvedValue({ available: false, reason: "not-the-authority" });
+    expect((await POST(request())).status).toBe(404);
+    expect(mockRelay).not.toHaveBeenCalled();
+  });
+
+  it("relays a well-formed request keyed by the caller's address and returns the CA's chain", async () => {
+    const response = await POST(request(body, { "x-forwarded-for": "192.168.0.200, 10.0.0.1" }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ accepted: true, certPem: "LEAF", chainPems: ["LEAF", "ROOT"], rootPem: "ROOT" });
+    expect(mockRelay).toHaveBeenCalledWith({ request: body, callerKey: "192.168.0.200" }, { rootPem: "ROOT" });
+  });
+
+  it("maps refusals to statuses: malformed 400, token or CA refusal 403, CA down 503, rate limit 429 with retry-after", async () => {
+    mockParse.mockReturnValueOnce(null);
+    expect((await POST(request())).status).toBe(400);
+    expect((await POST(request("not json"))).status).toBe(400);
+    mockRelay.mockResolvedValueOnce({ accepted: false, reason: "token-invalid", detail: "expired" });
+    const refused = await POST(request());
+    expect(refused.status).toBe(403);
+    expect(await refused.json()).toEqual({ accepted: false, reason: "token-invalid", detail: "expired" });
+    mockRelay.mockResolvedValueOnce({ accepted: false, reason: "ca-unreachable" });
+    expect((await POST(request())).status).toBe(503);
+    mockRelay.mockResolvedValueOnce({ accepted: false, reason: "rate-limited", retryAfterSeconds: 42 });
+    const limited = await POST(request());
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("retry-after")).toBe("42");
+  });
+});

--- a/apps/web/app/api/v1/federation/membership/sign/route.ts
+++ b/apps/web/app/api/v1/federation/membership/sign/route.ts
@@ -1,0 +1,50 @@
+// @exposure private-mesh
+//
+// POST /api/v1/federation/membership/sign — EP-ZERO-CONFIG-FEDERATION,
+// portal-mediated membership §5.1.
+//
+// A member installation holding an organization join file sends the CSR for a
+// key it generated plus the file's one-time enrollment token. This authority
+// portal relays both to its step-ca over the private compose network and
+// returns the CA's verdict verbatim. No bearer: the enrollment token is the
+// credential, and only the CA can honour it. On an installation that is not
+// the organization authority the route answers 404, so a member never learns
+// anything from a portal that cannot sign.
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { apiErrorResponse } from "@/lib/api/error";
+import {
+  membershipRelayAvailable,
+  parseMembershipSignRequest,
+  relayMembershipSign,
+} from "@/lib/federation/membership-relay";
+
+function callerKey(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  return forwarded || request.headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const relay = await membershipRelayAvailable();
+  if (!relay.available) {
+    return apiErrorResponse("NOT_FOUND", "Not found.", 404);
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiErrorResponse("INVALID_JSON", "Request body must be JSON.", 400);
+  }
+  const parsed = parseMembershipSignRequest(body);
+  if (!parsed) {
+    return NextResponse.json({ accepted: false, reason: "malformed" }, { status: 400 });
+  }
+  const result = await relayMembershipSign({ request: parsed, callerKey: callerKey(request) }, { rootPem: relay.rootPem });
+  if (!result.accepted) {
+    const status = result.reason === "rate-limited" ? 429 : result.reason === "ca-unreachable" ? 503 : 403;
+    const headers = result.retryAfterSeconds ? { "retry-after": String(result.retryAfterSeconds) } : undefined;
+    return NextResponse.json({ accepted: false, reason: result.reason, ...(result.detail ? { detail: result.detail } : {}) }, { status, headers });
+  }
+  return NextResponse.json({ accepted: true, certPem: result.certPem, chainPems: result.chainPems, rootPem: result.rootPem }, { status: 200 });
+}

--- a/apps/web/app/api/v1/federation/work/route.ts
+++ b/apps/web/app/api/v1/federation/work/route.ts
@@ -19,6 +19,7 @@ import {
 import { apiErrorResponse } from "@/lib/api/error";
 import { resolveFederationLinkAuth } from "@/lib/auth/federation-link-token";
 import { resolveFederationIdentity, type FederationIdentityDb } from "@/lib/federation/demand-identity";
+import { recordReachedAtHost, type ReachedAtDb } from "@/lib/federation/reached-at";
 import { buildFederatedWorkPage, type WorkPageDb } from "@/lib/federation/work-page";
 
 const ERROR_STATUS: Record<string, number> = {
@@ -45,6 +46,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   if (authz.role !== "same-org-peer") {
     return apiErrorResponse("LINK_NOT_SAME_ORGANIZATION", "Work sync is available only to a same-organization peer.", 403);
   }
+  // A trusted same-organization peer just reached us at this Host: that is one
+  // of our own addresses, learned without anyone typing it (reached-at.ts).
+  void recordReachedAtHost(prisma as unknown as ReachedAtDb, request.headers.get("x-forwarded-host") ?? request.headers.get("host"));
 
   const url = new URL(request.url);
   const cursor = url.searchParams.get("cursor");

--- a/apps/web/components/platform/federation-links/OrganizationJoinPanel.test.tsx
+++ b/apps/web/components/platform/federation-links/OrganizationJoinPanel.test.tsx
@@ -8,6 +8,7 @@ const {
   mockCancel,
   mockConfirm,
   mockDownload,
+  mockImport,
   mockQueue,
   mockStatus,
 } = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ const {
   mockCancel: vi.fn(),
   mockConfirm: vi.fn(),
   mockDownload: vi.fn(),
+  mockImport: vi.fn(),
   mockQueue: vi.fn(),
   mockStatus: vi.fn(),
 }));
@@ -25,6 +27,7 @@ vi.mock("@/lib/actions/organization-join", () => ({
   cancelOrganizationJoinActionAction: mockCancel,
   downloadIssuedJoinPackageAction: mockDownload,
   getOrganizationJoinActionStatusAction: mockStatus,
+  importOrganizationJoinFileAction: mockImport,
   queueOrganizationJoinActionAction: mockQueue,
 }));
 
@@ -81,6 +84,7 @@ beforeEach(() => {
   mockConfirm.mockResolvedValue(true);
   mockAuthorize.mockResolvedValue({ ok: true });
   mockQueue.mockResolvedValue({ ok: true, actionKey: "ra-join-1" });
+  mockImport.mockResolvedValue({ ok: true, data: { authorityUrl: "http://founder-hub.local:3000", intendedPeer: "windows-dev.local", message: "Joined the organization at founder-hub.local:3000." } });
   mockStatus.mockResolvedValue({
     ok: true,
     actionKey: "ra-join-1",
@@ -143,19 +147,42 @@ describe("OrganizationJoinPanel", () => {
     fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [file] } });
 
     expect(await screen.findByText("founder-hub.local:9000")).toBeTruthy();
-    expect(screen.getByText("windows-dev.local")).toBeTruthy();
+    expect(screen.getAllByText(/windows-dev\.local/).length).toBeGreaterThan(0);
     expect(document.body.textContent).not.toContain("must-never-render");
     expect(screen.getByRole("button", { name: "Join organization" }).hasAttribute("disabled")).toBe(true);
   });
 
-  it("rejects an expired or wrong-installation file before approval", async () => {
-    render(<OrganizationJoinPanel nodes={[member]} />);
+  it("joins through the portal with no installation selected and nothing typed", async () => {
+    render(<OrganizationJoinPanel nodes={[]} />);
     fireEvent.click(screen.getByRole("button", { name: "Join this installation" }));
-    const file = new File([joinPackage(new Date(Date.now() + 10 * 60_000), "another-host.local")], "wrong.dpfjoin");
-    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [file] } });
+    expect(screen.queryByText(/No installation has reported/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Enable secure setup" })).toBeNull();
+    const raw = joinPackage();
+    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [new File([raw], "join.dpfjoin")] } });
+    await screen.findByText("founder-hub.local:9000");
+    fireEvent.click(screen.getByLabelText(/I confirm this file is for windows-dev.local/));
+    fireEvent.click(screen.getByRole("button", { name: "Join organization" }));
 
-    expect((await screen.findByRole("alert")).textContent).toMatch(/created for another installation/i);
+    await waitFor(() => expect(mockImport).toHaveBeenCalledWith(raw));
     expect(mockQueue).not.toHaveBeenCalled();
+    expect((await screen.findByRole("status")).textContent).toMatch(/Joined the organization/);
+  });
+
+  it("rejects an expired file before approval and surfaces the server's wrong-host refusal", async () => {
+    render(<OrganizationJoinPanel nodes={[]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Join this installation" }));
+    const expired = new File([joinPackage(new Date(Date.now() - 60_000))], "expired.dpfjoin");
+    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [expired] } });
+    expect((await screen.findByRole("alert")).textContent).toMatch(/expired/i);
+    expect(mockImport).not.toHaveBeenCalled();
+
+    mockImport.mockResolvedValueOnce({ ok: false, error: "invalid_input", message: "The join file was created for another installation" });
+    const raw = joinPackage(new Date(Date.now() + 10 * 60_000), "another-host.local");
+    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [new File([raw], "wrong.dpfjoin")] } });
+    await screen.findByText("founder-hub.local:9000");
+    fireEvent.click(screen.getByLabelText(/I confirm this file is for another-host.local/));
+    fireEvent.click(screen.getByRole("button", { name: "Join organization" }));
+    expect((await screen.findByRole("alert")).textContent).toMatch(/created for another installation/i);
   });
 
   it("resumes a queued action from server state after refresh", () => {

--- a/apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx
+++ b/apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx
@@ -18,6 +18,7 @@ import {
   cancelOrganizationJoinActionAction,
   downloadIssuedJoinPackageAction,
   getOrganizationJoinActionStatusAction,
+  importOrganizationJoinFileAction,
   queueOrganizationJoinActionAction,
   type OrganizationJoinNodeSummary,
 } from "@/lib/actions/organization-join";
@@ -138,7 +139,6 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const authorityNodes = useMemo(() => nodes.filter((node) => node.role === "authority"), [nodes]);
-  const memberNodes = useMemo(() => nodes.filter((node) => node.role === "member"), [nodes]);
   const selectedNode = nodes.find((node) => node.edgeNodeId === selectedNodeId) ?? null;
 
   useEffect(() => {
@@ -168,9 +168,11 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
   }, [actions]);
 
   function openMode(nextMode: "issue" | "import") {
-    const candidates = nextMode === "issue" ? authorityNodes : memberNodes;
+    // Joining is portal-mediated: choosing the file is the whole act, so the
+    // import side selects no installation. Issuing still runs on the authority's
+    // host action until that side is portal-mediated too.
     setMode(nextMode);
-    setSelectedNodeId(candidates[0]?.edgeNodeId ?? null);
+    setSelectedNodeId(nextMode === "issue" ? authorityNodes[0]?.edgeNodeId ?? null : null);
     setNotice(null);
   }
 
@@ -242,23 +244,14 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
       setNotice({ kind: "error", text: parsed.reason === "join-package-expired" ? "This join file has expired. Create a new one." : "This is not a valid DPF organization join file." });
       return;
     }
-    if (!selectedNode?.hostIdentity || parsed.value.intendedPeer !== selectedNode.hostIdentity) {
-      setNotice({ kind: "error", text: "This join file was created for another installation." });
-      return;
-    }
     setJoinPackage(raw);
     setPackagePreview(parsed.value);
   }
 
-  function queueImport() {
-    if (!selectedNode || !joinPackage || !importConfirmed) return;
+  function importJoinFile() {
+    if (!joinPackage || !importConfirmed) return;
     startTransition(async () => {
-      const result = await queueOrganizationJoinActionAction({
-        actionType: "organization.join.import",
-        edgeNodeId: selectedNode.edgeNodeId,
-        parameters: { joinPackage },
-        operatorConfirmed: true,
-      });
+      const result = await importOrganizationJoinFileAction(joinPackage);
       setJoinPackage(null);
       setPackagePreview(null);
       setImportConfirmed(false);
@@ -267,19 +260,7 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
         setNotice({ kind: "error", text: result.message });
         return;
       }
-      setActions((current) => ({
-        ...current,
-        [selectedNode.edgeNodeId]: {
-          actionKey: result.actionKey,
-          actionType: "organization.join.import",
-          status: "queued",
-          approvalState: "approved",
-          packageReady: false,
-          evidence: {},
-          createdAt: new Date().toISOString(),
-        },
-      }));
-      setNotice({ kind: "success", text: "Organization join approved. The installation will apply and verify it shortly." });
+      setNotice({ kind: "success", text: result.data.message });
     });
   }
 
@@ -309,7 +290,7 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
     });
   }
 
-  const visibleNodes = mode === "issue" ? authorityNodes : mode === "import" ? memberNodes : nodes;
+  const visibleNodes = mode === "issue" ? authorityNodes : mode === "import" ? [] : nodes;
 
   return (
     <section className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5" aria-labelledby="organization-join-heading">
@@ -373,7 +354,7 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
               required
             />
           ) : null}
-          {!selectedNode ? <p className="text-sm text-[var(--dpf-muted)]">No installation has reported the required organization role yet.</p> : null}
+          {mode === "issue" && !selectedNode ? <p className="text-sm text-[var(--dpf-muted)]">No installation has reported the required organization role yet.</p> : null}
           {selectedNode && !selectedNode.ready ? (
             <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
               <p className="text-sm text-[var(--dpf-text)]">{selectedNode.readinessMessage}</p>
@@ -439,8 +420,8 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
             </form>
           ) : null}
 
-          {mode === "import" && selectedNode?.ready && !blocksNewRequest(actions[selectedNode.edgeNodeId]) ? (
-            <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); queueImport(); }}>
+          {mode === "import" ? (
+            <form className="space-y-4" noValidate onSubmit={(event) => { event.preventDefault(); importJoinFile(); }}>
               <FormField name="organization-join-file" label="Choose a .dpfjoin file" required>
                 {(control) => (
                   <input
@@ -467,7 +448,7 @@ export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSu
               {packagePreview ? (
                 <CheckboxField
                   name="confirm-organization-join"
-                  label={<>I confirm this file is for {selectedNode.hostIdentity} and I want this installation to join that organization.</>}
+                  label={<>I confirm this file is for {packagePreview.intendedPeer} and I want this installation to join that organization.</>}
                   checked={importConfirmed}
                   onCheckedChange={setImportConfirmed}
                 />

--- a/apps/web/lib/actions/organization-join.ts
+++ b/apps/web/lib/actions/organization-join.ts
@@ -13,10 +13,13 @@ import {
 } from "@dpf/db/organization-join-action";
 
 import { auth } from "@/lib/auth";
+import { importOrganizationJoinFile } from "@/lib/federation/organization-join-import";
+import { resolveLocalFederationAuthorityUrl } from "@/lib/federation/self-authority";
 import { makeRfcId } from "@/lib/change-management/lifecycle";
 import { assertEncryptionReadyForCredentialWrite } from "@/lib/govern/credential-crypto";
 import { syncUserPrincipal } from "@/lib/identity/principal-linking";
 import { can } from "@/lib/permissions";
+import { ok, type ActionSuccess } from "@/lib/shared/action-result";
 import { isRecord } from "@/lib/shared/coerce";
 import {
   cancelQueuedOrganizationJoinAction,
@@ -325,6 +328,43 @@ export async function queueOrganizationJoinActionAction(input: {
   }
 }
 
+const JOIN_FILE_MAX_BYTES = 64 * 1024;
+
+/**
+ * Portal-mediated join (EP-ZERO-CONFIG-FEDERATION): choosing the join file is
+ * the whole act. The portal generates a key, has the organization CA sign it
+ * through the authority's portal, keeps the material in the federation state
+ * directory, and the next federation tick records the link trusted on both
+ * sides. No edge node, no host script, nothing typed.
+ */
+export interface OrganizationJoinImported {
+  authorityUrl: string;
+  intendedPeer: string;
+  message: string;
+}
+
+export async function importOrganizationJoinFileAction(fileText: string): Promise<
+  ActionSuccess<OrganizationJoinImported> | OrganizationJoinActionFailure
+> {
+  const session = await auth();
+  if (!session?.user?.id) return { ok: false, error: "unauthorized", message: "Sign in required" };
+  if (!can({ platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser }, "manage_platform")) {
+    return { ok: false, error: "forbidden", message: "Platform management access is required" };
+  }
+  if (typeof fileText !== "string" || !fileText.trim() || Buffer.byteLength(fileText, "utf8") > JOIN_FILE_MAX_BYTES) {
+    return { ok: false, error: "invalid_input", message: "This is not a valid DPF organization join file" };
+  }
+  const requestHost = await resolveLocalFederationAuthorityUrl();
+  const result = await importOrganizationJoinFile({ fileText, requestHost });
+  if (!result.imported) return joinImportFailure(result.reason, result.detail);
+  revalidatePath(CONNECTIONS_PATH);
+  return ok({
+    authorityUrl: result.authorityUrl,
+    intendedPeer: result.intendedPeer,
+    message: `Joined the organization at ${new URL(result.authorityUrl).host}. The connection appears here trusted within a few minutes.`,
+  });
+}
+
 export async function getOrganizationJoinActionStatusAction(actionKey: string): Promise<
   | { ok: true; actionKey: string; actionType: string; status: string; approvalState: string; packageReady: boolean; evidence: Record<string, unknown> }
   | OrganizationJoinActionFailure
@@ -398,6 +438,25 @@ function actionFailure(reason: string): OrganizationJoinActionFailure {
       return { ok: false, error: "invalid_input", message: "The organization setup request is not valid" };
   }
 }
+function joinImportFailure(reason: string, detail?: string): OrganizationJoinActionFailure {
+  switch (reason) {
+    case "join-package-expired":
+      return { ok: false, error: "invalid_input", message: "The join file has expired. Create a new one on the organization installation" };
+    case "intended-for-another-host":
+      return { ok: false, error: "invalid_input", message: "The join file was created for another installation" };
+    case "authority-unreachable":
+      return { ok: false, error: "not_ready", message: `The organization installation could not be reached${detail ? ` (${detail})` : ""}` };
+    case "authority-refused":
+      return { ok: false, error: "conflict", message: `The organization installation refused the join file${detail ? ` (${detail})` : ""}. Create a new one and try again` };
+    case "chain-untrusted":
+      return { ok: false, error: "conflict", message: "The certificate the organization installation returned does not match the join file's trust fingerprint" };
+    case "material-not-writable":
+      return { ok: false, error: "not_ready", message: `This installation's state directory is not writable${detail ? ` (${detail})` : ""}` };
+    default:
+      return { ok: false, error: "invalid_input", message: "This is not a valid DPF organization join file" };
+  }
+}
+
 function edgeHostIdentity(value: unknown): string | null {
   if (!isRecord(value)) return null;
   if (typeof value.hostname === "string") return value.hostname;

--- a/apps/web/lib/coworker-lifecycle/capability-completeness.generated.json
+++ b/apps/web/lib/coworker-lifecycle/capability-completeness.generated.json
@@ -1935,7 +1935,7 @@
           "level": 1,
           "directSkills": 0,
           "wildcardSkills": 10,
-          "reachableTools": 124,
+          "reachableTools": 125,
           "heldGrants": [
             "registry_read",
             "backlog_read",
@@ -1953,7 +1953,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "no skill authored for it (10 wildcard only), 124 reachable tool(s)",
+          "detail": "no skill authored for it (10 wildcard only), 125 reachable tool(s)",
           "levelKey": "declared",
           "ceiling": 3,
           "atCeiling": false
@@ -1989,7 +1989,7 @@
           "plane": "toolsAndSkills",
           "level": 1,
           "ceiling": 3,
-          "detail": "no skill authored for it (10 wildcard only), 124 reachable tool(s)"
+          "detail": "no skill authored for it (10 wildcard only), 125 reachable tool(s)"
         },
         {
           "plane": "evidence",
@@ -4826,7 +4826,7 @@
           "level": 1,
           "directSkills": 0,
           "wildcardSkills": 10,
-          "reachableTools": 109,
+          "reachableTools": 110,
           "heldGrants": [
             "registry_read",
             "sandbox_execute",
@@ -4837,7 +4837,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "no skill authored for it (10 wildcard only), 109 reachable tool(s)",
+          "detail": "no skill authored for it (10 wildcard only), 110 reachable tool(s)",
           "levelKey": "declared",
           "ceiling": 3,
           "atCeiling": false
@@ -4873,7 +4873,7 @@
           "plane": "toolsAndSkills",
           "level": 1,
           "ceiling": 3,
-          "detail": "no skill authored for it (10 wildcard only), 109 reachable tool(s)"
+          "detail": "no skill authored for it (10 wildcard only), 110 reachable tool(s)"
         },
         {
           "plane": "evidence",
@@ -4963,7 +4963,7 @@
           "level": 1,
           "directSkills": 0,
           "wildcardSkills": 10,
-          "reachableTools": 109,
+          "reachableTools": 110,
           "heldGrants": [
             "registry_read",
             "sandbox_execute",
@@ -4974,7 +4974,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "no skill authored for it (10 wildcard only), 109 reachable tool(s)",
+          "detail": "no skill authored for it (10 wildcard only), 110 reachable tool(s)",
           "levelKey": "declared",
           "ceiling": 3,
           "atCeiling": false
@@ -5010,7 +5010,7 @@
           "plane": "toolsAndSkills",
           "level": 1,
           "ceiling": 3,
-          "detail": "no skill authored for it (10 wildcard only), 109 reachable tool(s)"
+          "detail": "no skill authored for it (10 wildcard only), 110 reachable tool(s)"
         },
         {
           "plane": "evidence",
@@ -5100,7 +5100,7 @@
           "level": 1,
           "directSkills": 0,
           "wildcardSkills": 10,
-          "reachableTools": 105,
+          "reachableTools": 106,
           "heldGrants": [
             "registry_read",
             "sandbox_execute",
@@ -5110,7 +5110,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "no skill authored for it (10 wildcard only), 105 reachable tool(s)",
+          "detail": "no skill authored for it (10 wildcard only), 106 reachable tool(s)",
           "levelKey": "declared",
           "ceiling": 3,
           "atCeiling": false
@@ -5146,7 +5146,7 @@
           "plane": "toolsAndSkills",
           "level": 1,
           "ceiling": 3,
-          "detail": "no skill authored for it (10 wildcard only), 105 reachable tool(s)"
+          "detail": "no skill authored for it (10 wildcard only), 106 reachable tool(s)"
         },
         {
           "plane": "evidence",
@@ -5236,7 +5236,7 @@
           "level": 1,
           "directSkills": 0,
           "wildcardSkills": 10,
-          "reachableTools": 109,
+          "reachableTools": 110,
           "heldGrants": [
             "registry_read",
             "sandbox_execute",
@@ -5247,7 +5247,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "no skill authored for it (10 wildcard only), 109 reachable tool(s)",
+          "detail": "no skill authored for it (10 wildcard only), 110 reachable tool(s)",
           "levelKey": "declared",
           "ceiling": 3,
           "atCeiling": false
@@ -5283,7 +5283,7 @@
           "plane": "toolsAndSkills",
           "level": 1,
           "ceiling": 3,
-          "detail": "no skill authored for it (10 wildcard only), 109 reachable tool(s)"
+          "detail": "no skill authored for it (10 wildcard only), 110 reachable tool(s)"
         },
         {
           "plane": "evidence",
@@ -8337,7 +8337,7 @@
           "level": 2,
           "directSkills": 33,
           "wildcardSkills": 10,
-          "reachableTools": 159,
+          "reachableTools": 160,
           "heldGrants": [
             "file_read",
             "code_graph_read",
@@ -8360,7 +8360,7 @@
           "unbackedSkillIds": [
             "build-sensitive-domain-requirements"
           ],
-          "detail": "33 skill(s), 159 tool(s); 1 service backing skill(s) missing: build-sensitive-domain-requirements",
+          "detail": "33 skill(s), 160 tool(s); 1 service backing skill(s) missing: build-sensitive-domain-requirements",
           "levelKey": "reachable",
           "ceiling": 3,
           "atCeiling": false
@@ -8384,7 +8384,7 @@
           "plane": "toolsAndSkills",
           "level": 2,
           "ceiling": 3,
-          "detail": "33 skill(s), 159 tool(s); 1 service backing skill(s) missing: build-sensitive-domain-requirements"
+          "detail": "33 skill(s), 160 tool(s); 1 service backing skill(s) missing: build-sensitive-domain-requirements"
         }
       ],
       "blockedPlanes": [
@@ -9387,7 +9387,7 @@
           "level": 3,
           "directSkills": 1,
           "wildcardSkills": 10,
-          "reachableTools": 171,
+          "reachableTools": 172,
           "heldGrants": [
             "file_read",
             "sandbox_execute",
@@ -9402,7 +9402,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "1 skill(s), 171 tool(s), all service backings resolve",
+          "detail": "1 skill(s), 172 tool(s), all service backings resolve",
           "levelKey": "proven",
           "ceiling": 3,
           "atCeiling": true
@@ -10439,7 +10439,7 @@
           "level": 3,
           "directSkills": 3,
           "wildcardSkills": 10,
-          "reachableTools": 75,
+          "reachableTools": 76,
           "heldGrants": [
             "file_read",
             "sandbox_execute",
@@ -10449,7 +10449,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "3 skill(s), 75 tool(s), all service backings resolve",
+          "detail": "3 skill(s), 76 tool(s), all service backings resolve",
           "levelKey": "proven",
           "ceiling": 3,
           "atCeiling": true

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 658,
+  "routeCount": 659,
   "routes": [
     {
       "routePath": "/",
@@ -2787,6 +2787,20 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/v1/federation/introductions/route.ts"
+    },
+    {
+      "routePath": "/api/v1/federation/membership/sign",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "federation",
+        "membership",
+        "sign"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/federation/membership/sign/route.ts",
+      "exposure": "private-mesh"
     },
     {
       "routePath": "/api/v1/federation/proposal",

--- a/apps/web/lib/federation/csr.test.ts
+++ b/apps/web/lib/federation/csr.test.ts
@@ -1,0 +1,109 @@
+import { createPublicKey, createVerify, X509Certificate } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCertificateSigningRequest,
+  classifySan,
+  generateMembershipKeypair,
+  looksLikeCertificateSigningRequest,
+  membershipSanSet,
+} from "./csr";
+
+/** Minimal DER reader: returns the tag, the content bytes and the next offset. */
+function readTlv(buf: Buffer, offset: number): { tag: number; content: Buffer; next: number } {
+  const tag = buf[offset]!;
+  let length = buf[offset + 1]!;
+  let cursor = offset + 2;
+  if (length & 0x80) {
+    const bytes = length & 0x7f;
+    length = 0;
+    for (let index = 0; index < bytes; index++) length = (length << 8) | buf[cursor + index]!;
+    cursor += bytes;
+  }
+  return { tag, content: buf.subarray(cursor, cursor + length), next: cursor + length };
+}
+
+function derOf(pem: string): Buffer {
+  return Buffer.from(pem.replace(/-----[A-Z ]+-----/g, "").replace(/\s+/g, ""), "base64");
+}
+
+describe("classifySan / membershipSanSet", () => {
+  it("classifies the way step-ca does: IP when it parses, DNS otherwise, and dedupes", () => {
+    expect(classifySan("192.168.0.200")).toEqual({ kind: "ip", value: "192.168.0.200" });
+    expect(classifySan("[fe80::1]")).toEqual({ kind: "ip", value: "fe80::1" });
+    expect(classifySan("Dev.Internal")).toEqual({ kind: "dns", value: "dev.internal" });
+    expect(membershipSanSet("192.168.0.200", ["192.168.0.200", " dev.internal ", "DEV.internal", ""])).toEqual(["192.168.0.200", "dev.internal"]);
+  });
+});
+
+describe("buildCertificateSigningRequest", () => {
+  it("emits a PKCS#10 request whose signature verifies with the generated key and which names CN and SANs", () => {
+    const kp = generateMembershipKeypair();
+    const pem = buildCertificateSigningRequest({ privateKeyPem: kp.privateKeyPem, commonName: "192.168.0.200", extraSans: ["dev.internal"] });
+    expect(looksLikeCertificateSigningRequest(pem)).toBe(true);
+
+    const csr = derOf(pem);
+    const outer = readTlv(csr, 0);
+    expect(outer.tag).toBe(0x30);
+    const info = readTlv(outer.content, 0);
+    const algorithm = readTlv(outer.content, info.next);
+    const signature = readTlv(outer.content, algorithm.next);
+    expect(info.tag).toBe(0x30);
+    expect(algorithm.content.toString("hex")).toBe("06082a8648ce3d040302"); // ecdsa-with-SHA256
+    expect(signature.tag).toBe(0x03);
+
+    const infoBytes = outer.content.subarray(0, info.next);
+    const verifier = createVerify("sha256");
+    verifier.update(infoBytes);
+    verifier.end();
+    expect(verifier.verify(createPublicKey(kp.publicKeyPem), signature.content.subarray(1))).toBe(true);
+
+    // CertificationRequestInfo: version, subject, spki, [0] attributes.
+    const version = readTlv(info.content, 0);
+    const subject = readTlv(info.content, version.next);
+    const spki = readTlv(info.content, subject.next);
+    const attributes = readTlv(info.content, spki.next);
+    expect(version.content.toString("hex")).toBe("00");
+    expect(subject.content.includes(Buffer.from("192.168.0.200", "utf8"))).toBe(true);
+    expect(spki.content.equals(createPublicKey(kp.publicKeyPem).export({ type: "spki", format: "der" }).subarray(2))).toBe(true);
+    expect(attributes.tag).toBe(0xa0);
+    // The SAN extension carries the IP as 4 raw octets and the DNS name as IA5.
+    expect(attributes.content.includes(Buffer.from([0x87, 0x04, 192, 168, 0, 200]))).toBe(true);
+    expect(attributes.content.includes(Buffer.concat([Buffer.from([0x82, 0x0c]), Buffer.from("dev.internal", "ascii")]))).toBe(true);
+  });
+
+  it("refuses an empty common name and a foreign key format", () => {
+    const kp = generateMembershipKeypair();
+    expect(() => buildCertificateSigningRequest({ privateKeyPem: kp.privateKeyPem, commonName: " " })).toThrow(/common name/);
+    expect(() => buildCertificateSigningRequest({ privateKeyPem: "not a key", commonName: "x" })).toThrow();
+  });
+
+  it("generates a P-256 key the way step-ca issues for", () => {
+    const kp = generateMembershipKeypair();
+    const key = createPublicKey(kp.publicKeyPem);
+    expect(key.asymmetricKeyType).toBe("ec");
+    expect(key.asymmetricKeyDetails?.namedCurve).toBe("prime256v1");
+    expect(kp.privateKeyPem).toContain("-----BEGIN PRIVATE KEY-----");
+  });
+});
+
+describe("looksLikeCertificateSigningRequest", () => {
+  it("accepts only a bare request block and never a private key", () => {
+    expect(looksLikeCertificateSigningRequest("-----BEGIN CERTIFICATE REQUEST-----\nAA==\n-----END CERTIFICATE REQUEST-----")).toBe(true);
+    expect(looksLikeCertificateSigningRequest("-----BEGIN CERTIFICATE-----\nAA==\n-----END CERTIFICATE-----")).toBe(false);
+    expect(looksLikeCertificateSigningRequest("-----BEGIN CERTIFICATE REQUEST-----\n-----BEGIN PRIVATE KEY-----\n-----END CERTIFICATE REQUEST-----")).toBe(false);
+    expect(looksLikeCertificateSigningRequest(42)).toBe(false);
+    expect(looksLikeCertificateSigningRequest("-----BEGIN CERTIFICATE REQUEST-----".padEnd(20_000, "A") + "-----END CERTIFICATE REQUEST-----")).toBe(false);
+  });
+});
+
+// Keep the fixture module honest: an X509 parse of a CSR must fail, which is
+// exactly why this module exists.
+describe("node has no CSR parser", () => {
+  it("cannot parse a request as a certificate", () => {
+    const kp = generateMembershipKeypair();
+    const pem = buildCertificateSigningRequest({ privateKeyPem: kp.privateKeyPem, commonName: "x" });
+    expect(() => new X509Certificate(pem)).toThrow();
+  });
+});

--- a/apps/web/lib/federation/csr.ts
+++ b/apps/web/lib/federation/csr.ts
@@ -1,0 +1,167 @@
+// EP-ZERO-CONFIG-FEDERATION — portal-mediated membership, key half.
+// Spec: docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md §5.2 step 2.
+//
+// A member installation turns its organization join file into a certificate
+// without a host script: it generates an EC P-256 keypair in the portal
+// process and a PKCS#10 certificate signing request for the hostname the
+// join file was issued for. Node's crypto module can make the key and sign
+// bytes but has no CSR builder, so the DER is assembled here by hand — a
+// handful of ASN.1 shapes, no dependency, no shell-out.
+//
+// The CA's one-time token names the subject and the SANs it will accept, so
+// the CSR carries exactly those: CN = intended hostname; SANs = the hostname
+// plus any extra names, each classified as an IP address or a DNS name the
+// way step-ca classifies them (`x509util.SplitSANs`).
+//
+// Pure: no I/O. The private key never leaves the caller.
+
+import { createPrivateKey, createPublicKey, createSign, generateKeyPairSync, type KeyObject } from "node:crypto";
+import { isIP } from "node:net";
+
+const OID_COMMON_NAME = [2, 5, 4, 3];
+const OID_EXTENSION_REQUEST = [1, 2, 840, 113549, 1, 9, 14];
+const OID_SUBJECT_ALT_NAME = [2, 5, 29, 17];
+const OID_ECDSA_WITH_SHA256 = [1, 2, 840, 10045, 4, 3, 2];
+
+const CSR_BEGIN = "-----BEGIN CERTIFICATE REQUEST-----";
+const CSR_END = "-----END CERTIFICATE REQUEST-----";
+
+function derLength(length: number): Buffer {
+  if (length < 0x80) return Buffer.from([length]);
+  if (length < 0x100) return Buffer.from([0x81, length]);
+  if (length < 0x10000) return Buffer.from([0x82, length >> 8, length & 0xff]);
+  throw new Error("DER value too long");
+}
+
+function tlv(tag: number, ...contents: Buffer[]): Buffer {
+  const body = Buffer.concat(contents);
+  return Buffer.concat([Buffer.from([tag]), derLength(body.length), body]);
+}
+
+const sequence = (...items: Buffer[]) => tlv(0x30, ...items);
+const set = (...items: Buffer[]) => tlv(0x31, ...items);
+const octetString = (bytes: Buffer) => tlv(0x04, bytes);
+const utf8String = (text: string) => tlv(0x0c, Buffer.from(text, "utf8"));
+const integer = (value: number) => tlv(0x02, Buffer.from([value]));
+const bitString = (bytes: Buffer) => tlv(0x03, Buffer.from([0x00]), bytes);
+/** [n] IMPLICIT, constructed. */
+const contextConstructed = (n: number, ...items: Buffer[]) => tlv(0xa0 | n, ...items);
+/** [n] IMPLICIT, primitive. */
+const contextPrimitive = (n: number, bytes: Buffer) => tlv(0x80 | n, bytes);
+
+function objectIdentifier(arcs: readonly number[]): Buffer {
+  const bytes: number[] = [arcs[0]! * 40 + arcs[1]!];
+  for (const arc of arcs.slice(2)) {
+    const stack: number[] = [arc & 0x7f];
+    let rest = arc >> 7;
+    while (rest > 0) {
+      stack.unshift((rest & 0x7f) | 0x80);
+      rest >>= 7;
+    }
+    bytes.push(...stack);
+  }
+  return tlv(0x06, Buffer.from(bytes));
+}
+
+function ipBytes(address: string): Buffer {
+  if (isIP(address) === 4) return Buffer.from(address.split(".").map((octet) => Number(octet)));
+  // IPv6: expand `::` and parse eight 16-bit groups.
+  const [head, tail = ""] = address.split("::");
+  const headGroups = head ? head.split(":") : [];
+  const tailGroups = tail ? tail.split(":") : [];
+  const missing = 8 - headGroups.length - tailGroups.length;
+  const groups = [...headGroups, ...Array.from({ length: missing }, () => "0"), ...tailGroups];
+  const out = Buffer.alloc(16);
+  groups.forEach((group, index) => out.writeUInt16BE(Number.parseInt(group || "0", 16), index * 2));
+  return out;
+}
+
+/** step-ca classifies a token SAN as an IP when it parses as one, else a DNS name. */
+export function classifySan(name: string): { kind: "ip"; value: string } | { kind: "dns"; value: string } {
+  const trimmed = name.trim().replace(/^\[|\]$/g, "");
+  return isIP(trimmed) ? { kind: "ip", value: trimmed } : { kind: "dns", value: trimmed.toLowerCase() };
+}
+
+function generalName(name: string): Buffer {
+  const san = classifySan(name);
+  // GeneralName: iPAddress is [7] IMPLICIT OCTET STRING; dNSName is [2] IMPLICIT
+  // IA5String — the context tag replaces the universal tag in both cases.
+  return san.kind === "ip"
+    ? contextPrimitive(7, ipBytes(san.value))
+    : contextPrimitive(2, Buffer.from(san.value, "ascii"));
+}
+
+/** The SAN set the CA's token names: the subject first, then extra names, deduplicated. */
+export function membershipSanSet(commonName: string, extraSans: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of [commonName, ...extraSans]) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const key = classifySan(trimmed).value;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+export interface MembershipKeypair {
+  /** PKCS#8 PEM. Written mode 0600 by the caller; never leaves the machine. */
+  privateKeyPem: string;
+  /** SubjectPublicKeyInfo PEM. */
+  publicKeyPem: string;
+}
+
+/** EC P-256, the curve step-ca issues for by default. */
+export function generateMembershipKeypair(): MembershipKeypair {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
+  };
+}
+
+function privateKeyFrom(pem: string): KeyObject {
+  return createPrivateKey(pem);
+}
+
+/**
+ * Build a PKCS#10 certificate signing request: CN = `commonName`, SANs =
+ * `membershipSanSet(commonName, extraSans)`, signed ecdsa-with-SHA256 by the
+ * key. Returns PEM.
+ */
+export function buildCertificateSigningRequest(input: {
+  privateKeyPem: string;
+  commonName: string;
+  extraSans?: readonly string[];
+}): string {
+  const commonName = input.commonName.trim();
+  if (!commonName) throw new Error("A common name is required");
+  const privateKey = privateKeyFrom(input.privateKeyPem);
+  const spki = createPublicKey(privateKey).export({ type: "spki", format: "der" });
+  const sans = membershipSanSet(commonName, input.extraSans ?? []);
+
+  const subject = sequence(set(sequence(objectIdentifier(OID_COMMON_NAME), utf8String(commonName))));
+  const sanExtension = sequence(
+    objectIdentifier(OID_SUBJECT_ALT_NAME),
+    octetString(sequence(...sans.map(generalName))),
+  );
+  const extensionRequest = sequence(objectIdentifier(OID_EXTENSION_REQUEST), set(sequence(sanExtension)));
+  const info = sequence(integer(0), subject, spki, contextConstructed(0, extensionRequest));
+
+  const signer = createSign("sha256");
+  signer.update(info);
+  signer.end();
+  const signature = signer.sign(privateKey);
+  const csr = sequence(info, sequence(objectIdentifier(OID_ECDSA_WITH_SHA256)), bitString(signature));
+  const body = csr.toString("base64").match(/.{1,64}/g)?.join("\n") ?? "";
+  return `${CSR_BEGIN}\n${body}\n${CSR_END}\n`;
+}
+
+/** Shape check for a peer-supplied CSR before it is relayed anywhere. */
+export function looksLikeCertificateSigningRequest(value: unknown, maxBytes = 16 * 1024): value is string {
+  if (typeof value !== "string" || value.length > maxBytes) return false;
+  const trimmed = value.trim();
+  return trimmed.startsWith(CSR_BEGIN) && trimmed.endsWith(CSR_END) && !trimmed.includes("PRIVATE KEY");
+}

--- a/apps/web/lib/federation/membership-material.test.ts
+++ b/apps/web/lib/federation/membership-material.test.ts
@@ -1,0 +1,94 @@
+import { X509Certificate } from "node:crypto";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { MEMBER_CERT_PEM, MEMBER_KEY_PKCS8_B64, ORG_ROOT_CERT_PEM } from "./membership-fixtures";
+import {
+  membershipMaterialDir,
+  membershipPathCandidates,
+  membershipPaths,
+  parseMembershipFacts,
+  readMembershipFacts,
+  readMembershipMaterial,
+  readPinnedRoot,
+  writeMembershipMaterial,
+} from "./membership-material";
+
+const now = new Date("2026-09-04T12:00:00.000Z");
+const rootFingerprint = new X509Certificate(ORG_ROOT_CERT_PEM).fingerprint256.replaceAll(":", "").toLowerCase();
+const keyPem = `-----BEGIN PRIVATE KEY-----\n${MEMBER_KEY_PKCS8_B64}\n-----END PRIVATE KEY-----`;
+const facts = { schemaVersion: 1 as const, caUrl: "https://192.168.0.152:9000", intendedPeer: "192.168.0.200", rootFingerprint, packageId: "a".repeat(32), joinedAt: now.toISOString() };
+
+let stateDir: string;
+let env: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  stateDir = await mkdtemp(join(tmpdir(), "dpf-federation-"));
+  env = { DPF_FEDERATION_STATE_DIR: stateDir };
+});
+afterEach(async () => {
+  await rm(stateDir, { recursive: true, force: true });
+});
+
+describe("membership paths", () => {
+  it("prefers the portal home under the federation state directory and falls back to the script home", () => {
+    expect(membershipMaterialDir(env)).toBe(join(stateDir, "pki"));
+    const [portal, legacy] = membershipPathCandidates(env);
+    expect(portal!.cert).toBe(join(stateDir, "pki", "authority.crt"));
+    expect(legacy).toEqual(membershipPaths(env));
+    expect(legacy!.root).toBe("/dpf-state/pki/root_ca.crt");
+    expect(membershipPaths({ DPF_PKI_CERT_PATH: "/x/c.crt" }).cert).toBe("/x/c.crt");
+  });
+});
+
+describe("writeMembershipMaterial / readMembershipMaterial", () => {
+  it("writes the set atomically into <state dir>/pki and reads it back verified against the root", async () => {
+    const written = await writeMembershipMaterial({ rootPem: ORG_ROOT_CERT_PEM, certPem: MEMBER_CERT_PEM, keyPem, facts }, { env });
+    expect(written).toEqual({ written: true, dir: join(stateDir, "pki") });
+    expect((await stat(join(stateDir, "pki", "authority.key"))).isFile()).toBe(true);
+    expect(JSON.parse(await readFile(join(stateDir, "pki", "membership.json"), "utf8"))).toEqual(facts);
+
+    const material = await readMembershipMaterial({ env, now });
+    expect(material?.rootFingerprint).toBe(rootFingerprint);
+    expect(material?.certPem).toBe(MEMBER_CERT_PEM);
+    expect(material?.keyPem).toBe(keyPem);
+    expect(await readPinnedRoot({ env, now })).toEqual({ rootPem: ORG_ROOT_CERT_PEM, rootFingerprint });
+    expect(await readMembershipFacts({ env })).toEqual(facts);
+  });
+
+  it("reports an unmounted federation state directory instead of throwing", async () => {
+    const result = await writeMembershipMaterial({ rootPem: ORG_ROOT_CERT_PEM, certPem: MEMBER_CERT_PEM, keyPem, facts }, { env: { DPF_FEDERATION_STATE_DIR: join(stateDir, "missing") } });
+    expect(result).toEqual({ written: false, reason: "federation state directory is not mounted" });
+  });
+
+  it("falls through to the script home when the portal home is empty, and to null when neither holds a valid set", async () => {
+    const reads: string[] = [];
+    const readText = async (path: string) => {
+      reads.push(path);
+      if (path.startsWith("/dpf-state/pki/")) {
+        if (path.endsWith("root_ca.crt")) return ORG_ROOT_CERT_PEM;
+        if (path.endsWith("authority.crt")) return MEMBER_CERT_PEM;
+        return keyPem;
+      }
+      throw new Error("ENOENT");
+    };
+    const material = await readMembershipMaterial({ env, readText, now });
+    expect(material?.rootFingerprint).toBe(rootFingerprint);
+    expect(reads[0]).toBe(join(stateDir, "pki", "root_ca.crt"));
+
+    expect(await readMembershipMaterial({ env, readText: async () => { throw new Error("ENOENT"); }, now })).toBeNull();
+    expect(await readPinnedRoot({ env, readText: async () => "not a certificate", now })).toBeNull();
+  });
+});
+
+describe("parseMembershipFacts", () => {
+  it("accepts only the v1 shape with a full fingerprint", () => {
+    expect(parseMembershipFacts(facts)).toEqual(facts);
+    expect(parseMembershipFacts({ ...facts, rootFingerprint: "abc" })).toBeNull();
+    expect(parseMembershipFacts({ ...facts, schemaVersion: 2 })).toBeNull();
+    expect(parseMembershipFacts(null)).toBeNull();
+  });
+});

--- a/apps/web/lib/federation/membership-material.ts
+++ b/apps/web/lib/federation/membership-material.ts
@@ -1,0 +1,189 @@
+// EP-ZERO-CONFIG-FEDERATION — where a member's organization material lives.
+// Spec: docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md §5.2 step 5.
+//
+// Two homes, read in this order:
+//   <federation state dir>/pki/   — written by the portal when a join file is
+//                                   imported on the Connections page or through
+//                                   the MCP tool. Read-write mount; survives
+//                                   teardown with DPF_STATE_DIR.
+//   /dpf-state/pki/               — written by the host bootstrap script on an
+//                                   authority (or a member that joined by
+//                                   script). Read-only mount.
+// Each home holds root_ca.crt, authority.crt and authority.key; the portal home
+// also holds membership.json, the join-file facts (CA URL, intended hostname,
+// root fingerprint) a fresh database re-reads at boot.
+//
+// Every read tolerates an absent home — callers get null — and the writer is
+// atomic and private (temp file + rename, mode 0600) like durable-state.ts.
+
+import { chmod, mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { join, posix } from "node:path";
+
+import { isRecord } from "@/lib/shared/coerce";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+import { federationStateDir } from "./durable-state";
+import { verifyMembershipChain } from "./membership-proof";
+
+export interface MembershipMaterial {
+  rootPem: string;
+  rootFingerprint: string;
+  certPem: string;
+  keyPem: string;
+}
+
+export interface MembershipPaths {
+  root: string;
+  cert: string;
+  key: string;
+}
+
+export const MEMBERSHIP_FACTS_FILE = "membership.json";
+const LEGACY_PKI_DIR = "/dpf-state/pki";
+
+/** The portal-owned material directory: `<federation state dir>/pki`. */
+export function membershipMaterialDir(env: Record<string, string | undefined> = process.env): string {
+  return join(federationStateDir(env), "pki");
+}
+
+function pathsIn(dir: string): MembershipPaths {
+  // The script home is a container path; the portal home may be a host temp
+  // directory under test, so it joins with the platform separator.
+  const j = dir.startsWith("/") ? posix.join : join;
+  return { root: j(dir, "root_ca.crt"), cert: j(dir, "authority.crt"), key: j(dir, "authority.key") };
+}
+
+/**
+ * The legacy, script-written home. Explicit DPF_PKI_*_PATH overrides still win
+ * for an operator who moved the PKI directory.
+ */
+export function membershipPaths(env: Record<string, string | undefined> = process.env): MembershipPaths {
+  const legacy = pathsIn(LEGACY_PKI_DIR);
+  return {
+    root: env.DPF_PKI_ROOT_PATH?.trim() || legacy.root,
+    cert: env.DPF_PKI_CERT_PATH?.trim() || legacy.cert,
+    key: env.DPF_PKI_KEY_PATH?.trim() || legacy.key,
+  };
+}
+
+/** Portal home first, script home second. */
+export function membershipPathCandidates(env: Record<string, string | undefined> = process.env): MembershipPaths[] {
+  return [pathsIn(membershipMaterialDir(env)), membershipPaths(env)];
+}
+
+type ReadText = (path: string) => Promise<string>;
+const defaultReadText: ReadText = (path) => readFile(path, "utf8");
+
+async function readMaterialAt(paths: MembershipPaths, read: ReadText, now: Date): Promise<MembershipMaterial | null> {
+  try {
+    const [rootPem, certPem, keyPem] = await Promise.all([read(paths.root), read(paths.cert), read(paths.key)]);
+    const self = verifyMembershipChain({ chainPems: [certPem], pinnedRootPem: rootPem, now });
+    if (!self.verified || !self.presentedRootFingerprint) return null;
+    return { rootPem, rootFingerprint: self.presentedRootFingerprint, certPem, keyPem };
+  } catch {
+    return null;
+  }
+}
+
+/** Read the join-file material from the first home that holds a valid set; null when this install has not joined an organization. */
+export async function readMembershipMaterial(
+  options: { env?: Record<string, string | undefined>; readText?: ReadText; now?: Date } = {},
+): Promise<MembershipMaterial | null> {
+  const read = options.readText ?? defaultReadText;
+  const now = options.now ?? new Date();
+  for (const paths of membershipPathCandidates(options.env)) {
+    const material = await readMaterialAt(paths, read, now);
+    if (material) return material;
+  }
+  return null;
+}
+
+/** Only the root, from the first home that has one: an authority that has not issued itself a member certificate can still ACCEPT proofs. */
+export async function readPinnedRoot(
+  options: { env?: Record<string, string | undefined>; readText?: ReadText; now?: Date } = {},
+): Promise<{ rootPem: string; rootFingerprint: string } | null> {
+  const read = options.readText ?? defaultReadText;
+  const now = options.now ?? new Date();
+  for (const paths of membershipPathCandidates(options.env)) {
+    try {
+      const rootPem = await read(paths.root);
+      const self = verifyMembershipChain({ chainPems: [rootPem], pinnedRootPem: rootPem, now });
+      if (self.verified && self.presentedRootFingerprint) return { rootPem, rootFingerprint: self.presentedRootFingerprint };
+    } catch {
+      // try the next home
+    }
+  }
+  return null;
+}
+
+/** The facts the join file carried, kept beside the material so a fresh database re-reads them. */
+export interface MembershipFactsV1 {
+  schemaVersion: 1;
+  caUrl: string;
+  intendedPeer: string;
+  rootFingerprint: string;
+  packageId: string;
+  joinedAt: string;
+}
+
+export function parseMembershipFacts(value: unknown): MembershipFactsV1 | null {
+  if (!isRecord(value) || value.schemaVersion !== 1) return null;
+  const s = (k: string) => (typeof value[k] === "string" ? (value[k] as string) : "");
+  if (!s("caUrl") || !s("intendedPeer") || !/^[a-f0-9]{64}$/.test(s("rootFingerprint"))) return null;
+  return {
+    schemaVersion: 1,
+    caUrl: s("caUrl"),
+    intendedPeer: s("intendedPeer"),
+    rootFingerprint: s("rootFingerprint"),
+    packageId: s("packageId"),
+    joinedAt: s("joinedAt") || new Date(0).toISOString(),
+  };
+}
+
+export async function readMembershipFacts(
+  options: { env?: Record<string, string | undefined>; readText?: ReadText } = {},
+): Promise<MembershipFactsV1 | null> {
+  const read = options.readText ?? defaultReadText;
+  try {
+    return parseMembershipFacts(JSON.parse((await read(join(membershipMaterialDir(options.env), MEMBERSHIP_FACTS_FILE))).replace(/^﻿/, "")));
+  } catch {
+    return null;
+  }
+}
+
+async function writePrivate(target: string, content: string): Promise<void> {
+  const temp = `${target}.${process.pid}.tmp`;
+  await writeFile(temp, content, { encoding: "utf8", mode: 0o600 });
+  try { await chmod(temp, 0o600); } catch { /* Windows bind mounts ignore modes */ }
+  await rename(temp, target);
+}
+
+/**
+ * Write the material set and the facts file into the portal home. The
+ * federation state directory itself must already exist (the compose mount
+ * provides it); only the `pki` subdirectory is created here. Returns false,
+ * never throws, when the home is not writable — the caller reports it.
+ */
+export async function writeMembershipMaterial(
+  input: { rootPem: string; certPem: string; keyPem: string; facts: MembershipFactsV1 },
+  options: { env?: Record<string, string | undefined>; dir?: string } = {},
+): Promise<{ written: true; dir: string } | { written: false; reason: string }> {
+  const dir = options.dir ?? membershipMaterialDir(options.env);
+  try {
+    const parent = join(dir, "..");
+    if (!(await stat(parent)).isDirectory()) return { written: false, reason: `federation state directory is not a directory: ${parent}` };
+  } catch {
+    return { written: false, reason: "federation state directory is not mounted" };
+  }
+  try {
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    const paths = pathsIn(dir);
+    await writePrivate(paths.key, input.keyPem);
+    await writePrivate(paths.cert, input.certPem);
+    await writePrivate(paths.root, input.rootPem);
+    await writePrivate(join(dir, MEMBERSHIP_FACTS_FILE), JSON.stringify(input.facts, null, 2));
+    return { written: true, dir };
+  } catch (error) {
+    return { written: false, reason: getErrorMessage(error) };
+  }
+}

--- a/apps/web/lib/federation/membership-relay.test.ts
+++ b/apps/web/lib/federation/membership-relay.test.ts
@@ -34,7 +34,8 @@ function auditDb(): RelayDb & { rows: Record<string, unknown> } {
   };
 }
 
-const caAccepts = vi.fn(async () => ({ status: 200, body: { crt: MEMBER_CERT_PEM, ca: ORG_ROOT_CERT_PEM, certChain: [MEMBER_CERT_PEM, ORG_ROOT_CERT_PEM] } }));
+// A real step-ca answers 201 Created with { crt, ca, certChain } (verified live).
+const caAccepts = vi.fn(async () => ({ status: 201, body: { crt: MEMBER_CERT_PEM, ca: ORG_ROOT_CERT_PEM, certChain: [MEMBER_CERT_PEM, ORG_ROOT_CERT_PEM] } }));
 
 beforeEach(() => {
   _resetNearbyPairingRateLimits();

--- a/apps/web/lib/federation/membership-relay.test.ts
+++ b/apps/web/lib/federation/membership-relay.test.ts
@@ -1,0 +1,124 @@
+import { X509Certificate } from "node:crypto";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { buildCertificateSigningRequest, generateMembershipKeypair } from "./csr";
+import { FOREIGN_ROOT_CERT_PEM, MEMBER_CERT_PEM, ORG_ROOT_CERT_PEM, STRANGER_CERT_PEM } from "./membership-fixtures";
+import {
+  MEMBERSHIP_RELAY_AUDIT_KEY,
+  MEMBERSHIP_SIGN_SPEC,
+  caInternalUrl,
+  membershipRelayAvailable,
+  parseMembershipSignRequest,
+  relayMembershipSign,
+  tokenIdHash,
+  type RelayDb,
+} from "./membership-relay";
+import { _resetNearbyPairingRateLimits } from "./nearby-pairing-rate-limit";
+
+const now = new Date("2026-09-04T12:00:00.000Z");
+const kp = generateMembershipKeypair();
+const csrPem = buildCertificateSigningRequest({ privateKeyPem: kp.privateKeyPem, commonName: "192.168.0.200" });
+const request = { spec: MEMBERSHIP_SIGN_SPEC, csrPem, enrollmentToken: "one-time.enrollment.token-1", memberAddress: "http://192.168.0.200:3000" } as const;
+
+function auditDb(): RelayDb & { rows: Record<string, unknown> } {
+  const rows: Record<string, unknown> = {};
+  return {
+    rows,
+    platformConfig: {
+      findUnique: vi.fn(async (args: { where: { key: string } }) => (rows[args.where.key] ? { value: rows[args.where.key] } : null)) as RelayDb["platformConfig"]["findUnique"],
+      upsert: vi.fn(async (args: { where: { key: string }; create: { value: unknown } }) => { rows[args.where.key] = args.create.value; return {}; }) as RelayDb["platformConfig"]["upsert"],
+    },
+  };
+}
+
+const caAccepts = vi.fn(async () => ({ status: 200, body: { crt: MEMBER_CERT_PEM, ca: ORG_ROOT_CERT_PEM, certChain: [MEMBER_CERT_PEM, ORG_ROOT_CERT_PEM] } }));
+
+beforeEach(() => {
+  _resetNearbyPairingRateLimits();
+  caAccepts.mockClear();
+});
+
+describe("parseMembershipSignRequest", () => {
+  it("accepts the v1 shape and refuses anything else before a byte reaches the CA", () => {
+    expect(parseMembershipSignRequest(request)).toEqual({ ...request, csrPem: csrPem.trim() });
+    expect(parseMembershipSignRequest({ ...request, spec: "dpf.membership-sign/2" })).toBeNull();
+    expect(parseMembershipSignRequest({ ...request, csrPem: MEMBER_CERT_PEM })).toBeNull();
+    expect(parseMembershipSignRequest({ ...request, enrollmentToken: "has spaces" })).toBeNull();
+    expect(parseMembershipSignRequest({ ...request, memberAddress: "ftp://x" })).toBeNull();
+    expect(parseMembershipSignRequest(null)).toBeNull();
+  });
+});
+
+describe("membershipRelayAvailable", () => {
+  const rootOnly = async (path: string) => { if (path.endsWith("root_ca.crt")) return ORG_ROOT_CERT_PEM; throw new Error("ENOENT"); };
+
+  it("needs the organization root and proof of being the authority", async () => {
+    expect(await membershipRelayAvailable({ env: {}, readText: async () => { throw new Error("ENOENT"); }, exists: async () => true })).toEqual({ available: false, reason: "no-organization-root" });
+    expect(await membershipRelayAvailable({ env: {}, readText: rootOnly, exists: async () => false })).toEqual({ available: false, reason: "not-the-authority" });
+    expect(await membershipRelayAvailable({ env: { DPF_ORGANIZATION_TRUST_ROLE: "authority" }, readText: rootOnly, exists: async () => false })).toEqual({ available: true, rootPem: ORG_ROOT_CERT_PEM });
+    const seen: string[] = [];
+    expect(await membershipRelayAvailable({ env: {}, readText: rootOnly, exists: async (path) => { seen.push(path); return true; } })).toEqual({ available: true, rootPem: ORG_ROOT_CERT_PEM });
+    expect(seen).toEqual(["/dpf-state/pki/secrets/step-ca-password"]);
+  });
+
+  it("reaches the CA at the compose service by default", () => {
+    expect(caInternalUrl({})).toBe("https://step-ca:9000");
+    expect(caInternalUrl({ DPF_ORGANIZATION_CA_INTERNAL_URL: "https://ca.internal:9443/" })).toBe("https://ca.internal:9443");
+  });
+});
+
+describe("relayMembershipSign", () => {
+  it("returns the CA's chain verbatim once it verifies to the pinned root, and audits without the token", async () => {
+    const db = auditDb();
+    const result = await relayMembershipSign({ request, callerKey: "192.168.0.200", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: caAccepts });
+    expect(result).toEqual({ accepted: true, certPem: MEMBER_CERT_PEM, chainPems: [MEMBER_CERT_PEM, ORG_ROOT_CERT_PEM], rootPem: ORG_ROOT_CERT_PEM });
+    expect(caAccepts).toHaveBeenCalledWith({ caUrl: "https://step-ca:9000", rootPem: ORG_ROOT_CERT_PEM, csrPem: csrPem, enrollmentToken: request.enrollmentToken });
+    const ring = db.rows[MEMBERSHIP_RELAY_AUDIT_KEY] as { events: Array<Record<string, unknown>> };
+    expect(ring.events).toHaveLength(1);
+    expect(ring.events[0]).toMatchObject({ verdict: "accepted", memberAddress: "http://192.168.0.200:3000", tokenId: tokenIdHash(request.enrollmentToken) });
+    expect(JSON.stringify(ring)).not.toContain(request.enrollmentToken);
+  });
+
+  it("relays one call per token: a replay is refused here, not at the CA", async () => {
+    const db = auditDb();
+    await relayMembershipSign({ request, callerKey: "a", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: caAccepts });
+    const replay = await relayMembershipSign({ request, callerKey: "b", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: caAccepts });
+    expect(replay).toMatchObject({ accepted: false, reason: "rate-limited" });
+    expect(caAccepts).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps the CA's verdicts: 401 is token-invalid, other refusals are ca-refused, a failed dial is ca-unreachable", async () => {
+    const db = auditDb();
+    const refused = await relayMembershipSign({ request: { ...request, enrollmentToken: "t2" }, callerKey: "a", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: async () => ({ status: 401, body: { message: "token expired" } }) });
+    expect(refused).toMatchObject({ accepted: false, reason: "token-invalid", detail: "token expired" });
+    const errored = await relayMembershipSign({ request: { ...request, enrollmentToken: "t3" }, callerKey: "a", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: async () => ({ status: 500, body: { message: "database down" } }) });
+    expect(errored).toMatchObject({ accepted: false, reason: "ca-refused" });
+    const down = await relayMembershipSign({ request: { ...request, enrollmentToken: "t4" }, callerKey: "a", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: async () => { throw new Error("ECONNREFUSED"); } });
+    expect(down).toMatchObject({ accepted: false, reason: "ca-unreachable", detail: "ECONNREFUSED" });
+  });
+
+  it("never hands back a chain that does not end at the pinned root", async () => {
+    const db = auditDb();
+    const foreign = await relayMembershipSign(
+      { request, callerKey: "a", now },
+      { rootPem: ORG_ROOT_CERT_PEM, db, post: async () => ({ status: 200, body: { crt: STRANGER_CERT_PEM, ca: FOREIGN_ROOT_CERT_PEM, certChain: [STRANGER_CERT_PEM, FOREIGN_ROOT_CERT_PEM] } }) },
+    );
+    expect(foreign).toMatchObject({ accepted: false, reason: "ca-refused" });
+    expect(String((foreign as { detail?: string }).detail)).toContain("pinned root");
+  });
+
+  it("rate-limits a chatty caller and bounds the audit ring", async () => {
+    const db = auditDb();
+    for (let index = 0; index < 6; index++) {
+      await relayMembershipSign({ request: { ...request, enrollmentToken: `loop-${index}` }, callerKey: "noisy", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: caAccepts });
+    }
+    const seventh = await relayMembershipSign({ request: { ...request, enrollmentToken: "loop-7" }, callerKey: "noisy", now }, { rootPem: ORG_ROOT_CERT_PEM, db, post: caAccepts });
+    expect(seventh).toMatchObject({ accepted: false, reason: "rate-limited" });
+    const ring = db.rows[MEMBERSHIP_RELAY_AUDIT_KEY] as { events: unknown[] };
+    expect(ring.events.length).toBe(7);
+    expect(new X509Certificate(MEMBER_CERT_PEM).subject).toContain("member.internal");
+  });
+});

--- a/apps/web/lib/federation/membership-relay.ts
+++ b/apps/web/lib/federation/membership-relay.ts
@@ -198,7 +198,8 @@ export async function recordMembershipRelayEvent(db: RelayDb, entry: MembershipR
 }
 
 function readCaAnswer(status: number, body: unknown): { certPem: string; chainPems: string[] } | { refused: string } {
-  if (status === 200 && isRecord(body) && typeof body.crt === "string") {
+  // step-ca answers 201 Created (verified against a live CA); 200 is tolerated.
+  if ((status === 200 || status === 201) && isRecord(body) && typeof body.crt === "string") {
     // step-ca answers { crt, ca, certChain }: certChain is leaf-first and
     // already includes crt; an older CA may send only crt + ca.
     const chain = Array.isArray(body.certChain) ? splitPemChain(body.certChain.filter((v): v is string => typeof v === "string")) : [];

--- a/apps/web/lib/federation/membership-relay.ts
+++ b/apps/web/lib/federation/membership-relay.ts
@@ -1,0 +1,269 @@
+// EP-ZERO-CONFIG-FEDERATION — the authority's certificate relay.
+// Spec: docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md §5.1.
+//
+// A member installation holding an organization join file asks the AUTHORITY'S
+// PORTAL — the address it already trusts, on the port it already reaches — to
+// have the organization CA sign a key the member generated. This module is the
+// relay: it forwards the member's CSR and the join file's one-time enrollment
+// token to step-ca's sign API over the private compose network and returns the
+// CA's answer verbatim.
+//
+// Safety invariants (spec §4):
+//   1. The CA decides, the portal relays. No provisioner key lives here; a bad
+//      or reused token is refused by the CA, and that refusal is what the
+//      member sees.
+//   2. The CA is reached over TLS pinned to the organization root the portal
+//      already reads from disk — never the system trust store.
+//   3. One relay per token per window, per-caller rate limit, and an audit ring
+//      (member address, token id hash, CA verdict — never the token).
+//
+// The relay exists only on an installation that holds the organization root
+// AND runs step-ca in its compose chain; elsewhere the route answers 404.
+
+import { createHash } from "node:crypto";
+import { access } from "node:fs/promises";
+import { request as httpsRequest } from "node:https";
+import { checkServerIdentity as tlsCheckServerIdentity, type PeerCertificate } from "node:tls";
+
+import { prisma } from "@dpf/db";
+
+import { isRecord } from "@/lib/shared/coerce";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+import { looksLikeCertificateSigningRequest } from "./csr";
+import { splitPemChain, verifyMembershipChain } from "./membership-proof";
+import { readPinnedRoot } from "./membership-material";
+import { checkNearbyPairingRateLimit } from "./nearby-pairing-rate-limit";
+
+export const MEMBERSHIP_SIGN_PATH = "/api/v1/federation/membership/sign";
+export const MEMBERSHIP_SIGN_SPEC = "dpf.membership-sign/1" as const;
+export const DEFAULT_CA_INTERNAL_URL = "https://step-ca:9000";
+/** PlatformConfig key of the bounded audit ring. */
+export const MEMBERSHIP_RELAY_AUDIT_KEY = "federation.membership.relay.v1";
+const AUDIT_RING_SIZE = 50;
+const RELAY_MAX_PER_MINUTE = 6;
+const SAFE_TOKEN = /^[A-Za-z0-9._-]{1,4096}$/;
+const CA_TIMEOUT_MS = 15_000;
+
+export interface MembershipSignRequest {
+  spec: typeof MEMBERSHIP_SIGN_SPEC;
+  csrPem: string;
+  enrollmentToken: string;
+  memberAddress: string;
+}
+
+export type MembershipSignRefusal = "ca-refused" | "ca-unreachable" | "token-invalid" | "malformed" | "rate-limited";
+
+export type MembershipSignResult =
+  | { accepted: true; certPem: string; chainPems: string[]; rootPem: string }
+  | { accepted: false; reason: MembershipSignRefusal; detail?: string; retryAfterSeconds?: number };
+
+/** Parse an untrusted request body. Null when its shape is wrong. */
+export function parseMembershipSignRequest(value: unknown): MembershipSignRequest | null {
+  if (!isRecord(value) || value.spec !== MEMBERSHIP_SIGN_SPEC) return null;
+  if (!looksLikeCertificateSigningRequest(value.csrPem)) return null;
+  if (typeof value.enrollmentToken !== "string" || !SAFE_TOKEN.test(value.enrollmentToken)) return null;
+  if (typeof value.memberAddress !== "string" || value.memberAddress.length > 400) return null;
+  try {
+    const url = new URL(value.memberAddress);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  } catch {
+    return null;
+  }
+  return { spec: MEMBERSHIP_SIGN_SPEC, csrPem: value.csrPem.trim(), enrollmentToken: value.enrollmentToken, memberAddress: value.memberAddress };
+}
+
+/** The token's id as an audit handle: a hash, never the token. */
+export function tokenIdHash(enrollmentToken: string): string {
+  return createHash("sha256").update(enrollmentToken).digest("hex").slice(0, 16);
+}
+
+export function caInternalUrl(env: Record<string, string | undefined> = process.env): string {
+  return env.DPF_ORGANIZATION_CA_INTERNAL_URL?.trim().replace(/\/+$/, "") || DEFAULT_CA_INTERNAL_URL;
+}
+
+/**
+ * Whether this installation can relay at all: it pins the organization root
+ * AND is the authority — declared by DPF_ORGANIZATION_TRUST_ROLE=authority or
+ * proven by the CA password file the PKI overlay mounts beside the root.
+ */
+export async function membershipRelayAvailable(
+  options: {
+    env?: Record<string, string | undefined>;
+    readText?: (path: string) => Promise<string>;
+    exists?: (path: string) => Promise<boolean>;
+  } = {},
+): Promise<{ available: true; rootPem: string } | { available: false; reason: "no-organization-root" | "not-the-authority" }> {
+  const env = options.env ?? process.env;
+  const root = await readPinnedRoot({ env, readText: options.readText });
+  if (!root) return { available: false, reason: "no-organization-root" };
+  if (env.DPF_ORGANIZATION_TRUST_ROLE?.trim().toLowerCase() === "authority") return { available: true, rootPem: root.rootPem };
+  const exists = options.exists ?? (async (path: string) => { try { await access(path); return true; } catch { return false; } });
+  const passwordFile = env.DPF_PKI_PASSWORD_PATH?.trim() || "/dpf-state/pki/secrets/step-ca-password";
+  if (await exists(passwordFile)) return { available: true, rootPem: root.rootPem };
+  return { available: false, reason: "not-the-authority" };
+}
+
+export interface CaSignResponse {
+  status: number;
+  body: unknown;
+}
+
+/**
+ * POST to step-ca's sign API over TLS pinned to the organization root. The
+ * CA's own certificate names the hostnames the authority was bootstrapped
+ * with (localhost and 127.0.0.1 always among them), not the compose service
+ * name, so identity is checked against the URL host first and those two
+ * bootstrap names second; the chain must still verify to the pinned root.
+ */
+export async function postToCaSign(input: {
+  caUrl: string;
+  rootPem: string;
+  csrPem: string;
+  enrollmentToken: string;
+  timeoutMs?: number;
+}): Promise<CaSignResponse> {
+  const url = new URL(`${input.caUrl}/1.0/sign`);
+  const body = JSON.stringify({ csr: input.csrPem, ott: input.enrollmentToken });
+  const candidates = [url.hostname, "localhost", "127.0.0.1"];
+  return new Promise<CaSignResponse>((resolve, reject) => {
+    const req = httpsRequest(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port || 443,
+        path: url.pathname,
+        method: "POST",
+        headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) },
+        ca: input.rootPem,
+        servername: url.hostname,
+        checkServerIdentity: (_host: string, cert: PeerCertificate) => {
+          let last: Error | undefined;
+          for (const candidate of candidates) {
+            const failure = tlsCheckServerIdentity(candidate, cert);
+            if (!failure) return undefined;
+            last = failure;
+          }
+          return last;
+        },
+        timeout: input.timeoutMs ?? CA_TIMEOUT_MS,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          let parsed: unknown = null;
+          try { parsed = JSON.parse(text); } catch { parsed = { raw: text.slice(0, 500) }; }
+          resolve({ status: res.statusCode ?? 0, body: parsed });
+        });
+      },
+    );
+    req.on("timeout", () => req.destroy(new Error("CA request timed out")));
+    req.on("error", reject);
+    req.end(body);
+  });
+}
+
+export interface RelayDb {
+  platformConfig: {
+    findUnique(args: unknown): Promise<{ value: unknown } | null>;
+    upsert(args: unknown): Promise<unknown>;
+  };
+}
+
+export interface MembershipRelayAuditEntry {
+  at: string;
+  memberAddress: string;
+  tokenId: string;
+  verdict: "accepted" | MembershipSignRefusal;
+  detail?: string;
+}
+
+/** Append to the bounded audit ring; never throws. */
+export async function recordMembershipRelayEvent(db: RelayDb, entry: MembershipRelayAuditEntry): Promise<void> {
+  try {
+    const row = await db.platformConfig.findUnique({ where: { key: MEMBERSHIP_RELAY_AUDIT_KEY }, select: { value: true } });
+    const existing = isRecord(row?.value) && Array.isArray(row.value.events) ? (row.value.events as unknown[]) : [];
+    const events = [...existing.slice(-(AUDIT_RING_SIZE - 1)), entry];
+    await db.platformConfig.upsert({
+      where: { key: MEMBERSHIP_RELAY_AUDIT_KEY },
+      create: { key: MEMBERSHIP_RELAY_AUDIT_KEY, value: { schemaVersion: 1, events } },
+      update: { value: { schemaVersion: 1, events } },
+    });
+  } catch {
+    // The audit ring is best effort; the console line below always lands.
+  }
+  console.log(`[federation] membership relay ${entry.verdict} for ${entry.memberAddress} token=${entry.tokenId}${entry.detail ? ` (${entry.detail})` : ""}`);
+}
+
+function readCaAnswer(status: number, body: unknown): { certPem: string; chainPems: string[] } | { refused: string } {
+  if (status === 200 && isRecord(body) && typeof body.crt === "string") {
+    // step-ca answers { crt, ca, certChain }: certChain is leaf-first and
+    // already includes crt; an older CA may send only crt + ca.
+    const chain = Array.isArray(body.certChain) ? splitPemChain(body.certChain.filter((v): v is string => typeof v === "string")) : [];
+    const leaf = splitPemChain(body.crt)[0] ?? body.crt.trim();
+    const ca = typeof body.ca === "string" ? splitPemChain(body.ca) : [];
+    const rest = chain.length ? chain : ca;
+    const chainPems = rest[0] === leaf ? rest : [leaf, ...rest];
+    return { certPem: leaf, chainPems };
+  }
+  const message = isRecord(body) && typeof body.message === "string" ? body.message : isRecord(body) && typeof body.error === "string" ? body.error : `status ${status}`;
+  return { refused: message.slice(0, 300) };
+}
+
+/**
+ * Relay one signing request. Rate-limited per caller and per token; the CA's
+ * verdict is returned as-is, with the issued chain verified against the pinned
+ * root before it is handed back (a CA that answered with a foreign chain would
+ * be a misconfiguration the member must not trust).
+ */
+export async function relayMembershipSign(
+  input: { request: MembershipSignRequest; callerKey: string; now?: Date },
+  deps: {
+    env?: Record<string, string | undefined>;
+    rootPem: string;
+    db?: RelayDb;
+    post?: typeof postToCaSign;
+  },
+): Promise<MembershipSignResult> {
+  const db = deps.db ?? (prisma as unknown as RelayDb);
+  const now = input.now ?? new Date();
+  const tokenId = tokenIdHash(input.request.enrollmentToken);
+  const audit = (verdict: MembershipRelayAuditEntry["verdict"], detail?: string) =>
+    recordMembershipRelayEvent(db, { at: now.toISOString(), memberAddress: input.request.memberAddress, tokenId, verdict, ...(detail ? { detail } : {}) });
+
+  const byCaller = checkNearbyPairingRateLimit(`membership-sign:caller:${input.callerKey}`, { maxRequests: RELAY_MAX_PER_MINUTE, now });
+  if (!byCaller.allowed) {
+    await audit("rate-limited", "caller");
+    return { accepted: false, reason: "rate-limited", retryAfterSeconds: byCaller.retryAfterSeconds };
+  }
+  const byToken = checkNearbyPairingRateLimit(`membership-sign:token:${tokenId}`, { maxRequests: 1, now });
+  if (!byToken.allowed) {
+    await audit("rate-limited", "token");
+    return { accepted: false, reason: "rate-limited", retryAfterSeconds: byToken.retryAfterSeconds };
+  }
+
+  const post = deps.post ?? postToCaSign;
+  let answer: CaSignResponse;
+  try {
+    answer = await post({ caUrl: caInternalUrl(deps.env), rootPem: deps.rootPem, csrPem: input.request.csrPem, enrollmentToken: input.request.enrollmentToken });
+  } catch (error) {
+    const detail = getErrorMessage(error);
+    await audit("ca-unreachable", detail);
+    return { accepted: false, reason: "ca-unreachable", detail };
+  }
+  const read = readCaAnswer(answer.status, answer.body);
+  if ("refused" in read) {
+    const reason: MembershipSignRefusal = answer.status === 401 || answer.status === 403 || /token|ott|jwt|claim|audience|expired/i.test(read.refused) ? "token-invalid" : "ca-refused";
+    await audit(reason, read.refused);
+    return { accepted: false, reason, detail: read.refused };
+  }
+  const verified = verifyMembershipChain({ chainPems: read.chainPems, pinnedRootPem: deps.rootPem, now });
+  if (!verified.verified) {
+    await audit("ca-refused", `issued chain does not verify to the pinned root: ${verified.failure}`);
+    return { accepted: false, reason: "ca-refused", detail: `issued chain does not verify to the pinned root: ${verified.failure}` };
+  }
+  await audit("accepted", verified.leafSubject ?? undefined);
+  return { accepted: true, certPem: read.certPem, chainPems: read.chainPems, rootPem: deps.rootPem };
+}

--- a/apps/web/lib/federation/organization-join-import.test.ts
+++ b/apps/web/lib/federation/organization-join-import.test.ts
@@ -1,0 +1,143 @@
+import { X509Certificate } from "node:crypto";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@/lib/app-url", () => ({ resolveAppBaseUrl: () => null }));
+
+import { FOREIGN_ROOT_CERT_PEM, MEMBER_CERT_PEM, MEMBER_KEY_PKCS8_B64, ORG_ROOT_CERT_PEM, STRANGER_CERT_PEM } from "./membership-fixtures";
+import { MEMBERSHIP_SIGN_PATH } from "./membership-relay";
+import { importOrganizationJoinFile, ownAddresses, type JoinImportDb } from "./organization-join-import";
+import { FEDERATION_MEMBERSHIP_CONFIG_KEY } from "./organization-membership";
+import { FEDERATION_REACHED_AT_CONFIG } from "./reached-at";
+
+const now = new Date("2026-09-04T12:00:00.000Z");
+const rootFingerprint = new X509Certificate(ORG_ROOT_CERT_PEM).fingerprint256.replaceAll(":", "").toLowerCase();
+const memberKeyPem = `-----BEGIN PRIVATE KEY-----\n${MEMBER_KEY_PKCS8_B64}\n-----END PRIVATE KEY-----`;
+const memberPublicKeyPem = new X509Certificate(MEMBER_CERT_PEM).publicKey.export({ type: "spki", format: "pem" }).toString();
+/** The fixture leaf certifies the fixture key, so the "CA" can answer with it. */
+const fixtureKeypair = () => ({ privateKeyPem: memberKeyPem, publicKeyPem: memberPublicKeyPem });
+
+function joinFile(overrides: Record<string, string> = {}): string {
+  const fields = {
+    package_id: "0123456789abcdef0123456789abcdef",
+    ca_url: "https://192.168.0.152:9000",
+    root_fingerprint: rootFingerprint,
+    intended_hostname: "192.168.0.200",
+    intended_sans: "192.168.0.200",
+    expires_at: String(Math.floor(now.getTime() / 1000) + 600),
+    enrollment_token: "one-time.token_1",
+    edge_client_enrollment_token: "edge.token_1",
+    ...overrides,
+  };
+  return ["DPF_ORGANIZATION_JOIN_V2", ...Object.entries(fields).map(([k, v]) => `${k}=${v}`), ""].join("\n");
+}
+
+function db(rows: Record<string, unknown> = {}): JoinImportDb & { rows: Record<string, unknown> } {
+  return {
+    rows,
+    platformConfig: {
+      findUnique: vi.fn(async (args: { where: { key: string } }) => (rows[args.where.key] ? { value: rows[args.where.key] } : null)) as JoinImportDb["platformConfig"]["findUnique"],
+      upsert: vi.fn(async (args: { where: { key: string }; create: { value: unknown } }) => { rows[args.where.key] = args.create.value; return {}; }) as JoinImportDb["platformConfig"]["upsert"],
+    },
+  };
+}
+
+const authorityAccepts = vi.fn(async () => ({ ok: true, status: 200, body: { accepted: true, certPem: MEMBER_CERT_PEM, chainPems: [MEMBER_CERT_PEM, ORG_ROOT_CERT_PEM], rootPem: ORG_ROOT_CERT_PEM } }));
+const writes: Array<Record<string, unknown>> = [];
+const writeOk = vi.fn(async (input: Record<string, unknown>) => { writes.push(input); return { written: true as const, dir: "/dpf-federation/pki" }; });
+
+beforeEach(() => {
+  authorityAccepts.mockClear();
+  writeOk.mockClear();
+  writes.length = 0;
+});
+
+describe("ownAddresses", () => {
+  it("unions the configured base URL, the request host and the hosts trusted peers reached us at", async () => {
+    const store = db({ [FEDERATION_REACHED_AT_CONFIG]: { schemaVersion: 1, hosts: { "192.168.0.200": now.toISOString(), "dev.internal": now.toISOString() } } });
+    const own = await ownAddresses(store, { requestHost: "http://127.0.0.1:3000", configuredBaseUrl: "https://Portal.Example:8443" });
+    expect([...own].sort()).toEqual(["127.0.0.1", "192.168.0.200", "dev.internal", "portal.example"]);
+  });
+});
+
+describe("importOrganizationJoinFile", () => {
+  it("turns a join file into material with nothing else configured: CSR to the authority's portal, chain pinned, facts recorded", async () => {
+    const store = db();
+    const result = await importOrganizationJoinFile(
+      { fileText: joinFile(), requestHost: "http://192.168.0.200:3000", now },
+      { db: store, post: authorityAccepts, write: writeOk, generateKeypair: fixtureKeypair, configuredBaseUrl: null },
+    );
+    expect(result).toEqual({
+      imported: true, authorityUrl: "http://192.168.0.152:3000", caUrl: "https://192.168.0.152:9000", intendedPeer: "192.168.0.200",
+      expiresAt: new Date((Math.floor(now.getTime() / 1000) + 600) * 1000).toISOString(), materialDir: "/dpf-federation/pki",
+    });
+    const calls = authorityAccepts.mock.calls as unknown as Array<[{ peerAuthorityUrl: string; path: string; sameOrgLan: boolean; cloudEvent: Record<string, unknown> }]>;
+    const call = calls[0]![0];
+    expect(call.peerAuthorityUrl).toBe("http://192.168.0.152:3000");
+    expect(call.path).toBe(MEMBERSHIP_SIGN_PATH);
+    expect(call.sameOrgLan).toBe(true);
+    expect(call.cloudEvent.enrollmentToken).toBe("one-time.token_1");
+    expect(String(call.cloudEvent.csrPem)).toContain("BEGIN CERTIFICATE REQUEST");
+    expect(call.cloudEvent.memberAddress).toBe("http://192.168.0.200:3000");
+    expect(writes[0]).toMatchObject({ rootPem: ORG_ROOT_CERT_PEM, certPem: MEMBER_CERT_PEM, keyPem: memberKeyPem });
+    expect(writes[0]!.facts).toEqual({ schemaVersion: 1, caUrl: "https://192.168.0.152:9000", intendedPeer: "192.168.0.200", rootFingerprint, packageId: "0123456789abcdef0123456789abcdef", joinedAt: now.toISOString() });
+    expect(store.rows[FEDERATION_MEMBERSHIP_CONFIG_KEY]).toEqual(writes[0]!.facts);
+  });
+
+  it("accepts the file over a loopback MCP call when a trusted peer has reached us at the intended host", async () => {
+    const store = db({ [FEDERATION_REACHED_AT_CONFIG]: { schemaVersion: 1, hosts: { "192.168.0.200": now.toISOString() } } });
+    const result = await importOrganizationJoinFile(
+      { fileText: joinFile(), requestHost: "http://127.0.0.1:3000", now },
+      { db: store, post: authorityAccepts, write: writeOk, generateKeypair: fixtureKeypair, configuredBaseUrl: null },
+    );
+    expect(result.imported).toBe(true);
+  });
+
+  it("refuses a wrong-host, expired or tampered file before any network call", async () => {
+    const store = db();
+    const deps = { db: store, post: authorityAccepts, write: writeOk, generateKeypair: fixtureKeypair, configuredBaseUrl: null };
+    expect(await importOrganizationJoinFile({ fileText: joinFile(), requestHost: "http://127.0.0.1:3000", now }, deps)).toMatchObject({ imported: false, reason: "intended-for-another-host" });
+    expect(await importOrganizationJoinFile({ fileText: joinFile({ expires_at: String(Math.floor(now.getTime() / 1000) - 1) }), requestHost: "http://192.168.0.200:3000", now }, deps)).toMatchObject({ imported: false, reason: "join-package-expired" });
+    expect(await importOrganizationJoinFile({ fileText: joinFile({ root_fingerprint: "zz" }), requestHost: "http://192.168.0.200:3000", now }, deps)).toMatchObject({ imported: false, reason: "invalid-join-file" });
+    expect(authorityAccepts).not.toHaveBeenCalled();
+    expect(writeOk).not.toHaveBeenCalled();
+  });
+
+  it("reports an authority that predates the relay, and a CA refusal, without writing anything", async () => {
+    const store = db();
+    const base = { db: store, write: writeOk, generateKeypair: fixtureKeypair, configuredBaseUrl: null };
+    const stale = await importOrganizationJoinFile({ fileText: joinFile(), requestHost: "http://192.168.0.200:3000", now }, { ...base, post: async () => ({ ok: false, status: 404, body: undefined }) });
+    expect(stale).toMatchObject({ imported: false, reason: "authority-unreachable" });
+    expect(String((stale as { detail?: string }).detail)).toContain("current release");
+    const refused = await importOrganizationJoinFile({ fileText: joinFile(), requestHost: "http://192.168.0.200:3000", now }, { ...base, post: async () => ({ ok: false, status: 403, body: { accepted: false, reason: "token-invalid", detail: "token expired" } }) });
+    expect(refused).toEqual({ imported: false, reason: "authority-refused", detail: "token-invalid: token expired" });
+    expect(writeOk).not.toHaveBeenCalled();
+  });
+
+  it("refuses a chain that ends at a root other than the one the file pins, or a leaf for another key", async () => {
+    const store = db();
+    const base = { db: store, write: writeOk, generateKeypair: fixtureKeypair, configuredBaseUrl: null };
+    const foreign = await importOrganizationJoinFile(
+      { fileText: joinFile(), requestHost: "http://192.168.0.200:3000", now },
+      { ...base, post: async () => ({ ok: true, status: 200, body: { accepted: true, certPem: STRANGER_CERT_PEM, chainPems: [STRANGER_CERT_PEM, FOREIGN_ROOT_CERT_PEM], rootPem: FOREIGN_ROOT_CERT_PEM } }) },
+    );
+    expect(foreign).toMatchObject({ imported: false, reason: "chain-untrusted" });
+    const otherKey = await importOrganizationJoinFile(
+      { fileText: joinFile(), requestHost: "http://192.168.0.200:3000", now },
+      { ...base, post: authorityAccepts, generateKeypair: undefined },
+    );
+    expect(otherKey).toMatchObject({ imported: false, reason: "chain-untrusted", detail: expect.stringContaining("not for the key") });
+    expect(writeOk).not.toHaveBeenCalled();
+  });
+
+  it("reports an unwritable state directory as the outcome", async () => {
+    const store = db();
+    const result = await importOrganizationJoinFile(
+      { fileText: joinFile(), requestHost: "http://192.168.0.200:3000", now },
+      { db: store, post: authorityAccepts, generateKeypair: fixtureKeypair, configuredBaseUrl: null, write: async () => ({ written: false, reason: "federation state directory is not mounted" }) },
+    );
+    expect(result).toEqual({ imported: false, reason: "material-not-writable", detail: "federation state directory is not mounted" });
+    expect(store.rows[FEDERATION_MEMBERSHIP_CONFIG_KEY]).toBeUndefined();
+  });
+});

--- a/apps/web/lib/federation/organization-join-import.ts
+++ b/apps/web/lib/federation/organization-join-import.ts
@@ -1,0 +1,191 @@
+// EP-ZERO-CONFIG-FEDERATION — importing the organization join file, member side.
+// Spec: docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md §5.2.
+//
+// Choosing the join file IS joining. Everything runs inside this portal:
+//   1. parse and validate the file; refuse one intended for another host
+//      before any network call;
+//   2. generate a keypair and a CSR for the intended hostname and SANs;
+//   3. ask the authority's PORTAL (derived from the CA URL, never typed) to
+//      have the organization CA sign it;
+//   4. verify the returned chain against the root fingerprint the file pins;
+//   5. write the material under the federation state directory and record the
+//      facts; the next federation tick enrols and the link is born trusted.
+// No edge node, no host script, no overlay, no `.env` line.
+
+import { createPublicKey, X509Certificate } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+import { parseOrganizationJoinPackageMaterial } from "@dpf/db/organization-join-action";
+
+import { resolveAppBaseUrl } from "@/lib/app-url";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+import { postToPeer } from "./client";
+import { buildCertificateSigningRequest, classifySan, generateMembershipKeypair } from "./csr";
+import { splitPemChain, verifyMembershipChain } from "./membership-proof";
+import { writeMembershipMaterial, type MembershipFactsV1 } from "./membership-material";
+import { MEMBERSHIP_SIGN_PATH, MEMBERSHIP_SIGN_SPEC } from "./membership-relay";
+import { deriveAuthorityPortalUrls, FEDERATION_MEMBERSHIP_CONFIG_KEY } from "./organization-membership";
+import { readReachedAtHosts, type ReachedAtDb } from "./reached-at";
+
+export type JoinImportDb = ReachedAtDb;
+
+export type JoinImportRefusal =
+  | "invalid-join-file"
+  | "join-package-expired"
+  | "intended-for-another-host"
+  | "authority-unreachable"
+  | "authority-refused"
+  | "chain-untrusted"
+  | "material-not-writable";
+
+export type JoinImportResult =
+  | { imported: true; authorityUrl: string; caUrl: string; intendedPeer: string; expiresAt: string; materialDir: string }
+  | { imported: false; reason: JoinImportRefusal; detail?: string };
+
+function hostnameOf(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url.includes("://") ? url : `http://${url}`).hostname.toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The hostnames this installation answers to, none of them typed: the
+ * configured base URL, the host the current request arrived on, and the hosts
+ * trusted peers have reached us at.
+ */
+export async function ownAddresses(
+  db: JoinImportDb,
+  input: { requestHost?: string | null; configuredBaseUrl?: string | null } = {},
+): Promise<Set<string>> {
+  const out = new Set<string>();
+  const configured = input.configuredBaseUrl === undefined ? resolveAppBaseUrl() : input.configuredBaseUrl;
+  for (const candidate of [hostnameOf(configured), hostnameOf(input.requestHost), ...(await readReachedAtHosts(db))]) {
+    if (candidate) out.add(classifySan(candidate).value);
+  }
+  return out;
+}
+
+/** The leaf must certify OUR key; a certificate for any other key is useless and suspect. */
+function certifiesKey(chainPems: readonly string[], publicKeyPem: string): boolean {
+  try {
+    const leaf = new X509Certificate(splitPemChain(chainPems)[0] ?? "");
+    const ours = createPublicKey(publicKeyPem).export({ type: "spki", format: "der" });
+    return leaf.publicKey.export({ type: "spki", format: "der" }).equals(ours);
+  } catch {
+    return false;
+  }
+}
+
+function fingerprintOf(pem: string): string | null {
+  try {
+    return new X509Certificate(pem).fingerprint256.replaceAll(":", "").toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export async function importOrganizationJoinFile(
+  input: { fileText: string; requestHost?: string | null; now?: Date },
+  deps: {
+    db?: JoinImportDb;
+    env?: Record<string, string | undefined>;
+    configuredBaseUrl?: string | null;
+    post?: typeof postToPeer;
+    write?: typeof writeMembershipMaterial;
+    generateKeypair?: typeof generateMembershipKeypair;
+  } = {},
+): Promise<JoinImportResult> {
+  const db = deps.db ?? (prisma as unknown as JoinImportDb);
+  const now = input.now ?? new Date();
+
+  // 1. The file, and whom it is for — refused before any network call.
+  const parsed = parseOrganizationJoinPackageMaterial(input.fileText, now);
+  if (!parsed.ok) {
+    return { imported: false, reason: parsed.reason === "join-package-expired" ? "join-package-expired" : "invalid-join-file", detail: parsed.reason };
+  }
+  const pkg = parsed.value;
+  const own = await ownAddresses(db, { requestHost: input.requestHost, configuredBaseUrl: deps.configuredBaseUrl });
+  if (!own.has(classifySan(pkg.intendedPeer).value)) {
+    return { imported: false, reason: "intended-for-another-host", detail: `the file is for ${pkg.intendedPeer}` };
+  }
+
+  // 2. A key that never leaves this machine, and the request to certify it.
+  const keypair = (deps.generateKeypair ?? generateMembershipKeypair)();
+  const csrPem = buildCertificateSigningRequest({ privateKeyPem: keypair.privateKeyPem, commonName: pkg.intendedPeer, extraSans: pkg.intendedSans });
+
+  // 3. The authority's portal, derived from the CA URL exactly as enrolment does.
+  const authorityUrls = deriveAuthorityPortalUrls(pkg.caUrl);
+  if (authorityUrls.length === 0) return { imported: false, reason: "invalid-join-file", detail: "the CA URL names no host" };
+  const memberAddress = `http://${pkg.intendedPeer.includes(":") ? `[${pkg.intendedPeer}]` : pkg.intendedPeer}:3000`;
+  const post = deps.post ?? postToPeer;
+  let answer: { certPem: string; chainPems: string[]; rootPem: string; authorityUrl: string } | null = null;
+  let failure: { reason: JoinImportRefusal; detail: string } | null = null;
+  for (const authorityUrl of authorityUrls) {
+    const res = await post({
+      peerAuthorityUrl: authorityUrl,
+      linkToken: "dpflink_membership-sign",
+      path: MEMBERSHIP_SIGN_PATH,
+      cloudEvent: { spec: MEMBERSHIP_SIGN_SPEC, csrPem, enrollmentToken: pkg.enrollmentToken, memberAddress },
+      sameOrgLan: true,
+    });
+    const body = res.body as { accepted?: boolean; reason?: string; detail?: string; certPem?: string; chainPems?: unknown; rootPem?: string } | undefined;
+    if (res.ok && body?.accepted === true && typeof body.certPem === "string" && typeof body.rootPem === "string") {
+      const chainPems = Array.isArray(body.chainPems) ? body.chainPems.filter((v): v is string => typeof v === "string") : [];
+      answer = { certPem: body.certPem, chainPems: chainPems.length ? chainPems : [body.certPem], rootPem: body.rootPem, authorityUrl };
+      break;
+    }
+    if (res.status === 404) {
+      failure = { reason: "authority-unreachable", detail: `${authorityUrl} has no membership relay (the organization installation needs the current release)` };
+      continue;
+    }
+    if (body && body.accepted === false) {
+      failure = { reason: "authority-refused", detail: `${body.reason ?? "refused"}${body.detail ? `: ${body.detail}` : ""}` };
+      // The CA's verdict is final; a second portal URL would spend nothing more.
+      break;
+    }
+    failure = { reason: "authority-unreachable", detail: res.error ? `${authorityUrl}: ${res.error}` : `${authorityUrl} answered ${res.status}` };
+  }
+  if (!answer) return { imported: false, reason: failure?.reason ?? "authority-unreachable", detail: failure?.detail };
+
+  // 4. Trust only a chain that ends at the root the file pins.
+  const pinnedFingerprint = pkg.rootFingerprint.toLowerCase();
+  const returnedRootFingerprint = fingerprintOf(answer.rootPem);
+  if (!returnedRootFingerprint || returnedRootFingerprint !== pinnedFingerprint) {
+    return { imported: false, reason: "chain-untrusted", detail: "the authority returned a root other than the one the join file pins" };
+  }
+  const chain = verifyMembershipChain({ chainPems: answer.chainPems, pinnedRootPem: answer.rootPem, now });
+  if (!chain.verified) return { imported: false, reason: "chain-untrusted", detail: chain.failure ?? undefined };
+  if (!certifiesKey(answer.chainPems, keypair.publicKeyPem)) {
+    return { imported: false, reason: "chain-untrusted", detail: "the certificate is not for the key this installation generated" };
+  }
+  // Keep the leaf and any intermediates; the pinned root lives in its own file.
+  const certPem = splitPemChain(answer.chainPems).filter((pem) => fingerprintOf(pem) !== pinnedFingerprint).join("\n");
+
+  // 5. Material and facts on disk, facts in the database.
+  const facts: MembershipFactsV1 = {
+    schemaVersion: 1,
+    caUrl: pkg.caUrl,
+    intendedPeer: pkg.intendedPeer,
+    rootFingerprint: pinnedFingerprint,
+    packageId: pkg.packageId,
+    joinedAt: now.toISOString(),
+  };
+  const written = await (deps.write ?? writeMembershipMaterial)({ rootPem: answer.rootPem, certPem, keyPem: keypair.privateKeyPem, facts }, { env: deps.env });
+  if (!written.written) return { imported: false, reason: "material-not-writable", detail: written.reason };
+  try {
+    await db.platformConfig.upsert({
+      where: { key: FEDERATION_MEMBERSHIP_CONFIG_KEY },
+      create: { key: FEDERATION_MEMBERSHIP_CONFIG_KEY, value: facts },
+      update: { value: facts },
+    });
+  } catch (error) {
+    // The facts file beside the material is the durable copy; the row is a cache.
+    console.warn(`[federation] membership facts row not written: ${getErrorMessage(error)}`);
+  }
+  console.log(`[federation] joined the organization at ${answer.authorityUrl} as ${pkg.intendedPeer} (material in ${written.dir})`);
+  return { imported: true, authorityUrl: answer.authorityUrl, caUrl: pkg.caUrl, intendedPeer: pkg.intendedPeer, expiresAt: pkg.expiresAt.toISOString(), materialDir: written.dir };
+}

--- a/apps/web/lib/federation/organization-membership.test.ts
+++ b/apps/web/lib/federation/organization-membership.test.ts
@@ -19,6 +19,7 @@ import {
   buildMembershipProof,
   deriveAuthorityPortalUrls,
   enrolWithOrganizationAuthority,
+  readJoinPackageFacts,
   readMembershipMaterial,
   reconcileOrganizationMembership,
   type MembershipDb,
@@ -143,6 +144,27 @@ describe("acceptOrganizationEnrolment", () => {
     expect(await acceptOrganizationEnrolment(authority.db, { envelope: built, localAuthorityUrl: "http://x", displayName: "P", now, readText: async () => { throw new Error("no pki"); } }))
       .toMatchObject({ accepted: false, status: 404, reason: "organization-trust-not-configured" });
     expect(authority.created).toHaveLength(0);
+  });
+});
+
+describe("readJoinPackageFacts", () => {
+  it("reads the portal-mediated facts row first and only then the script-era host action", async () => {
+    const facts = { schemaVersion: 1, caUrl: "https://192.168.0.152:9000", intendedPeer: "192.168.0.200", rootFingerprint, packageId: "b".repeat(32), joinedAt: now.toISOString() };
+    const remoteAction = { findFirst: vi.fn().mockResolvedValue(null) };
+    const db = {
+      platformConfig: { findUnique: vi.fn(async (args: { where: { key: string } }) => (args.where.key === "federation.membership.v1" ? { value: facts } : null)) },
+      federationLink: { findMany: vi.fn().mockResolvedValue([]) },
+      remoteAction,
+      $transaction: vi.fn(),
+    } as unknown as MembershipDb;
+    expect(await readJoinPackageFacts(db, () => null, { readText: async () => { throw new Error("ENOENT"); } })).toEqual({
+      caUrl: "https://192.168.0.152:9000", intendedPeer: "192.168.0.200", rootFingerprint,
+    });
+    expect(remoteAction.findFirst).not.toHaveBeenCalled();
+
+    const empty = { ...db, platformConfig: { findUnique: vi.fn().mockResolvedValue(null) } } as unknown as MembershipDb;
+    expect(await readJoinPackageFacts(empty, () => null, { readText: async () => { throw new Error("ENOENT"); } })).toBeNull();
+    expect(remoteAction.findFirst).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/lib/federation/organization-membership.ts
+++ b/apps/web/lib/federation/organization-membership.ts
@@ -1,14 +1,12 @@
 // EP-ZERO-CONFIG-FEDERATION §5.6 — membership-proof pairing, runtime half.
 //
-// Membership material is what the organization join package left on disk:
-//   <state dir>/pki/root_ca.crt   — the organization root (pinned)
-//   <state dir>/pki/authority.crt — this installation's certificate, issued by
-//                                   the organization CA
-//   <state dir>/pki/authority.key — its private key
-// The portal reads them from the read-only /dpf-state mount (the same paths the
-// LDAPS listener already uses). With that material an installation can PROVE
-// membership to a peer at the message layer (membership-proof.ts) and ACCEPT a
-// peer's proof — no TLS overlay, no invitation token, no click.
+// Membership material is what importing the organization join file left on
+// disk — root_ca.crt (the pinned organization root), authority.crt (this
+// installation's certificate, issued by the organization CA) and
+// authority.key — in one of the two homes membership-material.ts reads. With
+// that material an installation can PROVE membership to a peer at the message
+// layer (membership-proof.ts) and ACCEPT a peer's proof — no TLS overlay, no
+// invitation token, no click.
 //
 // The authority installation is the one whose CA issued the join package; its
 // portal is reached at the CA host on the portal port (derived, never typed).
@@ -18,7 +16,6 @@
 // DB and filesystem are injected so the policy runs under unit test.
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
 
 import { prisma } from "@dpf/db";
 import type { FederationRole } from "@dpf/db/federation-link-types";
@@ -35,6 +32,13 @@ import { postToPeer, type PeerPostResult } from "./client";
 import { resolveFederationIdentity, type FederationIdentityDb } from "./demand-identity";
 import { createFederationLinkRow } from "./enrollment";
 import {
+  parseMembershipFacts,
+  readMembershipFacts,
+  readMembershipMaterial,
+  readPinnedRoot,
+  type MembershipMaterial,
+} from "./membership-material";
+import {
   checkMembershipStatement,
   parseMembershipStatement,
   signMembershipStatement,
@@ -46,59 +50,17 @@ import {
 } from "./membership-proof";
 import { generateLinkToken } from "./tokens";
 
+export { membershipPaths, readMembershipMaterial, readPinnedRoot, type MembershipMaterial } from "./membership-material";
+
 export const ORGANIZATION_ENROLL_PATH = "/api/v1/federation/enroll/organization";
+/** PlatformConfig key holding the join-file facts a portal-mediated import recorded. */
+export const FEDERATION_MEMBERSHIP_CONFIG_KEY = "federation.membership.v1";
 const SAME_ORG_ROLE: FederationRole = "same-org-peer";
 const SAME_ORG_PROJECTION = {
   includeSlices: ["demand"],
   excludeSlices: ["localBacklog", "workCapsule", "privatePlanning", "attachments", "customerContext"],
   retentionClass: "standard",
 };
-
-export interface MembershipMaterial {
-  rootPem: string;
-  rootFingerprint: string;
-  certPem: string;
-  keyPem: string;
-}
-
-export function membershipPaths(env: Record<string, string | undefined> = process.env): { root: string; cert: string; key: string } {
-  return {
-    root: env.DPF_PKI_ROOT_PATH?.trim() || "/dpf-state/pki/root_ca.crt",
-    cert: env.DPF_PKI_CERT_PATH?.trim() || "/dpf-state/pki/authority.crt",
-    key: env.DPF_PKI_KEY_PATH?.trim() || "/dpf-state/pki/authority.key",
-  };
-}
-
-/** Read the join-package material; null when this install has not joined an organization. */
-export async function readMembershipMaterial(
-  options: { env?: Record<string, string | undefined>; readText?: (path: string) => Promise<string> } = {},
-): Promise<MembershipMaterial | null> {
-  const paths = membershipPaths(options.env);
-  const read = options.readText ?? ((path: string) => readFile(path, "utf8"));
-  try {
-    const [rootPem, certPem, keyPem] = await Promise.all([read(paths.root), read(paths.cert), read(paths.key)]);
-    const self = verifyMembershipChain({ chainPems: [certPem], pinnedRootPem: rootPem, now: new Date() });
-    if (!self.verified || !self.presentedRootFingerprint) return null;
-    return { rootPem, rootFingerprint: self.presentedRootFingerprint, certPem, keyPem };
-  } catch {
-    return null;
-  }
-}
-
-/** Only the root: an authority that has not issued itself a member certificate can still ACCEPT proofs. */
-export async function readPinnedRoot(
-  options: { env?: Record<string, string | undefined>; readText?: (path: string) => Promise<string> } = {},
-): Promise<{ rootPem: string; rootFingerprint: string } | null> {
-  const paths = membershipPaths(options.env);
-  const read = options.readText ?? ((path: string) => readFile(path, "utf8"));
-  try {
-    const rootPem = await read(paths.root);
-    const self = verifyMembershipChain({ chainPems: [rootPem], pinnedRootPem: rootPem, now: new Date() });
-    return self.verified && self.presentedRootFingerprint ? { rootPem, rootFingerprint: self.presentedRootFingerprint } : null;
-  } catch {
-    return null;
-  }
-}
 
 export interface MembershipDb extends FederationIdentityDb {
   platformConfig: FederationIdentityDb["platformConfig"] & {
@@ -271,11 +233,21 @@ export async function acceptOrganizationEnrolment(
  * organization: the CA host (where the authority lives) and the hostname the
  * package was issued for (this installation's own reachable name). Expiry is
  * ignored on purpose — the package was consumed long ago; its facts still hold.
+ *
+ * Read order: the PlatformConfig row a portal-mediated import wrote, then the
+ * facts file beside the material (a fresh database re-reads it), then the
+ * completed `organization.join.import` host action a script-era member left.
  */
 export async function readJoinPackageFacts(
   db: MembershipDb,
   decrypt: (stored: string) => string | null = decryptSecret,
+  options: { env?: Record<string, string | undefined>; readText?: (path: string) => Promise<string> } = {},
 ): Promise<{ caUrl: string; intendedPeer: string; rootFingerprint: string } | null> {
+  const row = await db.platformConfig.findUnique({ where: { key: FEDERATION_MEMBERSHIP_CONFIG_KEY }, select: { value: true } });
+  const recorded = parseMembershipFacts(row?.value);
+  if (recorded) return { caUrl: recorded.caUrl, intendedPeer: recorded.intendedPeer, rootFingerprint: recorded.rootFingerprint };
+  const onDisk = await readMembershipFacts(options);
+  if (onDisk) return { caUrl: onDisk.caUrl, intendedPeer: onDisk.intendedPeer, rootFingerprint: onDisk.rootFingerprint };
   if (!db.remoteAction) return null;
   const record = await db.remoteAction.findFirst({
     where: { actionType: "organization.join.import", status: "completed" },
@@ -407,7 +379,7 @@ export async function reconcileOrganizationMembership(
     const env = deps.env ?? process.env;
     const material = await readMembershipMaterial({ env, readText: deps.readText });
     if (!material) return { outcome: "not-a-member" };
-    const facts = await readJoinPackageFacts(db);
+    const facts = await readJoinPackageFacts(db, decryptSecret, { env, readText: deps.readText });
     const caUrl = deps.caUrl ?? facts?.caUrl ?? env.DPF_ORGANIZATION_CA_URL ?? null;
     if (!caUrl) return { outcome: "no-authority", detail: "No organization CA URL is recorded on this installation." };
     const authorityUrls = deriveAuthorityPortalUrls(caUrl);

--- a/apps/web/lib/federation/reached-at.test.ts
+++ b/apps/web/lib/federation/reached-at.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FEDERATION_REACHED_AT_CONFIG, hostnameFromHostHeader, readReachedAtHosts, recordReachedAtHost, type ReachedAtDb } from "./reached-at";
+
+const now = new Date("2026-09-04T12:00:00.000Z");
+
+function db(initial?: unknown): ReachedAtDb & { rows: Record<string, unknown>; upserts: number } {
+  const rows: Record<string, unknown> = initial ? { [FEDERATION_REACHED_AT_CONFIG]: initial } : {};
+  const store = {
+    rows,
+    upserts: 0,
+    platformConfig: {
+      findUnique: vi.fn(async (args: { where: { key: string } }) => (rows[args.where.key] ? { value: rows[args.where.key] } : null)) as ReachedAtDb["platformConfig"]["findUnique"],
+      upsert: vi.fn(async (args: { where: { key: string }; create: { value: unknown } }) => { store.upserts += 1; rows[args.where.key] = args.create.value; return {}; }) as ReachedAtDb["platformConfig"]["upsert"],
+    },
+  };
+  return store;
+}
+
+describe("hostnameFromHostHeader", () => {
+  it("keeps the hostname, drops the port, lower-cases, and refuses junk", () => {
+    expect(hostnameFromHostHeader("192.168.0.200:3000")).toBe("192.168.0.200");
+    expect(hostnameFromHostHeader("Dev.Internal")).toBe("dev.internal");
+    expect(hostnameFromHostHeader("[fe80::1]:3000")).toBe("[fe80::1]");
+    expect(hostnameFromHostHeader("a.example, b.example")).toBe("a.example");
+    expect(hostnameFromHostHeader("")).toBeNull();
+    expect(hostnameFromHostHeader(null)).toBeNull();
+  });
+});
+
+describe("recordReachedAtHost / readReachedAtHosts", () => {
+  it("records the host a trusted peer used, most recent first, and ignores loopback", async () => {
+    const store = db();
+    await recordReachedAtHost(store, "192.168.0.200:3000", now);
+    await recordReachedAtHost(store, "localhost:3000", now);
+    await recordReachedAtHost(store, "127.0.0.1:3000", now);
+    await recordReachedAtHost(store, "dev.internal", new Date(now.getTime() + 1_000));
+    expect(await readReachedAtHosts(store)).toEqual(["dev.internal", "192.168.0.200"]);
+  });
+
+  it("does not rewrite a host seen again within the interval, and bounds the set", async () => {
+    const store = db();
+    await recordReachedAtHost(store, "192.168.0.200:3000", now);
+    await recordReachedAtHost(store, "192.168.0.200:3000", new Date(now.getTime() + 60_000));
+    expect(store.upserts).toBe(1);
+    await recordReachedAtHost(store, "192.168.0.200:3000", new Date(now.getTime() + 11 * 60_000));
+    expect(store.upserts).toBe(2);
+    for (let index = 0; index < 20; index++) await recordReachedAtHost(store, `h${index}.example`, new Date(now.getTime() + 20 * 60_000 + index));
+    expect((await readReachedAtHosts(store)).length).toBe(16);
+  });
+
+  it("never throws when the store fails", async () => {
+    const broken: ReachedAtDb = { platformConfig: { findUnique: async () => { throw new Error("db down"); }, upsert: async () => { throw new Error("db down"); } } };
+    await expect(recordReachedAtHost(broken, "192.168.0.200", now)).resolves.toBeUndefined();
+    expect(await readReachedAtHosts(broken)).toEqual([]);
+  });
+});

--- a/apps/web/lib/federation/reached-at.ts
+++ b/apps/web/lib/federation/reached-at.ts
@@ -1,0 +1,86 @@
+// EP-ZERO-CONFIG-FEDERATION — the addresses trusted peers reach us at.
+//
+// A member installation must refuse a join file intended for another host
+// (spec §4 invariant 3), so it needs to know its own reachable addresses
+// without an operator typing one. Inside the portal container the network
+// interfaces show only the Docker bridge, PUBLIC_URL is usually unset on a
+// LAN install, and an agent's MCP client arrives over loopback. The one
+// zero-config source that is always right is the Host header a TRUSTED
+// same-organization peer used when it called us: that address is, by
+// construction, one a peer reaches us at.
+//
+// This module records those hosts (bounded, throttled) in PlatformConfig and
+// hands them back as part of the install's own-address set.
+
+import { isRecord } from "@/lib/shared/coerce";
+
+export const FEDERATION_REACHED_AT_CONFIG = "federation.reachedat.v1";
+const MAX_HOSTS = 16;
+/** A host seen again within this window is not rewritten. */
+const REWRITE_INTERVAL_MS = 10 * 60_000;
+
+export interface ReachedAtDb {
+  platformConfig: {
+    findUnique(args: unknown): Promise<{ value: unknown } | null>;
+    upsert(args: unknown): Promise<unknown>;
+  };
+}
+
+interface ReachedAtV1 {
+  schemaVersion: 1;
+  hosts: Record<string, string>;
+}
+
+function parse(value: unknown): ReachedAtV1 {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !isRecord(value.hosts)) return { schemaVersion: 1, hosts: {} };
+  const hosts: Record<string, string> = {};
+  for (const [host, seen] of Object.entries(value.hosts)) if (typeof seen === "string") hosts[host] = seen;
+  return { schemaVersion: 1, hosts };
+}
+
+/** Normalise a Host header to a lower-case hostname without port; null when it is not one. */
+export function hostnameFromHostHeader(header: string | null | undefined): string | null {
+  const raw = header?.split(",")[0]?.trim();
+  if (!raw || raw.length > 260) return null;
+  try {
+    const hostname = new URL(`http://${raw}`).hostname.toLowerCase();
+    return hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Record that a trusted peer reached us at `hostHeader`. Throttled; never throws. */
+export async function recordReachedAtHost(db: ReachedAtDb, hostHeader: string | null | undefined, now: Date = new Date()): Promise<void> {
+  const hostname = hostnameFromHostHeader(hostHeader);
+  if (!hostname || hostname === "localhost" || hostname.startsWith("127.") || hostname === "::1") return;
+  try {
+    const row = await db.platformConfig.findUnique({ where: { key: FEDERATION_REACHED_AT_CONFIG }, select: { value: true } });
+    const current = parse(row?.value);
+    const last = current.hosts[hostname] ? Date.parse(current.hosts[hostname]!) : Number.NaN;
+    if (Number.isFinite(last) && now.getTime() - last < REWRITE_INTERVAL_MS) return;
+    const entries = Object.entries({ ...current.hosts, [hostname]: now.toISOString() })
+      .sort((a, b) => Date.parse(b[1]) - Date.parse(a[1]))
+      .slice(0, MAX_HOSTS);
+    const value: ReachedAtV1 = { schemaVersion: 1, hosts: Object.fromEntries(entries) };
+    await db.platformConfig.upsert({
+      where: { key: FEDERATION_REACHED_AT_CONFIG },
+      create: { key: FEDERATION_REACHED_AT_CONFIG, value },
+      update: { value },
+    });
+  } catch {
+    // Best effort: a missed record costs nothing today and is retried on the next call.
+  }
+}
+
+/** Hostnames trusted peers have reached us at, most recent first. */
+export async function readReachedAtHosts(db: ReachedAtDb): Promise<string[]> {
+  try {
+    const row = await db.platformConfig.findUnique({ where: { key: FEDERATION_REACHED_AT_CONFIG }, select: { value: true } });
+    return Object.entries(parse(row?.value).hosts)
+      .sort((a, b) => Date.parse(b[1]) - Date.parse(a[1]))
+      .map(([host]) => host);
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -106,6 +106,7 @@ import { buildLifecyclePack } from "./packs/build-lifecycle-pack";
 import { buildReviewPack } from "./packs/build-review-pack";
 import { buildChangePack } from "./packs/build-change-pack";
 import { gateContextPack } from "./packs/gate-context-pack";
+import { federationMembershipPack } from "./packs/federation-membership-pack";
 import { uxVerificationPack } from "./packs/ux-verification-pack";
 
 export const TOOL_PACK_REGISTRY = composeToolPacks([
@@ -128,6 +129,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   activityRoutingPack,
   selfUpgradePack,
   uxVerificationPack,
+  federationMembershipPack,
   coworkerServiceCatalogPack,
   coworkerToolGrantPack,
   coworkerEstablishPack,

--- a/apps/web/lib/mcp/packs/federation-membership-pack.ts
+++ b/apps/web/lib/mcp/packs/federation-membership-pack.ts
@@ -1,0 +1,88 @@
+// apps/web/lib/mcp/packs/federation-membership-pack.ts
+//
+// EP-ZERO-CONFIG-FEDERATION (BI-4DD1E739, BI-AC7BCC58) — an agent pairing two
+// installations of one organization in the operator's absence imports the
+// organization join file through the platform, exactly as the Connections
+// page does. The portal generates the key, has the organization CA sign it
+// through the authority's portal, keeps the material in the federation state
+// directory, and the next federation tick records the link trusted on both
+// sides. Nothing is typed, no edge node or host script is involved, and the
+// join file's one-time token never passes through the agent's own hands
+// beyond the file it was given.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "import_organization_join_file",
+    description:
+      "Join this installation to its organization by importing a .dpfjoin file issued on the organization installation. Pass the file's text. The platform validates it (version, expiry, that it was issued for one of this installation's own addresses), generates a key here, has the organization CA sign it through the organization installation's portal, stores the material under the federation state directory, and the next federation tick (within five minutes) records the connection trusted on both sides with no approval. Refuses a tampered, expired or wrong-host file before any network call.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        joinFileText: {
+          type: "string",
+          description: "The full text of the .dpfjoin file (starts with DPF_ORGANIZATION_JOIN_V2). At most 64 KB.",
+        },
+        reason: {
+          type: "string",
+          description: "Short audit tag for why the join is being performed.",
+        },
+      },
+      required: ["joinFileText"],
+    },
+    requiredCapability: "manage_platform",
+    executionMode: "immediate",
+    sideEffect: true,
+    consequence: "authority",
+  },
+];
+
+async function importOrganizationJoinFileTool(
+  params: Record<string, unknown>,
+  _userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const { importOrganizationJoinFile } = await import("@/lib/federation/organization-join-import");
+  const { resolveLocalFederationAuthorityUrl } = await import("@/lib/federation/self-authority");
+  const fileText = typeof params["joinFileText"] === "string" ? params["joinFileText"] : "";
+  if (!fileText.trim() || Buffer.byteLength(fileText, "utf8") > 64 * 1024) {
+    return { success: false, message: "joinFileText must be the text of a .dpfjoin file (at most 64 KB).", data: { reason: "invalid-join-file" } };
+  }
+  const reason = typeof params["reason"] === "string" ? params["reason"].trim().slice(0, 80) : "";
+  console.log(`[federation] join file import requested by mcp:${context?.agentId?.trim() || "agent"}${reason ? `:${reason}` : ""}`);
+  const requestHost = await resolveLocalFederationAuthorityUrl();
+  const result = await importOrganizationJoinFile({ fileText, requestHost });
+  if (!result.imported) {
+    return {
+      success: false,
+      message: `Join file refused: ${result.reason}${result.detail ? ` (${result.detail})` : ""}`,
+      data: { reason: result.reason, ...(result.detail ? { detail: result.detail } : {}) },
+    };
+  }
+  return {
+    success: true,
+    message: `Joined the organization at ${result.authorityUrl} as ${result.intendedPeer}. The next federation tick enrols and records the connection trusted on both sides.`,
+    data: {
+      authorityUrl: result.authorityUrl,
+      caUrl: result.caUrl,
+      intendedPeer: result.intendedPeer,
+      joinFileExpiresAt: result.expiresAt,
+      materialDir: result.materialDir,
+    },
+  };
+}
+
+export const federationMembershipPack: ToolPack = {
+  packId: "federation-membership",
+  definitions,
+  handlers: {
+    import_organization_join_file: importOrganizationJoinFileTool,
+  },
+  grants: {
+    // The same grant the UX-verification sign-in carries: pairing the
+    // installations an agent tests is part of the same automation job.
+    import_organization_join_file: ["sandbox_execute"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -768,7 +768,6 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   generate_design_system:     ["file_read"],
   // HR — query
   query_employees: ["consumer_read", "registry_read"],
-
   // Recruiting pipeline lens (BI-E64D11AE) — unified native + Greenhouse funnel.
   get_recruiting_pipeline: ["consumer_read", "registry_read"],
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -756,6 +756,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   trigger_contributor_inventory_sync: ["admin_write"],
   request_self_upgrade: ["admin_write"],
   issue_ux_verification_sign_in: ["sandbox_execute"], // BI-9369DEB5: UX verification sign-in; a development token already holds it
+  import_organization_join_file: ["sandbox_execute"], // BI-4DD1E739: portal-mediated organization join; the same automation grant
   // Governed self-heal for the "promoter image not built" self-upgrade skip.
   // Same admin_write scope as request_self_upgrade so the platform-engineer
   // ("AI Ops Engineer") coworker can build the promoter image on request.

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -12,4 +12,4 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma enums | 85 | `packages/db/prisma/schema/` |
 | Migrations | 566 | `packages/db/prisma/migrations/` |
 | Kernel principles | 100 | `docs/founder-kernel/wiki/principles/` |
-| App routes | 658 | `apps/web/lib/ea/route-manifest.json` |
+| App routes | 659 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md
+++ b/docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md
@@ -1,0 +1,191 @@
+---
+status: binding
+---
+
+# Portal-Mediated Organization Membership: the join file is sufficient
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-09-03 |
+| Epic | `EP-ZERO-CONFIG-FEDERATION` |
+| Backlog | BI-4DD1E739 (blocking), BI-105BB8B2, BI-AC7BCC58, BI-1F69D3F8 |
+| Surface | member-side join import, authority-side certificate relay, federation tick |
+| Supersedes in part | `2026-09-02-zero-configuration-organization-federation-design.md` §5.6 (how the member obtains its certificate); `2026-08-23-zero-touch-organization-federation-design.md` edge-host import path for members |
+
+## 1. Decision
+
+Choosing the organization join file on a member installation is sufficient to
+make it a member. Nothing else is configured, generated or clicked: no edge
+node role, no edge-actions overlay, no signing keys, no mTLS secret, no second
+network port, no `.env` line. The member portal itself turns the join file into
+a certificate by asking the **authority's portal** — the address it already
+trusts, on the port it already reaches — to have the organization CA sign a
+key the member generated. The authority portal relays that request to its
+step-ca over the private compose network; the CA remains the only thing that
+decides, and it can stay bound to loopback.
+
+Founder ruling (2026-09-02): "membership — holding the organization's join
+package — is the only switch." Founder ruling (2026-09-03): agents must be
+able to test and pair installations in the founder's complete absence, never
+by bypass.
+
+## 2. What the live pair proved on 2026-09-03
+
+- The member's only existing import path is a host script wrapped by a
+  host-native edge node (`scripts/bootstrap-organization-pki.ps1 -Mode join`,
+  `services/edge-node-go/internal/action/organization_join.go`). It needs
+  `DPF_ORGANIZATION_TRUST_ROLE=member`, `DPF_EDGE_ACTION_*` files, the
+  edge-actions compose overlay and a flag in `.env`. No installer sets any of
+  it; the development installation's edge node has never reported the member
+  role, so the Connections page says "No installation has reported the
+  required organization role yet".
+- That path runs `step ca root` and `step ca certificate` against the
+  authority's step-ca directly. The authority bootstrap binds step-ca to
+  `127.0.0.1`; production refuses 9000, 8443 and 443 from the LAN. A join file
+  issued on production therefore cannot be imported by any member on the
+  network today.
+- The authority side's own edge-node cards still read "Enable secure host
+  actions" with an enrollment conflict.
+
+Each of these is a seam the founder ruling forbids. This design removes the
+member-side seams entirely and keeps the authority's CA private.
+
+## 3. Research and benchmarking
+
+| System | Pattern | DPF decision |
+| --- | --- | --- |
+| [step-ca sign API](https://smallstep.com/docs/step-ca/provisioners/) (`POST /1.0/sign` with a one-time JWK token and a CSR) | The token, not network position, is the credential; the CSR carries the requester's key. | Adopt: the member generates its key locally, the join file's enrollment token authorises exactly one signing, the CA never sees a private key. |
+| [ACME over an existing HTTPS front door](https://datatracker.ietf.org/doc/html/rfc8555) | Certificate issuance rides the same reachable endpoint as the service. | Adopt the shape: the authority's portal is the only endpoint a member needs. |
+| [Kubernetes kubelet TLS bootstrap](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/) | A bootstrap token yields a CSR that policy auto-approves; the node keeps its key in its state directory. | Adopt: material lands in the state directory the installer already preserves (`<state dir>/federation/pki`). |
+| [Tailscale auth keys](https://tailscale.com/kb/1085/auth-keys) | One pre-authorised key enrols a device with no interactive step. | Adopt: the join file is the whole act; expiry is measured from issue and long enough for a file to be moved between machines. |
+
+Rejected: opening step-ca to the LAN (a second port to keep reachable, TLS
+name and firewall seams, contradicts the loopback default); shipping the CA
+password to members (a shared secret); keeping the edge-node host script as
+the member path (five prerequisites no installer produces).
+
+## 4. Safety invariants
+
+1. **The CA decides, the portal relays.** The authority portal forwards the
+   member's CSR and the join file's enrollment token to step-ca's sign API and
+   returns the CA's answer verbatim. It holds no provisioner key and cannot
+   sign anything itself. A bad or reused token is refused by the CA.
+2. **Private keys never leave the machine that generated them.** The member
+   generates its keypair in the portal process and writes it mode `0600`
+   under `<state dir>/federation/pki/`, the read-write mount slice 1 already
+   established.
+3. **Intended peer is enforced twice.** The member refuses a join file whose
+   `intended_hostname` is not one of its own addresses; the CA refuses a CSR
+   whose subject or SANs are not the ones the token was minted for.
+4. **The relay is rate-limited and audited.** One relay call per token; the
+   authority records `federation.membership.relay` events (member address,
+   token id hash, CA verdict), never the token.
+5. **Root pinning is unchanged.** The member pins the root by the join file's
+   `root_fingerprint` before trusting the returned chain, exactly as the
+   host script did.
+6. **Membership survives teardown.** Material and facts live in the state
+   directory; a fresh database re-reads them at boot (slice 1 `boot-reconcile`).
+
+## 5. Contracts
+
+### 5.1 Authority: certificate relay
+
+`POST /api/v1/federation/membership/sign` (`@exposure private-mesh`, no
+bearer; the enrollment token is the credential).
+
+Request: `{ "spec": "dpf.membership-sign/1", "csrPem": "...", "enrollmentToken": "...", "memberAddress": "http://192.168.0.200:3000" }`.
+
+The portal calls `${DPF_ORGANIZATION_CA_INTERNAL_URL:-https://step-ca:9000}/1.0/sign`
+with `{ csr, ott }`, trusting the CA by the pinned root it already reads from
+`/dpf-state/pki/root_ca.crt`. Response: `{ "accepted": true, "certPem": "...",
+"chainPems": [...], "rootPem": "..." }` or `{ "accepted": false, "reason": "ca-refused" | "ca-unreachable" | "token-invalid" }`.
+The route is available only on an installation that holds the organization
+root and runs step-ca in its compose chain (`DPF_ORGANIZATION_TRUST_ROLE=authority`
+or the `docker-compose.pki.yml` service present); elsewhere it answers 404.
+
+### 5.2 Member: importing the join file
+
+`importOrganizationJoinFile(fileText)` — a session-gated server action on the
+Connections page ("Join this installation" → choose file), and the MCP tool
+`import_organization_join_file` (pack `federation-membership`, capability
+`manage_platform`, grant `sandbox_execute`) for automation.
+
+Steps, all inside the member portal:
+
+1. Parse and validate the package (`parseOrganizationJoinPackage`; version
+   V1/V2; expiry; `intended_hostname` must equal one of the member's own
+   addresses: `resolveAppBaseUrl()` host, `PUBLIC_URL` host, or any address
+   the trusted peer records for us).
+2. Generate an EC P-256 keypair and a CSR for `intended_hostname` plus
+   `intended_sans`.
+3. Derive the authority portal from `ca_url` as slice 2 already does
+   (`deriveAuthorityPortalUrls`) and call §5.1.
+4. Verify the returned chain against the pinned `root_fingerprint`
+   (`verifyMembershipChain`).
+5. Write `<state dir>/federation/pki/{root_ca.crt,authority.crt,authority.key}`
+   (0600, atomic) and PlatformConfig `federation.membership.v1`
+   `{ caUrl, intendedPeer, rootFingerprint, packageId, joinedAt }`.
+6. Return `{ imported: true, authorityUrl, expiresAt }`; the next federation
+   tick runs `reconcileOrganizationMembership`, which enrols with the
+   authority and records the link trusted on both sides.
+
+`membershipPaths()` prefers `<state dir>/federation/pki/` and falls back to
+`/dpf-state/pki/` so an authority that bootstrapped by script is unaffected.
+`readJoinPackageFacts()` reads `federation.membership.v1` first and the
+completed `organization.join.import` RemoteAction second.
+
+### 5.3 Authority: issuing the join file without an edge node
+
+`issueOrganizationJoinFile({ intendedPeer })` — server action on the
+Connections page and MCP tool `issue_organization_join_file`. `intendedPeer`
+is chosen from the trusted same-organization links and discovery candidates
+(BI-1F69D3F8), with a typed hostname as the fallback. The portal asks step-ca
+for the one-time tokens the package carries through the CA's token endpoint
+using the provisioner password the authority already keeps at
+`/dpf-state/pki/secrets/step-ca-password`; the package is returned once and
+expires 30 minutes after issue. This slice retires the edge-node
+`organization.join.issue` action for the authority once it ships; until then
+the existing issue path stays.
+
+## 6. Slices
+
+1. **Member import + authority relay** (§5.1, §5.2): a join file issued by
+   today's authority path is importable by a member with nothing else
+   configured; the CA stays on loopback.
+2. **Authority issues without an edge node** (§5.3) and the MCP tools
+   (BI-AC7BCC58 folds in here).
+3. Retire the member-side host script path and the "Enable secure setup"
+   requirement from the Connections page; the page shows only "Create join
+   file" and "Join this installation".
+
+## 7. Acceptance
+
+1. On the live pair, a join file issued on production and imported on
+   development by choosing the file, with production's step-ca still bound to
+   loopback, results in a `trusted` link on both sides with
+   `confirmationProvenance: organization-trust` within two federation ticks,
+   with no approval and nothing typed.
+2. The same import driven by an agent through the MCP tool, in the platform's
+   own browser session or headless, succeeds identically.
+3. A tampered or expired join file, or one intended for another host, is
+   refused before any network call.
+4. Tearing down and reinstalling the member keeping `DPF_STATE_DIR` keeps its
+   membership; a fresh database re-reads the material at boot.
+5. No route, action or installer step on the member reads
+   `DPF_ORGANIZATION_TRUST_ROLE`, `DPF_EDGE_ACTION_*` or the edge-actions
+   overlay for membership.
+
+## Ordered fix sequence (this doc is the plan)
+
+1. `apps/web/lib/federation/membership-material.ts`: keypair + CSR generation,
+   atomic writes under `<state dir>/federation/pki/`, `membershipPaths`
+   preference order; tests.
+2. `apps/web/app/api/v1/federation/membership/sign/route.ts` + `lib/federation/membership-relay.ts`:
+   step-ca sign relay, pinned-root TLS, audit events, rate limit; tests with a
+   fake CA.
+3. `lib/federation/organization-join-import.ts` + server action + Connections
+   page wiring; `readJoinPackageFacts` reads PlatformConfig first; tests.
+4. MCP pack `federation-membership` with `import_organization_join_file`;
+   registry/grant/tool-surface updates; tests.
+5. Live proof on the pair (acceptance 1–2), evidence on BI-105BB8B2.
+6. Slice 2 and 3 as separate PRs.

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -56,17 +56,22 @@ page. On the organization installation, choose **Create join file**, enter the
 joining installation's reported host name, confirm it, and download the file
 when ready. Move the `.dpfjoin` file to the joining computer within its 5- to
 15-minute lifetime. On that installation, choose **Join this installation**,
-select the file, check the safe preview, and approve the join. No command line,
-certificate copying, CA password, or installer rerun is required.
+select the file, check the safe preview, and confirm. Choosing the file is the
+whole step: the joining installation checks the file, generates its own key,
+asks the organization installation to certify it, and keeps the result in its
+own state directory. No command line, certificate copying, CA password, Edge
+node, or installer rerun is required, and nothing is typed. Within a few
+minutes the connection appears on both Connections pages as trusted, with no
+approval to click. An automation agent can do the same through the
+`import_organization_join_file` tool.
 
 The file carries the public-root fingerprint and one-time enrollment authority;
 it never carries the organization's CA private key. It works only for the named
-installation and can be downloaded once. The native Edge host applies the trust
-settings, checks certificate trust, saved settings, portal health, and its secure
-heartbeat, and restores the prior settings if a check fails. The Connections
-page keeps showing progress after a refresh. This establishes machine trust
-only—it does not share backlog data. Demand sharing is a separate, explicit
-choice in Delivery Flow.
+installation, is honoured by the organization's certificate authority once, and
+can be downloaded once. The joining installation refuses a tampered or expired
+file, or one created for another installation, before contacting anyone. This
+establishes machine trust only—it does not share backlog data. Demand sharing
+is a separate, explicit choice in Delivery Flow.
 
 If the candidate uses HTTP, its certificate cannot be verified, or discovery is
 unavailable, use the invitation controls on the same page. Never bypass the TLS

--- a/docs/ux-fit/2026-09-05-portal-mediated-organization-join.ux-fit.json
+++ b/docs/ux-fit/2026-09-05-portal-mediated-organization-join.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "portal-native-import-form",
+  "decisionInteractionId": "DI-81CDA477D08C",
+  "scope": {
+    "files": [
+      "apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "portal-native-import-form",
+      "keep-edge-node-import-form",
+      "dual-path-import-with-selector"
+    ],
+    "note": "EP-ZERO-CONFIG-FEDERATION, BI-4DD1E739 (spec docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md §5.2). 'Join this installation' now opens the file chooser directly: no installation selector, no 'Enable secure setup' prerequisite, no member-role edge node. The existing FormField, CheckboxField, SubmitButton and FormStatus primitives are reused; the preview still never renders the enrollment tokens; the confirmation names the host the file was issued for; the server refuses a wrong-host, expired or tampered file before any network call and reports the refusal in the same status line. The kernel scored the portal-native form highest (composite 9.40, margin 4.38, confidence high) on cognitive load and operator effort against keeping the edge-node form or offering both behind a selector."
+  }
+}

--- a/packages/db/src/organization-join-action.test.ts
+++ b/packages/db/src/organization-join-action.test.ts
@@ -4,6 +4,7 @@ import {
   ORGANIZATION_JOIN_ACTION_TYPES,
   parseOrganizationJoinDispatchParameters,
   parseOrganizationJoinPackage,
+  parseOrganizationJoinPackageMaterial,
   parseOrganizationJoinRequest,
   requiredOrganizationTrustRole,
 } from "./organization-join-action";
@@ -28,6 +29,27 @@ function joinPackage(overrides: Record<string, string> = {}): string {
     "",
   ].join("\n");
 }
+
+describe("parseOrganizationJoinPackageMaterial", () => {
+  it("exposes the enrollment token to the member portal while the preview never carries it", () => {
+    const material = parseOrganizationJoinPackageMaterial(joinPackage(), NOW);
+    expect(material.ok).toBe(true);
+    if (!material.ok) throw new Error(material.reason);
+    expect(material.value.enrollmentToken).toBe("token-safe_123");
+    expect(material.value.intendedPeer).toBe("windows-dev.local");
+    expect(material.value.intendedSans).toEqual(["windows-dev.local", "192.168.1.42"]);
+    const preview = parseOrganizationJoinPackage(joinPackage(), NOW);
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) throw new Error(preview.reason);
+    expect("enrollmentToken" in preview.value).toBe(false);
+  });
+
+  it("refuses the same tampered, expired and malformed files the preview refuses", () => {
+    expect(parseOrganizationJoinPackageMaterial(joinPackage({ expires_at: String(Math.floor(NOW.getTime() / 1000) - 1) }), NOW)).toEqual({ ok: false, reason: "join-package-expired" });
+    expect(parseOrganizationJoinPackageMaterial(joinPackage({ enrollment_token: "bad token!" }), NOW)).toEqual({ ok: false, reason: "invalid-enrollment-authority" });
+    expect(parseOrganizationJoinPackageMaterial(["DPF_ORGANIZATION_JOIN_V1", "package_id=x"].join("\n"), NOW).ok).toBe(false);
+  });
+});
 
 describe("organization join action registry", () => {
   it("contains exactly the two founder-approved action types and binds their host roles", () => {

--- a/packages/db/src/organization-join-action.ts
+++ b/packages/db/src/organization-join-action.ts
@@ -108,10 +108,31 @@ export function parseOrganizationJoinDispatchParameters(
   return parseOrganizationJoinRequest(actionType, parameters, now);
 }
 
+/** The preview plus the one-time enrollment authority the CA honours exactly once. */
+export interface OrganizationJoinPackageMaterial extends OrganizationJoinPackagePreview {
+  enrollmentToken: string;
+}
+
 export function parseOrganizationJoinPackage(
   raw: string,
   now: Date = new Date(),
 ): ParseResult<OrganizationJoinPackagePreview> {
+  const parsed = parseOrganizationJoinPackageMaterial(raw, now);
+  if (!parsed.ok) return parsed;
+  const { enrollmentToken: _token, ...preview } = parsed.value;
+  return { ...parsed, value: preview };
+}
+
+/**
+ * The full material a member portal needs to turn the package into a
+ * certificate (EP-ZERO-CONFIG-FEDERATION, portal-mediated membership): the
+ * preview facts plus the enrollment token. Never render the token; it is the
+ * credential the organization CA accepts once.
+ */
+export function parseOrganizationJoinPackageMaterial(
+  raw: string,
+  now: Date = new Date(),
+): ParseResult<OrganizationJoinPackageMaterial> {
   if (typeof raw !== "string" || new TextEncoder().encode(raw).byteLength > MAX_JOIN_PACKAGE_BYTES || raw.includes("\0")) {
     return { ok: false, reason: "invalid-join-package" };
   }
@@ -152,7 +173,7 @@ export function parseOrganizationJoinPackage(
   }
   return {
     ok: true,
-    value: { packageId, caUrl, rootFingerprint, intendedPeer, intendedSans, expiresAt },
+    value: { packageId, caUrl, rootFingerprint, intendedPeer, intendedSans, expiresAt, enrollmentToken: fields.get("enrollment_token")! },
   };
 }
 

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,14 +3,14 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 406,
-      "reason": "issue_ux_verification_sign_in (BI-9369DEB5): a fully automated installation is verified by agents with no person present, and most pages are session-gated. No existing tool can put the platform's own browser behind a session; this one mints a one-time link for the seeded automation persona so an agent can judge layout, type, colour and overrun in a real browser without typing a password or asking the operator.",
-      "recordedAt": "2026-09-03"
+      "value": 407,
+      "reason": "import_organization_join_file (BI-4DD1E739, EP-ZERO-CONFIG-FEDERATION): pairing two installations of one organization in the operator's absence was impossible — the only member-side import path was a host script behind an edge node no installer configures. This tool is the session-free twin of the Connections page's 'Join this installation': the portal validates the join file, generates its own key, has the organization CA sign it through the authority's portal, and the next tick records the link trusted on both sides. No existing tool touches organization membership.",
+      "recordedAt": "2026-09-05"
     },
     "registry.packFiles": {
-      "value": 99,
-      "reason": "New ux-verification-pack.ts: browser-verification sign-in is a delivery-surface concern distinct from self-upgrade, sandbox and admin packs, and a single-tool pack keeps the grant (sandbox_execute) and capability (manage_platform) visible next to the tool they govern.",
-      "recordedAt": "2026-09-03"
+      "value": 100,
+      "reason": "New federation-membership-pack.ts: organization membership (join-file import, and the issue side to follow in the next slice) is a federation-trust concern distinct from ux-verification, self-upgrade and admin packs; a dedicated pack keeps the grant (sandbox_execute) and capability (manage_platform) beside the tools they govern.",
+      "recordedAt": "2026-09-05"
     },
     "tier.coreToolNames": {
       "value": 30,


### PR DESCRIPTION
## Summary

Slice 1 of the binding spec `docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md` (carried on this branch; also #5054) for **EP-ZERO-CONFIG-FEDERATION** / **BI-4DD1E739**.

Choosing the organization join file on a member installation is now sufficient to make it a member. Nothing else is configured: no edge node, no host script, no edge-actions overlay, no signing keys, no `.env` line. The member portal generates a key and a CSR in-process, asks the **authority's portal** to have the organization CA sign it, pins the returned chain by the file's root fingerprint, stores the material under `<state dir>/federation/pki`, and the next federation tick enrols with `confirmationProvenance: organization-trust` on both sides.

## What changed

- **`packages/db` `organization-join-action`**: `parseOrganizationJoinPackageMaterial` exposes the enrollment token to the member portal; the preview never carries it.
- **`lib/federation/csr.ts`** (new, pure): EC P-256 keypair + hand-assembled PKCS#10 CSR (Node has no CSR builder). CN = intended hostname; SANs classified IP/DNS the way step-ca does. Verified with `openssl req -verify`.
- **`lib/federation/membership-material.ts`** (new): two homes read in order — portal home `<federation state dir>/pki/`, then the script home `/dpf-state/pki/`; atomic 0600 writes; `membership.json` facts a fresh database re-reads.
- **`lib/federation/membership-relay.ts`** + **`POST /api/v1/federation/membership/sign`** (`@exposure private-mesh`, no bearer — the enrollment token is the credential): relays CSR + token to step-ca `/1.0/sign` over the compose network, TLS pinned to the organization root; one relay per token, per-caller rate limit, bounded audit ring (token id hash, never the token). 404 unless the install holds the root **and** is the authority.
- **`lib/federation/organization-join-import.ts`** + `importOrganizationJoinFileAction`: parse/validate → own-address check (refused before any network call) → keypair + CSR → authority portal (derived from the CA URL exactly as enrolment does) → chain pinned by the file's fingerprint and leaf checked against our key → material + `federation.membership.v1`.
- **`lib/federation/reached-at.ts`** (new): the Host a trusted same-organization peer reaches us at (recorded on the work-sync pull) joins the install's own-address set, so an agent importing over loopback MCP passes the intended-host check without anything typed.
- **Connections page**: "Join this installation" opens the file chooser directly — no installation selector, no "Enable secure setup" prerequisite. UX shape chosen by `principle_decide` **DI-81CDA477D08C** (`docs/ux-fit/2026-09-05-portal-mediated-organization-join.ux-fit.json`).
- **MCP pack `federation-membership`**: `import_organization_join_file` (capability `manage_platform`, grant `sandbox_execute`, consequence `authority`).
- `readJoinPackageFacts` reads the PlatformConfig row first, the facts file second, the script-era host action third. `reconcileOrganizationMembership` is otherwise unchanged.

## Design grounding

Implements the ordered fix sequence of the spec above (steps 1–4). Extends the slice-2 membership-proof enrolment path unchanged; reuses `verifyMembershipChain`, `deriveAuthorityPortalUrls`, `postToPeer` (same-org LAN allowance), `checkNearbyPairingRateLimit`, and the form primitives. Research & benchmarking (step-ca sign API, ACME, kubelet TLS bootstrap, Tailscale auth keys) is in the spec §3.

## Verification

- `vitest`: csr (5), membership-material (5), membership-relay (8, fake CA), organization-join-import (7), reached-at (4), sign route (3), organization-membership (+1 facts read order), db parser (+2), OrganizationJoinPanel (8, portal-native submit + refusals) — all green; broader `lib/federation`, tool registry, consequence coverage: 58 files / 484 tests green.
- `pnpm --filter web typecheck` clean.
- Guards: tool-surface (407 tools / 100 packs, reasons recorded), endpoint classification, one-ActionResult, raw-error-message, prose-lint, `check:guards` loop — all OK.
- Live proof (spec §7 acceptance 1–2) follows after release: issue on production, import on development in the platform's own browser session, link trusted on both sides within two ticks. Evidence goes on BI-105BB8B2 and BI-4DD1E739.

Slices 2 (authority issues without an edge node + `issue_organization_join_file`) and 3 (retire the edge path) follow as separate PRs.

Design-Grounding-Decision: implements slice 1 of the binding spec docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md; UX shape by principle_decide DI-81CDA477D08C
Docs-Impact-Decision: docs/user-guide/platform/index.md Connections paragraph rewritten; spec is the design record; tool-surface baseline records the new tool and pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
