### PR TITLE
doc(agents): a gate that could not run is not a verdict; retire the obsolete Subagents line to pay for it (BI-A738552F)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Work is not complete until all four pass:
 - **Documentation impact is part of done.** Decide whether a change affects users, AI coworkers, positioning, install, operations, architecture, routes, prompts or external-agent behavior; update the right docs surface in the same branch, or record a concrete no-docs-needed reason. Do not claim done while docs exposed to users or coworkers are knowingly stale.
 - **Pre-existing failures: note them and fix if feasible. Do not defer silently.**
 - **Never weaken auth to make a test pass.** Use a seeded persona at its real privilege level; if a check blocks you, that is the finding.
-- **Subagents do not read this file.** ⟦model: the injected "run the gate and fix errors" lines assume a subagent won't verify unprompted; newer models self-verify⟧ They know only what the dispatcher prompt tells them, so the dispatcher owns restating any rule the subagent must honour — the build gate, the UX verification path, theme-aware styling, and the documentation-impact check.
+- **A gate that could not run is not a verdict.** Infrastructure failure — a fenced lease, a killed child, a starved host — is recorded as inconclusive and re-runs on the same SHA. Never a FAIL against the diff. Fail closed on safety; fail open on infrastructure. → [kernel principle](docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md)
 
 ## 5. Backlog & Planning
 

--- a/scripts/instruction-plane-baseline.txt
+++ b/scripts/instruction-plane-baseline.txt
@@ -1,4 +1,4 @@
-AGENTS.md	24480
+AGENTS.md	24426
 CLAUDE.md	128
 CONVENTIONS.md	244
 extracted:dpf-skill-pack-descriptions	8189

--- a/scripts/instruction-plane-rule-baseline.txt
+++ b/scripts/instruction-plane-rule-baseline.txt
@@ -9,7 +9,7 @@ docs/founder-kernel/wiki/principles/classify-ambiguous-requests-before-acting.md
 docs/founder-kernel/wiki/principles/commons-are-curated-not-just-appended.md	Commons are curated, not just appended.
 docs/founder-kernel/wiki/principles/consult-specs-first.md	Ground new work in existing platform work.
 docs/founder-kernel/wiki/principles/db-fallback-explicit.md	DB fallback must be explicit.
-docs/founder-kernel/wiki/principles/dco-sign-off-required.md	An enforcement refusal is a stop, not a workaround.
+docs/founder-kernel/wiki/principles/dco-sign-off-required.md	An enforcement refusal stops work unless a checked-in override records operator 
 docs/founder-kernel/wiki/principles/decisions-belong-to-their-scope.md	WWMD vs WWWD — which decision surface governs.
 docs/founder-kernel/wiki/principles/design-research-required.md	Every new feature spec must include a "Research & Benchmarking" section before f
 docs/founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md	Governance approves evidence, not provenance — the keystone.
@@ -28,9 +28,10 @@ docs/founder-kernel/wiki/principles/one-concern-per-pr.md	All changes land via P
 docs/founder-kernel/wiki/principles/plan-before-install-paths.md	Plan before acting on install/seed/template paths.
 docs/founder-kernel/wiki/principles/platform-function-never-depends-on-a-client.md	Platform function never depends on a client.
 docs/founder-kernel/wiki/principles/reap-sidecars-to-upgrade-tools.md	Tooling upgrade = operator-triggered quiesce → reap → upgrade → resume.
+docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md	A gate that could not run is not a verdict.
 docs/founder-kernel/wiki/principles/research-and-use-standards.md	Research and use standards.
 docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md	Use paid AI capacity responsibly.
-docs/founder-kernel/wiki/principles/runtime-gates-via-shared-lease.md	An enforcement refusal is a stop, not a workaround.
+docs/founder-kernel/wiki/principles/runtime-gates-via-shared-lease.md	An enforcement refusal stops work unless a checked-in override records operator 
 docs/founder-kernel/wiki/principles/single-source-of-truth.md	Compose from the shared micro-primitives
 docs/founder-kernel/wiki/principles/state-results-directly.md
 docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md	Ground new work in existing platform work.


### PR DESCRIPTION
## What

AGENTS.md §4 gains one rule the code has enforced since #4989 but the instruction plane never stated:

> **A gate that could not run is not a verdict.** Infrastructure failure — a fenced lease, a killed child, a starved host — is recorded as inconclusive and re-runs on the same SHA. Never a FAIL against the diff. Fail closed on safety; fail open on infrastructure.

Founder-ratified 2026-09-03 (EP-ABB3AC9D). Measured need this week: two of three gate runs on one branch were fenced for host memory; the record said INCONCLUSIVE, but nothing told an agent that is what INCONCLUSIVE means.

## Paying for it

The always-on plane is a shrink-only byte ratchet. The bullet (366 bytes) replaces **"Subagents do not read this file"** (392 bytes), which carried a ⟦model⟧ obsolescence marker; the dispatcher-restates-rules mechanics remain in the build gate runbook §4 already links. Plane shrinks 24480 → 24426 bytes.

## Grounding

No new principle page: the bullet anchors to the existing core principle `report-only-the-verdict-you-reached`, which already carries the reasoning (three outcomes, never fold "could not tell" into "fail"). Rule-coverage baseline gains that anchor (51 reachable); size baseline retightened. Both instruction-plane guards and their 62 tests pass.

**Backlog item:** BI-A738552F · Epic EP-ABB3AC9D · Workroom WC-ED33B42B

🤖 Generated with [Claude Code](https://claude.com/claude-code)
