### PR TITLE
fix(ci): read Dependabot and Secret scanning alerts through a GitHub App token (BI-3E6AFF04)

### DIFF
--- a/.github/workflows/audit-stale-overrides.yml
+++ b/.github/workflows/audit-stale-overrides.yml
@@ -51,12 +51,27 @@ jobs:
       - name: Unit tests
         run: node --test scripts/audit-stale-overrides.test.mjs scripts/check-override-comments.test.mjs
 
+      # Same credential order as security-findings-watch.yml (BI-3E6AFF04):
+      # App installation token, else DEPENDABOT_ALERTS_TOKEN, else GITHUB_TOKEN.
+      - name: Mint a GitHub App token for the alert surfaces
+        id: app-token
+        env:
+          APP_ID: ${{ secrets.SECURITY_SWEEP_APP_ID }}
+        if: env.APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SECURITY_SWEEP_APP_ID }}
+          private-key: ${{ secrets.SECURITY_SWEEP_APP_PRIVATE_KEY }}
+          permission-dependabot-alerts: read
+          permission-secret-scanning-alerts: read
+          permission-security-events: read
+
       - name: Audit stale overrides
         # On scheduled/manual runs require the API (a silent skip would hide that
         # the audit didn't run). On PRs, tolerate an outage so a transient blip
         # can't block unrelated merges — it degrades to tag-coverage only.
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           FLAGS=""

--- a/.github/workflows/security-findings-watch.yml
+++ b/.github/workflows/security-findings-watch.yml
@@ -55,13 +55,30 @@ jobs:
 
       # The default GITHUB_TOKEN can read Code Scanning but NOT Dependabot or
       # Secret Scanning alerts — both 403 even with `security-events: read`.
-      # DEPENDABOT_ALERTS_TOKEN (a token with the security_events scope) is the
-      # existing convention from audit-stale-overrides.yml. Until that secret is
-      # set, the sweep reports those two surfaces as UNREADABLE rather than zero,
-      # which is the intended degradation: incomplete, and visibly so.
+      # Credential order (BI-3E6AFF04): a GitHub App installation token minted
+      # per run from SECURITY_SWEEP_APP_ID + SECURITY_SWEEP_APP_PRIVATE_KEY (no
+      # expiry cliff; the App needs "Dependabot alerts: read" and "Secret
+      # scanning alerts: read"), else DEPENDABOT_ALERTS_TOKEN (a fine-grained
+      # PAT with the same two permissions), else GITHUB_TOKEN. Until one of the
+      # first two exists, the sweep reports those two surfaces as UNREADABLE
+      # rather than zero, which is the intended degradation: incomplete, and
+      # visibly so.
+      - name: Mint a GitHub App token for the alert surfaces
+        id: app-token
+        env:
+          APP_ID: ${{ secrets.SECURITY_SWEEP_APP_ID }}
+        if: env.APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SECURITY_SWEEP_APP_ID }}
+          private-key: ${{ secrets.SECURITY_SWEEP_APP_PRIVATE_KEY }}
+          permission-dependabot-alerts: read
+          permission-secret-scanning-alerts: read
+          permission-security-events: read
+
       - name: Sweep all three security surfaces
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN }}
         run: node scripts/sbom/sweep-security-surfaces.mjs --json sbom/security-sweep.json --md sbom/security-sweep.md
 
       - name: Publish sweep to the run summary

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 696,
+  "pageCount": 697,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -8825,6 +8825,20 @@
         "quarantine-renames-the-key-it-does-not-retire-the-row",
         "preventing-recurrence",
         "related"
+      ]
+    },
+    "docs/runbooks/2026-09-05-security-sweep-credential.md": {
+      "publicHref": "/runbooks/2026-09-05-security-sweep-credential/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "security-sweep-credential-read-all-three-alert-surfaces",
+        "symptom",
+        "credential-order-what-the-workflows-try",
+        "operator-step-once-by-a-repository-admin",
+        "verify-the-sweep-is-complete",
+        "rollback"
       ]
     },
     "docs/runbooks/bet5-windows-self-upgrade.md": {

--- a/docs/runbooks/2026-09-05-security-sweep-credential.md
+++ b/docs/runbooks/2026-09-05-security-sweep-credential.md
@@ -1,0 +1,35 @@
+---
+status: active
+---
+
+# Security sweep credential: read all three alert surfaces
+
+**Backlog item:** BI-3E6AFF04 · **Workflows:** `security-findings-watch.yml`, `audit-stale-overrides.yml` · **Standing report:** issue #4389
+
+## Symptom
+
+The daily sweep's report opens with "2 of 3 surfaces could not be read". Dependabot and Secret scanning alerts answer 403 because the workflow is running on the default `GITHUB_TOKEN`, which cannot read those two surfaces no matter what `permissions:` declares.
+
+## Credential order (what the workflows try)
+
+1. **GitHub App installation token**, minted per run by `actions/create-github-app-token` from the repository secrets `SECURITY_SWEEP_APP_ID` and `SECURITY_SWEEP_APP_PRIVATE_KEY`. Lives one hour. No renewal cliff. Preferred.
+2. **Fine-grained PAT** in `DEPENDABOT_ALERTS_TOKEN`. Works with no code change but expires; record the owner and expiry.
+3. `GITHUB_TOKEN`. Code scanning only; the report says the other two are unreadable.
+
+## Operator step (once, by a repository admin)
+
+This is the one step an agent cannot do: it needs the GitHub web UI under your own sign-in.
+
+1. GitHub → the organization's Settings → Developer settings → GitHub Apps → New GitHub App. Name it `dpf-security-sweep`. Webhook: off.
+2. Repository permissions: **Dependabot alerts: Read**, **Secret scanning alerts: Read**, **Code scanning alerts: Read**. Nothing else.
+3. Create the App, note the **App ID**, then **Generate a private key** (a `.pem` download).
+4. Install the App on the `opendigitalproductfactory` repository only.
+5. Repository → Settings → Secrets and variables → Actions: add `SECURITY_SWEEP_APP_ID` (the number) and `SECURITY_SWEEP_APP_PRIVATE_KEY` (the whole `.pem` contents).
+
+## Verify the sweep is complete
+
+Run `security-findings-watch.yml` by hand (Actions → the workflow → Run workflow) and read issue #4389 after it finishes. The header must no longer say any surface could not be read, and the summary must list counts for all three surfaces. A green run with the "could not be read" header is still an incomplete sweep.
+
+## Rollback
+
+Delete the two secrets. The mint step is skipped and the workflows fall back to the PAT, then `GITHUB_TOKEN`.

--- a/docs/superpowers/specs/2026-09-05-security-sweep-app-token-design.md
+++ b/docs/superpowers/specs/2026-09-05-security-sweep-app-token-design.md
@@ -1,0 +1,33 @@
+---
+status: draft
+---
+
+# Security sweep reads all three alert surfaces through a GitHub App token
+
+**Backlog item:** BI-3E6AFF04
+**Profile:** fix
+
+## Problem and reproduced cause
+
+At main `961ef9c8cf`, `.github/workflows/security-findings-watch.yml:64` and `audit-stale-overrides.yml:59` read alerts with `secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN`. The repository secret does not exist (`gh secret list` shows none), so both fall back to `GITHUB_TOKEN`, which cannot read Dependabot or Secret scanning alerts even with `security-events: read`. The standing report (#4389) opens by declaring itself incomplete. Confirmed 2026-09-05: the same endpoints answer 200 to a user token with `repo` scope, so the org has the surfaces; the workflow simply lacks a credential that may read them.
+
+## Objectives and acceptance criteria
+
+1. Both workflows mint a short-lived GitHub App installation token per run when `SECURITY_SWEEP_APP_ID` and `SECURITY_SWEEP_APP_PRIVATE_KEY` exist, and fall back to the PAT, then `GITHUB_TOKEN`, so the change is safe to merge before the secrets exist.
+2. The 403 remedy text in both scripts names the two credential paths.
+3. The operator step (create the App with "Dependabot alerts: read" and "Secret scanning alerts: read", install it on the repository, store the two secrets) is documented in the runbook and is the only human step.
+
+## Ordered fix sequence
+
+1. Add the `actions/create-github-app-token@v2` step, gated on the App id secret, to both workflows; point `GITHUB_TOKEN` at `steps.app-token.outputs.token || DEPENDABOT_ALERTS_TOKEN || GITHUB_TOKEN`.
+2. Update the remedy strings in `scripts/sbom/sweep-security-surfaces.mjs` and `scripts/audit-stale-overrides.mjs`.
+3. Runbook entry: how to create and install the App, and how to verify the sweep is complete (the report header must not say "2 of 3 surfaces could not be read").
+
+## Boundaries
+
+- No change to what the sweep does with the alerts.
+- `actions/*` first-party actions are pinned by major tag in this repository; third-party actions by SHA. This one is first-party.
+
+## Rollback
+
+Delete the two secrets; the step is skipped and the fallback chain is what runs today.

--- a/scripts/audit-stale-overrides.mjs
+++ b/scripts/audit-stale-overrides.mjs
@@ -145,7 +145,7 @@ async function fetchAllDependabotAlerts({ repo, token }) {
     if (res.status === 403) {
       throw new Error(
         "GitHub API 403 reading Dependabot alerts — the default GITHUB_TOKEN cannot read this surface. " +
-          "Set the DEPENDABOT_ALERTS_TOKEN repository secret to a token with the security_events scope.",
+          "Set the SECURITY_SWEEP_APP_ID + SECURITY_SWEEP_APP_PRIVATE_KEY repository secrets (GitHub App with Dependabot alerts: read and Secret scanning alerts: read), or DEPENDABOT_ALERTS_TOKEN (fine-grained PAT with the same permissions).",
       );
     }
     if (!res.ok) throw new Error(`GitHub API ${res.status} ${res.statusText}`);

--- a/scripts/sbom/sweep-security-surfaces.mjs
+++ b/scripts/sbom/sweep-security-surfaces.mjs
@@ -69,7 +69,7 @@ async function fetchAlerts(surface) {
       return {
         ok: false,
         alerts: [],
-        reason: "403 — the default GITHUB_TOKEN cannot read this surface; set the DEPENDABOT_ALERTS_TOKEN secret (security_events scope)",
+        reason: "403 — the default GITHUB_TOKEN cannot read this surface; set the SECURITY_SWEEP_APP_ID + SECURITY_SWEEP_APP_PRIVATE_KEY secrets (GitHub App) or DEPENDABOT_ALERTS_TOKEN (fine-grained PAT) — see BI-3E6AFF04",
       };
     }
     if (!res.ok) return { ok: false, alerts: [], reason: `HTTP ${res.status}` };


### PR DESCRIPTION
## Why

The daily security sweep can read only one of its three alert surfaces. `security-findings-watch.yml` and `audit-stale-overrides.yml` fall back to the default `GITHUB_TOKEN` because the `DEPENDABOT_ALERTS_TOKEN` secret was never created, and that token cannot read Dependabot or Secret scanning alerts however `permissions:` is declared. The standing report (#4389) opens by declaring itself incomplete. BI-3E6AFF04.

## What changed

- **Both workflows** gain a step that mints a per-run GitHub App installation token with `actions/create-github-app-token@v2` when `SECURITY_SWEEP_APP_ID` exists, then read alerts with `steps.app-token.outputs.token || DEPENDABOT_ALERTS_TOKEN || GITHUB_TOKEN`. Safe to merge before the secrets exist: the step is skipped and today's fallback chain runs.
- **Remedy strings** in `sweep-security-surfaces.mjs` and `audit-stale-overrides.mjs` name both credential paths.
- **Runbook** `docs/runbooks/2026-09-05-security-sweep-credential.md`: the one operator step (create the App with Dependabot alerts: read, Secret scanning alerts: read, Code scanning alerts: read; install on the repo; store the two secrets) and how to verify a complete sweep.
- **Spec** `docs/superpowers/specs/2026-09-05-security-sweep-app-token-design.md`.

## Design grounding

- Spec: `docs/superpowers/specs/2026-09-05-security-sweep-app-token-design.md`
- Code: `.github/workflows/security-findings-watch.yml`, `.github/workflows/audit-stale-overrides.yml`, `scripts/sbom/sweep-security-surfaces.mjs`, `scripts/audit-stale-overrides.mjs`

## Verification

- Script tests 10/10; both workflows parse with the mint step ahead of the consumer.
- Guard loop clean on 245553b3e3.
- The sweep is only proven complete after the operator creates the App and re-runs the workflow; #4389's header must stop saying "could not be read".

## Rollback

Delete the two secrets. No code change needed.

Local-CI-Evidence: cmtnyaf7c03rf01qp7msaizvl
Docs-Impact-Decision: updated
Design-Grounding-Decision: no-contract-change (credential order in two workflows; no product surface or schema touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
