### PR TITLE
fix(tasks): preserve durable remote request objective

### DIFF
--- a/apps/web/lib/mcp-task-background-worker.test.ts
+++ b/apps/web/lib/mcp-task-background-worker.test.ts
@@ -152,6 +152,58 @@ describe("persisted remote TaskRun worker", () => {
     });
   });
 
+  it("reconstructs a long request from its complete durable objective", () => {
+    const objective = `Review the complete remote request packet. ${"evidence ".repeat(150)}`.trim();
+    const durableParams = { ...params, objective };
+    const reconstructed = reconstructPersistedRemoteTask(row({
+      objective: objective.slice(0, 1_000),
+      a2aMetadata: {
+        ...row().a2aMetadata,
+        requestObjective: objective,
+        requestDigest: remoteTaskRequestDigest(durableParams),
+      },
+    }));
+
+    expect(objective.length).toBeGreaterThan(1_000);
+    expect(reconstructed).toMatchObject({
+      ok: true,
+      data: { parsed: { objective } },
+    });
+  });
+
+  it("fails closed when the complete durable objective does not match the request digest", () => {
+    const objective = `Review the complete remote request packet. ${"evidence ".repeat(150)}`.trim();
+    const reconstructed = reconstructPersistedRemoteTask(row({
+      objective: objective.slice(0, 1_000),
+      a2aMetadata: {
+        ...row().a2aMetadata,
+        requestObjective: `${objective} tampered`,
+        requestDigest: remoteTaskRequestDigest({ ...params, objective }),
+      },
+    }));
+
+    expect(reconstructed).toEqual({
+      ok: false,
+      code: "request_digest_mismatch",
+      message: "Persisted remote task request does not match its immutable digest.",
+    });
+  });
+
+  it("fails closed when a present durable objective is not valid text", () => {
+    const reconstructed = reconstructPersistedRemoteTask(row({
+      a2aMetadata: {
+        ...row().a2aMetadata,
+        requestObjective: { unexpected: true },
+      },
+    }));
+
+    expect(reconstructed).toEqual({
+      ok: false,
+      code: "persisted_request_invalid",
+      message: "Persisted remote task request objective is invalid.",
+    });
+  });
+
   it("fails closed when persisted request bytes no longer match the immutable digest", () => {
     const reconstructed = reconstructPersistedRemoteTask(row({
       messages: [{ parts: [{ type: "message", text: "changed prompt" }] }],

--- a/apps/web/lib/mcp-task-background-worker.ts
+++ b/apps/web/lib/mcp-task-background-worker.ts
@@ -140,6 +140,20 @@ export function reconstructPersistedRemoteTask(
   const routeContext = string(row.routeContext);
   const prompt = storedTextPart(row.messages[0]?.parts);
   const authorityScope = stringArray(row.authorityScope);
+  const hasRequestObjective = metadata !== null
+    && Object.prototype.hasOwnProperty.call(metadata, "requestObjective");
+  let requestObjective = row.objective;
+  if (hasRequestObjective) {
+    const storedRequestObjective = string(metadata?.["requestObjective"]);
+    if (!storedRequestObjective) {
+      return {
+        ok: false,
+        code: "persisted_request_invalid",
+        message: "Persisted remote task request objective is invalid.",
+      };
+    }
+    requestObjective = storedRequestObjective;
+  }
 
   if (
     !row.id
@@ -210,7 +224,7 @@ export function reconstructPersistedRemoteTask(
     agentId,
     routeContext,
     title: row.title,
-    objective: row.objective,
+    objective: requestObjective,
     prompt,
     idempotencyKey,
     riskClass,

--- a/apps/web/lib/mcp-task-request-packet.test.ts
+++ b/apps/web/lib/mcp-task-request-packet.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  findUnique: vi.fn(),
+  findModelConfig: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+  upsertThread: vi.fn(),
+}));
+const autonomous = vi.hoisted(() => ({
+  create: vi.fn(),
+  execute: vi.fn(),
+  resolveAgent: vi.fn(),
+  resolveTools: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findFirst: (...args: unknown[]) => db.findFirst(...args),
+      findUnique: (...args: unknown[]) => db.findUnique(...args),
+      update: (...args: unknown[]) => db.update(...args),
+      updateMany: (...args: unknown[]) => db.updateMany(...args),
+    },
+    coworkerActionEnvelope: { findFirst: vi.fn() },
+    toolExecution: { findFirst: vi.fn() },
+    agentThread: { upsert: (...args: unknown[]) => db.upsertThread(...args) },
+    agentModelConfig: { findUnique: (...args: unknown[]) => db.findModelConfig(...args) },
+  },
+}));
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: (...args: unknown[]) => autonomous.create(...args),
+  executeAutonomousAgenticLoop: (...args: unknown[]) => autonomous.execute(...args),
+  executeAutonomousWorkTool: vi.fn(),
+  resolveAutonomousWorkAgent: (...args: unknown[]) => autonomous.resolveAgent(...args),
+  resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
+}));
+vi.mock("@/lib/tak/task-records", () => ({ createTaskMessage: vi.fn() }));
+vi.mock("@/lib/queue/inngest-client", () => ({ inngest: { send: vi.fn() } }));
+
+import { submitRemoteCoworkerTask } from "./mcp-task-submit";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("DPF_EXTERNAL_MCP_TASK_ASYNC", "0");
+  db.findFirst.mockResolvedValue(null);
+  db.findUnique.mockResolvedValue({ status: "working" });
+  db.findModelConfig.mockResolvedValue({
+    minimumTier: "strong",
+    budgetClass: "quality_first",
+    pinnedProviderId: "local",
+    pinnedModelId: "local-model",
+  });
+  db.upsertThread.mockResolvedValue({ id: "thread-external" });
+  db.update.mockResolvedValue({});
+  db.updateMany.mockResolvedValue({ count: 1 });
+  autonomous.create.mockImplementation(async (input: Record<string, unknown>) => ({
+    id: "task-internal",
+    taskRunId: input["taskRunId"],
+    contextId: "thread-external",
+  }));
+  autonomous.resolveAgent.mockResolvedValue({
+    agentId: "reviewer",
+    displayName: "Reviewer",
+    systemPrompt: "Review the request.",
+    sensitivity: "internal",
+  });
+  autonomous.resolveTools.mockResolvedValue({ tools: [], toolsForProvider: [], deferredTools: [] });
+  autonomous.execute.mockResolvedValue({ content: "Done.", executedTools: [] });
+});
+
+describe("remote TaskRun request packet", () => {
+  it("persists the complete normalized objective in server-owned metadata", async () => {
+    const objective = `Review the complete remote request packet. ${"evidence ".repeat(150)}`.trim();
+
+    await submitRemoteCoworkerTask({
+      token: { tokenId: "PAT-LONG", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      params: {
+        agentId: "AGT-WS-REVIEW",
+        routeContext: "/platform/build",
+        title: "Long immutable request",
+        objective,
+        prompt: "Review the complete packet.",
+        idempotencyKey: "remote-packet:long-objective",
+        riskClass: "bounded-write",
+        authorityScope: [],
+      },
+    });
+
+    expect(objective.length).toBeGreaterThan(1_000);
+    expect(autonomous.create).toHaveBeenCalledWith(expect.objectContaining({
+      objective,
+      metadata: expect.objectContaining({ requestObjective: objective }),
+    }));
+  });
+});

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -694,6 +694,7 @@ export async function submitRemoteCoworkerTask(input: {
         idempotencyKey: parsed.idempotencyKey,
         requestDigest,
         requestDigestVersion: REMOTE_TASK_REQUEST_DIGEST_VERSION,
+        requestObjective: parsed.objective,
         collaborationKind: parsed.collaborationKind ?? null,
         riskClass: parsed.riskClass,
         apiTokenId: token.tokenId,

--- a/docs/superpowers/plans/2026-09-05-durable-remote-task-request-packet.md
+++ b/docs/superpowers/plans/2026-09-05-durable-remote-task-request-packet.md
@@ -57,8 +57,7 @@ introduces an unused duplicate field.
 - Dependencies: none
 - Rationale: persistence and reconstruction are the two sides of one immutable
   packet contract and cannot be deployed independently.
-- Receipt: pending immutable plan publication and
-  `record_plan_backlog_coverage`.
+- Receipt: `cmtnut9ww026z01n9wzgyqmvu`
 
 ## Rollback
 

--- a/docs/superpowers/plans/2026-09-05-durable-remote-task-request-packet.md
+++ b/docs/superpowers/plans/2026-09-05-durable-remote-task-request-packet.md
@@ -1,0 +1,67 @@
+---
+status: active
+---
+
+# Durable remote TaskRun request packet plan
+
+**Backlog item:** BI-2014236E  
+**Workroom:** WC-42C01441  
+**Design:** `docs/superpowers/specs/2026-09-05-durable-remote-task-request-packet-design.md`
+
+**For agentic workers:** execute this plan one independently reviewable backlog
+item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+implementation, `dpf-local-merge-ci-before-push` plus the plan's completion
+gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Atomic delivery
+
+`REMOTE-PACKET` is one atomic repair. The submit path must persist the exact
+normalized objective in the existing immutable packet, and the background
+worker must select that server-owned value before validating the existing
+request digest. Shipping either side alone leaves new TaskRuns unrecoverable or
+introduces an unused duplicate field.
+
+## Ordered implementation
+
+1. In `apps/web/lib/mcp-task-submit.test.ts`, reproduce an external request
+   whose objective is longer than 1,000 characters and prove the full
+   normalized value is not included in the server-owned creation metadata.
+2. In `apps/web/lib/mcp-task-background-worker.test.ts`, reproduce the live
+   bounded-row/full-digest mismatch. Prove legacy short rows still reconstruct
+   and a conflicting durable objective still fails closed.
+3. In `apps/web/lib/mcp-task-submit.ts`, persist `requestObjective` from the
+   parsed request in the TaskRun's existing `a2aMetadata` transaction.
+4. In `apps/web/lib/mcp-task-background-worker.ts`, use a valid durable
+   `requestObjective` when present and otherwise retain the legacy bounded-row
+   fallback. Keep the canonical digest comparison as the final authority check.
+5. Run the colocated worker/submit tests, graph-linked capacity, approval,
+   terminal-writer, and readiness-grant suites, web typecheck, style guard, and
+   preflight. Record an occupied local immutable lane as inconclusive if
+   necessary; never waive deterministic or protected failures.
+6. Publish one DCO PR and require protected merge checks. Release and deploy one
+   canonical artifact, verify exact served SHA/CAN-TEST, then create one fresh
+   immutable BI-801 review identity. Preserve the corrupted historical TaskRun
+   as audit evidence.
+
+## Traceability
+
+| Deliverable | Requirements | Contracts | Flow | Verification |
+| --- | --- | --- | --- | --- |
+| REMOTE-PACKET | OBJ-REMOTE-PACKET-01, OBJ-REMOTE-PACKET-02, OBJ-REMOTE-PACKET-03 | AC-REMOTE-PACKET-01, AC-REMOTE-PACKET-02, AC-REMOTE-PACKET-03 | steps 1-6 | AC-REMOTE-PACKET-04 |
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: BI-2014236E
+- Deliverable: REMOTE-PACKET -> BI-2014236E
+- Dependencies: none
+- Rationale: persistence and reconstruction are the two sides of one immutable
+  packet contract and cannot be deployed independently.
+- Receipt: pending immutable plan publication and
+  `record_plan_backlog_coverage`.
+
+## Rollback
+
+Disable writing `requestObjective` and revert the worker selection. The field
+is additive JSON metadata, so rollback needs no schema or data migration and
+legacy short-objective reconstruction remains unchanged.

--- a/docs/superpowers/specs/2026-09-05-durable-remote-task-request-packet-design.md
+++ b/docs/superpowers/specs/2026-09-05-durable-remote-task-request-packet-design.md
@@ -1,0 +1,99 @@
+---
+status: active
+---
+
+# Durable remote TaskRun request packet
+
+**Backlog item:** BI-2014236E  
+**Workroom:** WC-42C01441  
+**Extends:** `docs/superpowers/specs/2026-08-31-taskrun-async-push-delivery-design.md`
+
+## Problem and current-tree evidence
+
+External MCP TaskRuns hash the complete normalized request, including the full
+`objective`. `createAutonomousWorkRun` intentionally bounds the human-facing
+`TaskRun.objective` projection to 1,000 characters, but the background worker
+later reconstructs the immutable request from that bounded projection. A valid
+request whose objective exceeds 1,000 characters therefore commits one digest
+and later recomputes another. The worker terminally fails with
+`request_digest_mismatch` before inference, even though the caller supplied the
+same request key and the database still owns every other request field.
+
+The live BI-801 acceptance occurrence is TaskRun
+`TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-642659D60508`. Its failure is a
+request-persistence defect, not provider capacity or an idempotency conflict.
+
+## Objectives and acceptance criteria
+
+- **OBJ-REMOTE-PACKET-01:** **Lossless immutable recovery.** Persist the exact
+  normalized objective used by the request digest without widening the
+  human-facing TaskRun summary.
+- **OBJ-REMOTE-PACKET-02:** **Server-owned authority.** Only the request accepted
+  by `tasks/submit` may populate the durable objective; queue events and replay
+  callers cannot replace it.
+- **OBJ-REMOTE-PACKET-03:** **Fail-closed compatibility.** Historical rows keep
+  their current reconstruction path, while any conflicting or altered durable
+  objective still fails the existing digest check.
+
+| ID | Objective | Acceptance criterion | Evidence |
+| --- | --- | --- | --- |
+| AC-REMOTE-PACKET-01 | OBJ-REMOTE-PACKET-01 | A normalized objective longer than 1,000 characters is stored losslessly in server-owned TaskRun metadata while `TaskRun.objective` remains bounded; the background worker reconstructs the original request and matches its exact digest. | Submit persistence and worker reconstruction RED/GREEN tests |
+| AC-REMOTE-PACKET-02 | OBJ-REMOTE-PACKET-02 | Submission derives the durable value from parsed request input before enqueue; the event continues to carry only TaskRun identity. | Submit argument assertion and existing queue contract tests |
+| AC-REMOTE-PACKET-03 | OBJ-REMOTE-PACKET-03 | Rows without the new field reconstruct from the legacy TaskRun objective; changing the durable field, prompt, binding, or other hashed request bytes remains `request_digest_mismatch`. | Compatibility and tamper matrix tests |
+| AC-REMOTE-PACKET-04 | OBJ-REMOTE-PACKET-01, OBJ-REMOTE-PACKET-02, OBJ-REMOTE-PACKET-03 | The repair changes no provider routing, approval, terminal-writer, recipe, cancellation, or notification authority and passes adjacent TaskRun suites, typecheck, protected CI, canonical release, and live same-identity acceptance. | Adjacent tests, typecheck, protected CI, live acceptance |
+
+## Architecture decision
+
+Keep `TaskRun.objective` as the bounded operator-facing summary. Add one exact
+`requestObjective` field to the existing server-owned `a2aMetadata` packet for
+new external MCP rows. The submit path writes it in the same serializable
+transaction as the TaskRun and first deferred message. The background worker
+prefers this exact field when present, otherwise falls back to
+`TaskRun.objective` for historical rows. It then runs the existing canonical
+digest comparison over the reconstructed request.
+
+This is deliberately not a second request ledger. The field is one missing
+member of the existing immutable packet, protected by the already persisted
+SHA-256 request digest. No queue payload, client replay field, or provider
+metadata is trusted as recovery authority.
+
+## Ordered fix sequence
+
+1. Add a failing submit test proving a >1,000-character objective reaches the
+   exact server-owned metadata passed to `createAutonomousWorkRun`.
+2. Add a failing reconstruction test using the live shape: bounded
+   `TaskRun.objective`, full durable `requestObjective`, and a digest computed
+   from the full request. Add tamper and legacy-absence controls.
+3. Persist `requestObjective` from the parsed request and select it during
+   background reconstruction before the existing digest validation.
+4. Run the colocated submit/worker suites plus graph-linked capacity,
+   approval-recovery, terminal-writer, and readiness-tool-grant tests; run web
+   typecheck and preflight. An occupied local immutable gate may be ledgered as
+   inconclusive, but deterministic failures and protected checks remain
+   mandatory.
+5. Publish one DCO PR, protected merge, canonical release, and governed live
+   upgrade. Then issue one fresh immutable BI-801 review identity; the already
+   corrupted TaskRun remains terminal audit evidence and is not rewritten.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: BI-2014236E
+- Deliverable: `REMOTE-PACKET` — persist and reconstruct one exact external MCP
+  request objective under the existing digest and TaskRun identity.
+- Rationale: persistence without reconstruction still fails, and
+  reconstruction without same-transaction persistence has no authoritative
+  bytes. The two changes are one non-shippable contract repair.
+- Receipt: pending immutable artifact publication and
+  `record_plan_backlog_coverage`.
+
+## Risks and rollback
+
+- Metadata size grows by the normalized objective length. Input is already
+  accepted and hashed; PostgreSQL JSONB/Text supports the same bounded MCP
+  request payload. No credential or unscreened provider response is added.
+- A malformed or tampered metadata value cannot execute because canonical
+  digest validation still fails closed.
+- Rollback stops writing the new field. New rows retain harmless metadata and
+  historical reconstruction behavior remains available; no schema rollback or
+  data rewrite is required.


### PR DESCRIPTION
## Summary

Preserve the complete immutable remote-task request objective in the durable TaskRun packet so background execution reconstructs the exact request that was hashed at submission time. This removes the 1,000-character projection mismatch that left valid long-running coworker requests unable to resume, while retaining legacy-row compatibility and fail-closed digest validation.

## Changes

- Persist the parsed request objective in `a2aMetadata.requestObjective` when the TaskRun is created.
- Validate and prefer the durable objective during background reconstruction, retaining the legacy objective fallback only for rows created before this field existed.
- Fail closed when the persisted request packet is malformed or no longer matches the immutable request digest.
- Add the governed design, ordered repair plan, and focused regression coverage for long objectives, tampering, invalid metadata, and legacy compatibility.

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] Web typecheck passed on the authored implementation head.
  - [x] Targeted unit tests: `mcp-task-request-packet.test.ts`, `mcp-task-background-worker.test.ts`, and `mcp-task-submit.test.ts` — 32/32 passed after current-main integration.
  - [x] Adjacent task submission/capacity/approval/terminal-writer/grants suite — 65/65 passed on the authored implementation head.

- [x] **Runtime-bound change** (background TaskRun execution)
  - [x] Source checks passed where they can run in the worktree.
  - [ ] Canonical-runtime functional verification will run against the root local install after protected merge, canonical release, and governed upgrade.
  - [x] Evidence captured below.

- [x] **Verification-harness limitation acknowledged**

### Verification evidence

- Workroom `WC-42C01441` records TDD/test evidence `cmtnuc21t00nx01n9e9qar5sr`, build/type evidence `cmtnuc1zx00nu01n996kt3oe4`, and source verification `cmtnuc7fg00o301n9jb49wi4d`.
- Genuine spec-approval receipt: `initiative-37cdcd49-3341-40d2-b026-868ad75d47aa`; canonical baseline: `baseline-4c8f1ab4-6e0b-483d-b56b-350fdc3b3bd2`.
- Genuine research receipt: `initiative-0e9a0bca-dffc-4ed9-95e4-9dd4ba242d08`.
- Genuine atomic plan-coverage receipt: `cmtnut9ww026z01n9wzgyqmvu`.

## Pre-PR readiness

- [x] Gate context reviewed against the final diff.
- [ ] `pnpm run pregate:preflight` entered the repository guard loop and made no progress for more than 60 seconds; stopped and durably recorded as INCONCLUSIVE/NO PASS under the operator's occupied-local-gate boundary.
- [ ] Exact-tree shared local CI was not claimed; DCO and every protected PR/merge-group check remain mandatory.
- [ ] `pnpm pr:ready` likewise produced no terminal result for more than 60 seconds and was durably recorded as INCONCLUSIVE/NO PASS; direct clean/pushed/DCO/readiness checks passed.

Local-CI-Override: operator-authorized occupied/local-gate bypass; no PASS inferred, protected GitHub checks mandatory

## Related issues / Epic

- BI-2014236E: Return governed coworker TaskRuns asynchronously with push and reconciliation
- Parent: EP-129D11FD — Initiative Readiness and Governed Completion Enforcement

## Epic / Backlog linkage (for multi-BI work)

This PR is the narrow durable-request-packet repair for BI-2014236E. It does not claim completion of the broader async-delivery epic.

## Overlap sweep

- Open PR #5062 changes objective-mapping evidence contracts; no overlap with this request-packet slice.
- Open PR #5063 changes CA/provider transport; no overlap with this request-packet slice.
- Current protected main was merged normally before the final push.

## Notes for the reviewer

- The digest remains the authority; the added metadata is validated before use.
- No database migration is required.
- The runtime acceptance proof is intentionally deferred until protected merge and canonical deployment.
