### PR TITLE
fix(federation): honour net.connect's { all: true } lookup form in the CA client (BI-41EB722B)

### DIFF
--- a/apps/web/lib/federation/ca-client.test.ts
+++ b/apps/web/lib/federation/ca-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { caInternalUrl, resolveCaHost } from "./ca-client";
+import { caInternalUrl, offThreadpoolLookup, resolveCaHost } from "./ca-client";
 
 describe("resolveCaHost", () => {
   it("returns an IP literal untouched, without touching any resolver", async () => {
@@ -30,6 +30,20 @@ describe("resolveCaHost", () => {
     };
     expect(await resolveCaHost("host.docker.internal", resolver as never)).toEqual({ address: "127.0.0.1", family: 4 });
     expect(resolver.lookup).toHaveBeenCalledWith("host.docker.internal");
+  });
+});
+
+describe("offThreadpoolLookup", () => {
+  it("answers net.connect's { all: true } happy-eyeballs form with an array, and the plain form with address + family", async () => {
+    const resolver = { resolve4: vi.fn(async () => ["172.18.0.7"]), resolve6: vi.fn(), lookup: vi.fn() };
+    const all = await new Promise<unknown[]>((resolve) => offThreadpoolLookup("step-ca", { all: true }, (...args) => resolve(args), resolver as never));
+    expect(all).toEqual([null, [{ address: "172.18.0.7", family: 4 }]]);
+    const single = await new Promise<unknown[]>((resolve) => offThreadpoolLookup("step-ca", {}, (...args) => resolve(args), resolver as never));
+    expect(single).toEqual([null, "172.18.0.7", 4]);
+    const failing = { resolve4: vi.fn(async () => { throw new Error("x"); }), resolve6: vi.fn(async () => { throw new Error("x"); }), lookup: vi.fn(async () => { throw Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" }); }) };
+    const failed = await new Promise<unknown[]>((resolve) => offThreadpoolLookup("nosuch", { all: true }, (...args) => resolve(args), failing as never));
+    expect((failed[0] as Error).message).toBe("ENOTFOUND");
+    expect(failed[1]).toEqual([]);
   });
 });
 

--- a/apps/web/lib/federation/ca-client.ts
+++ b/apps/web/lib/federation/ca-client.ts
@@ -27,7 +27,8 @@ const CA_TIMEOUT_MS = 15_000;
  */
 const caAgent = new HttpsAgent({ keepAlive: false, maxSockets: 8 });
 
-type LookupCallback = (error: NodeJS.ErrnoException | null, address: string, family: number) => void;
+/** net.connect calls lookup with `{ all: true }` (happy-eyeballs) and expects an array then; otherwise a single address. */
+type LookupCallback = (error: NodeJS.ErrnoException | null, address: string | LookupAddress[], family?: number) => void;
 
 /**
  * Resolve the CA host without the libuv thread pool. Node's default
@@ -58,10 +59,11 @@ export async function resolveCaHost(hostname: string, resolver: Pick<typeof dns,
   return resolver.lookup(hostname);
 }
 
-function offThreadpoolLookup(hostname: string, _options: unknown, callback: LookupCallback): void {
-  resolveCaHost(hostname).then(
-    (found) => callback(null, found.address, found.family),
-    (error: NodeJS.ErrnoException) => callback(error, "", 0),
+export function offThreadpoolLookup(hostname: string, options: unknown, callback: LookupCallback, resolver?: Pick<typeof dns, "resolve4" | "resolve6" | "lookup">): void {
+  const wantsAll = typeof options === "object" && options !== null && (options as { all?: boolean }).all === true;
+  resolveCaHost(hostname, resolver).then(
+    (found) => (wantsAll ? callback(null, [found]) : callback(null, found.address, found.family)),
+    (error: NodeJS.ErrnoException) => (wantsAll ? callback(error, []) : callback(error, "", 0)),
   );
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #5061/#5063 (**BI-41EB722B**). `net.connect` calls a custom `lookup` with `{ all: true }` (happy-eyeballs) and expects an array of `{ address, family }`; the c-ares lookup answered in the single-address form, so on the development install every CA request now failed instantly with `Invalid IP address: undefined`. Both forms are honoured, with a test for each.

## Verification
- ca-client tests (both callback forms, failure form) and membership-relay tests green.
- Live: to be re-checked on the development install after release (BI-41EB722B).

Design-Grounding-Decision: no-contract-change (lookup callback shape inside lib/federation/ca-client.ts)
Docs-Impact-Decision: no docs affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)