### PR TITLE
fix(federation): resolve the CA host off the libuv thread pool (BI-41EB722B)

### DIFF
--- a/apps/web/lib/federation/ca-client.test.ts
+++ b/apps/web/lib/federation/ca-client.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { caInternalUrl, resolveCaHost } from "./ca-client";
+
+describe("resolveCaHost", () => {
+  it("returns an IP literal untouched, without touching any resolver", async () => {
+    const resolver = { resolve4: vi.fn(), resolve6: vi.fn(), lookup: vi.fn() };
+    expect(await resolveCaHost("172.18.0.7", resolver as never)).toEqual({ address: "172.18.0.7", family: 4 });
+    expect(await resolveCaHost("::1", resolver as never)).toEqual({ address: "::1", family: 6 });
+    expect(resolver.resolve4).not.toHaveBeenCalled();
+    expect(resolver.lookup).not.toHaveBeenCalled();
+  });
+
+  it("resolves a compose service name through c-ares (A, then AAAA) and never reaches getaddrinfo", async () => {
+    const resolver = { resolve4: vi.fn(async () => ["172.18.0.7"]), resolve6: vi.fn(), lookup: vi.fn() };
+    expect(await resolveCaHost("step-ca", resolver as never)).toEqual({ address: "172.18.0.7", family: 4 });
+    expect(resolver.resolve6).not.toHaveBeenCalled();
+    expect(resolver.lookup).not.toHaveBeenCalled();
+
+    const v6only = { resolve4: vi.fn(async () => { throw Object.assign(new Error("ENODATA"), { code: "ENODATA" }); }), resolve6: vi.fn(async () => ["fd00::7"]), lookup: vi.fn() };
+    expect(await resolveCaHost("step-ca", v6only as never)).toEqual({ address: "fd00::7", family: 6 });
+    expect(v6only.lookup).not.toHaveBeenCalled();
+  });
+
+  it("falls back to getaddrinfo only when the resolver has no record (hosts-file names)", async () => {
+    const resolver = {
+      resolve4: vi.fn(async () => { throw Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" }); }),
+      resolve6: vi.fn(async () => { throw Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" }); }),
+      lookup: vi.fn(async () => ({ address: "127.0.0.1", family: 4 })),
+    };
+    expect(await resolveCaHost("host.docker.internal", resolver as never)).toEqual({ address: "127.0.0.1", family: 4 });
+    expect(resolver.lookup).toHaveBeenCalledWith("host.docker.internal");
+  });
+});
+
+describe("caInternalUrl", () => {
+  it("defaults to the compose service and trims a configured trailing slash", () => {
+    expect(caInternalUrl({})).toBe("https://step-ca:9000");
+    expect(caInternalUrl({ DPF_ORGANIZATION_CA_INTERNAL_URL: "https://ca.internal:9443/" })).toBe("https://ca.internal:9443");
+  });
+});

--- a/apps/web/lib/federation/ca-client.ts
+++ b/apps/web/lib/federation/ca-client.ts
@@ -11,11 +11,51 @@
 // Two callers: the membership sign relay (POST /1.0/sign) and the join-file
 // issuer (GET /provisioners). Both inject this so a fake CA runs under test.
 
+import { promises as dns, type LookupAddress } from "node:dns";
 import { request as httpsRequest } from "node:https";
+import { isIP } from "node:net";
 import { checkServerIdentity as tlsCheckServerIdentity, type PeerCertificate } from "node:tls";
 
 export const DEFAULT_CA_INTERNAL_URL = "https://step-ca:9000";
 const CA_TIMEOUT_MS = 15_000;
+
+type LookupCallback = (error: NodeJS.ErrnoException | null, address: string, family: number) => void;
+
+/**
+ * Resolve the CA host without the libuv thread pool. Node's default
+ * `dns.lookup` is a getaddrinfo call on that pool, and libuv caps such "slow"
+ * work at half the pool: two stalled lookups elsewhere in the portal process
+ * (seen live on 2026-09-05: two workers parked in poll on Docker's resolver)
+ * queue every later lookup behind them, so the relay's request never even
+ * opened a socket and timed out while the same request from a fresh process
+ * answered in 75 ms. `dns.resolve4/6` go through c-ares on the event loop and
+ * Docker's embedded DNS answers compose service names directly; the
+ * getaddrinfo path stays as the fallback for hosts only /etc/hosts knows.
+ */
+export async function resolveCaHost(hostname: string, resolver: Pick<typeof dns, "resolve4" | "resolve6" | "lookup"> = dns): Promise<LookupAddress> {
+  const literal = isIP(hostname);
+  if (literal) return { address: hostname, family: literal };
+  try {
+    const [address] = await resolver.resolve4(hostname);
+    if (address) return { address, family: 4 };
+  } catch {
+    // fall through to AAAA, then getaddrinfo
+  }
+  try {
+    const [address] = await resolver.resolve6(hostname);
+    if (address) return { address, family: 6 };
+  } catch {
+    // fall through to getaddrinfo
+  }
+  return resolver.lookup(hostname);
+}
+
+function offThreadpoolLookup(hostname: string, _options: unknown, callback: LookupCallback): void {
+  resolveCaHost(hostname).then(
+    (found) => callback(null, found.address, found.family),
+    (error: NodeJS.ErrnoException) => callback(error, "", 0),
+  );
+}
 
 export function caInternalUrl(env: Record<string, string | undefined> = process.env): string {
   return env.DPF_ORGANIZATION_CA_INTERNAL_URL?.trim().replace(/\/+$/, "") || DEFAULT_CA_INTERNAL_URL;
@@ -50,6 +90,7 @@ export const caRequest: CaRequest = (input) => {
         headers: payload === undefined ? {} : { "content-type": "application/json", "content-length": Buffer.byteLength(payload) },
         ca: input.rootPem,
         servername: url.hostname,
+        lookup: offThreadpoolLookup,
         checkServerIdentity: (_host: string, cert: PeerCertificate) => {
           let last: Error | undefined;
           for (const candidate of candidates) {


### PR DESCRIPTION
On the development install the membership sign relay answered
"ca-unreachable: CA request timed out" three times in a row while the same
request from a fresh node process in the same container answered 201 in
75 ms. During each relay call the portal process opened no TCP connection to
step-ca at all: its default dns.lookup is a getaddrinfo call on the libuv
thread pool, libuv caps such slow work at half the pool, and two workers were
parked in poll on Docker's resolver, so every later lookup queued behind them
until the 15 s socket timeout fired. The same starvation explains the
inngest:8288 connect timeouts in the same window, while work-sync to an IP
literal kept working.

The CA client now resolves the CA host through c-ares (dns.resolve4, then
resolve6) on the event loop — Docker's embedded DNS answers compose service
names directly — and falls back to getaddrinfo only for names that just the
hosts file knows. IP literals are used as-is. The relay and the join-file
issuer both go through this client, so an authority whose portal process is
starved this way still reaches its CA.

Design-Grounding-Decision: no-contract-change (transport hardening inside lib/federation/ca-client.ts; spec §5.1 contract unchanged)
Docs-Impact-Decision: no docs affected — internal resolver choice, no operator-visible behaviour beyond the fault it removes

## Verification
- ca-client.test.ts (IP literal untouched; c-ares A then AAAA; getaddrinfo only as fallback), membership-relay and organization-join-issue tests green; typecheck clean; raw-error and one-ActionResult guards OK.
- Live evidence for the defect on BI-41EB722B: no TCP connection from the Next process to step-ca during three 15 s relay timeouts; identical request from a fresh node process in the same container: 201 in 75 ms; two libuv workers parked in poll.

Design-Grounding-Decision: no-contract-change (transport hardening inside lib/federation/ca-client.ts; spec §5.1 contract unchanged)
Docs-Impact-Decision: no docs affected — internal resolver choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)