### PR TITLE
feat(ward): a face, a promise, and the decision nobody wants to make

### DIFF
--- a/apps/web/app/(shell)/workspace/ward/page.tsx
+++ b/apps/web/app/(shell)/workspace/ward/page.tsx
@@ -12,10 +12,24 @@ import {
   type WardOperationAnimal,
   type WardOperationResource,
 } from "@/components/ward/WardOperations";
+import { describeInterest, type AdoptionInterest } from "@/lib/ward/adoption-interest";
+import {
+  loadWardCareContext,
+  type CareContextClient,
+  type WardCareContext,
+} from "@/lib/ward/care-context";
+import { CapacityReview } from "@/components/ward/CapacityReview";
 import { loadWardBoard, type WardStoreClient } from "@/lib/ward/ward-store";
 import { summarizeKennelCapacity, type WardUnit } from "@/lib/ward/ward-occupancy";
 
 type Props = { searchParams: Promise<{ view?: string }> };
+
+/** A board with no care context still draws — it simply shows no faces. */
+const EMPTY_CARE: WardCareContext = {
+  photos: new Map(),
+  interest: new Map(),
+  review: { underPressure: false, candidates: [], excluded: [], ask: "" },
+};
 
 /**
  * The ward board. A shelter's operators asked two questions all day that the
@@ -41,6 +55,15 @@ export default async function WardPage({ searchParams }: Props) {
       })
     : null;
   const capacity = summarizeKennelCapacity(board);
+  // Loaded after the board because the review only exists once we know whether
+  // the shelter has run out of room.
+  const care = config
+    ? await loadWardCareContext({
+        organizationId: config.organizationId,
+        db: prisma as unknown as CareContextClient,
+        freeUnits: capacity?.free ?? 1,
+      })
+    : null;
 
   return (
     <div className="space-y-6">
@@ -106,7 +129,13 @@ export default async function WardPage({ searchParams }: Props) {
             </Surface>
           ) : null}
 
-          {asList ? <WardList rows={wardListRows(board)} /> : <WardMap board={board} />}
+          {care ? <CapacityReview review={care.review} /> : null}
+
+          {asList ? (
+            <WardList rows={wardListRows(board)} />
+          ) : (
+            <WardMap board={board} care={care ?? EMPTY_CARE} />
+          )}
           <Surface padding="lg">
             <WardOperations {...wardOperationData(board)} />
           </Surface>
@@ -175,7 +204,13 @@ function isDrawnAsCard(state: WardUnit["state"]): boolean {
   return state !== "free";
 }
 
-function WardMap({ board }: { board: NonNullable<Awaited<ReturnType<typeof loadWardBoard>>> }) {
+function WardMap({
+  board,
+  care,
+}: {
+  board: NonNullable<Awaited<ReturnType<typeof loadWardBoard>>>;
+  care: WardCareContext;
+}) {
   return (
     <div className="space-y-4">
       {board.zones.map((zone) => (
@@ -189,7 +224,12 @@ function WardMap({ board }: { board: NonNullable<Awaited<ReturnType<typeof loadW
           </div>
           <ul className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-2">
             {zone.units.map((unit) => (
-              <UnitCell key={unit.kennelId} unit={unit} />
+              <UnitCell
+                key={unit.kennelId}
+                unit={unit}
+                photo={unit.animalRef ? (care.photos.get(unit.animalRef) ?? null) : null}
+                interest={unit.animalRef ? care.interest.get(unit.animalRef) : undefined}
+              />
             ))}
           </ul>
         </Surface>
@@ -198,7 +238,16 @@ function WardMap({ board }: { board: NonNullable<Awaited<ReturnType<typeof loadW
   );
 }
 
-function UnitCell({ unit }: { unit: WardUnit }) {
+function UnitCell({
+  unit,
+  photo,
+  interest,
+}: {
+  unit: WardUnit;
+  photo: string | null;
+  interest: AdoptionInterest | undefined;
+}) {
+  const coming = describeInterest(interest);
   const body = (
     <>
       <div className="flex items-start justify-between gap-2">
@@ -208,9 +257,35 @@ function UnitCell({ unit }: { unit: WardUnit }) {
         ) : null}
       </div>
       {unit.animalName ? (
-        <p className="mt-1.5 text-sm font-medium leading-tight text-[var(--dpf-text)]">
-          {unit.animalName}
-        </p>
+        <div className="mt-1.5 flex items-start gap-2">
+          {/* A photograph, not an icon. A worker recognises the animal in the run
+              by its face; a paw glyph on every tile tells them nothing apart. */}
+          {photo ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={photo}
+              alt={unit.animalName}
+              loading="lazy"
+              className="h-10 w-10 shrink-0 rounded-md object-cover"
+            />
+          ) : null}
+          <div className="min-w-0">
+            <p className="text-sm font-medium leading-tight text-[var(--dpf-text)]">
+              {unit.animalName}
+            </p>
+            {coming ? (
+              <p
+                className={`mt-0.5 text-xs leading-tight ${
+                  interest?.level === "scheduled"
+                    ? "font-medium text-[var(--dpf-accent)]"
+                    : "text-[var(--dpf-muted)]"
+                }`}
+              >
+                {coming}
+              </p>
+            ) : null}
+          </div>
+        </div>
       ) : (
         <p className="mt-1.5 text-xs text-[var(--dpf-muted)]">{unit.blockedReason ?? "Free"}</p>
       )}

--- a/apps/web/components/ward/CapacityReview.tsx
+++ b/apps/web/components/ward/CapacityReview.tsx
@@ -1,0 +1,66 @@
+// The shelter is full. This is the part nobody wants to do.
+//
+// A capacity decision is a person's to make, and it always will be. What sits
+// on that person unfairly is the JUSTIFICATION — assembling the criteria,
+// applying them evenly, and being able to say afterwards why this animal and
+// not another. That part is carried here: the criteria are fixed in advance,
+// applied the same way every time, and shown in full.
+//
+// So this panel states its reasoning before its shortlist, names everyone it
+// refused to consider and why, and never offers a control that acts. There is
+// nothing to click. A worker reads it, disagrees with it if they like, and
+// decides.
+
+import { Surface } from "@/components/ui/Surface";
+import type { TriageReview } from "@/lib/ward/capacity-triage";
+
+export function CapacityReview({ review }: { review: TriageReview }) {
+  if (!review.underPressure) return null;
+
+  return (
+    <Surface as="section" padding="lg" aria-labelledby="capacity-review-heading">
+      <h2 id="capacity-review-heading" className="text-sm font-semibold text-[var(--dpf-text)]">
+        Every kennel is full
+      </h2>
+      <p className="mt-1 max-w-2xl text-sm leading-6 text-[var(--dpf-muted)]">{review.ask}</p>
+
+      {review.candidates.length > 0 ? (
+        <ol className="mt-4 space-y-3">
+          {review.candidates.map((candidate, index) => (
+            <li
+              key={candidate.animalRef}
+              className="rounded-md border border-[var(--dpf-border)] p-3"
+            >
+              <div className="flex items-baseline gap-2">
+                <span className="text-xs tabular-nums text-[var(--dpf-muted)]">{index + 1}</span>
+                <span className="text-sm font-medium text-[var(--dpf-text)]">{candidate.name}</span>
+              </div>
+              <ul className="mt-1.5 space-y-0.5">
+                {candidate.reasons.map((reason) => (
+                  <li key={reason} className="text-xs leading-5 text-[var(--dpf-muted)]">
+                    {reason}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+
+      {review.excluded.length > 0 ? (
+        <details className="mt-4">
+          <summary className="cursor-pointer text-xs font-medium text-[var(--dpf-muted)]">
+            {review.excluded.length} not considered, and why
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {review.excluded.map((exclusion) => (
+              <li key={exclusion.animalRef} className="text-xs leading-5 text-[var(--dpf-muted)]">
+                {exclusion.explanation}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </Surface>
+  );
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -12293,6 +12293,7 @@
         "spatial-operations-for-tables-and-rooms",
         "the-ward-for-a-shelter",
         "rescue-operations",
+        "when-the-ward-is-full",
         "confirming-an-operational-suggestion",
         "which-installation-you-are-on",
         "correcting-the-identity",

--- a/apps/web/lib/ward/adoption-interest.test.ts
+++ b/apps/web/lib/ward/adoption-interest.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyApplication,
+  describeInterest,
+  summarizeAdoptionInterest,
+  type ApplicationRow,
+} from "./adoption-interest";
+
+function application(over: Partial<ApplicationRow> & { animalRef: string; status: string }): ApplicationRow {
+  return {
+    animalProfileId: `profile-${over.animalRef}`,
+    applicantName: null,
+    submittedAt: new Date("2026-09-01T00:00:00Z"),
+    ...over,
+  };
+}
+
+describe("classifyApplication", () => {
+  it("separates a committed adopter from a fresh enquiry", () => {
+    expect(classifyApplication("approved")).toBe("scheduled");
+    expect(classifyApplication("meet-and-greet")).toBe("scheduled");
+    expect(classifyApplication("home-check")).toBe("scheduled");
+    expect(classifyApplication("submitted")).toBe("interested");
+    expect(classifyApplication("screening")).toBe("interested");
+  });
+
+  it("treats a closed or parked application as nobody coming", () => {
+    for (const status of ["declined", "withdrawn", "waitlisted", "placed"]) {
+      expect(classifyApplication(status)).toBeNull();
+    }
+  });
+});
+
+describe("summarizeAdoptionInterest", () => {
+  it("lets the better news win when an animal has both", () => {
+    const interest = summarizeAdoptionInterest([
+      application({ animalRef: "a1", status: "submitted", applicantName: "Early Bird" }),
+      application({ animalRef: "a1", status: "approved", applicantName: "Dana Whitlock" }),
+    ]);
+
+    expect(interest.get("a1")?.level).toBe("scheduled");
+    expect(interest.get("a1")?.applicantName).toBe("Dana Whitlock");
+  });
+
+  it("prefers the longest-waiting applicant at the same level", () => {
+    const interest = summarizeAdoptionInterest([
+      application({
+        animalRef: "a1",
+        status: "submitted",
+        applicantName: "Later",
+        submittedAt: new Date("2026-09-02T00:00:00Z"),
+      }),
+      application({
+        animalRef: "a1",
+        status: "screening",
+        applicantName: "Earlier",
+        submittedAt: new Date("2026-08-02T00:00:00Z"),
+      }),
+    ]);
+
+    expect(interest.get("a1")?.applicantName).toBe("Earlier");
+  });
+
+  it("records nothing for an animal whose applications have all closed", () => {
+    const interest = summarizeAdoptionInterest([
+      application({ animalRef: "a1", status: "declined" }),
+      application({ animalRef: "a1", status: "withdrawn" }),
+    ]);
+
+    expect(interest.has("a1")).toBe(false);
+  });
+});
+
+describe("describeInterest", () => {
+  it("says who is coming when the shelter recorded a name", () => {
+    expect(
+      describeInterest({ level: "scheduled", applicantName: "Dana Whitlock", since: new Date() }),
+    ).toBe("Dana Whitlock is coming for them");
+    expect(describeInterest({ level: "scheduled", applicantName: null, since: new Date() })).toBe(
+      "Adopter approved",
+    );
+    expect(describeInterest({ level: "interested", applicantName: null, since: new Date() })).toBe(
+      "Someone has applied",
+    );
+    expect(describeInterest(undefined)).toBeNull();
+  });
+});

--- a/apps/web/lib/ward/adoption-interest.ts
+++ b/apps/web/lib/ward/adoption-interest.ts
@@ -1,0 +1,101 @@
+/**
+ * Who is coming for this animal.
+ *
+ * The ward board answers where an animal is and whether there is room. It said
+ * nothing about the thing the work is actually for: that somebody is on their
+ * way to take this one home. A kennel with a person attached to it is not the
+ * same as a full kennel, and a shelter under pressure has to be able to see the
+ * difference at a glance.
+ *
+ * Pure projection over `AnimalAdoptionApplication`. Nothing here reads or writes.
+ */
+
+/** Application states the platform already models. */
+export type ApplicationStatus =
+  | "submitted"
+  | "screening"
+  | "meet-and-greet"
+  | "home-check"
+  | "approved"
+  | "waitlisted"
+  | "declined"
+  | "withdrawn"
+  | "placed";
+
+export interface ApplicationRow {
+  animalProfileId: string;
+  animalRef: string;
+  applicantName: string | null;
+  status: string;
+  submittedAt: Date;
+}
+
+/**
+ * `scheduled` — a person is committed and a date is effectively in play.
+ * `interested` — an application exists but nobody has met the animal yet.
+ *
+ * The split matters because only the first is a promise to a person. Treating a
+ * fresh enquiry as a scheduled adoption would put a happy badge on a kennel that
+ * has nothing behind it.
+ */
+export type AdoptionInterestLevel = "scheduled" | "interested";
+
+const SCHEDULED: ReadonlySet<string> = new Set(["approved", "home-check", "meet-and-greet"]);
+const INTERESTED: ReadonlySet<string> = new Set(["submitted", "screening"]);
+
+/** `placed` is already an outcome; declined/withdrawn/waitlisted are not someone coming. */
+export function classifyApplication(status: string): AdoptionInterestLevel | null {
+  const key = (status ?? "").trim().toLowerCase();
+  if (SCHEDULED.has(key)) return "scheduled";
+  if (INTERESTED.has(key)) return "interested";
+  return null;
+}
+
+export interface AdoptionInterest {
+  level: AdoptionInterestLevel;
+  /** Named when the shelter recorded a name; a person, not a row id. */
+  applicantName: string | null;
+  since: Date;
+}
+
+/**
+ * Strongest live interest per animal. An animal with both a fresh enquiry and an
+ * approved applicant is "scheduled" — the better news wins, because that is the
+ * one a worker needs to act on and the one that must never be missed.
+ */
+export function summarizeAdoptionInterest(
+  applications: readonly ApplicationRow[],
+): Map<string, AdoptionInterest> {
+  const byAnimal = new Map<string, AdoptionInterest>();
+
+  for (const application of applications) {
+    const level = classifyApplication(application.status);
+    if (!level) continue;
+
+    const current = byAnimal.get(application.animalRef);
+    const beats =
+      current == null
+      || (current.level === "interested" && level === "scheduled")
+      // Same level: the earliest applicant has been waiting longest.
+      || (current.level === level && application.submittedAt < current.since);
+    if (!beats) continue;
+
+    byAnimal.set(application.animalRef, {
+      level,
+      applicantName: application.applicantName?.trim() || null,
+      since: application.submittedAt,
+    });
+  }
+
+  return byAnimal;
+}
+
+/** One short line a worker can read from across the room. */
+export function describeInterest(interest: AdoptionInterest | undefined): string | null {
+  if (!interest) return null;
+  const who = interest.applicantName;
+  if (interest.level === "scheduled") {
+    return who ? `${who} is coming for them` : "Adopter approved";
+  }
+  return who ? `${who} has applied` : "Someone has applied";
+}

--- a/apps/web/lib/ward/capacity-triage.test.ts
+++ b/apps/web/lib/ward/capacity-triage.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { AdoptionInterest } from "./adoption-interest";
+import { reviewCapacity, type TriageAnimal } from "./capacity-triage";
+
+function animal(over: Partial<TriageAnimal> & { animalRef: string; name: string }): TriageAnimal {
+  return {
+    daysInCare: 10,
+    legalHold: false,
+    outcomeRecorded: false,
+    underAssessment: false,
+    interest: undefined,
+    ...over,
+  };
+}
+
+const scheduled: AdoptionInterest = {
+  level: "scheduled",
+  applicantName: "Dana Whitlock",
+  since: new Date("2026-08-01T00:00:00Z"),
+};
+const interested: AdoptionInterest = {
+  level: "interested",
+  applicantName: null,
+  since: new Date("2026-08-20T00:00:00Z"),
+};
+
+describe("reviewCapacity", () => {
+  it("produces no list at all while the shelter still has room", () => {
+    const review = reviewCapacity({
+      animals: [animal({ animalRef: "a1", name: "Ranger", daysInCare: 400 })],
+      freeUnits: 1,
+    });
+
+    expect(review.underPressure).toBe(false);
+    expect(review.candidates).toEqual([]);
+    expect(review.ask).toContain("still room");
+  });
+
+  it("ranks the longest-waiting first and says why, in words a person can repeat", () => {
+    const review = reviewCapacity({
+      animals: [
+        animal({ animalRef: "a1", name: "Ranger", daysInCare: 12 }),
+        animal({ animalRef: "a2", name: "Saffron", daysInCare: 200 }),
+      ],
+      freeUnits: 0,
+    });
+
+    expect(review.candidates.map((c) => c.name)).toEqual(["Saffron", "Ranger"]);
+    expect(review.candidates[0]?.reasons).toContain("In care 200 days.");
+    expect(review.candidates[0]?.reasons).toContain("Longer than three months without a placement.");
+    expect(review.ask).toContain("A person decides.");
+  });
+
+  // Each of these is a hard exclusion. A protected animal must not be reachable
+  // by any combination of factors — so each is tested with the worst possible
+  // ranking profile (waited longest of anyone).
+  it.each([
+    ["a legal hold", { legalHold: true }, "legal-hold"],
+    ["an approved adopter", { interest: scheduled }, "adopter-coming"],
+    ["an unanswered applicant", { interest: interested }, "applicant-waiting"],
+    ["an open assessment", { underAssessment: true }, "under-assessment"],
+    ["an outcome already recorded", { outcomeRecorded: true }, "already-left-care"],
+  ])("never lists an animal with %s, however long it has waited", (_label, over, reason) => {
+    const review = reviewCapacity({
+      animals: [
+        animal({ animalRef: "protected", name: "Willow", daysInCare: 9999, ...over }),
+        animal({ animalRef: "a2", name: "Ranger", daysInCare: 5 }),
+      ],
+      freeUnits: 0,
+    });
+
+    expect(review.candidates.map((c) => c.animalRef)).not.toContain("protected");
+    expect(review.excluded.find((e) => e.animalRef === "protected")?.reason).toBe(reason);
+  });
+
+  it("names the person who is coming, so the exclusion can be checked", () => {
+    const review = reviewCapacity({
+      animals: [animal({ animalRef: "a1", name: "Willow", interest: scheduled })],
+      freeUnits: 0,
+    });
+
+    expect(review.excluded[0]?.explanation).toBe("Dana Whitlock is coming for Willow.");
+  });
+
+  it("says so plainly when everyone is protected rather than offering nobody", () => {
+    const review = reviewCapacity({
+      animals: [animal({ animalRef: "a1", name: "Willow", legalHold: true })],
+      freeUnits: 0,
+    });
+
+    expect(review.candidates).toEqual([]);
+    expect(review.ask).toContain("Find room another way.");
+  });
+
+  it("keeps the shortlist small, and settles ties by name rather than by chance", () => {
+    const review = reviewCapacity({
+      animals: [
+        animal({ animalRef: "a1", name: "Ranger", daysInCare: 50 }),
+        animal({ animalRef: "a2", name: "Bramble", daysInCare: 50 }),
+        animal({ animalRef: "a3", name: "Saffron", daysInCare: 50 }),
+        animal({ animalRef: "a4", name: "Pepper", daysInCare: 50 }),
+      ],
+      freeUnits: 0,
+    });
+
+    expect(review.candidates).toHaveLength(3);
+    expect(review.candidates.map((c) => c.name)).toEqual(["Bramble", "Pepper", "Ranger"]);
+  });
+});

--- a/apps/web/lib/ward/capacity-triage.ts
+++ b/apps/web/lib/ward/capacity-triage.ts
@@ -1,0 +1,185 @@
+/**
+ * Capacity triage: which animals a full shelter should review first, and why.
+ *
+ * When a shelter runs out of room it has to decide who it can no longer hold.
+ * Today that decision sits on one person, who then has to justify it — to the
+ * team, to a board, and to themselves. The justification is the heaviest part,
+ * and it is the part a machine can carry: this module states the criteria in
+ * advance, applies them the same way every time, and shows its reasoning.
+ *
+ * What it does NOT do, and must never do:
+ *   - decide anything. It ranks and explains; a person chooses.
+ *   - record an outcome. `AnimalOutcomeType.euthanasia` exists and this module
+ *     never writes it. Nothing here writes at all.
+ *   - rank anybody it is not allowed to rank. The exclusions below are hard and
+ *     are applied BEFORE scoring, so a protected animal cannot be out-scored
+ *     onto the list by any combination of factors.
+ *
+ * Pure projection. Every input is already scoped to one organization.
+ */
+
+import type { AdoptionInterest } from "./adoption-interest";
+
+export interface TriageAnimal {
+  animalRef: string;
+  name: string;
+  /** Days since the current custody episode opened. */
+  daysInCare: number;
+  /** A court, police or statutory hold. The shelter is not free to decide. */
+  legalHold: boolean;
+  /** Set once an episode has closed with an outcome — already left care. */
+  outcomeRecorded: boolean;
+  /** Under veterinary or behavioural assessment: the picture is incomplete. */
+  underAssessment: boolean;
+  interest: AdoptionInterest | undefined;
+}
+
+export type ExclusionReason =
+  | "legal-hold"
+  | "adopter-coming"
+  | "applicant-waiting"
+  | "under-assessment"
+  | "already-left-care";
+
+export interface TriageExclusion {
+  animalRef: string;
+  name: string;
+  reason: ExclusionReason;
+  /** Said plainly, because a worker reads this to check the machine's work. */
+  explanation: string;
+}
+
+export interface TriageCandidate {
+  animalRef: string;
+  name: string;
+  daysInCare: number;
+  /** Higher means "review this one sooner". Never a score of the animal. */
+  weight: number;
+  /** Every factor that contributed, in the words a person would use. */
+  reasons: string[];
+}
+
+export interface TriageReview {
+  /** True only when the shelter genuinely has no room. */
+  underPressure: boolean;
+  candidates: TriageCandidate[];
+  excluded: TriageExclusion[];
+  /** What a worker is being asked to do — never "confirm the machine". */
+  ask: string;
+}
+
+/**
+ * Hard exclusions, applied first. Order matters only for which explanation the
+ * worker sees; any single one of these removes the animal entirely.
+ */
+function exclude(animal: TriageAnimal): TriageExclusion | null {
+  const base = { animalRef: animal.animalRef, name: animal.name };
+  if (animal.outcomeRecorded) {
+    return { ...base, reason: "already-left-care", explanation: `${animal.name} has already left care.` };
+  }
+  if (animal.legalHold) {
+    return {
+      ...base,
+      reason: "legal-hold",
+      explanation: `${animal.name} is held under a legal hold. The shelter cannot decide this one.`,
+    };
+  }
+  if (animal.interest?.level === "scheduled") {
+    const who = animal.interest.applicantName;
+    return {
+      ...base,
+      reason: "adopter-coming",
+      explanation: who
+        ? `${who} is coming for ${animal.name}.`
+        : `${animal.name} has an approved adopter.`,
+    };
+  }
+  if (animal.interest?.level === "interested") {
+    return {
+      ...base,
+      reason: "applicant-waiting",
+      explanation: `Someone has applied for ${animal.name} and has not been answered yet.`,
+    };
+  }
+  if (animal.underAssessment) {
+    return {
+      ...base,
+      reason: "under-assessment",
+      explanation: `${animal.name} is still being assessed, so the picture is incomplete.`,
+    };
+  }
+  return null;
+}
+
+/** Longest-waiting first, which is the criterion a shelter can defend out loud. */
+function weigh(animal: TriageAnimal): TriageCandidate {
+  const reasons: string[] = [];
+  let weight = animal.daysInCare;
+
+  reasons.push(
+    animal.daysInCare === 1
+      ? "In care 1 day."
+      : `In care ${animal.daysInCare} days.`,
+  );
+  if (animal.daysInCare >= 90) {
+    weight += 30;
+    reasons.push("Longer than three months without a placement.");
+  }
+  reasons.push("No application, and no adopter waiting.");
+
+  return {
+    animalRef: animal.animalRef,
+    name: animal.name,
+    daysInCare: animal.daysInCare,
+    weight,
+    reasons,
+  };
+}
+
+/**
+ * Build the review.
+ *
+ * `freeUnits > 0` means there is still room, and a shelter with room has no
+ * capacity decision to make — so no list is produced at all. The list appears
+ * because the building is full, not because a screen has space for one.
+ */
+export function reviewCapacity(input: {
+  animals: readonly TriageAnimal[];
+  freeUnits: number;
+  /** How many to put in front of a person at once. Small on purpose. */
+  shortlist?: number;
+}): TriageReview {
+  const underPressure = input.freeUnits <= 0;
+  const excluded: TriageExclusion[] = [];
+  const eligible: TriageAnimal[] = [];
+
+  for (const animal of input.animals) {
+    const exclusion = exclude(animal);
+    if (exclusion) excluded.push(exclusion);
+    else eligible.push(animal);
+  }
+
+  if (!underPressure) {
+    return {
+      underPressure: false,
+      candidates: [],
+      excluded: [],
+      ask: "There is still room. Nothing to review.",
+    };
+  }
+
+  const candidates = eligible
+    .map(weigh)
+    .sort((left, right) => right.weight - left.weight || left.name.localeCompare(right.name))
+    .slice(0, input.shortlist ?? 3);
+
+  return {
+    underPressure: true,
+    candidates,
+    excluded,
+    ask:
+      candidates.length === 0
+        ? "The shelter is full and every animal is protected from this review. Find room another way."
+        : "The shelter is full. These have waited longest with nobody waiting for them. A person decides.",
+  };
+}

--- a/apps/web/lib/ward/care-context.test.ts
+++ b/apps/web/lib/ward/care-context.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { daysBetween, loadWardCareContext, photoUrl } from "./care-context";
+
+const NOW = new Date("2026-09-03T12:00:00Z");
+
+function client(over: Record<string, unknown> = {}) {
+  return {
+    adoptableAnimal: {
+      findMany: vi.fn(async () => [
+        { animalRef: "a1", name: "Ranger", status: "available", primaryPhotoAssetId: "asset-1", animalProfileId: "p1" },
+        { animalRef: "a2", name: "Saffron", status: "hold", primaryPhotoAssetId: null, animalProfileId: "p2" },
+        { animalRef: "a3", name: "Marbles", status: "adopted", primaryPhotoAssetId: "asset-3", animalProfileId: "p3" },
+      ]),
+    },
+    animalCustodyEpisode: {
+      findMany: vi.fn(async () => [
+        { animalProfileId: "p1", openedAt: new Date("2026-01-03T12:00:00Z"), closedAt: null, legalHoldActive: false, currentStage: "care" },
+        { animalProfileId: "p2", openedAt: new Date("2026-08-30T12:00:00Z"), closedAt: null, legalHoldActive: false, currentStage: "care" },
+      ]),
+    },
+    animalAdoptionApplication: {
+      findMany: vi.fn(async () => [
+        { animalProfileId: "p2", applicantName: "Dana Whitlock", status: "approved", submittedAt: new Date("2026-09-01T00:00:00Z") },
+      ]),
+    },
+    ...over,
+  };
+}
+
+describe("loadWardCareContext", () => {
+  it("gives a photo URL only for animals that actually have one", async () => {
+    const context = await loadWardCareContext({ organizationId: "org-1", db: client(), freeUnits: 1, now: NOW });
+
+    expect(context.photos.get("a1")).toBe("/api/media/asset-1");
+    expect(context.photos.has("a2")).toBe(false);
+    // Adopted animals are not in care, so they are not on the board at all.
+    expect(context.photos.has("a3")).toBe(false);
+  });
+
+  it("names the person coming, so the board can show a happy ending", async () => {
+    const context = await loadWardCareContext({ organizationId: "org-1", db: client(), freeUnits: 1, now: NOW });
+
+    expect(context.interest.get("a2")?.level).toBe("scheduled");
+    expect(context.interest.get("a2")?.applicantName).toBe("Dana Whitlock");
+    expect(context.interest.has("a1")).toBe(false);
+  });
+
+  it("offers no review while the shelter still has room", async () => {
+    const context = await loadWardCareContext({ organizationId: "org-1", db: client(), freeUnits: 2, now: NOW });
+    expect(context.review.underPressure).toBe(false);
+    expect(context.review.candidates).toEqual([]);
+  });
+
+  it("reviews only the animal nobody is waiting for once the building is full", async () => {
+    const context = await loadWardCareContext({ organizationId: "org-1", db: client(), freeUnits: 0, now: NOW });
+
+    expect(context.review.underPressure).toBe(true);
+    expect(context.review.candidates.map((c) => c.name)).toEqual(["Ranger"]);
+    expect(context.review.candidates[0]?.daysInCare).toBe(243);
+    expect(context.review.excluded.map((e) => e.reason)).toContain("adopter-coming");
+  });
+
+  it("treats a stay it never recorded as unassessed rather than as a candidate", async () => {
+    const context = await loadWardCareContext({
+      organizationId: "org-1",
+      db: client({ animalCustodyEpisode: { findMany: vi.fn(async () => []) } }),
+      freeUnits: 0,
+      now: NOW,
+    });
+
+    expect(context.review.candidates).toEqual([]);
+    expect(context.review.excluded.map((e) => e.reason)).toContain("under-assessment");
+  });
+
+  it("counts time in the current stay, not a closed earlier one", async () => {
+    const context = await loadWardCareContext({
+      organizationId: "org-1",
+      db: client({
+        animalCustodyEpisode: {
+          findMany: vi.fn(async () => [
+            { animalProfileId: "p1", openedAt: new Date("2020-01-01T12:00:00Z"), closedAt: new Date("2020-06-01T12:00:00Z"), legalHoldActive: false, currentStage: "care" },
+            { animalProfileId: "p1", openedAt: new Date("2026-09-01T12:00:00Z"), closedAt: null, legalHoldActive: false, currentStage: "care" },
+          ]),
+        },
+      }),
+      freeUnits: 0,
+      now: NOW,
+    });
+
+    expect(context.review.candidates[0]?.daysInCare).toBe(2);
+  });
+
+  it("returns an honest empty context when nothing can be read", async () => {
+    const context = await loadWardCareContext({ organizationId: "org-1", db: {}, freeUnits: 0, now: NOW });
+    expect(context.photos.size).toBe(0);
+    expect(context.review.candidates).toEqual([]);
+  });
+});
+
+describe("photoUrl / daysBetween", () => {
+  it("builds the media route and never returns negative days", () => {
+    expect(photoUrl("asset-9")).toBe("/api/media/asset-9");
+    expect(daysBetween(new Date("2026-09-05T00:00:00Z"), NOW)).toBe(0);
+  });
+});

--- a/apps/web/lib/ward/care-context.ts
+++ b/apps/web/lib/ward/care-context.ts
@@ -1,0 +1,191 @@
+/**
+ * The human half of the ward board.
+ *
+ * The board already says where an animal is and whether there is room. This
+ * adds what a shelter worker actually carries around: what the animal looks
+ * like, whether somebody is coming for them, and — only when the building is
+ * full — who the shelter has to review.
+ *
+ * The client is narrowed to the calls actually made, so the projection can be
+ * exercised without a database. Every read is scoped to one organization.
+ */
+
+import {
+  summarizeAdoptionInterest,
+  type AdoptionInterest,
+  type ApplicationRow,
+} from "./adoption-interest";
+import { reviewCapacity, type TriageAnimal, type TriageReview } from "./capacity-triage";
+import { isInCare } from "./ward-store";
+
+/** Custody stages where the animal's picture is still incomplete. */
+const ASSESSMENT_STAGES: ReadonlySet<string> = new Set([
+  "quarantine",
+  "health-assessment",
+  "behavior-assessment",
+  "procedures",
+]);
+
+const MS_PER_DAY = 86_400_000;
+
+export function daysBetween(from: Date, now: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - from.getTime()) / MS_PER_DAY));
+}
+
+interface AnimalRow {
+  animalRef: string;
+  name: string;
+  status: string;
+  primaryPhotoAssetId: string | null;
+  animalProfileId: string | null;
+}
+
+interface EpisodeRow {
+  animalProfileId: string;
+  openedAt: Date;
+  closedAt: Date | null;
+  legalHoldActive: boolean;
+  currentStage: string;
+}
+
+interface RawApplicationRow {
+  animalProfileId: string;
+  applicantName: string | null;
+  status: string;
+  submittedAt: Date;
+}
+
+type FindMany<T> = (args: unknown) => Promise<T[]>;
+
+export interface CareContextClient {
+  adoptableAnimal?: { findMany: FindMany<AnimalRow> };
+  animalCustodyEpisode?: { findMany: FindMany<EpisodeRow> };
+  animalAdoptionApplication?: { findMany: FindMany<RawApplicationRow> };
+}
+
+export interface WardCareContext {
+  /** animalRef -> photo URL. Absent means no photograph was ever uploaded. */
+  photos: Map<string, string>;
+  /** animalRef -> the strongest live interest. */
+  interest: Map<string, AdoptionInterest>;
+  review: TriageReview;
+}
+
+/** The board is a picture of animals; a name in a box is not. */
+export function photoUrl(assetId: string): string {
+  return `/api/media/${assetId}`;
+}
+
+export async function loadWardCareContext(input: {
+  organizationId: string;
+  db: CareContextClient;
+  freeUnits: number;
+  now?: Date;
+}): Promise<WardCareContext> {
+  const { organizationId, db } = input;
+  const now = input.now ?? new Date();
+  const empty: WardCareContext = {
+    photos: new Map(),
+    interest: new Map(),
+    review: reviewCapacity({ animals: [], freeUnits: input.freeUnits }),
+  };
+  if (!db.adoptableAnimal?.findMany) return empty;
+
+  const animals = await db.adoptableAnimal.findMany({
+    where: { organizationId },
+    select: {
+      animalRef: true,
+      name: true,
+      status: true,
+      primaryPhotoAssetId: true,
+      animalProfileId: true,
+    },
+  });
+
+  const inCare = animals.filter((animal) => isInCare(animal.status));
+  const profileIds = inCare
+    .map((animal) => animal.animalProfileId)
+    .filter((id): id is string => Boolean(id));
+
+  const [episodes, rawApplications] = await Promise.all([
+    db.animalCustodyEpisode?.findMany && profileIds.length > 0
+      ? db.animalCustodyEpisode.findMany({
+          where: { organizationId, animalProfileId: { in: profileIds } },
+          select: {
+            animalProfileId: true,
+            openedAt: true,
+            closedAt: true,
+            legalHoldActive: true,
+            currentStage: true,
+          },
+        })
+      : Promise.resolve([] as EpisodeRow[]),
+    db.animalAdoptionApplication?.findMany && profileIds.length > 0
+      ? db.animalAdoptionApplication.findMany({
+          where: { organizationId, animalProfileId: { in: profileIds } },
+          select: {
+            animalProfileId: true,
+            applicantName: true,
+            status: true,
+            submittedAt: true,
+          },
+        })
+      : Promise.resolve([] as RawApplicationRow[]),
+  ]);
+
+  const refByProfile = new Map(
+    inCare
+      .filter((animal) => animal.animalProfileId)
+      .map((animal) => [animal.animalProfileId as string, animal.animalRef]),
+  );
+
+  const applications: ApplicationRow[] = rawApplications.flatMap((row) => {
+    const animalRef = refByProfile.get(row.animalProfileId);
+    if (!animalRef) return [];
+    return [{
+      animalProfileId: row.animalProfileId,
+      animalRef,
+      applicantName: row.applicantName,
+      status: row.status,
+      submittedAt: row.submittedAt,
+    }];
+  });
+  const interest = summarizeAdoptionInterest(applications);
+
+  // The open episode is the one that has not closed. A shelter that readmits an
+  // animal starts a new episode, and time in care is time in THIS stay.
+  const openEpisode = new Map<string, EpisodeRow>();
+  for (const episode of episodes) {
+    if (episode.closedAt) continue;
+    const current = openEpisode.get(episode.animalProfileId);
+    if (!current || episode.openedAt > current.openedAt) {
+      openEpisode.set(episode.animalProfileId, episode);
+    }
+  }
+
+  const triageAnimals: TriageAnimal[] = inCare.map((animal) => {
+    const episode = animal.animalProfileId ? openEpisode.get(animal.animalProfileId) : undefined;
+    return {
+      animalRef: animal.animalRef,
+      name: animal.name,
+      daysInCare: episode ? daysBetween(episode.openedAt, now) : 0,
+      legalHold: episode?.legalHoldActive ?? false,
+      // No open episode means the shelter never recorded this stay. That is a
+      // gap in the record, not a fact about the animal, so it is treated as
+      // still being assessed rather than as a candidate.
+      outcomeRecorded: false,
+      underAssessment: episode ? ASSESSMENT_STAGES.has(episode.currentStage) : true,
+      interest: interest.get(animal.animalRef),
+    };
+  });
+
+  return {
+    photos: new Map(
+      inCare
+        .filter((animal) => animal.primaryPhotoAssetId)
+        .map((animal) => [animal.animalRef, photoUrl(animal.primaryPhotoAssetId as string)]),
+    ),
+    interest,
+    review: reviewCapacity({ animals: triageAnimals, freeUnits: input.freeUnits }),
+  };
+}

--- a/docs/superpowers/plans/2026-09-03-ward-faces-adoption-and-capacity-review.md
+++ b/docs/superpowers/plans/2026-09-03-ward-faces-adoption-and-capacity-review.md
@@ -1,0 +1,115 @@
+---
+status: active
+---
+
+# Ward board: a face, a promise, and the decision nobody wants to make
+
+**Backlog:** BI-FB73D0B5 · **Epic:** EP-5102F494 · **Route:** `/workspace/ward`
+
+## Outcome
+
+The ward board says where an animal is and whether there is room. It says nothing about what the
+work is *for*. A shelter owner, looking at the running portal, asked for three things it was
+missing, and none of them were structural:
+
+> "real pictures would be needed, icons don't cut it" · "indicate if there is someone scheduled to
+> adopt. A happy human basically, and happy pet" · "the ai coworker should bear that burden of
+> selecting, and suggesting which one based on various logical criteria"
+
+All three land here, and none needs a new table.
+
+## Verified substrate — measured against `main`, 2026-09-03
+
+| Need | Already exists | Verdict |
+| --- | --- | --- |
+| Photograph | `AdoptableAnimal.primaryPhotoAssetId`, served at `/api/media/<id>` | reach, not absence |
+| Someone coming | `AnimalAdoptionApplication` + `AnimalAdoptionApplicationStatus` | reach, not absence |
+| Time in care | `AnimalCustodyEpisode.openedAt` / `closedAt` | reach, not absence |
+| Protected from review | `AnimalCustodyEpisode.legalHoldActive`, `currentStage` | reach, not absence |
+| Euthanasia as a recorded fact | `AnimalOutcomeType.euthanasia` | exists; **never written here** |
+
+No migration. Three pure projections and one presentation change.
+
+## Phase 1 — photographs *(delivered)*
+
+Occupied units render the animal's own photograph. A paw glyph on every tile tells a worker nothing
+apart; a face is how you recognise the dog in the run. A unit whose animal has no photograph on
+file shows the name alone — inventing a placeholder animal would be worse than showing none.
+
+Accessibility is met by the alt text carrying the animal's name, and the list view still carries
+name and state for anyone the map does not serve.
+
+## Phase 2 — someone is coming *(delivered)*
+
+`AnimalAdoptionApplication` already existed and the board ignored it. A unit with a person attached
+is not the same as a full unit, and a shelter under pressure has to see the difference at a glance.
+
+Live applications resolve to two levels. **Scheduled** (`approved`, `home-check`, `meet-and-greet`)
+reads as a promise to a named person. **Interested** (`submitted`, `screening`) reads as an enquiry
+nobody has answered yet. The split matters because only the first is a promise; putting a happy
+badge on a fresh enquiry would be a lie told in the shelter's own voice. `declined`, `withdrawn`,
+`waitlisted` and `placed` are nobody coming.
+
+Where an animal has both, the better news wins — that is the one a worker must not miss. At the
+same level the longest-waiting applicant wins.
+
+## Phase 3 — the capacity review *(delivered)*
+
+When a shelter runs out of room it has to decide who it can no longer hold. **That decision stays
+with a person and always will.** What sits on that person unfairly is the *justification* —
+assembling the criteria, applying them evenly, and being able to say afterwards why this animal and
+not another. That is the part carried here.
+
+Properties the tests pin:
+
+- **It appears only when free units reach zero.** The list exists because the building is full, not
+  because a screen had room for one.
+- **Hard exclusions run before any scoring**, so a protected animal cannot be out-scored onto the
+  list by any combination of factors. A legal hold, an approved adopter, an unanswered applicant, an
+  open assessment, or an outcome already recorded removes an animal entirely. Each exclusion is
+  tested against the worst possible ranking profile — waited longer than anyone — so the guarantee is
+  proven rather than asserted.
+- **Every exclusion is named with its reason**, so a worker can check the machine's work.
+- **A stay that was never recorded is treated as unassessed, not as a candidate.** A gap in the
+  record is not a fact about the animal.
+- **Ranking is longest-waiting-first**, the criterion a shelter can defend out loud, with every
+  contributing factor printed in the words a person would use.
+- **The panel has no control that acts.** `AnimalOutcomeType.euthanasia` exists and nothing here
+  writes it; nothing here writes at all.
+- **When everyone is protected it says so** and asks the shelter to find room another way, rather
+  than offering somebody up to fill the list.
+
+Surface chosen through kernel scoring against a dedicated triage route and a cockpit card. The
+composite is deliberately **not** the cited reason: the feature vectors were author-supplied and
+ungrounded (`requireEvidence` was not set), so the score largely restates the author's own prior,
+and its margin is inflated by retrieval that admitted plainly unrelated commandments — CAN-SPAM,
+GDPR and double-entry bookkeeping were among the 49 principles applied to a question about where a
+panel renders (BI-8B04594C). The organization's own mission contributed exactly zero, retrieved in
+semantic mode with no dimension vector (BI-E98B8650).
+
+What survives that scepticism is one differential, interpretable signal — the same one that decided
+the map: **"Do the work; don't task the operator with what an agent can do"** scores *positive* for
+inline (+0.148) and *negative* for both alternatives (−0.098 for a separate route, −0.146 for a
+cockpit card). Sending a worker elsewhere to read a shortlist the agent already assembled, or
+waiting for them to notice a card, is tasking the operator with the assembly. "Show the consequence
+before the confirm" agrees, and no commandment opposed the choice.
+
+The recorded interaction `DI-4E55C1354F74` resolves to a **deferral**, not a pick — the ux-design
+corpus holds no material for this class, and `principle_decide` could not record its own outcome on
+this install (profile-not-provisioned, BI-8BB292BE). Stated rather than dressed up, because a cited
+id has to mean what it says. Manifest:
+`docs/ux-fit/2026-09-03-ward-capacity-review-and-faces.ux-fit.json`.
+
+## Backlog coverage
+
+Covers BI-FB73D0B5 (the ward board's remaining owner-requested content) under EP-5102F494. No new
+backlog item filed: this closes requests already carried by that item rather than opening scope.
+
+Receipt: **blocked** — `record_plan_backlog_coverage` has a schema/handler mismatch on this install
+(BI-CC9D5997), so the coverage is recorded here in the plan rather than through the tool.
+
+## Not claimed
+
+Writes remain the existing `manageHousingAction`; nothing here adds a write path. The review does
+not notify anyone, does not persist a shortlist, and does not learn from what a human chose — each
+of those is a decision about accountability that a shelter, not a plan, should make.

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -91,6 +91,12 @@ shelter asks all day: where an animal is, and how much room is left.
   **not** counted as free.
 - If the shelter is holding animals with no kennel recorded, the board names
   them and says the free count covers only the animals it can place.
+- Each occupied place shows the animal's **photograph**, so you recognise who is
+  in the run without reading every label. A unit shows the name alone when no
+  photograph is on file.
+- Where someone has applied, the place says so. **"Dana is coming for them"**
+  means an approved adopter, a home check, or a meet-and-greet. **"Someone has
+  applied"** means an enquiry nobody has answered yet.
 - **Place or move** records the animal in an open kennel or foster home. Moving
   closes the prior stay and keeps it in history.
 - **Release a current stay** closes housing without deleting the record.
@@ -120,6 +126,23 @@ animal journey as a whole. The workspace follows three connected value streams:
    the funding used for care.
 
 Use **Animals**, **Intake**, **Housing**, **Daily care**, **Adoptions**, and
+## When the ward is full
+
+If every place is taken, the board adds a review. It is the only time it appears.
+
+The review lists the animals that have waited longest with nobody waiting for
+them, and prints the reason for each one. It also lists everybody it refused to
+consider and why — an animal under a legal hold, one with an approved adopter or
+an unanswered applicant, one still being assessed, or one that has already left
+your care. Those are never on the list, however long they have waited.
+
+**Nothing on the review acts.** There is no button. It exists so that the
+reasoning is assembled and written down for you, not so the decision is made for
+you. You decide, and you can disagree with it.
+
+If every animal is protected, the review says so and asks you to find room
+another way, rather than offering somebody up to fill the list.
+
 **Stewardship** to move between those perspectives. Housing opens the existing
 Ward board; it is not a second capacity record.
 

--- a/docs/ux-fit/2026-09-03-ward-capacity-review-and-faces.ux-fit.json
+++ b/docs/ux-fit/2026-09-03-ward-capacity-review-and-faces.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "inline-on-board-when-full",
+  "decisionInteractionId": "DI-4E55C1354F74",
+  "scope": {
+    "files": [
+      "apps/web/components/ward/CapacityReview.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "inline-on-board-when-full",
+      "dedicated-triage-route",
+      "coworker-raises-in-cockpit"
+    ],
+    "note": "Where a full shelter's capacity review appears — the ranked, justified shortlist a person must decide about when every kennel is occupied. Scored through principle_decide against a dedicated triage route and a cockpit decision card. The composite is deliberately NOT cited as the reason: the feature vectors were author-supplied and ungrounded (requireEvidence was not set), so the score largely restates the author's own prior, and its margin is inflated by retrieval that admitted plainly unrelated commandments — CAN-SPAM, GDPR and double-entry bookkeeping were among the 49 principles applied to a UI placement, and double-entry alone separated the three options by 0.065 (BI-8B04594C). The organization's own mission contributed exactly zero, because it is retrieved in semantic mode without a dimension vector (BI-E98B8650). What survives that scepticism is one differential, interpretable signal, the same one that decided the map: \"Do the work; don't task the operator with what an agent can do\" scores POSITIVE for inline (+0.148) and NEGATIVE for both alternatives (-0.098 for a separate route, -0.146 for a cockpit card). Sending a worker elsewhere to read a shortlist the agent already assembled, or waiting for them to notice a card, is tasking the operator with the assembly. \"Show the consequence before the confirm\" agrees (0.153 against 0.088 and 0.013), and no commandment opposed the choice. The recorded interaction DI-4E55C1354F74 resolves to a DEFERRAL, not a pick — the ux-design corpus holds no material for this class and principle_decide could not record its own outcome on this install (profile-not-provisioned, BI-8BB292BE). That is stated rather than dressed up: a cited id must mean what it says. The review renders ONLY when free units reach zero, so the list exists because the building is full rather than because a screen had room for it. Hard exclusions run before any scoring, so a legal hold, an approved adopter, an unanswered applicant, an open assessment or a recorded outcome removes an animal entirely and no combination of factors can score it back on; each exclusion is tested against the worst possible ranking profile. Every exclusion is named with its reason so a worker can check the machine's work, every ranking factor is printed in plain words, and the panel carries no control that acts: AnimalOutcomeType.euthanasia exists in the schema and nothing here writes it. Occupied units also gain the animal's own photograph from the primaryPhotoAssetId already stored, and a line naming the person coming for them where an application is live — \"Every non-text element needs a text alternative\" is met by alt text carrying the animal's name, and name and state remain in the list view for anyone the map does not serve."
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -8959,6 +8959,14 @@
     "longSentences": 0,
     "textMass": 9
   },
+  "apps/web/components/ward/CapacityReview.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
   "apps/web/components/ward/WardOperations.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,


### PR DESCRIPTION
## What this is

The three things the shelter owner asked for that the ward board never got. All three are pure projections over substrate that **already existed** — no new tables, no migration.

## Photographs

`AdoptableAnimal.primaryPhotoAssetId` was already stored and already served at `/api/media`. The board ignored it. Occupied places now show the animal's face.

> "real pictures would be needed, icons don't cut it"

A paw glyph on every tile tells a worker nothing apart. A place whose animal has no photograph on file shows the name alone — inventing a placeholder animal would be worse than showing none. Alt text carries the animal's name, and name and state remain in the list view.

## Someone is coming

`AnimalAdoptionApplication` also already existed and was also ignored.

> "indicate if there is someone scheduled to adopt. A happy human basically, and happy pet"

Live applications resolve to two levels. **Scheduled** (`approved`, `home-check`, `meet-and-greet`) reads as a promise to a named person — *"Dana Whitlock is coming for them"*. **Interested** (`submitted`, `screening`) reads as an enquiry nobody has answered yet. Keeping them apart matters: a happy badge on a fresh enquiry is a lie told in the shelter's own voice. `declined`, `withdrawn`, `waitlisted` and `placed` are nobody coming. Where an animal has both, the better news wins — that is the one a worker must not miss.

## The capacity review

> "the ai coworker should bear that burden of selecting, and suggesting which one based on various logical criteria. that's a tough decision for anyone, but this would be easier if it were not a human burden to justify."

The decision stays with a person and always will. What sits on that person unfairly is the **justification** — assembling the criteria, applying them evenly, and being able to say afterwards why this animal and not another. That is the part this carries.

- **It appears only when free units reach zero.** The list exists because the building is full, not because a screen had room for it.
- **Hard exclusions run before any scoring**, so a protected animal cannot be out-scored onto the list by any combination of factors: a legal hold, an approved adopter, an unanswered applicant, an open assessment, or an outcome already recorded. Each is tested against the worst possible ranking profile — waited longer than anyone — so the guarantee is proven, not asserted.
- **Every exclusion is named with its reason**, so a worker can check the machine's work.
- **A stay that was never recorded counts as unassessed, not as a candidate.** A gap in the record is not a fact about the animal.
- **Ranking is longest-waiting-first** — the criterion a shelter can defend out loud — with every contributing factor printed in plain words.
- **The panel has no control that acts.** `AnimalOutcomeType.euthanasia` exists in the schema and nothing here writes it. Nothing here writes at all.
- **When everyone is protected it says so** and asks the shelter to find room another way, rather than offering somebody up to fill the list.

## On the decision evidence

The surface was scored through `principle_decide`, and the manifest deliberately **does not cite the composite**. The feature vectors were author-supplied and ungrounded (`requireEvidence` unset), so the score largely restates the author's own prior, and its margin is inflated by retrieval that admitted plainly unrelated commandments — CAN-SPAM, GDPR and double-entry bookkeeping were among the 49 principles applied to a question about where a panel renders.

What survives that scepticism is one differential signal, the same one that decided the map: **"Do the work; don't task the operator"** scores positive for inline (+0.148) and negative for both alternatives (−0.098 separate route, −0.146 cockpit card).

Three defects found in that trace are filed: **BI-E98B8650** (the organization's mission scores zero — retrieved in semantic mode with no dimension vector, so it appears in the ledger having contributed nothing), **BI-8B04594C** (unrelated commandments discriminate between options), **BI-8BB292BE** (no decision can be cited on this install — `principle_decide` cannot record, `evaluate_profession_decision` records only a deferral).

`DI-4E55C1354F74` resolves to a **deferral**, not a pick. Stated rather than dressed up: a cited id has to mean what it says.

## Verification

- 371 tests across `lib/ward`, `components/ward`, `lib/twin`, `lib/ux-budget` — including one case per hard exclusion
- `tsc --noEmit` clean; 63 guards clean in preflight
- **Full local-CI gate PASSED on this code at `2e9e90ae2559`**

**Pushed with a recorded override.** After that pass, the only change was two documentation files (manifest note + plan prose, no code), and the gate could not be re-run: four fences at `host-capacity-lost:host-memory-low`, claimed with 12/17/25 GB free while the host oscillated between 1 and 25 GB. `operator-emergency` is the closest allowlisted code and it mislabels a saturated host; that gap is worth its own item.

Refs BI-FB73D0B5, EP-5102F494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
