### PR TITLE
fix(federation): CA requests report the phase they reached on timeout and use a fresh non-keep-alive agent (BI-41EB722B)

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/web/lib/federation/ca-client.ts
+++ b/apps/web/lib/federation/ca-client.ts
@@ -12,12 +12,20 @@
 // issuer (GET /provisioners). Both inject this so a fake CA runs under test.
 
 import { promises as dns, type LookupAddress } from "node:dns";
-import { request as httpsRequest } from "node:https";
+import { Agent as HttpsAgent, request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
 import { checkServerIdentity as tlsCheckServerIdentity, type PeerCertificate } from "node:tls";
 
 export const DEFAULT_CA_INTERNAL_URL = "https://step-ca:9000";
 const CA_TIMEOUT_MS = 15_000;
+
+/**
+ * One fresh connection per CA request. The portal's production server
+ * replaces the global HTTPS agent with a keep-alive one; a CA request must
+ * never be handed a pooled socket the CA has since closed, so the client
+ * keeps its own agent with keep-alive off.
+ */
+const caAgent = new HttpsAgent({ keepAlive: false, maxSockets: 8 });
 
 type LookupCallback = (error: NodeJS.ErrnoException | null, address: string, family: number) => void;
 
@@ -95,6 +103,7 @@ export const caRequest: CaRequest = (input) => {
         ca: input.rootPem,
         servername: url.hostname,
         lookup: offThreadpoolLookup,
+        agent: caAgent,
         checkServerIdentity: (_host: string, cert: PeerCertificate) => {
           let last: Error | undefined;
           for (const candidate of candidates) {

--- a/apps/web/lib/federation/ca-client.ts
+++ b/apps/web/lib/federation/ca-client.ts
@@ -79,6 +79,10 @@ export const caRequest: CaRequest = (input) => {
   const url = new URL(`${input.caUrl}${input.path}`);
   const payload = input.body === undefined ? undefined : JSON.stringify(input.body);
   const candidates = [url.hostname, "localhost", "127.0.0.1"];
+  // Which phases the request reached — reported on a timeout so a stall is
+  // attributable (name resolution, TCP connect, TLS, or the CA itself).
+  const reached: string[] = [];
+  const startedAt = Date.now();
   return new Promise<CaResponse>((resolve, reject) => {
     const req = httpsRequest(
       {
@@ -113,7 +117,16 @@ export const caRequest: CaRequest = (input) => {
         });
       },
     );
-    req.on("timeout", () => req.destroy(new Error("CA request timed out")));
+    req.on("socket", (socket) => {
+      reached.push("socket");
+      socket.once("lookup", () => reached.push("lookup"));
+      socket.once("connect", () => reached.push("connect"));
+      socket.once("secureConnect", () => reached.push("tls"));
+    });
+    req.on("response", () => reached.push("response"));
+    req.on("timeout", () => {
+      req.destroy(new Error(`CA request timed out after ${Date.now() - startedAt}ms (reached: ${reached.join(">") || "nothing"})`));
+    });
     req.on("error", reject);
     req.end(payload);
   });

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Follow-up to #5061 for **BI-41EB722B**. From the deployed portal process every POST to step-ca's `/1.0/sign` times out after 15 s without ever opening a TCP connection, while a GET from the same process and the same POST from a fresh node process in the same container succeed. Two changes to the CA client:

- **Timeout attribution**: a timed-out request now reports the elapsed time and the phases the socket reached (socket › lookup › connect › tls › response), so the next deployed timeout says whether it stalled before a socket, in name resolution, in TCP, in TLS or at the CA.
- **Fresh connection per request**: the portal's production server replaces the global HTTPS agent with a keep-alive one; the CA client now keeps its own agent with keep-alive off so a request is never handed a pooled socket the CA has since closed.

## Verification
- ca-client, membership-relay and organization-join-issue tests green; guards OK on the override path.
- Live check after release: POST to the sign route on the development install, then read the relay audit ring for the phase report if it still times out.

Design-Grounding-Decision: no-contract-change (transport diagnostics and agent choice inside lib/federation/ca-client.ts)
Docs-Impact-Decision: no docs affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)