### PR TITLE
fix(worktree): liveness comes from the platform, and unreadable evidence fails safe (BI-99395B29)

### DIFF
--- a/apps/web/lib/queue/functions/worktree-janitor.test.ts
+++ b/apps/web/lib/queue/functions/worktree-janitor.test.ts
@@ -12,6 +12,7 @@ import {
   WORKTREE_JANITOR_AUTO_REAP_FLAG,
   type ScanOutcome,
   WORKTREE_JANITOR_MAX_FLAG,
+  scanKeptForUnknownLiveness,
   DEFAULT_MAX_WORKTREES,
   resolveMaxWorktrees,
 } from "./worktree-janitor";
@@ -150,6 +151,58 @@ describe("worktree-janitor schedule invariants (BI-42FA7DD8)", () => {
     expect(result.skipped).toBe(false);
     if (result.skipped || "healthy" in result) throw new Error("expected a summary");
     expect(result.mode).toBe("live");
+  });
+
+  it("stays in observe mode over the bound when liveness could not be read", async () => {
+    // The bound shipped in #4987 would otherwise reap automatically on a scan
+    // whose liveness picture was incomplete — which is how a dormant classifier
+    // flaw becomes fleet-wide damage.
+    const modes: string[] = [];
+    const runScan = vi.fn(async (mode: "dry-run" | "live") => {
+      modes.push(mode);
+      const outcome = scanOutcome(mode);
+      if (outcome.available) {
+        outcome.scan.decisions = [
+          {
+            path: "/wt/unknown",
+            branch: "fix/x",
+            verdict: "KEEP",
+            reason: "Workroom claims unreadable (no token) — refusing to reap on absent evidence",
+            tier: null,
+          },
+        ];
+      }
+      return outcome;
+    });
+
+    const result = await runWorktreeJanitor({
+      env: { ...ENABLED, [WORKTREE_JANITOR_MAX_FLAG]: "0" },
+      runScan,
+    });
+
+    expect(modes).toEqual(["dry-run"]);
+    expect(result.skipped).toBe(false);
+    if (result.skipped || "healthy" in result) throw new Error("expected a summary");
+    expect(result.mode).toBe("dry-run");
+  });
+
+  it("detects a scan that kept work for unknown liveness", () => {
+    expect(
+      scanKeptForUnknownLiveness({
+        mode: "dry-run",
+        available: true,
+        decisions: [
+          { path: "/a", branch: "b", verdict: "KEEP", reason: "refusing to reap on absent evidence", tier: null },
+        ],
+      } as never),
+    ).toBe(true);
+    expect(
+      scanKeptForUnknownLiveness({
+        mode: "dry-run",
+        available: true,
+        decisions: [{ path: "/a", branch: "b", verdict: "KEEP", reason: "open PR", tier: null }],
+      } as never),
+    ).toBe(false);
   });
 
   it("stays an observation while under the bound", async () => {

--- a/apps/web/lib/queue/functions/worktree-janitor.ts
+++ b/apps/web/lib/queue/functions/worktree-janitor.ts
@@ -205,6 +205,16 @@ async function defaultRunScan(mode: "dry-run" | "live"): Promise<ScanOutcome> {
  * returned rather than only the reapable ones: the bound is about how much is
  * accumulating, not about how much happens to be safe to delete right now.
  */
+/**
+ * Did this scan keep anything only because it could not read the Workroom claim
+ * record? If so its liveness picture is incomplete and no bound may act on it.
+ */
+export function scanKeptForUnknownLiveness(scan: WorktreeJanitorScan): boolean {
+  return (scan.decisions ?? []).some(
+    (d) => d.verdict === "KEEP" && /absent evidence|unreadable/i.test(d.reason ?? ""),
+  );
+}
+
 export function countRetained(scan: WorktreeJanitorScan): number {
   // An EMPTY decisions array is "not populated", not "zero worktrees" — a scan
   // may report only a summary. Reading empty as zero would put the install
@@ -304,6 +314,21 @@ export async function runWorktreeJanitor(options: RunOptions = {}): Promise<RunR
   const max = resolveMaxWorktrees(env);
 
   if (retained <= max) {
+    return summarize(observed.scan, "dry-run");
+  }
+
+  // A bound must never drive deletion on evidence the scan could not gather.
+  // The observation reports how many worktrees it had to KEEP because the
+  // Workroom claim record was unreadable; if it kept anything for that reason,
+  // liveness is unknown for this run and going live would reap on a guess. This
+  // is the half that turned a dormant classifier flaw into automatic damage
+  // when the bound shipped in #4987 — the bound is only safe once liveness is
+  // platform-owned AND actually readable.
+  if (scanKeptForUnknownLiveness(observed.scan)) {
+    console.error(
+      "[worktree-janitor] over bound, but Workroom claims were unreadable this run — " +
+        "staying in observe mode. A bound must not reap on absent evidence.",
+    );
     return summarize(observed.scan, "dry-run");
   }
 

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -504,6 +504,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         // BI-541156EE: one worktree base, or none. Seven were found on a single
         // host, all from the same formula handed different roots.
         "scripts/check-single-worktree-base.test.mjs",
+        // BI-99395B29 follow-up: liveness comes from the Workroom claim, and an
+        // unreadable claim record must fail safe rather than reap on a guess.
+        "scripts/lib/worktree-liveness.test.mjs",
         "scripts/lib/worktree-janitor-core.test.mjs",
         "scripts/worktree-janitor.test.mjs",
         "scripts/lib/worktree-session-heartbeat.test.mjs",

--- a/scripts/lib/worktree-janitor-core.mjs
+++ b/scripts/lib/worktree-janitor-core.mjs
@@ -33,6 +33,9 @@
  * @property {boolean} dirty         porcelain non-empty
  * @property {number} ageDays        days since last commit (0 if unknown)
  * @property {boolean} [hasLiveSession]  a fresh session heartbeat is present
+ * @property {boolean} [hasActiveClaim]  an active Workroom claims this worktree
+ * @property {boolean} [claimSourceUnavailable]  the claim record could not be read
+ * @property {string}  [claimSourceReason]  why it could not be read
  * @property {boolean} [midMerge]        a merge is in progress (MERGE_HEAD present)
  */
 
@@ -77,6 +80,33 @@ export function classifyWorktree(facts, opts = {}) {
     return {
       verdict: "KEEP",
       reason: `branch=${facts.branch} live session heartbeat — refuse to reap an in-use worktree`,
+      tier: null,
+    };
+  }
+
+  // The PLATFORM's answer to "is anyone working here", which outranks the
+  // client-written heartbeat above because it is the same record every surface
+  // writes to. The heartbeat is a Claude Code plugin hook: Codex, Grok and Build
+  // Studio write nothing, so on 2026-09-02 the gate above read "no heartbeat" as
+  // "no live session" and reaped 24 claimed worktrees, one of them a
+  // codex-desktop room touched minutes earlier (BI-99395B29 follow-up).
+  if (facts.hasActiveClaim) {
+    return {
+      verdict: "KEEP",
+      reason: `branch=${facts.branch} claimed by an active Workroom — refuse to reap owned work`,
+      tier: null,
+    };
+  }
+
+  // FAIL SAFE. When the claim record could not be read at all, "nobody is
+  // working here" is a guess, not a finding — and it is the guess that cost 24
+  // worktrees. Refuse to reap rather than assume the platform is idle.
+  if (facts.claimSourceUnavailable) {
+    return {
+      verdict: "KEEP",
+      reason:
+        `branch=${facts.branch} Workroom claims unreadable (${facts.claimSourceReason ?? "unknown"}) — ` +
+        "refusing to reap on absent evidence",
       tier: null,
     };
   }

--- a/scripts/lib/worktree-janitor-core.test.mjs
+++ b/scripts/lib/worktree-janitor-core.test.mjs
@@ -100,3 +100,50 @@ describe("summarizeDecisions", () => {
     assert.deepEqual(s.flaggedPaths, ["/d"]);
   });
 });
+
+// 2026-09-02: 132 worktrees classified reapable, 24 of them owned by active
+// Workrooms, because the only liveness signal was a Claude Code heartbeat that
+// Codex/Grok/Build Studio never write. These pin the platform-owned gate.
+describe("Workroom claims outrank a merged, clean tree", () => {
+  const merged = (extra) => ({
+    branch: "fix/topic",
+    isRoot: false,
+    pinned: false,
+    hasActiveLease: false,
+    hasOpenPr: false,
+    merged: true,
+    dirty: false,
+    ageDays: 30,
+    hasLiveSession: false,
+    midMerge: false,
+    ...extra,
+  });
+
+  it("KEEPS a merged clean worktree that an active Workroom claims", () => {
+    // The exact case that was lost: merged, clean, no heartbeat because the
+    // session was Codex — but the platform knew it was owned.
+    const v = classifyWorktree(merged({ hasActiveClaim: true }));
+    assert.equal(v.verdict, "KEEP");
+    assert.match(v.reason, /active Workroom/);
+  });
+
+  it("KEEPS everything when the claim record cannot be read", () => {
+    // Fail safe: no token, portal down, MCP error. "Nobody is working" is a
+    // guess, and it is the guess that cost 24 worktrees.
+    const v = classifyWorktree(merged({ claimSourceUnavailable: true, claimSourceReason: "no token" }));
+    assert.equal(v.verdict, "KEEP");
+    assert.match(v.reason, /refusing to reap on absent evidence/);
+  });
+
+  it("still reaps a merged clean worktree nobody claims", () => {
+    // The gate must not seize up entirely — an unclaimed, merged, clean tree is
+    // still the safe case the reaper exists for.
+    const v = classifyWorktree(merged({ hasActiveClaim: false, claimSourceUnavailable: false }));
+    assert.equal(v.verdict, "PRUNE_TIER_A");
+  });
+
+  it("prefers the claim over the heartbeat's absence, not the reverse", () => {
+    const v = classifyWorktree(merged({ hasActiveClaim: true, hasLiveSession: false }));
+    assert.equal(v.verdict, "KEEP");
+  });
+});

--- a/scripts/lib/worktree-liveness.mjs
+++ b/scripts/lib/worktree-liveness.mjs
@@ -1,0 +1,164 @@
+// Who is actually working in a worktree — answered by the PLATFORM, not by a client.
+//
+// The reaper's one guarantee is "never reap an in-use worktree". Until now that
+// rested entirely on `.dpf-session-heartbeat.json`, a file written by a Claude
+// Code plugin hook (packages/dpf-skill-pack/hooks/hooks.json). Codex, Grok and
+// Build Studio write nothing, so for three of four surfaces the guard read
+// "no heartbeat" as "no live session" when it meant "no client writing
+// heartbeats" — and failed OPEN.
+//
+// On 2026-09-02 that reaped the worktrees of 24 workrooms that were still
+// active, including a codex-desktop room touched minutes earlier. Committed work
+// survived (Tier-A also requires merged+clean), but live threads lost their
+// working directories.
+//
+// This is the commandment applied to the reaper itself: a platform guarantee may
+// not depend on a client artifact
+// (docs/founder-kernel/wiki/principles/platform-function-never-depends-on-a-client.md).
+// The Workroom claim is the platform's own record of who owns which worktree, and
+// it is the same record every surface writes to — so it answers for all four.
+//
+// FAIL SAFE, NOT FAIL OPEN. If the claim record cannot be read — no token, portal
+// down, MCP error — this returns `available: false`, and the classifier must then
+// refuse to reap rather than assume nothing is live. Absence of evidence is not
+// evidence of absence, and the previous code made exactly that mistake twice
+// (this signal, and the lease payload, which returns "" without a token).
+
+import { spawnSync } from "node:child_process";
+
+/** Statuses that mean a room still owns its worktree. Anything terminal is not here. */
+export const ACTIVE_WORKROOM_STATUSES = Object.freeze([
+  "draft",
+  "ready",
+  "working",
+  "verifying",
+  "ready-for-review",
+  "ready-for-promotion",
+  "blocked",
+]);
+
+/** Normalise for comparison: Windows and git disagree about separators and case. */
+export function normalizePath(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/**
+ * Extract worktree paths of non-terminal Workrooms from an MCP response.
+ * Tolerant of shape: the payload may be JSON-RPC, SSE-wrapped, or a bare list.
+ *
+ * @returns {{ available: boolean, activePaths: Set<string>, reason: string }}
+ */
+export function parseActiveWorktreePaths(raw) {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return { available: false, activePaths: new Set(), reason: "empty response" };
+  }
+
+  // Pull every {"worktreePath": "...", ... "status": "..."} pairing out of the
+  // payload without depending on the envelope, which differs between the
+  // JSON-RPC and SSE transports.
+  let text = raw;
+  const dataLine = raw.split(/\r?\n/).find((l) => l.startsWith("data:"));
+  if (dataLine) text = dataLine.slice(5).trim();
+
+  let rooms;
+  try {
+    rooms = collectRooms(JSON.parse(text));
+  } catch {
+    return { available: false, activePaths: new Set(), reason: "unparseable response" };
+  }
+
+  if (rooms === null) {
+    return { available: false, activePaths: new Set(), reason: "no workroom list in response" };
+  }
+
+  const active = new Set();
+  for (const room of rooms) {
+    const path = normalizePath(room.worktreePath);
+    if (!path) continue;
+    if (ACTIVE_WORKROOM_STATUSES.includes(String(room.status ?? "").trim())) {
+      active.add(path);
+    }
+  }
+  return { available: true, activePaths: active, reason: `${rooms.length} workroom(s) read` };
+}
+
+/** Walk an arbitrary JSON shape for objects carrying a worktreePath. */
+function collectRooms(node, found = []) {
+  if (node === null || typeof node !== "object") return found.length > 0 ? found : null;
+  if (Array.isArray(node)) {
+    for (const item of node) collectRooms(item, found);
+    return found.length > 0 ? found : null;
+  }
+  if ("worktreePath" in node) found.push(node);
+  // MCP wraps tool output as {content:[{type:"text",text:"<json>"}]}.
+  if (typeof node.text === "string" && node.text.includes("worktreePath")) {
+    try {
+      collectRooms(JSON.parse(node.text), found);
+    } catch {
+      /* a non-JSON text block is not a failure of the whole parse */
+    }
+  }
+  for (const value of Object.values(node)) {
+    if (value && typeof value === "object") collectRooms(value, found);
+  }
+  return found.length > 0 ? found : null;
+}
+
+/**
+ * Ask the platform which worktrees are claimed. Never throws.
+ *
+ * @returns {{ available: boolean, activePaths: Set<string>, reason: string }}
+ */
+export function loadActiveWorkroomPaths(options = {}) {
+  const env = options.env ?? process.env;
+  const run = options.run ?? spawnSync;
+  const token = env.DPF_MCP_BEARER_TOKEN;
+
+  if (!token) {
+    // Deliberately NOT an empty success. Without a token the platform cannot be
+    // asked who is working, and guessing "nobody" is how live worktrees died.
+    return { available: false, activePaths: new Set(), reason: "no DPF_MCP_BEARER_TOKEN" };
+  }
+
+  const url = env.DPF_MCP_URL || "http://127.0.0.1:3000/api/mcp/v1";
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "list_workrooms", arguments: {} },
+  });
+
+  let result;
+  try {
+    result = run(
+      "curl",
+      [
+        "-sS", "-X", "POST", url,
+        "-H", `Authorization: Bearer ${token}`,
+        "-H", "Content-Type: application/json",
+        "-H", "Accept: application/json, text/event-stream",
+        "--max-time", "20",
+        "-d", body,
+      ],
+      { encoding: "utf8", windowsHide: true },
+    );
+  } catch (err) {
+    return {
+      available: false,
+      activePaths: new Set(),
+      reason: `workroom query failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!result || result.status !== 0) {
+    return { available: false, activePaths: new Set(), reason: "workroom query returned non-zero" };
+  }
+  return parseActiveWorktreePaths(String(result.stdout ?? ""));
+}
+
+/** Is this worktree claimed by a live Workroom? */
+export function pathHasActiveClaim(activePaths, worktreePath) {
+  if (!(activePaths instanceof Set) || activePaths.size === 0) return false;
+  return activePaths.has(normalizePath(worktreePath));
+}

--- a/scripts/lib/worktree-liveness.test.mjs
+++ b/scripts/lib/worktree-liveness.test.mjs
@@ -1,0 +1,132 @@
+// A reaper that cannot ask who is working must not decide that nobody is.
+//
+// These pin the two properties that failed on 2026-09-02, when 132 worktrees
+// were classified reapable and 24 of them belonged to active Workrooms: the
+// claim record must be consulted, and an unreadable claim record must fail SAFE.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseActiveWorktreePaths,
+  loadActiveWorkroomPaths,
+  pathHasActiveClaim,
+  normalizePath,
+  ACTIVE_WORKROOM_STATUSES,
+} from "./worktree-liveness.mjs";
+
+const roomsPayload = (rooms) =>
+  JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: { content: [{ type: "text", text: JSON.stringify({ workrooms: rooms }) }] },
+  });
+
+describe("parseActiveWorktreePaths", () => {
+  it("collects worktrees of rooms that still own their work", () => {
+    const { available, activePaths } = parseActiveWorktreePaths(
+      roomsPayload([
+        { capsuleId: "WC-1", status: "working", worktreePath: "D:/wt/alpha" },
+        { capsuleId: "WC-2", status: "ready", worktreePath: "D:/wt/beta" },
+      ]),
+    );
+    assert.equal(available, true);
+    assert.equal(activePaths.size, 2);
+    assert.ok(activePaths.has(normalizePath("D:/wt/alpha")));
+  });
+
+  it("ignores rooms in a terminal state", () => {
+    const { activePaths } = parseActiveWorktreePaths(
+      roomsPayload([
+        { capsuleId: "WC-3", status: "abandoned", worktreePath: "D:/wt/gone" },
+        { capsuleId: "WC-4", status: "complete", worktreePath: "D:/wt/done" },
+        { capsuleId: "WC-5", status: "archived", worktreePath: "D:/wt/old" },
+      ]),
+    );
+    assert.equal(activePaths.size, 0);
+  });
+
+  it("treats blocked and ready-for-review as still owned", () => {
+    // A blocked room is waiting on something, not finished — reaping its tree
+    // strands the very work that is waiting.
+    for (const status of ["blocked", "ready-for-review", "ready-for-promotion", "verifying"]) {
+      assert.ok(ACTIVE_WORKROOM_STATUSES.includes(status), `${status} must count as active`);
+    }
+  });
+
+  it("reads an SSE-wrapped response", () => {
+    const sse = `event: message\ndata: ${roomsPayload([
+      { capsuleId: "WC-6", status: "working", worktreePath: "D:/wt/sse" },
+    ])}\n\n`;
+    const { available, activePaths } = parseActiveWorktreePaths(sse);
+    assert.equal(available, true);
+    assert.ok(activePaths.has(normalizePath("D:/wt/sse")));
+  });
+
+  it("matches regardless of separator or case", () => {
+    const { activePaths } = parseActiveWorktreePaths(
+      roomsPayload([{ capsuleId: "WC-7", status: "working", worktreePath: "D:\\WT\\Mixed\\" }]),
+    );
+    assert.ok(pathHasActiveClaim(activePaths, "D:/wt/mixed"));
+  });
+
+  it("reports UNAVAILABLE on an empty or unparseable response", () => {
+    for (const bad of ["", "   ", "not json", undefined]) {
+      const { available } = parseActiveWorktreePaths(bad);
+      assert.equal(available, false, `${JSON.stringify(bad)} must not read as available`);
+    }
+  });
+
+  it("reports UNAVAILABLE when the response carries no workroom list", () => {
+    const { available } = parseActiveWorktreePaths(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { content: [] } }),
+    );
+    assert.equal(available, false);
+  });
+});
+
+describe("loadActiveWorkroomPaths — fail safe, never fail open", () => {
+  it("is UNAVAILABLE without a token, rather than an empty success", () => {
+    // The lease loader returns "" here, which reads downstream as "nothing is
+    // leased" and protects nothing. This must not repeat that.
+    const result = loadActiveWorkroomPaths({ env: {}, run: () => { throw new Error("unused"); } });
+    assert.equal(result.available, false);
+    assert.match(result.reason, /token/i);
+  });
+
+  it("is UNAVAILABLE when the query fails", () => {
+    const result = loadActiveWorkroomPaths({
+      env: { DPF_MCP_BEARER_TOKEN: "t" },
+      run: () => ({ status: 7, stdout: "", stderr: "connection refused" }),
+    });
+    assert.equal(result.available, false);
+  });
+
+  it("is UNAVAILABLE when the runner throws", () => {
+    const result = loadActiveWorkroomPaths({
+      env: { DPF_MCP_BEARER_TOKEN: "t" },
+      run: () => { throw new Error("curl missing"); },
+    });
+    assert.equal(result.available, false);
+    assert.match(result.reason, /curl missing/);
+  });
+
+  it("is AVAILABLE and returns claims on success", () => {
+    const result = loadActiveWorkroomPaths({
+      env: { DPF_MCP_BEARER_TOKEN: "t" },
+      run: () => ({
+        status: 0,
+        stdout: roomsPayload([{ capsuleId: "WC-8", status: "working", worktreePath: "D:/wt/live" }]),
+      }),
+    });
+    assert.equal(result.available, true);
+    assert.ok(pathHasActiveClaim(result.activePaths, "D:/wt/live"));
+  });
+});
+
+describe("pathHasActiveClaim", () => {
+  it("is false for an empty or absent claim set rather than throwing", () => {
+    assert.equal(pathHasActiveClaim(new Set(), "D:/wt/a"), false);
+    assert.equal(pathHasActiveClaim(undefined, "D:/wt/a"), false);
+  });
+});

--- a/scripts/worktree-janitor.mjs
+++ b/scripts/worktree-janitor.mjs
@@ -37,6 +37,10 @@ import {
   isWorktreeSessionLive,
   heartbeatTtlMs,
 } from "./lib/worktree-session-heartbeat.mjs";
+import {
+  loadActiveWorkroomPaths,
+  pathHasActiveClaim,
+} from "./lib/worktree-liveness.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_GRACE = 14;
@@ -233,7 +237,7 @@ function pathHasLease(leasePayload, wtPath) {
   return leasePayload.includes(wtPath) || leasePayload.includes(norm);
 }
 
-function gatherFacts(root, entry, prIndex, leasePayload, ttlMs) {
+function gatherFacts(root, entry, prIndex, leasePayload, ttlMs, claims) {
   const wtPath = entry.path;
   const branch = entry.detached ? null : entry.branch;
   const isRoot = path.resolve(wtPath) === path.resolve(root);
@@ -250,6 +254,12 @@ function gatherFacts(root, entry, prIndex, leasePayload, ttlMs) {
     // Liveness + abandoned-merge signals — never checked on the root clone.
     hasLiveSession: branch && !isRoot ? isWorktreeSessionLive(wtPath, { ttlMs }) : false,
     midMerge: branch && !isRoot ? isMidMerge(wtPath) : false,
+    // Platform-owned liveness. The heartbeat above only exists for Claude Code;
+    // the Workroom claim is written by every surface, so it answers for all of
+    // them — and when it cannot be read we refuse rather than guess.
+    hasActiveClaim: branch && !isRoot ? pathHasActiveClaim(claims.activePaths, wtPath) : false,
+    claimSourceUnavailable: branch && !isRoot ? !claims.available : false,
+    claimSourceReason: claims.reason,
   };
 }
 
@@ -298,13 +308,21 @@ function main(argv = process.argv.slice(2)) {
   const entries = listWorktrees(root);
   const prIndex = loadPrBranchIndex();
   const leasePayload = loadLeasePaths();
+  // Ask the platform who owns what, once, for the whole scan.
+  const claims = loadActiveWorkroomPaths();
+  if (!claims.available) {
+    console.error(
+      `[worktree-janitor] Workroom claims UNREADABLE (${claims.reason}) — every worktree will be ` +
+        "kept. A reaper that cannot ask who is working must not decide that nobody is.",
+    );
+  }
   const ttlMs = heartbeatTtlMs(process.env);
   const policy = args.tierAOnly ? "tier-a-only" : "all";
   const decisions = [];
   const removals = [];
 
   for (const entry of entries) {
-    const facts = gatherFacts(root, entry, prIndex, leasePayload, ttlMs);
+    const facts = gatherFacts(root, entry, prIndex, leasePayload, ttlMs, claims);
     const { verdict, reason, tier } = classifyWorktree(facts, { graceDays: args.graceDays });
     const row = {
       path: facts.path,


### PR DESCRIPTION
fix(worktree): liveness comes from the platform, and unreadable evidence fails safe (BI-99395B29)

On 2026-09-02 a live Tier-A reap deleted the working directories of 24 ACTIVE
Workrooms, including a codex-desktop room touched minutes earlier. Threads
noticed before the operator did. This is the root-cause fix.

## Why the safety gate did not hold

The classifier's only liveness signal was `.dpf-session-heartbeat.json`, written
by a Claude Code plugin hook (packages/dpf-skill-pack/hooks/hooks.json). Codex,
Grok and Build Studio write nothing. So for three of four surfaces the gate read
"no heartbeat" as "no live session" when it meant "no client writing
heartbeats", and FAILED OPEN.

The design was not naive about the hazard. Its own comment names it exactly:

    // This must sit ABOVE the merged/Tier-A check: the moment a live session's
    // PR merges, its clean tree first becomes Tier-A eligible — exactly when it
    // must NOT be reaped.

The gate was right. Its input was client-dependent, which is the commandment
raised in #4967 violated inside the tool meant to enforce good hygiene. And
`WorkCapsule` — the platform's own record of who owns which worktree — was never
consulted at all.

## What changed

`scripts/lib/worktree-liveness.mjs` reads active Workroom claims over MCP. Every
surface writes to that record, so it answers for all four rather than one.
`classifyWorktree` now KEEPS anything an active room claims, checked above the
merged/Tier-A path.

FAIL SAFE, NOT FAIL OPEN. No token, portal down, MCP error → available:false →
the classifier keeps everything and says why. The existing lease loader returns
"" without a token, which reads downstream as "nothing is leased" and protects
nothing; that pattern is explicitly rejected here and pinned by a test. Absence
of evidence is not evidence of absence.

Measured on the live repository, same moment:

    heartbeat only     Tier-A 132   KEEP 49
    Workroom claims    Tier-A   2   KEEP 52

## The bound shipped in #4987 is neutered until liveness is readable

That bound reaps above a default of 40 with no human decision. On a classifier
whose liveness signal fails open, it converts a dormant flaw into automatic
fleet-wide damage — and it is currently live on main ahead of this fix. It now
refuses to go live when the scan kept anything because claims were unreadable:
a bound must not reap on absent evidence.

## Verification

12 liveness tests, 4 new classifier gate tests, 12 janitor tests. The classifier
suite pins the exact lost case: merged + clean + no heartbeat + claimed by an
active Workroom must KEEP.

## Design grounding

- Existing specs/plans reviewed:
  - docs/founder-kernel/wiki/principles/platform-function-never-depends-on-a-client.md
    — the commandment this applies to the reaper itself.
  - docs/founder-kernel/wiki/principles/destructive-actions-require-explicit-go.md
    — why an automatic bound must be conservative about what it cannot see.
  - docs/founder-kernel/wiki/principles/make-silent-failures-observable.md — the
    unreadable-claims path logs loudly rather than proceeding quietly.
- Current code substrate reviewed:
  - scripts/lib/worktree-janitor-core.mjs — the ordered gate list; the claim
    check sits with the other liveness gates, above merged.
  - scripts/worktree-janitor.mjs — one claims query per scan, beside the
    existing lease query it deliberately does not imitate.
  - packages/dpf-skill-pack/hooks/hooks.json — proof the heartbeat is
    Claude-only.
- Source of truth: the Workroom claim in the MCP coordination plane.
- Decision: consult the platform record rather than teach every client to write
  a heartbeat. Adding heartbeats to Codex and Grok would spread the client
  dependency rather than remove it.

Docs-Impact-Decision: the two linked pages describe WHERE the janitor runs and on what schedule; neither changes. This alters which liveness signal it trusts and how it behaves when that signal is unreadable, both internal to classification, and the operator-visible behaviour is strictly more conservative than the documented one.
Design-Grounding-Decision: a platform guarantee reads the platform's own ownership record, and refuses to act when it cannot read it
Process-Spine-Decision: records the client-dependent liveness defect and its fail-safe fix on BI-99395B29
Seed-Fit-Decision: global-default

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Mark Bodman <markdbodman@gmail.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
