### PR TITLE
fix(edge-node): the shipped container crashed at module load, and then reported itself as a peer

### DIFF
--- a/services/edge-node/src/__tests__/federation-contract-parity.test.ts
+++ b/services/edge-node/src/__tests__/federation-contract-parity.test.ts
@@ -1,0 +1,144 @@
+// The Edge Node carries a runtime copy of the federation discovery contract
+// because `@dpf/validators` cannot be require()d from the shipped container
+// (see src/lib/federation-contract.ts for why). Two copies of a rule that
+// decides what the scanner DIALS and what the Authority ACCEPTS is a drift
+// hazard: if they disagree, the scanner either skips peers the Authority would
+// have taken, or submits batches it rejects wholesale — losing the good
+// candidates in them too.
+//
+// So the agreement is asserted, not assumed. This test imports BOTH and runs
+// them over one corpus. It runs under vitest, which compiles TypeScript, so it
+// can import the canonical package that the container cannot.
+
+import { describe, expect, it } from "vitest";
+
+import * as canonical from "@dpf/validators";
+import * as local from "../lib/federation-contract";
+
+const ENDPOINTS = [
+  "http://192.168.1.43:3000",
+  "https://10.0.0.2",
+  "https://172.16.4.4:3000",
+  "https://172.32.0.1",
+  "http://dpf-node.local:3000",
+  "https://[fe90::2]:3443",
+  "https://[fd12::2]:3443",
+  "https://[::1]",
+  "http://169.254.10.9",
+  "https://peer.example.com",
+  "https://user:pass@10.0.0.2",
+  "https://10.0.0.2/path?q=1",
+  "https://10.0.0.2#frag",
+  "ftp://10.0.0.2",
+  "http://8.8.8.8",
+  "not-a-url",
+  "",
+];
+
+const ADVERTISEMENTS: unknown[] = [
+  { protocol: "1", install: "yM4sS9VcH0rW2nQ8", caps: "8f31c9a2", pair: "/connect/pair" },
+  {
+    protocol: "1",
+    install: "yM4sS9VcH0rW2nQ8",
+    caps: "8f31c9a2",
+    pair: "/connect/pair",
+    organization: "North Wind",
+  },
+  { protocol: "2", install: "yM4sS9VcH0rW2nQ8", caps: "8f31c9a2", pair: "/connect/pair" },
+  { protocol: "1", install: "tooshort", caps: "8f31c9a2", pair: "/connect/pair" },
+  { protocol: "1", install: "yM4sS9VcH0rW2nQ8", caps: "ZZZZZZZZ", pair: "/connect/pair" },
+  { protocol: "1", install: "yM4sS9VcH0rW2nQ8", caps: "8f31c9a2", pair: "/pair" },
+  // An extra key must be refused by both: the field set IS the privacy boundary.
+  {
+    protocol: "1",
+    install: "yM4sS9VcH0rW2nQ8",
+    caps: "8f31c9a2",
+    pair: "/connect/pair",
+    hostname: "peer-01",
+  },
+  { hello: "world" },
+  null,
+  42,
+];
+
+describe("edge-node federation contract parity with @dpf/validators", () => {
+  it("agrees on which endpoints are in scope", () => {
+    for (const endpoint of ENDPOINTS) {
+      expect([endpoint, local.isFederationScopedEndpoint(endpoint)]).toEqual([
+        endpoint,
+        canonical.isFederationScopedEndpoint(endpoint),
+      ]);
+    }
+  });
+
+  it("agrees on which advertisements are well formed", () => {
+    for (const advertisement of ADVERTISEMENTS) {
+      const mine = local.federationAdvertisementSchema.safeParse(advertisement);
+      const theirs = canonical.federationAdvertisementSchema.safeParse(advertisement);
+      expect([advertisement, mine.success]).toEqual([advertisement, theirs.success]);
+      if (mine.success && theirs.success) expect(mine.data).toEqual(theirs.data);
+    }
+  });
+
+  it("agrees on the candidate a descriptor produces for an origin", () => {
+    const advertisement = {
+      protocol: "1" as const,
+      install: "yM4sS9VcH0rW2nQ8",
+      caps: "8f31c9a2",
+      pair: "/connect/pair" as const,
+      organization: "North Wind",
+    };
+    for (const endpoint of ENDPOINTS) {
+      expect([endpoint, local.candidateFromAdvertisement(advertisement, endpoint)]).toEqual([
+        endpoint,
+        canonical.candidateFromAdvertisement(advertisement, endpoint),
+      ]);
+    }
+  });
+
+  it("agrees on the constants the wire format is built from", () => {
+    expect(local.FEDERATION_PROTOCOL_VERSION).toBe(canonical.FEDERATION_PROTOCOL_VERSION);
+    expect(local.FEDERATION_PAIR_PATH).toBe(canonical.FEDERATION_PAIR_PATH);
+    expect(local.FEDERATION_ADVERTISEMENT_PATH).toBe(canonical.FEDERATION_ADVERTISEMENT_PATH);
+    expect(local.FEDERATION_CAPABILITY_VERSION).toBe(canonical.FEDERATION_CAPABILITY_VERSION);
+    expect(local.FEDERATION_CANDIDATE_SNAPSHOT_MAX).toBe(
+      canonical.FEDERATION_CANDIDATE_SNAPSHOT_MAX,
+    );
+  });
+});
+
+describe("the shipped Edge Node never require()s @dpf/validators", () => {
+  it("keeps every remaining validators import type-only", async () => {
+    // The container cannot type-strip that package from node_modules, so a value
+    // import crashes it at module load. Tests are exempt: vitest compiles them
+    // and they never ship inside the image.
+    const { readdirSync, readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    // Resolve from THIS file, never process.cwd(): vitest may run with
+    // `--root <package>`, which points the cwd outside the repository.
+    // `__dirname` rather than `import.meta`: this package compiles to CommonJS.
+    const srcDir = join(__dirname, "..");
+    const offenders: string[] = [];
+
+    // `withFileTypes` rather than a separate statSync: one readdir answers both
+    // "what is it" and "what is it called", so there is no window between the
+    // check and the read for the entry to change (CodeQL js/file-system-race).
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== "__tests__") walk(full);
+          continue;
+        }
+        if (!entry.name.endsWith(".ts")) continue;
+        for (const line of readFileSync(full, "utf8").split("\n")) {
+          if (!line.includes('from "@dpf/validators"')) continue;
+          if (!/^\s*import\s+type\s/.test(line)) offenders.push(`${full}: ${line.trim()}`);
+        }
+      }
+    };
+    walk(srcDir);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/services/edge-node/src/__tests__/federation-scan.test.ts
+++ b/services/edge-node/src/__tests__/federation-scan.test.ts
@@ -349,4 +349,31 @@ describe("runFederationScanLoop", () => {
       }),
     ).resolves.toBeUndefined();
   });
+  it("publishes nothing when it cannot tell a peer apart from itself", async () => {
+    // Observed live 2026-09-05: resolveSelfDiscoveryId returns null on any
+    // failure, and the exclusion is `selfDiscoveryId && ...`, so a null id
+    // silently dropped the guard and the install submitted ITSELF as two peers.
+    const submitFederationCandidates = vi.fn(async () => ({ ok: true }));
+    const probeAdapter: FederationProbeAdapter = {
+      fetchAdvertisement: async (url: string) => {
+        // The authority (self) is unreachable this pass; the peer answers, and
+        // it is in fact this same install reached by another address.
+        if (url.startsWith("http://portal:3000")) return null;
+        return { status: 200, body: JSON.stringify(advertisement) };
+      },
+    };
+
+    await runFederationScanLoop({
+      config,
+      api: { submitFederationCandidates } as never,
+      state: state("trusted"),
+      settings,
+      probeAdapter,
+      sleep: async () => {},
+      log: () => {},
+      maxIterations: 1,
+    });
+
+    expect(submitFederationCandidates).not.toHaveBeenCalled();
+  });
 });

--- a/services/edge-node/src/collectors/federation-probe.ts
+++ b/services/edge-node/src/collectors/federation-probe.ts
@@ -22,7 +22,7 @@ import {
   federationAdvertisementSchema,
   type FederationAdvertisement,
   type FederationCandidate,
-} from "@dpf/validators";
+} from "../lib/federation-contract";
 
 /** Per-probe timeout. A peer that cannot answer promptly is not on this segment. */
 export const PROBE_TIMEOUT_MS = 1_500;

--- a/services/edge-node/src/federation-scan.ts
+++ b/services/edge-node/src/federation-scan.ts
@@ -24,7 +24,7 @@
 //
 // Design: docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md §5.11
 
-import { isFederationScopedEndpoint, type FederationCandidate } from "@dpf/validators";
+import { isFederationScopedEndpoint, type FederationCandidate } from "./lib/federation-contract";
 
 import { AuthorityHttpError, type AuthorityApiClient } from "./api-client";
 import { readArpCache, type ArpAdapter } from "./collectors/arp";
@@ -266,12 +266,24 @@ export async function runFederationScanLoop(opts: FederationScanOptions): Promis
       }
       if (targets.origins.length > 0) {
         const selfDiscoveryId = await resolveSelfDiscoveryId();
-        const candidates = await scanFederationCandidates({
-          origins: targets.origins,
-          probe,
-          selfDiscoveryId,
-        });
-        await submitCandidates({ api, state, candidates, observedAt: now(), log });
+        if (!selfDiscoveryId) {
+          // Fail CLOSED. Self-exclusion is a value comparison, so a null id makes
+          // the guard vanish and this install publishes ITSELF as a peer -- seen
+          // live on 2026-09-05, one flaky self-probe in ~80 passes submitting two
+          // candidates that were both this portal. Skipping a pass costs one
+          // observation; reporting yourself pollutes every operator's pairing list.
+          log(
+            "warn",
+            "Federation scan skipped this pass: could not read this install's own advertisement, so a peer cannot be told apart from self.",
+          );
+        } else {
+          const candidates = await scanFederationCandidates({
+            origins: targets.origins,
+            probe,
+            selfDiscoveryId,
+          });
+          await submitCandidates({ api, state, candidates, observedAt: now(), log });
+        }
       }
     } catch (err) {
       log("warn", `Federation scan pass failed: ${(err as Error).message}`);

--- a/services/edge-node/src/lib/federation-contract.ts
+++ b/services/edge-node/src/lib/federation-contract.ts
@@ -1,22 +1,21 @@
-// Federation discovery — the one contract both halves of nearby-peer discovery
-// speak.
+// Runtime copy of the federation discovery contract, for the Edge Node only.
 //
-// A DPF install advertises itself at `/.well-known/dpf-federation.json`; an Edge
-// Node probes its segment for that descriptor and submits what it found to
-// `POST /api/v1/edge/federation-candidates`. Producer and acceptor therefore have
-// to agree on the same field set, the same grammar, and the same endpoint scope.
-// Defining that once here is what makes the agreement real rather than a comment
-// in two files.
+// WHY A COPY. `@dpf/validators` resolves to `src/index.ts`, and Node refuses to
+// strip TypeScript types for files under `node_modules`
+// (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING). Every other Edge Node import of
+// that package is `import type`, which the compiler erases, so the package had
+// never been loaded at runtime here. The first VALUE import crashed the shipped
+// container at module load, before any flag could disable it -- and the image
+// builds cleanly, so nothing short of starting the container reveals it.
 //
-// The field set is the SAME closed allow-list the DNS-SD advertisement already
-// carries (services/edge-node-go/internal/federation/discovery.go
-// `AdvertisementTXT`): protocol, install, caps, pair — plus the organization the
-// peer belongs to, which the estate-identity contract already sanctions
-// publishing in a discovery record. No hostname, no device id, no token, no
-// organization id. Discovery is secret-free; pairing separately requires TLS and
-// a chain that validates against the pinned organization root.
+// The canonical contract is still packages/validators/src/federation-discovery.ts:
+// the Authority parses submissions with it, and this file must agree with it
+// exactly or the scanner would dial what the Authority refuses, or submit batches
+// it rejects wholesale. That agreement is not left to inspection --
+// __tests__/federation-contract-parity.test.ts imports BOTH and asserts identical
+// behaviour across a shared corpus, so drift fails CI rather than the LAN.
 //
-// Design: docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md §5.11
+// Delete this file the moment @dpf/validators ships runtime-loadable JS.
 
 import { z } from "zod";
 


### PR DESCRIPTION
> **The released `dpf-edge-node:latest` image does not boot.** It crash-loops at module load. Both defects here came from #4828 and neither was visible until the container was actually deployed and watched.

## 1. The container could not load

```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently
unsupported for files under node_modules, for
"/app/node_modules/.pnpm/@dpf+validators@.../src/index.ts"
    at Object.<anonymous> (/app/dist/federation-scan.js:34:22)
```

`@dpf/validators` resolves to `src/index.ts`, and Node will not type-strip inside `node_modules`. Every prior Edge Node import of that package is `import type`, erased by the compiler — so it had **never** been required at runtime here. #4828's were the first value imports, and they kill the process before any flag can disable the feature.

Observed on the live install against the released image, restart count 8.

**Why nothing caught it:** `tsc` is happy. The image *builds*. Only `publish-image.yml` builds that Dockerfile at all, and nothing anywhere *starts* the container. #4828's live verification ran the same source through `tsx`, which resolves the workspace directly and so bypasses exactly the packaging that fails.

The Edge Node now carries its own runtime copy (`src/lib/federation-contract.ts`), and every remaining `@dpf/validators` import in shipped code is type-only again.

Two copies of a rule that decides what the scanner **dials** and what the Authority **accepts** is a drift hazard, so the agreement is asserted rather than trusted:

- `federation-contract-parity.test.ts` imports **both** and compares endpoint scope, advertisement parsing, candidate construction and the wire constants across one corpus
- a second test walks `src/` and fails if any shipped file imports that package for a value — catching the mistake itself, not its symptom

Writing that parity test immediately found a bug in the canonical module: `candidateFromAdvertisement` **threw** `TypeError: Invalid URL` on an unparseable endpoint instead of returning null, because zod still evaluates the endpoint refinement after `.url()` has failed and `new URL` was unguarded. Fixed in `packages/validators`, and the Edge Node copy regenerated from it.

## 2. It published itself as a peer

```
Federation candidates submitted: 2 nearby peer(s).
```

On the live install exactly one advertising install is reachable and it **is** this install — `q0nEK4TuWM5qCa9O`, reached both as `portal:3000` and `172.18.0.9:3000`; the sandbox advertises nothing. The correct output was zero.

```js
if (input.selfDiscoveryId && candidate.discoveryId === input.selfDiscoveryId) continue;
```

`resolveSelfDiscoveryId()` returns `null` on **any** failure, and a null id makes that guard vanish rather than tighten. One flaky probe of this node's own authority disabled self-exclusion for the entire pass. One submission across ~80 passes — the loop logs nothing when it correctly finds none — matches exactly.

That is fail-**open** where it must fail closed: an agent that cannot establish its own identity must not publish peers. It now skips the pass and says why. Skipping costs one observation per 90s; reporting yourself pollutes the pairing list of every operator who looks.

This is the same defect class as the compose-URL bug fixed during #4828, where self-exclusion was silently inert because the id could not be read through the candidate contract. Same failure, different route in — the guard was still shaped so "unknown" reads as "no exclusion needed".

## Verified by running it

- the container boots past module load and resumes its existing enrolment — `Resuming as nodeId=edge_c6c55d0bc523495b (trustState=trusted)`, `restarts=0`
- the fail-closed test fails with the guard removed, passes with it restored
- edge-node **226 pass** / 5 skipped · validators **119 pass** · `tsc` clean · PR guards **7/7**
- the guard-parity preflight caught a `process.cwd()` path base in the new test (it breaks under `vitest --root`); fixed to resolve from the test file

## Pushed with a recorded override

A released image that cannot boot is the emergency. The override path still ran the full guard-parity preflight and refused until the cwd violation above was fixed — it was not waved through. Required CI here is the authoritative check.

## Follow-up this does not cover

**No CI job starts the Edge Node container.** A build-and-boot smoke check would have caught defect 1 in minutes instead of on a user's machine. That gap is the reason both of these reached a release, and it is worth its own fix.

Refs: BI-105966A1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
