### PR TITLE
feat(federation): retire the edge-node join path from the Connections page (slice 3)

### DIFF
--- a/apps/web/app/(shell)/platform/federation-links/page.tsx
+++ b/apps/web/app/(shell)/platform/federation-links/page.tsx
@@ -20,7 +20,6 @@ import {
   type PartnerBusinessRow,
 } from "@/components/platform/federation-links/PartnerBusinessPanel";
 import { OrganizationJoinPanel } from "@/components/platform/federation-links/OrganizationJoinPanel";
-import { getOrganizationJoinNodeSummariesAction } from "@/lib/actions/organization-join";
 import {
   deriveNearbyDiscoveryHealth,
   deriveEdgeNodeReadiness,
@@ -45,7 +44,7 @@ export default async function FederationLinksPage() {
     redirect("/403");
   }
 
-  const [links, edgeNodes, partnerAccounts, nearbyPairingSessions, organizationJoinNodes, introducedCandidates] = await Promise.all([
+  const [links, edgeNodes, partnerAccounts, nearbyPairingSessions, introducedCandidates] = await Promise.all([
     prisma.federationLink.findMany({
       include: { principal: { select: { displayName: true } } },
       orderBy: { createdAt: "desc" },
@@ -79,7 +78,6 @@ export default async function FederationLinksPage() {
       orderBy: { requestedAt: "desc" },
       take: 20,
     }),
-    getOrganizationJoinNodeSummariesAction(),
     prisma.federationIntroductionCandidate.findMany({
       where: {
         expiresAt: { gt: new Date() }, withdrawnAt: null, dismissedAt: null,
@@ -218,7 +216,7 @@ export default async function FederationLinksPage() {
           both sides approve; either side can pause or revoke the connection.
         </p>
       </div>
-      <OrganizationJoinPanel nodes={organizationJoinNodes.ok ? organizationJoinNodes.nodes : []} candidates={joinCandidates} />
+      <OrganizationJoinPanel candidates={joinCandidates} />
       <FederationLinksAdminClient
         rows={rows}
         nearbyCandidates={connectionCandidates}

--- a/apps/web/components/platform/federation-links/OrganizationJoinPanel.test.tsx
+++ b/apps/web/components/platform/federation-links/OrganizationJoinPanel.test.tsx
@@ -3,71 +3,19 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  mockAuthorize,
-  mockCancel,
-  mockConfirm,
-  mockDownload,
-  mockImport,
-  mockIssue,
-  mockQueue,
-  mockStatus,
-} = vi.hoisted(() => ({
-  mockAuthorize: vi.fn(),
-  mockCancel: vi.fn(),
-  mockConfirm: vi.fn(),
-  mockDownload: vi.fn(),
+const { mockImport, mockIssue } = vi.hoisted(() => ({
   mockImport: vi.fn(),
   mockIssue: vi.fn(),
-  mockQueue: vi.fn(),
-  mockStatus: vi.fn(),
 }));
 
-vi.mock("@/components/ui/Dialog", () => ({ confirmDialog: mockConfirm }));
 vi.mock("@/lib/actions/organization-join", () => ({
-  authorizeOrganizationJoinNodeAction: mockAuthorize,
-  cancelOrganizationJoinActionAction: mockCancel,
-  downloadIssuedJoinPackageAction: mockDownload,
-  getOrganizationJoinActionStatusAction: mockStatus,
   importOrganizationJoinFileAction: mockImport,
   issueOrganizationJoinFileAction: mockIssue,
-  queueOrganizationJoinActionAction: mockQueue,
 }));
 
 import { OrganizationJoinPanel } from "./OrganizationJoinPanel";
-import type { OrganizationJoinNodeSummary } from "@/lib/actions/organization-join";
 
-const authority: OrganizationJoinNodeSummary = {
-  edgeNodeId: "edge-authority",
-  nodeId: "edge-1",
-  displayName: "Founder Hub Mac",
-  platform: "darwin",
-  status: "active",
-  trustState: "trusted",
-  role: "authority",
-  actionType: "organization.join.issue",
-  hostIdentity: "founder-hub.local",
-  ready: true,
-  readinessMessage: "Secure host action channel ready",
-  latestAction: null,
-};
-
-const member: OrganizationJoinNodeSummary = {
-  edgeNodeId: "edge-member",
-  nodeId: "edge-2",
-  displayName: "Windows test installation",
-  platform: "win32",
-  status: "active",
-  trustState: "trusted",
-  role: "member",
-  actionType: "organization.join.import",
-  hostIdentity: "windows-dev.local",
-  ready: true,
-  readinessMessage: "Secure host action channel ready",
-  latestAction: null,
-};
-
-function joinPackage(expiresAt = new Date(Date.now() + 10 * 60_000), peer = member.hostIdentity!) {
+function joinPackage(expiresAt = new Date(Date.now() + 10 * 60_000), peer = "windows-dev.local") {
   return [
     "DPF_ORGANIZATION_JOIN_V2",
     "package_id=0123456789abcdef0123456789abcdef",
@@ -84,70 +32,45 @@ function joinPackage(expiresAt = new Date(Date.now() + 10 * 60_000), peer = memb
 
 beforeEach(() => {
   vi.resetAllMocks();
-  mockConfirm.mockResolvedValue(true);
-  mockAuthorize.mockResolvedValue({ ok: true });
-  mockQueue.mockResolvedValue({ ok: true, actionKey: "ra-join-1" });
+  mockImport.mockResolvedValue({ ok: true, data: { authorityUrl: "http://founder-hub.local:3000", intendedPeer: "windows-dev.local", message: "Joined the organization at founder-hub.local:3000." } });
   mockIssue.mockResolvedValue({ ok: true, data: { fileName: "organization-join-windows-dev.local-abcd1234.dpfjoin", content: "DPF_ORGANIZATION_JOIN_V2\n", intendedPeer: "windows-dev.local", expiresAt: new Date(Date.now() + 30 * 60_000).toISOString() } });
   Object.defineProperty(URL, "createObjectURL", { configurable: true, value: vi.fn(() => "blob:join") });
   Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: vi.fn() });
   HTMLAnchorElement.prototype.click = vi.fn();
-  mockImport.mockResolvedValue({ ok: true, data: { authorityUrl: "http://founder-hub.local:3000", intendedPeer: "windows-dev.local", message: "Joined the organization at founder-hub.local:3000." } });
-  mockStatus.mockResolvedValue({
-    ok: true,
-    actionKey: "ra-join-1",
-    actionType: "organization.join.issue",
-    status: "queued",
-    approvalState: "approved",
-    packageReady: false,
-    evidence: {},
-  });
 });
 
 afterEach(() => cleanup());
 
 describe("OrganizationJoinPanel", () => {
-  it("presents the no-command workflow before technical detail", () => {
-    render(<OrganizationJoinPanel nodes={[authority, member]} />);
+  it("offers exactly the two portal-mediated acts and no edge-node setup", () => {
+    render(<OrganizationJoinPanel candidates={[]} />);
 
     expect(screen.getByRole("heading", { name: "Connect your own installations" })).toBeTruthy();
     expect(screen.getByText(/No commands, certificate copying, or CA password handling/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Create join file" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Join this installation" })).toBeTruthy();
+    expect(screen.queryByText(/Enable secure/)).toBeNull();
+    expect(screen.queryByText(/No installation has reported/)).toBeNull();
     expect(screen.getByText(/does not share backlog data/)).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Create join file" }));
     expect(screen.getByRole("button", { name: "Back to choices" }).className).toContain("min-h-11");
   });
 
-  it("explicitly enables only the named host action after confirmation", async () => {
-    render(<OrganizationJoinPanel nodes={[{ ...member, ready: false, readinessMessage: "Allow the organization setup action for this installation" }]} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Enable secure setup" }));
-
-    await waitFor(() => expect(mockAuthorize).toHaveBeenCalledWith({
-      edgeNodeId: "edge-member",
-      actionType: "organization.join.import",
-      operatorConfirmed: true,
-    }));
-  });
-
   it("issues the file through the portal for a chosen trusted installation and downloads it once", async () => {
-    render(<OrganizationJoinPanel nodes={[]} candidates={[{ hostname: "windows-dev.local", displayName: "Windows test installation" }]} />);
+    render(<OrganizationJoinPanel candidates={[{ hostname: "windows-dev.local", displayName: "Windows test installation" }]} />);
     fireEvent.click(screen.getByRole("button", { name: "Create join file" }));
-    expect(screen.queryByText(/No installation has reported/)).toBeNull();
-    expect(screen.queryByLabelText(/^Join file expiry/)).toBeNull();
     expect((screen.getByLabelText(/^Installation that will join/) as HTMLSelectElement).value).toBe("windows-dev.local");
     fireEvent.click(screen.getByLabelText(/I confirm this file is for windows-dev.local/));
     fireEvent.click(screen.getByRole("button", { name: "Create one-time file" }));
 
     await waitFor(() => expect(mockIssue).toHaveBeenCalledWith({ intendedPeer: "windows-dev.local" }));
-    expect(mockQueue).not.toHaveBeenCalled();
     await waitFor(() => expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled());
     expect((await screen.findByRole("status")).textContent).toMatch(/downloaded once/i);
   });
 
-  it("lets the operator name another installation when it is not a trusted peer yet", async () => {
-    render(<OrganizationJoinPanel nodes={[]} candidates={[]} />);
+  it("lets the operator name another installation and surfaces the server's refusal", async () => {
+    render(<OrganizationJoinPanel />);
     fireEvent.click(screen.getByRole("button", { name: "Create join file" }));
     expect((screen.getByLabelText(/^Installation that will join/) as HTMLSelectElement).value).toBe("__other__");
     fireEvent.change(screen.getByLabelText(/^Installation name/), { target: { value: "192.168.0.200" } });
@@ -159,10 +82,9 @@ describe("OrganizationJoinPanel", () => {
   });
 
   it("previews a valid file without rendering either enrollment token", async () => {
-    render(<OrganizationJoinPanel nodes={[member]} />);
+    render(<OrganizationJoinPanel />);
     fireEvent.click(screen.getByRole("button", { name: "Join this installation" }));
-    const file = new File([joinPackage()], "founder-hub-to-windows.dpfjoin", { type: "application/octet-stream" });
-    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [file] } });
+    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [new File([joinPackage()], "join.dpfjoin", { type: "application/octet-stream" })] } });
 
     expect(await screen.findByText("founder-hub.local:9000")).toBeTruthy();
     expect(screen.getAllByText(/windows-dev\.local/).length).toBeGreaterThan(0);
@@ -170,11 +92,9 @@ describe("OrganizationJoinPanel", () => {
     expect(screen.getByRole("button", { name: "Join organization" }).hasAttribute("disabled")).toBe(true);
   });
 
-  it("joins through the portal with no installation selected and nothing typed", async () => {
-    render(<OrganizationJoinPanel nodes={[]} />);
+  it("joins through the portal with nothing typed", async () => {
+    render(<OrganizationJoinPanel />);
     fireEvent.click(screen.getByRole("button", { name: "Join this installation" }));
-    expect(screen.queryByText(/No installation has reported/)).toBeNull();
-    expect(screen.queryByRole("button", { name: "Enable secure setup" })).toBeNull();
     const raw = joinPackage();
     fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [new File([raw], "join.dpfjoin")] } });
     await screen.findByText("founder-hub.local:9000");
@@ -182,15 +102,13 @@ describe("OrganizationJoinPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Join organization" }));
 
     await waitFor(() => expect(mockImport).toHaveBeenCalledWith(raw));
-    expect(mockQueue).not.toHaveBeenCalled();
     expect((await screen.findByRole("status")).textContent).toMatch(/Joined the organization/);
   });
 
   it("rejects an expired file before approval and surfaces the server's wrong-host refusal", async () => {
-    render(<OrganizationJoinPanel nodes={[]} />);
+    render(<OrganizationJoinPanel />);
     fireEvent.click(screen.getByRole("button", { name: "Join this installation" }));
-    const expired = new File([joinPackage(new Date(Date.now() - 60_000))], "expired.dpfjoin");
-    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [expired] } });
+    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [new File([joinPackage(new Date(Date.now() - 60_000))], "expired.dpfjoin")] } });
     expect((await screen.findByRole("alert")).textContent).toMatch(/expired/i);
     expect(mockImport).not.toHaveBeenCalled();
 
@@ -201,42 +119,5 @@ describe("OrganizationJoinPanel", () => {
     fireEvent.click(screen.getByLabelText(/I confirm this file is for another-host.local/));
     fireEvent.click(screen.getByRole("button", { name: "Join organization" }));
     expect((await screen.findByRole("alert")).textContent).toMatch(/created for another installation/i);
-  });
-
-  it("resumes a queued action from server state after refresh", () => {
-    render(<OrganizationJoinPanel nodes={[{
-      ...authority,
-      latestAction: {
-        actionKey: "ra-resume",
-        actionType: "organization.join.issue",
-        status: "queued",
-        approvalState: "approved",
-        packageReady: false,
-        evidence: { intendedPeer: "windows-dev.local" },
-        createdAt: new Date().toISOString(),
-      },
-    }]} />);
-
-    expect(screen.getByText("Approved and waiting for Founder Hub Mac")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Cancel request" })).toBeTruthy();
-  });
-
-  it("keeps a failed host action visible and still offers the portal-native request", () => {
-    render(<OrganizationJoinPanel nodes={[{
-      ...authority,
-      latestAction: {
-        actionKey: "ra-failed",
-        actionType: "organization.join.issue",
-        status: "failed",
-        approvalState: "approved",
-        packageReady: false,
-        evidence: { errorCode: "portal-health-failed" },
-        createdAt: new Date().toISOString(),
-      },
-    }]} />);
-
-    expect(screen.getByText(/restored its previous settings/i)).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Create join file" }));
-    expect(screen.getByLabelText(/^Installation that will join/)).toBeTruthy();
   });
 });

--- a/apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx
+++ b/apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { parseOrganizationJoinPackage, type OrganizationJoinActionType, type OrganizationJoinPackagePreview } from "@dpf/db/organization-join-action";
-import { useEffect, useRef, useState, useTransition } from "react";
+// EP-ZERO-CONFIG-FEDERATION — connecting an organization's own installations.
+// Spec: docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md.
+//
+// Two portal-mediated acts, nothing else: the organization installation
+// creates a one-time join file (it mints the file itself), and the joining
+// installation chooses that file (it certifies itself through the organization
+// installation's portal). No edge node, no host script, no "secure setup".
 
-import { confirmDialog } from "@/components/ui/Dialog";
-import { InlineBusy } from "@/components/ui/InlineBusy";
+import { parseOrganizationJoinPackage, type OrganizationJoinPackagePreview } from "@dpf/db/organization-join-action";
+import { useRef, useState, useTransition } from "react";
+
 import {
   CheckboxField,
   FormField,
@@ -14,106 +20,12 @@ import {
   TextField,
 } from "@/components/ui/form";
 import {
-  authorizeOrganizationJoinNodeAction,
-  cancelOrganizationJoinActionAction,
-  downloadIssuedJoinPackageAction,
-  getOrganizationJoinActionStatusAction,
   importOrganizationJoinFileAction,
   issueOrganizationJoinFileAction,
-  type OrganizationJoinNodeSummary,
 } from "@/lib/actions/organization-join";
 
 type PanelMode = "overview" | "issue" | "import";
 type Notice = { kind: "success" | "error"; text: string } | null;
-type ActionState = NonNullable<OrganizationJoinNodeSummary["latestAction"]>;
-
-const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed-out"]);
-
-function safeEvidenceText(evidence: Record<string, unknown>, key: string): string | null {
-  return typeof evidence[key] === "string" ? evidence[key] : null;
-}
-
-function recoveryMessage(evidence: Record<string, unknown>): string {
-  switch (safeEvidenceText(evidence, "errorCode")) {
-    case "join-package-expired":
-      return "The join file expired. Create a new file on the organization installation.";
-    case "join-package-intended-for-another-host":
-      return "The join file was created for another installation.";
-    case "portal-health-failed":
-      return "The installation restored its previous settings because the portal health check failed.";
-    case "edge-heartbeat-failed":
-      return "The installation restored its previous settings because its secure host connection did not recover.";
-    default:
-      return "Secure setup did not finish. Review the technical details, then try again with a new join file.";
-  }
-}
-
-function ActionProgress({
-  action,
-  node,
-  busy,
-  onCancel,
-  onDownload,
-}: {
-  action: ActionState;
-  node: OrganizationJoinNodeSummary;
-  busy: boolean;
-  onCancel: () => void;
-  onDownload: () => void;
-}) {
-  const verification = [
-    ["certificateTrust", "Certificate trust"],
-    ["overlayPersistence", "Saved organization settings"],
-    ["portalHealth", "Portal health"],
-    ["edgeHeartbeat", "Secure host connection"],
-  ] as const;
-
-  let message = `Secure setup status: ${action.status}.`;
-  if (action.status === "queued") message = `Approved and waiting for ${node.displayName}`;
-  if (action.status === "claimed" || action.status === "running") message = `${node.displayName} is applying and checking the secure setup.`;
-  if (action.status === "succeeded" && action.actionType === "organization.join.issue") {
-    message = action.packageReady ? "The one-time join file is ready to download." : "The join file has already been downloaded or expired.";
-  }
-  if (action.status === "succeeded" && action.actionType === "organization.join.import") {
-    message = "This installation joined the organization and passed its local checks.";
-  }
-  if (action.status === "failed" || action.status === "timed-out") message = recoveryMessage(action.evidence);
-  if (action.status === "cancelled") message = "The secure setup request was cancelled before it started.";
-
-  return (
-    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4" aria-live="polite">
-      <p className="text-sm font-medium text-[var(--dpf-text)]">{message}</p>
-      {action.status === "succeeded" && action.actionType === "organization.join.import" ? (
-        <ul className="mt-3 grid gap-1 text-sm text-[var(--dpf-muted)] sm:grid-cols-2">
-          {verification.map(([key, label]) => (
-            <li key={key}>{action.evidence[key] === true ? "Passed" : "Not confirmed"}: {label}</li>
-          ))}
-        </ul>
-      ) : null}
-      <div className="mt-3 flex flex-wrap gap-2">
-        {action.status === "queued" ? (
-          <button type="button" className="rounded-md border border-[var(--dpf-border)] px-3 py-2 text-sm text-[var(--dpf-text)]" disabled={busy} onClick={onCancel}>
-            {busy ? <InlineBusy label="Cancelling…" /> : "Cancel request"}
-          </button>
-        ) : null}
-        {action.status === "succeeded" && action.actionType === "organization.join.issue" && action.packageReady ? (
-          <button type="button" className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-sm font-medium text-[var(--dpf-bg)]" disabled={busy} onClick={onDownload}>
-            {busy ? <InlineBusy label="Preparing file…" tone="current" /> : "Download join file"}
-          </button>
-        ) : null}
-      </div>
-      <details className="mt-3 text-sm text-[var(--dpf-muted)]">
-        <summary className="cursor-pointer text-[var(--dpf-accent)]">Technical details</summary>
-        <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 break-all">
-          <dt>Installation</dt><dd>{node.nodeId}</dd>
-          <dt>Request</dt><dd>{action.actionKey}</dd>
-          <dt>Status</dt><dd>{action.status}</dd>
-          {safeEvidenceText(action.evidence, "errorCode") ? <><dt>Error code</dt><dd>{safeEvidenceText(action.evidence, "errorCode")}</dd></> : null}
-        </dl>
-      </details>
-    </div>
-  );
-}
 
 /** A trusted same-organization installation the authority may issue a join file for. */
 export interface OrganizationJoinCandidate {
@@ -135,7 +47,7 @@ function downloadText(fileName: string, content: string) {
   URL.revokeObjectURL(url);
 }
 
-export function OrganizationJoinPanel({ nodes, candidates = [] }: { nodes: OrganizationJoinNodeSummary[]; candidates?: OrganizationJoinCandidate[] }) {
+export function OrganizationJoinPanel({ candidates = [] }: { candidates?: OrganizationJoinCandidate[] }) {
   const [mode, setMode] = useState<PanelMode>("overview");
   const [candidateChoice, setCandidateChoice] = useState<string>(candidates[0]?.hostname ?? OTHER_INSTALLATION);
   const [intendedPeer, setIntendedPeer] = useState("");
@@ -144,68 +56,14 @@ export function OrganizationJoinPanel({ nodes, candidates = [] }: { nodes: Organ
   const [packagePreview, setPackagePreview] = useState<OrganizationJoinPackagePreview | null>(null);
   const [importConfirmed, setImportConfirmed] = useState(false);
   const [notice, setNotice] = useState<Notice>(null);
-  const [actions, setActions] = useState<Record<string, ActionState>>(() => Object.fromEntries(
-    nodes.flatMap((node) => node.latestAction ? [[node.edgeNodeId, node.latestAction]] : []),
-  ));
   const [isPending, startTransition] = useTransition();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const chosenPeer = candidateChoice === OTHER_INSTALLATION ? intendedPeer.trim() : candidateChoice;
 
-  useEffect(() => {
-    const active = Object.entries(actions).find(([, action]) => !TERMINAL_STATUSES.has(action.status));
-    if (!active) return;
-    const [edgeNodeId, action] = active;
-    const timer = window.setTimeout(() => {
-      void getOrganizationJoinActionStatusAction(action.actionKey).then((result) => {
-        if (!result.ok) {
-          setNotice({ kind: "error", text: result.message });
-          return;
-        }
-        setActions((current) => ({
-          ...current,
-          [edgeNodeId]: {
-            ...action,
-            actionType: result.actionType as OrganizationJoinActionType,
-            status: result.status,
-            approvalState: result.approvalState,
-            packageReady: result.packageReady,
-            evidence: result.evidence,
-          },
-        }));
-      });
-    }, 2_500);
-    return () => window.clearTimeout(timer);
-  }, [actions]);
-
   function openMode(nextMode: "issue" | "import") {
-    // Both sides are portal-mediated: the authority mints the file itself and
-    // the member imports it itself, so neither mode selects an edge node.
     setMode(nextMode);
     setNotice(null);
-  }
-
-  async function authorize(node: OrganizationJoinNodeSummary) {
-    if (!node.actionType) {
-      setNotice({ kind: "error", text: node.readinessMessage });
-      return;
-    }
-    const confirmed = await confirmDialog({
-      title: "Enable secure setup",
-      message: `Allow only the ${node.actionType === "organization.join.issue" ? "join-file creation" : "organization join"} action on ${node.displayName}?`,
-      confirmLabel: "Enable secure setup",
-    });
-    if (!confirmed) return;
-    startTransition(async () => {
-      const result = await authorizeOrganizationJoinNodeAction({
-        edgeNodeId: node.edgeNodeId,
-        actionType: node.actionType!,
-        operatorConfirmed: true,
-      });
-      setNotice(result.ok
-        ? { kind: "success", text: `Secure setup enabled for ${node.displayName}. Refresh this page to continue.` }
-        : { kind: "error", text: result.message });
-    });
   }
 
   function issueJoinFile() {
@@ -258,33 +116,6 @@ export function OrganizationJoinPanel({ nodes, candidates = [] }: { nodes: Organ
     });
   }
 
-  function cancel(node: OrganizationJoinNodeSummary, action: ActionState) {
-    startTransition(async () => {
-      const result = await cancelOrganizationJoinActionAction(action.actionKey);
-      if (!result.ok) setNotice({ kind: "error", text: result.message });
-      else setActions((current) => ({ ...current, [node.edgeNodeId]: { ...action, status: "cancelled" } }));
-    });
-  }
-
-  function download(node: OrganizationJoinNodeSummary, action: ActionState) {
-    startTransition(async () => {
-      const result = await downloadIssuedJoinPackageAction(action.actionKey);
-      if (!result.ok) {
-        setNotice({ kind: "error", text: result.message });
-        return;
-      }
-      const url = URL.createObjectURL(new Blob([result.content], { type: "application/octet-stream" }));
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = result.fileName;
-      link.click();
-      URL.revokeObjectURL(url);
-      setActions((current) => ({ ...current, [node.edgeNodeId]: { ...action, packageReady: false } }));
-      setNotice({ kind: "success", text: "Join file downloaded once. Move it to the installation that will join." });
-    });
-  }
-
-
   return (
     <section className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5" aria-labelledby="organization-join-heading">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -323,130 +154,110 @@ export function OrganizationJoinPanel({ nodes, candidates = [] }: { nodes: Organ
         </div>
       ) : null}
 
-      {mode === "overview" ? nodes.filter((node) => !node.ready).map((node) => (
-        <div key={node.edgeNodeId} className="mt-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-          <p className="text-sm font-medium text-[var(--dpf-text)]">{node.displayName}</p>
-          <p className="mt-1 text-sm text-[var(--dpf-muted)]">{node.readinessMessage}</p>
-          {node.trustState === "trusted" && node.actionType ? (
-            <button type="button" className="mt-3 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-sm font-medium text-[var(--dpf-bg)]" disabled={isPending} onClick={() => void authorize(node)}>
-              {isPending ? <InlineBusy label="Enabling…" tone="current" /> : "Enable secure setup"}
-            </button>
+      {mode === "issue" ? (
+        <form className="mt-5 space-y-4" noValidate onSubmit={(event) => { event.preventDefault(); issueJoinFile(); }}>
+          <SelectField
+            name="intended-installation"
+            label="Installation that will join"
+            required
+            value={candidateChoice}
+            onValueChange={(value) => {
+              setCandidateChoice(value);
+              setIssueConfirmed(false);
+            }}
+            options={[
+              ...candidates.map((candidate) => ({ value: candidate.hostname, label: `${candidate.displayName} (${candidate.hostname})` })),
+              { value: OTHER_INSTALLATION, label: "Another installation…" },
+            ]}
+          />
+          {candidateChoice === OTHER_INSTALLATION ? (
+            <TextField
+              name="intended-installation-name"
+              label="Installation name"
+              required
+              autoComplete="off"
+              value={intendedPeer}
+              onValueChange={(value) => {
+                setIntendedPeer(value);
+                setIssueConfirmed(false);
+              }}
+              placeholder="192.168.0.200"
+            />
           ) : null}
-        </div>
-      )) : null}
-
-      {mode !== "overview" ? (
-        <div className="mt-5 space-y-4">
-          {mode === "issue" ? (
-            <form className="space-y-4" noValidate onSubmit={(event) => { event.preventDefault(); issueJoinFile(); }}>
-              <SelectField
-                name="intended-installation"
-                label="Installation that will join"
-                required
-                value={candidateChoice}
-                onValueChange={(value) => {
-                  setCandidateChoice(value);
-                  setIssueConfirmed(false);
-                }}
-                options={[
-                  ...candidates.map((candidate) => ({ value: candidate.hostname, label: `${candidate.displayName} (${candidate.hostname})` })),
-                  { value: OTHER_INSTALLATION, label: "Another installation…" },
-                ]}
-              />
-              {candidateChoice === OTHER_INSTALLATION ? (
-                <TextField
-                  name="intended-installation-name"
-                  label="Installation name"
-                  required
-                  autoComplete="off"
-                  value={intendedPeer}
-                  onValueChange={(value) => {
-                    setIntendedPeer(value);
-                    setIssueConfirmed(false);
-                  }}
-                  placeholder="192.168.0.200"
-                />
-              ) : null}
-              {chosenPeer ? (
-                <CheckboxField
-                  name="confirm-intended-installation"
-                  label={<>I confirm this file is for {chosenPeer}</>}
-                  checked={issueConfirmed}
-                  onCheckedChange={setIssueConfirmed}
-                />
-              ) : null}
-              <div className="flex flex-wrap items-center gap-3">
-                <SubmitButton
-                  pending={isPending}
-                  pendingLabel="Creating…"
-                  disabled={!issueConfirmed || !chosenPeer}
-                  data-dpf-primary-action
-                >
-                  Create one-time file
-                </SubmitButton>
-                <FormStatus
-                  error={notice?.kind === "error" ? notice.text : null}
-                  success={notice?.kind === "success" ? notice.text : null}
-                />
-              </div>
-            </form>
+          {chosenPeer ? (
+            <CheckboxField
+              name="confirm-intended-installation"
+              label={<>I confirm this file is for {chosenPeer}</>}
+              checked={issueConfirmed}
+              onCheckedChange={setIssueConfirmed}
+            />
           ) : null}
-
-          {mode === "import" ? (
-            <form className="space-y-4" noValidate onSubmit={(event) => { event.preventDefault(); importJoinFile(); }}>
-              <FormField name="organization-join-file" label="Choose a .dpfjoin file" required>
-                {(control) => (
-                  <input
-                    {...control}
-                    ref={fileInputRef}
-                    type="file"
-                    accept=".dpfjoin,application/octet-stream"
-                    className="block w-full text-sm text-[var(--dpf-muted)]"
-                    onChange={(event) => void readJoinFile(event.target.files?.[0])}
-                  />
-                )}
-              </FormField>
-              {packagePreview ? (
-                <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4 text-sm text-[var(--dpf-text)]">
-                  <p className="font-medium">Join file preview</p>
-                  <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 break-all text-[var(--dpf-muted)]">
-                    <dt>Organization host</dt><dd>{new URL(packagePreview.caUrl).host}</dd>
-                    <dt>For installation</dt><dd>{packagePreview.intendedPeer}</dd>
-                    <dt>Expires</dt><dd>{packagePreview.expiresAt.toLocaleString()}</dd>
-                    <dt>Trust fingerprint</dt><dd>{packagePreview.rootFingerprint.slice(0, 12)}…</dd>
-                  </dl>
-                </div>
-              ) : null}
-              {packagePreview ? (
-                <CheckboxField
-                  name="confirm-organization-join"
-                  label={<>I confirm this file is for {packagePreview.intendedPeer} and I want this installation to join that organization.</>}
-                  checked={importConfirmed}
-                  onCheckedChange={setImportConfirmed}
-                />
-              ) : null}
-              <div className="flex flex-wrap items-center gap-3">
-                <SubmitButton
-                  pending={isPending}
-                  pendingLabel="Joining…"
-                  disabled={!packagePreview || !importConfirmed}
-                  data-dpf-primary-action
-                >
-                  Join organization
-                </SubmitButton>
-                <FormStatus
-                  error={notice?.kind === "error" ? notice.text : null}
-                  success={notice?.kind === "success" ? notice.text : null}
-                />
-              </div>
-            </form>
-          ) : null}
-        </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <SubmitButton
+              pending={isPending}
+              pendingLabel="Creating…"
+              disabled={!issueConfirmed || !chosenPeer}
+              data-dpf-primary-action
+            >
+              Create one-time file
+            </SubmitButton>
+            <FormStatus
+              error={notice?.kind === "error" ? notice.text : null}
+              success={notice?.kind === "success" ? notice.text : null}
+            />
+          </div>
+        </form>
       ) : null}
 
-      {mode === "overview" ? nodes.flatMap((node) => actions[node.edgeNodeId] ? [
-        <div key={node.edgeNodeId} className="mt-4"><ActionProgress action={actions[node.edgeNodeId]} node={node} busy={isPending} onCancel={() => cancel(node, actions[node.edgeNodeId])} onDownload={() => download(node, actions[node.edgeNodeId])} /></div>,
-      ] : []) : null}
+      {mode === "import" ? (
+        <form className="mt-5 space-y-4" noValidate onSubmit={(event) => { event.preventDefault(); importJoinFile(); }}>
+          <FormField name="organization-join-file" label="Choose a .dpfjoin file" required>
+            {(control) => (
+              <input
+                {...control}
+                ref={fileInputRef}
+                type="file"
+                accept=".dpfjoin,application/octet-stream"
+                className="block w-full text-sm text-[var(--dpf-muted)]"
+                onChange={(event) => void readJoinFile(event.target.files?.[0])}
+              />
+            )}
+          </FormField>
+          {packagePreview ? (
+            <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4 text-sm text-[var(--dpf-text)]">
+              <p className="font-medium">Join file preview</p>
+              <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 break-all text-[var(--dpf-muted)]">
+                <dt>Organization host</dt><dd>{new URL(packagePreview.caUrl).host}</dd>
+                <dt>For installation</dt><dd>{packagePreview.intendedPeer}</dd>
+                <dt>Expires</dt><dd>{packagePreview.expiresAt.toLocaleString()}</dd>
+                <dt>Trust fingerprint</dt><dd>{packagePreview.rootFingerprint.slice(0, 12)}…</dd>
+              </dl>
+            </div>
+          ) : null}
+          {packagePreview ? (
+            <CheckboxField
+              name="confirm-organization-join"
+              label={<>I confirm this file is for {packagePreview.intendedPeer} and I want this installation to join that organization.</>}
+              checked={importConfirmed}
+              onCheckedChange={setImportConfirmed}
+            />
+          ) : null}
+          <div className="flex flex-wrap items-center gap-3">
+            <SubmitButton
+              pending={isPending}
+              pendingLabel="Joining…"
+              disabled={!packagePreview || !importConfirmed}
+              data-dpf-primary-action
+            >
+              Join organization
+            </SubmitButton>
+            <FormStatus
+              error={notice?.kind === "error" ? notice.text : null}
+              success={notice?.kind === "success" ? notice.text : null}
+            />
+          </div>
+        </form>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/lib/actions/organization-join.test.ts
+++ b/apps/web/lib/actions/organization-join.test.ts
@@ -1,296 +1,79 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  mockAssertEncryptionReady,
-  mockAuth,
-  mockCan,
-  mockCancel,
-  mockConsume,
-  mockCreateAction,
-  mockPrisma,
-  mockRevalidatePath,
-  mockSyncUserPrincipal,
-  tx,
-} = vi.hoisted(() => {
-  const transactionClient = {
-    changeRequest: { create: vi.fn() },
-  };
-  return {
-    mockAssertEncryptionReady: vi.fn(),
-    mockAuth: vi.fn(),
-    mockCan: vi.fn(),
-    mockCancel: vi.fn(),
-    mockConsume: vi.fn(),
-    mockCreateAction: vi.fn(),
-    mockRevalidatePath: vi.fn(),
-    mockSyncUserPrincipal: vi.fn(),
-    tx: transactionClient,
-    mockPrisma: {
-      principalAlias: { findFirst: vi.fn() },
-      employeeProfile: { findUnique: vi.fn() },
-      edgeNode: { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
-      edgeNodeCapability: { update: vi.fn() },
-      remoteAction: { findMany: vi.fn(), findUnique: vi.fn() },
-      $transaction: vi.fn(async (callback: (client: typeof transactionClient) => unknown) => callback(transactionClient)),
-    },
-  };
-});
+const { mockAuth, mockCan, mockIssue, mockImport, mockRevalidate, mockSelfUrl } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCan: vi.fn(),
+  mockIssue: vi.fn(),
+  mockImport: vi.fn(),
+  mockRevalidate: vi.fn(),
+  mockSelfUrl: vi.fn(),
+}));
 
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidate }));
 vi.mock("@/lib/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/permissions", () => ({ can: mockCan }));
-vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
-vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
-vi.mock("@/lib/change-management/lifecycle", () => ({ makeRfcId: () => "RFC-JOIN-1" }));
-vi.mock("@/lib/govern/credential-crypto", () => ({
-  assertEncryptionReadyForCredentialWrite: mockAssertEncryptionReady,
-}));
-vi.mock("@/lib/identity/principal-linking", () => ({ syncUserPrincipal: mockSyncUserPrincipal }));
-vi.mock("@/lib/remote-action/organization-join-actions", () => ({
-  cancelQueuedOrganizationJoinAction: mockCancel,
-  consumeIssuedJoinPackage: mockConsume,
-  createOrganizationJoinAction: mockCreateAction,
-}));
+vi.mock("@/lib/federation/organization-join-issue", () => ({ issueOrganizationJoinFile: mockIssue }));
+vi.mock("@/lib/federation/organization-join-import", () => ({ importOrganizationJoinFile: mockImport }));
+vi.mock("@/lib/federation/self-authority", () => ({ resolveLocalFederationAuthorityUrl: mockSelfUrl }));
 
-import {
-  authorizeOrganizationJoinNodeAction,
-  getOrganizationJoinActionStatusAction,
-  getOrganizationJoinNodeSummariesAction,
-  queueOrganizationJoinActionAction,
-} from "./organization-join";
+import { importOrganizationJoinFileAction, issueOrganizationJoinFileAction } from "./organization-join";
 
-const ADMIN = { user: { id: "user-1", platformRole: "HR-000", isSuperuser: false } };
+const operator = { user: { id: "user-1", platformRole: "PLATFORM_ADMIN", isSuperuser: false } };
+const EXPIRES = new Date(Date.now() + 30 * 60_000).toISOString();
 
 beforeEach(() => {
   vi.resetAllMocks();
-  mockAuth.mockResolvedValue(ADMIN);
+  mockAuth.mockResolvedValue(operator);
   mockCan.mockReturnValue(true);
-  mockPrisma.principalAlias.findFirst.mockResolvedValue({ principalId: "principal-1" });
-  mockPrisma.employeeProfile.findUnique.mockResolvedValue({ id: "employee-1" });
-  mockPrisma.remoteAction.findMany.mockResolvedValue([]);
-  tx.changeRequest.create.mockResolvedValue({ id: "change-1" });
-  mockCreateAction.mockResolvedValue({ ok: true, actionKey: "ra-join-1" });
-  mockPrisma.$transaction.mockImplementation(async (callback) => callback(tx));
+  mockSelfUrl.mockResolvedValue("http://192.168.0.152:3000");
+  mockIssue.mockResolvedValue({ issued: true, packageText: "DPF_ORGANIZATION_JOIN_V2\n", fileName: "organization-join-192.168.0.200-abcd1234.dpfjoin", packageId: "a".repeat(32), intendedPeer: "192.168.0.200", caUrl: "https://192.168.0.152:9000/", expiresAt: EXPIRES });
+  mockImport.mockResolvedValue({ imported: true, authorityUrl: "http://192.168.0.152:3000", caUrl: "https://192.168.0.152:9000/", intendedPeer: "192.168.0.200", expiresAt: EXPIRES, materialDir: "/dpf-federation/pki" });
 });
 
-describe("organization join action boundary", () => {
-  it("rejects an unauthenticated caller before reading host state", async () => {
-    mockAuth.mockResolvedValue(null);
+describe("organization join actions — session boundary", () => {
+  it("refuses an unauthenticated caller and a caller without manage_platform before touching the federation code", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+    expect(await issueOrganizationJoinFileAction({ intendedPeer: "192.168.0.200" })).toMatchObject({ ok: false, error: "unauthorized" });
+    mockCan.mockReturnValueOnce(false);
+    expect(await importOrganizationJoinFileAction("DPF_ORGANIZATION_JOIN_V2\n")).toMatchObject({ ok: false, error: "forbidden" });
+    expect(mockIssue).not.toHaveBeenCalled();
+    expect(mockImport).not.toHaveBeenCalled();
+  });
+});
 
-    const result = await getOrganizationJoinNodeSummariesAction();
-
-    expect(result).toEqual({ ok: false, error: "unauthorized", message: "Sign in required" });
-    expect(mockPrisma.edgeNode.findMany).not.toHaveBeenCalled();
+describe("issueOrganizationJoinFileAction", () => {
+  it("mints through the portal with the request host as this authority's own address and returns the file once", async () => {
+    const result = await issueOrganizationJoinFileAction({ intendedPeer: " 192.168.0.200 " });
+    expect(result).toEqual({ ok: true, data: { fileName: "organization-join-192.168.0.200-abcd1234.dpfjoin", content: "DPF_ORGANIZATION_JOIN_V2\n", intendedPeer: "192.168.0.200", expiresAt: EXPIRES } });
+    expect(mockIssue).toHaveBeenCalledWith({ intendedPeer: "192.168.0.200", requestHost: "http://192.168.0.152:3000" });
+    expect(mockRevalidate).toHaveBeenCalledWith("/platform/federation-links");
   });
 
-  it("reports only role-correct, trusted, allow-listed installations as ready", async () => {
-    mockPrisma.edgeNode.findMany.mockResolvedValue([
-      {
-        id: "edge-row-1",
-        nodeId: "edge-1",
-        platform: "darwin",
-        status: "online",
-        trustState: "trusted",
-        scopePolicy: { actionTypes: ["organization.join.issue"] },
-        principal: { displayName: "Founder Hub" },
-        capabilityRows: [{ mode: "enabled", status: "online", evidence: { organizationTrustRole: "authority" } }],
-      },
-      {
-        id: "edge-row-2",
-        nodeId: "edge-2",
-        platform: "windows",
-        status: "online",
-        trustState: "trusted",
-        scopePolicy: { actionTypes: ["inventory.collect"] },
-        principal: { displayName: "Windows test" },
-        capabilityRows: [{ mode: "enabled", status: "online", evidence: { organizationTrustRole: "member" } }],
-      },
-    ]);
+  it("maps the issuer's refusals to plain operator messages", async () => {
+    expect(await issueOrganizationJoinFileAction({ intendedPeer: "" })).toMatchObject({ ok: false, error: "invalid_input" });
+    mockIssue.mockResolvedValueOnce({ issued: false, reason: "not-the-authority" });
+    expect(await issueOrganizationJoinFileAction({ intendedPeer: "x" })).toMatchObject({ ok: false, error: "not_ready", message: expect.stringContaining("organization installation") });
+    mockIssue.mockResolvedValueOnce({ issued: false, reason: "own-address-unknown" });
+    expect(await issueOrganizationJoinFileAction({ intendedPeer: "x" })).toMatchObject({ ok: false, error: "not_ready", message: expect.stringContaining("network address") });
+    mockIssue.mockResolvedValueOnce({ issued: false, reason: "ca-unreachable", detail: "ECONNREFUSED" });
+    expect(await issueOrganizationJoinFileAction({ intendedPeer: "x" })).toMatchObject({ ok: false, error: "not_ready", message: expect.stringContaining("ECONNREFUSED") });
+  });
+});
 
-    const result = await getOrganizationJoinNodeSummariesAction();
+describe("importOrganizationJoinFileAction", () => {
+  it("imports through the portal and reports where the installation joined", async () => {
+    const result = await importOrganizationJoinFileAction("DPF_ORGANIZATION_JOIN_V2\npackage_id=x\n");
+    expect(result).toEqual({ ok: true, data: { authorityUrl: "http://192.168.0.152:3000", intendedPeer: "192.168.0.200", message: "Joined the organization at 192.168.0.152:3000. The connection appears here trusted within a few minutes." } });
+    expect(mockImport).toHaveBeenCalledWith({ fileText: "DPF_ORGANIZATION_JOIN_V2\npackage_id=x\n", requestHost: "http://192.168.0.152:3000" });
+  });
 
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.nodes[0]).toMatchObject({ displayName: "Founder Hub", actionType: "organization.join.issue", ready: true });
-      expect(result.nodes[1]).toMatchObject({ displayName: "Windows test", actionType: "organization.join.import", ready: false });
+  it("refuses an empty or oversized file before the importer runs, and maps the importer's refusals", async () => {
+    expect(await importOrganizationJoinFileAction("   ")).toMatchObject({ ok: false, error: "invalid_input" });
+    expect(await importOrganizationJoinFileAction("x".repeat(64 * 1024 + 1))).toMatchObject({ ok: false, error: "invalid_input" });
+    expect(mockImport).not.toHaveBeenCalled();
+    for (const [reason, error] of [["join-package-expired", "invalid_input"], ["intended-for-another-host", "invalid_input"], ["authority-unreachable", "not_ready"], ["authority-refused", "conflict"], ["chain-untrusted", "conflict"], ["material-not-writable", "not_ready"]] as const) {
+      mockImport.mockResolvedValueOnce({ imported: false, reason });
+      expect(await importOrganizationJoinFileAction("DPF_ORGANIZATION_JOIN_V2\n")).toMatchObject({ ok: false, error });
     }
-  });
-
-  it("returns the safe latest action so progress survives a page refresh", async () => {
-    mockPrisma.edgeNode.findMany.mockResolvedValue([{
-      id: "edge-row-1",
-      nodeId: "edge-1",
-      platform: "darwin",
-      status: "online",
-      trustState: "trusted",
-      metadata: { hostname: "founder-hub.local" },
-      scopePolicy: { actionTypes: ["organization.join.issue"] },
-      principal: { displayName: "Founder Hub" },
-      capabilityRows: [{ mode: "enabled", status: "healthy", evidence: { organizationTrustRole: "authority" } }],
-    }]);
-    mockPrisma.remoteAction.findMany.mockResolvedValue([{
-      actionKey: "ra-join-1",
-      actionType: "organization.join.issue",
-      edgeNodeId: "edge-row-1",
-      status: "succeeded",
-      approvalState: "approved",
-      result: { joinPackageEnc: "enc:must-not-escape" },
-      evidence: { intendedPeer: "windows-dev.local", enrollmentToken: "must-not-escape" },
-      createdAt: new Date("2026-07-22T10:00:00Z"),
-    }]);
-
-    const result = await getOrganizationJoinNodeSummariesAction();
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.nodes[0]).toMatchObject({
-        hostIdentity: "founder-hub.local",
-        latestAction: {
-          actionKey: "ra-join-1",
-          status: "succeeded",
-          packageReady: true,
-          evidence: { intendedPeer: "windows-dev.local" },
-        },
-      });
-      expect(JSON.stringify(result)).not.toContain("must-not-escape");
-    }
-  });
-
-  it("explicitly authorizes only the role-correct action on the named installation", async () => {
-    mockPrisma.edgeNode.findUnique.mockResolvedValue({
-      id: "edge-row-2",
-      trustState: "trusted",
-      scopePolicy: { actionTypes: ["inventory.collect"] },
-      capabilityRows: [{ id: "cap-1", evidence: { organizationTrustRole: "member" } }],
-    });
-    mockPrisma.edgeNode.update.mockResolvedValue({});
-    mockPrisma.edgeNodeCapability.update.mockResolvedValue({});
-    mockPrisma.$transaction.mockResolvedValue([]);
-
-    const result = await authorizeOrganizationJoinNodeAction({
-      edgeNodeId: "edge-row-2",
-      actionType: "organization.join.import",
-      operatorConfirmed: true,
-    });
-
-    expect(result).toEqual({ ok: true });
-    expect(mockPrisma.edgeNode.update).toHaveBeenCalledWith({
-      where: { id: "edge-row-2" },
-      data: { scopePolicy: { actionTypes: ["inventory.collect", "organization.join.import"] } },
-    });
-    expect(mockPrisma.edgeNodeCapability.update).toHaveBeenCalledWith({
-      where: { id: "cap-1" },
-      data: { mode: "enabled" },
-    });
-  });
-
-  it("does not authorize a host action without explicit confirmation", async () => {
-    const result = await authorizeOrganizationJoinNodeAction({
-      edgeNodeId: "edge-row-2",
-      actionType: "organization.join.import",
-      operatorConfirmed: false,
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: "invalid_input",
-      message: "Confirm this installation before enabling secure organization setup",
-    });
-    expect(mockPrisma.edgeNode.findUnique).not.toHaveBeenCalled();
-  });
-
-  it("creates the approved high-risk change anchor and action atomically", async () => {
-    const input = {
-      actionType: "organization.join.issue" as const,
-      edgeNodeId: "edge-row-1",
-      parameters: { intendedPeer: "windows-dev.local", ttlSeconds: 600 },
-      operatorConfirmed: true,
-    };
-
-    const result = await queueOrganizationJoinActionAction(input);
-
-    expect(result).toEqual({ ok: true, actionKey: "ra-join-1" });
-    expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
-    expect(tx.changeRequest.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        rfcId: "RFC-JOIN-1",
-        riskLevel: "high",
-        status: "approved",
-        approvedById: "employee-1",
-        postChangeVerification: {
-          certificateTrust: true,
-          overlayPersistence: true,
-          portalHealth: true,
-          edgeHeartbeat: true,
-        },
-      }),
-      select: { id: true },
-    });
-    expect(mockCreateAction).toHaveBeenCalledWith(tx, expect.objectContaining({
-      changeRequestId: "change-1",
-      requestedByPrincipalId: "principal-1",
-      operatorConfirmed: true,
-    }));
-    expect(mockRevalidatePath).toHaveBeenCalledWith("/platform/federation-links");
-  });
-
-  it("checks credential encryption before creating an import change", async () => {
-    mockAssertEncryptionReady.mockRejectedValue(new Error("missing key"));
-
-    const result = await queueOrganizationJoinActionAction({
-      actionType: "organization.join.import",
-      edgeNodeId: "edge-row-2",
-      parameters: { joinPackage: "sensitive" },
-      operatorConfirmed: true,
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: "not_ready",
-      message: "Secure credential storage is not configured",
-    });
-    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
-  });
-
-  it("returns a safe failure while causing the transaction to roll back on a governance rejection", async () => {
-    mockCreateAction.mockResolvedValue({ ok: false, reason: "wrong-host-role" });
-
-    const result = await queueOrganizationJoinActionAction({
-      actionType: "organization.join.issue",
-      edgeNodeId: "edge-row-2",
-      parameters: { intendedPeer: "windows-dev.local", ttlSeconds: 600 },
-      operatorConfirmed: true,
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: "not_ready",
-      message: "This installation cannot perform that organization setup step",
-    });
-    expect(mockRevalidatePath).not.toHaveBeenCalled();
-  });
-
-  it("never returns encrypted package material or sensitive evidence in status", async () => {
-    mockPrisma.remoteAction.findUnique.mockResolvedValue({
-      actionKey: "ra-join-1",
-      actionType: "organization.join.issue",
-      status: "succeeded",
-      approvalState: "approved",
-      result: { joinPackageEnc: "enc:iv:tag:cipher" },
-      evidence: {
-        portalHealth: true,
-        nested: { edgeHeartbeat: true, enrollmentToken: "must-not-escape" },
-        joinPackage: "must-not-escape",
-      },
-    });
-
-    const result = await getOrganizationJoinActionStatusAction("ra-join-1");
-
-    expect(result).toEqual(expect.objectContaining({
-      ok: true,
-      packageReady: true,
-      evidence: { portalHealth: true, nested: { edgeHeartbeat: true } },
-    }));
-    expect(JSON.stringify(result)).not.toContain("must-not-escape");
-    expect(JSON.stringify(result)).not.toContain("enc:iv:tag:cipher");
   });
 });

--- a/apps/web/lib/actions/organization-join.ts
+++ b/apps/web/lib/actions/organization-join.ts
@@ -1,357 +1,82 @@
 "use server";
 
-// BI-A8399604 — session-gated portal boundary for the two governed host
-// actions. The Connections UI calls these actions; no browser code executes a
-// host command and no generic command/action surface exists.
+// EP-ZERO-CONFIG-FEDERATION — the session-gated boundary for connecting an
+// organization's own installations. Both acts are portal-mediated (spec
+// docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md
+// §5.2–5.3): the authority portal mints the join file itself and the member
+// portal certifies itself through the authority's portal. The edge-node host
+// actions that used to carry this (BI-A8399604) are retired from the page;
+// no browser code executes a host command.
 
 import { revalidatePath } from "next/cache";
-
-import { prisma } from "@dpf/db";
-import {
-  isOrganizationJoinActionType,
-  type OrganizationJoinActionType,
-} from "@dpf/db/organization-join-action";
 
 import { auth } from "@/lib/auth";
 import { importOrganizationJoinFile } from "@/lib/federation/organization-join-import";
 import { issueOrganizationJoinFile } from "@/lib/federation/organization-join-issue";
 import { resolveLocalFederationAuthorityUrl } from "@/lib/federation/self-authority";
-import { makeRfcId } from "@/lib/change-management/lifecycle";
-import { assertEncryptionReadyForCredentialWrite } from "@/lib/govern/credential-crypto";
-import { syncUserPrincipal } from "@/lib/identity/principal-linking";
 import { can } from "@/lib/permissions";
 import { ok, type ActionSuccess } from "@/lib/shared/action-result";
-import { isRecord } from "@/lib/shared/coerce";
-import {
-  cancelQueuedOrganizationJoinAction,
-  consumeIssuedJoinPackage,
-  createOrganizationJoinAction,
-  type OrganizationJoinActionDb,
-} from "@/lib/remote-action/organization-join-actions";
-import { sanitizeActionEvidence } from "@/lib/remote-action/dispatch-orchestrator";
 
 const CONNECTIONS_PATH = "/platform/federation-links";
+const JOIN_FILE_MAX_BYTES = 64 * 1024;
 
-class OrganizationJoinRequestError extends Error {
-  constructor(readonly reason: string) {
-    super(reason);
-  }
-}
-
-type OrganizationJoinActionFailure = {
+export type OrganizationJoinActionFailure = {
   ok: false;
   error: "unauthorized" | "forbidden" | "invalid_input" | "not_ready" | "conflict" | "internal_error";
   message: string;
 };
 
-async function assertManagePlatform(): Promise<
-  | { ok: true; userId: string; principalId: string; employeeProfileId: string }
-  | OrganizationJoinActionFailure
-> {
+async function assertManagePlatform(): Promise<OrganizationJoinActionFailure | null> {
   const session = await auth();
   if (!session?.user?.id) return { ok: false, error: "unauthorized", message: "Sign in required" };
   if (!can({ platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser }, "manage_platform")) {
     return { ok: false, error: "forbidden", message: "Platform management access is required" };
   }
-  const [alias, employee] = await Promise.all([
-    prisma.principalAlias.findFirst({
-      where: { aliasType: "user", aliasValue: session.user.id },
-      select: { principalId: true },
-    }),
-    prisma.employeeProfile.findUnique({ where: { userId: session.user.id }, select: { id: true } }),
-  ]);
-  if (!employee) {
-    return { ok: false, error: "not_ready", message: "Your operator profile is not linked to change management" };
-  }
-  const principalId = alias?.principalId ?? (await syncUserPrincipal(session.user.id)).id;
-  return { ok: true, userId: session.user.id, principalId, employeeProfileId: employee.id };
+  return null;
 }
 
-export interface OrganizationJoinNodeSummary {
-  edgeNodeId: string;
-  nodeId: string;
-  displayName: string;
-  platform: string;
-  status: string;
-  trustState: string;
-  role: "authority" | "member" | null;
-  actionType: OrganizationJoinActionType | null;
-  hostIdentity: string | null;
-  ready: boolean;
-  readinessMessage: string;
-  latestAction: {
-    actionKey: string;
-    actionType: OrganizationJoinActionType;
-    status: string;
-    approvalState: string;
-    packageReady: boolean;
-    evidence: Record<string, unknown>;
-    createdAt: string;
-  } | null;
+export interface OrganizationJoinFileIssued {
+  fileName: string;
+  content: string;
+  intendedPeer: string;
+  expiresAt: string;
 }
-
-export async function getOrganizationJoinNodeSummariesAction(): Promise<
-  { ok: true; nodes: OrganizationJoinNodeSummary[] } | OrganizationJoinActionFailure
-> {
-  const gate = await assertManagePlatform();
-  if (!gate.ok) return gate;
-  const rows = await prisma.edgeNode.findMany({
-    orderBy: { updatedAt: "desc" },
-    select: {
-      id: true, nodeId: true, platform: true, status: true, trustState: true,
-      metadata: true, scopePolicy: true,
-      principal: { select: { displayName: true } },
-      capabilityRows: {
-        where: { capability: "action.execute" },
-        select: { mode: true, status: true, evidence: true },
-      },
-    },
-  });
-  const actions = rows.length === 0
-    ? []
-    : await prisma.remoteAction.findMany({
-        where: {
-          edgeNodeId: { in: rows.map((row) => row.id) },
-          actionType: { in: ["organization.join.issue", "organization.join.import"] },
-        },
-        orderBy: { createdAt: "desc" },
-        select: {
-          actionKey: true,
-          actionType: true,
-          edgeNodeId: true,
-          status: true,
-          approvalState: true,
-          result: true,
-          evidence: true,
-          createdAt: true,
-        },
-      });
-  const latestByNode = new Map<string, (typeof actions)[number]>();
-  for (const action of actions) {
-    if (action.edgeNodeId && !latestByNode.has(action.edgeNodeId)) latestByNode.set(action.edgeNodeId, action);
-  }
-  return {
-    ok: true,
-    nodes: rows.map((row) => {
-      const capability = row.capabilityRows[0];
-      const evidence = isRecord(capability?.evidence) ? capability.evidence : {};
-      const role = evidence.organizationTrustRole === "authority" || evidence.organizationTrustRole === "member"
-        ? evidence.organizationTrustRole
-        : null;
-      const actionType = role === "authority"
-        ? "organization.join.issue"
-        : role === "member" ? "organization.join.import" : null;
-      const configured = isRecord(row.scopePolicy) && Array.isArray(row.scopePolicy.actionTypes)
-        ? row.scopePolicy.actionTypes.includes(actionType)
-        : false;
-      const ready = row.trustState === "trusted" && capability?.mode === "enabled" && actionType !== null && configured;
-      const latest = latestByNode.get(row.id);
-      return {
-        edgeNodeId: row.id,
-        nodeId: row.nodeId,
-        displayName: row.principal.displayName,
-        platform: row.platform,
-        status: row.status,
-        trustState: row.trustState,
-        role,
-        actionType,
-        hostIdentity: edgeHostIdentity(row.metadata),
-        ready,
-        readinessMessage: ready
-          ? "Secure host action channel ready"
-          : row.trustState !== "trusted"
-            ? "Trust this installation before organization setup"
-            : capability?.mode !== "enabled"
-              ? "Enable secure host actions for this installation"
-              : !role
-                ? "The installation has not reported its organization role"
-                : "Allow the organization setup action for this installation",
-        latestAction: latest && isOrganizationJoinActionType(latest.actionType)
-          ? {
-              actionKey: latest.actionKey,
-              actionType: latest.actionType,
-              status: latest.status,
-              approvalState: latest.approvalState,
-              packageReady: isRecord(latest.result) && typeof latest.result.joinPackageEnc === "string",
-              evidence: sanitizeActionEvidence(isRecord(latest.evidence) ? latest.evidence : undefined),
-              createdAt: latest.createdAt.toISOString(),
-            }
-          : null,
-      };
-    }),
-  };
-}
-
-export async function authorizeOrganizationJoinNodeAction(input: {
-  edgeNodeId: string;
-  actionType: OrganizationJoinActionType;
-  operatorConfirmed: boolean;
-}): Promise<{ ok: true } | OrganizationJoinActionFailure> {
-  const gate = await assertManagePlatform();
-  if (!gate.ok) return gate;
-  if (!input.operatorConfirmed) {
-    return {
-      ok: false,
-      error: "invalid_input",
-      message: "Confirm this installation before enabling secure organization setup",
-    };
-  }
-  const node = await prisma.edgeNode.findUnique({
-    where: { id: input.edgeNodeId },
-    select: {
-      id: true,
-      trustState: true,
-      scopePolicy: true,
-      capabilityRows: {
-        where: { capability: "action.execute" },
-        select: { id: true, mode: true, evidence: true },
-      },
-    },
-  });
-  if (!node || node.trustState !== "trusted") {
-    return { ok: false, error: "not_ready", message: "Trust this installation before enabling organization setup" };
-  }
-  const capability = node.capabilityRows[0];
-  const evidence = isRecord(capability?.evidence) ? capability.evidence : {};
-  const role = evidence.organizationTrustRole === "authority" || evidence.organizationTrustRole === "member"
-    ? evidence.organizationTrustRole
-    : null;
-  const expectedAction = role === "authority"
-    ? "organization.join.issue"
-    : role === "member" ? "organization.join.import" : null;
-  if (!capability || expectedAction !== input.actionType) {
-    return {
-      ok: false,
-      error: "not_ready",
-      message: "This installation has not reported the required secure organization role",
-    };
-  }
-  const scopePolicy = isRecord(node.scopePolicy) ? node.scopePolicy : {};
-  const existing = Array.isArray(scopePolicy.actionTypes)
-    ? scopePolicy.actionTypes.filter((value): value is string => typeof value === "string")
-    : [];
-  const actionTypes = [...new Set([...existing, input.actionType])];
-  await prisma.$transaction([
-    prisma.edgeNode.update({
-      where: { id: node.id },
-      data: { scopePolicy: { ...scopePolicy, actionTypes } },
-    }),
-    prisma.edgeNodeCapability.update({
-      where: { id: capability.id },
-      data: { mode: "enabled" },
-    }),
-  ]);
-  revalidatePath(CONNECTIONS_PATH);
-  return { ok: true };
-}
-
-export async function queueOrganizationJoinActionAction(input: {
-  actionType: OrganizationJoinActionType;
-  edgeNodeId: string;
-  parameters: unknown;
-  operatorConfirmed: boolean;
-}): Promise<{ ok: true; actionKey: string } | OrganizationJoinActionFailure> {
-  const gate = await assertManagePlatform();
-  if (!gate.ok) return gate;
-  if (input.actionType === "organization.join.import") {
-    try {
-      await assertEncryptionReadyForCredentialWrite();
-    } catch {
-      return { ok: false, error: "not_ready", message: "Secure credential storage is not configured" };
-    }
-  }
-  const now = new Date();
-  const rfcId = makeRfcId();
-  const issue = input.actionType === "organization.join.issue";
-  const title = issue ? "Create an expiring organization join file" : "Join this installation to an organization";
-  try {
-    const result = await prisma.$transaction(async (tx) => {
-      const change = await tx.changeRequest.create({
-        data: {
-        rfcId,
-        title,
-        description: issue
-          ? "Issue one intended-peer-bound organization join package through the native Edge host."
-          : "Validate and import one intended-peer-bound organization join package through the native Edge host.",
-        type: "normal",
-        scope: "organization-trust",
-        riskLevel: "high",
-        status: "approved",
-        submittedAt: now,
-        assessedAt: now,
-        approvedAt: now,
-        requestedById: gate.employeeProfileId,
-        assessedById: gate.employeeProfileId,
-        approvedById: gate.employeeProfileId,
-        impactReport: {
-          edgeNodeId: input.edgeNodeId,
-          actionType: input.actionType,
-          impact: issue ? "Creates a short-lived enrollment package" : "Changes local organization trust overlays",
-          operatorConfirmation: input.operatorConfirmed,
-        },
-        postChangeVerification: {
-          certificateTrust: true,
-          overlayPersistence: true,
-          portalHealth: true,
-          edgeHeartbeat: true,
-        },
-        changeItems: {
-          create: {
-            itemType: "organization-trust",
-            title,
-            impactDescription: issue
-              ? "A single-use package is available briefly to the confirmed operator."
-              : "The local certificate trust and persisted runtime overlays change.",
-            rollbackPlan: issue
-              ? "Cancel the queued action or let the undownloaded package expire."
-              : "Restore the pre-action PKI and environment snapshot, then re-verify portal and Edge health.",
-          },
-        },
-        },
-        select: { id: true },
-      });
-      const created = await createOrganizationJoinAction(tx as unknown as OrganizationJoinActionDb, {
-        actionType: input.actionType,
-        edgeNodeId: input.edgeNodeId,
-        changeRequestId: change.id,
-        requestedByPrincipalId: gate.principalId,
-        operatorConfirmed: input.operatorConfirmed,
-        parameters: input.parameters,
-      });
-      if (!created.ok) throw new OrganizationJoinRequestError(created.reason);
-      return created;
-    });
-    revalidatePath(CONNECTIONS_PATH);
-    return result;
-  } catch (error) {
-    if (error instanceof OrganizationJoinRequestError) return actionFailure(error.reason);
-    return { ok: false, error: "internal_error", message: "Organization setup could not be queued" };
-  }
-}
-
-const JOIN_FILE_MAX_BYTES = 64 * 1024;
 
 /**
- * Portal-mediated join (EP-ZERO-CONFIG-FEDERATION): choosing the join file is
- * the whole act. The portal generates a key, has the organization CA sign it
- * through the authority's portal, keeps the material in the federation state
- * directory, and the next federation tick records the link trusted on both
- * sides. No edge node, no host script, nothing typed.
+ * The authority portal mints the join file itself — no edge node, no host
+ * script. Returned once; the browser downloads it and it expires in 30 minutes.
  */
+export async function issueOrganizationJoinFileAction(input: { intendedPeer: string }): Promise<
+  ActionSuccess<OrganizationJoinFileIssued> | OrganizationJoinActionFailure
+> {
+  const refused = await assertManagePlatform();
+  if (refused) return refused;
+  const intendedPeer = typeof input?.intendedPeer === "string" ? input.intendedPeer.trim() : "";
+  if (!intendedPeer) return { ok: false, error: "invalid_input", message: "Choose the installation the file is for" };
+  const requestHost = await resolveLocalFederationAuthorityUrl();
+  const result = await issueOrganizationJoinFile({ intendedPeer, requestHost });
+  if (!result.issued) return joinIssueFailure(result.reason, result.detail);
+  revalidatePath(CONNECTIONS_PATH);
+  return ok({ fileName: result.fileName, content: result.packageText, intendedPeer: result.intendedPeer, expiresAt: result.expiresAt });
+}
+
 export interface OrganizationJoinImported {
   authorityUrl: string;
   intendedPeer: string;
   message: string;
 }
 
+/**
+ * Choosing the join file is the whole act: the portal generates a key, has the
+ * organization CA sign it through the authority's portal, keeps the material
+ * in the federation state directory, and the next federation tick records the
+ * link trusted on both sides.
+ */
 export async function importOrganizationJoinFileAction(fileText: string): Promise<
   ActionSuccess<OrganizationJoinImported> | OrganizationJoinActionFailure
 > {
-  const session = await auth();
-  if (!session?.user?.id) return { ok: false, error: "unauthorized", message: "Sign in required" };
-  if (!can({ platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser }, "manage_platform")) {
-    return { ok: false, error: "forbidden", message: "Platform management access is required" };
-  }
+  const refused = await assertManagePlatform();
+  if (refused) return refused;
   if (typeof fileText !== "string" || !fileText.trim() || Buffer.byteLength(fileText, "utf8") > JOIN_FILE_MAX_BYTES) {
     return { ok: false, error: "invalid_input", message: "This is not a valid DPF organization join file" };
   }
@@ -366,108 +91,6 @@ export async function importOrganizationJoinFileAction(fileText: string): Promis
   });
 }
 
-export interface OrganizationJoinFileIssued {
-  fileName: string;
-  content: string;
-  intendedPeer: string;
-  expiresAt: string;
-}
-
-/**
- * Portal-mediated issue (EP-ZERO-CONFIG-FEDERATION §5.3): the authority portal
- * mints the join file itself — no edge node, no host script. Returned once;
- * the browser downloads it and it expires in 30 minutes.
- */
-export async function issueOrganizationJoinFileAction(input: { intendedPeer: string }): Promise<
-  ActionSuccess<OrganizationJoinFileIssued> | OrganizationJoinActionFailure
-> {
-  const session = await auth();
-  if (!session?.user?.id) return { ok: false, error: "unauthorized", message: "Sign in required" };
-  if (!can({ platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser }, "manage_platform")) {
-    return { ok: false, error: "forbidden", message: "Platform management access is required" };
-  }
-  const intendedPeer = typeof input?.intendedPeer === "string" ? input.intendedPeer.trim() : "";
-  if (!intendedPeer) return { ok: false, error: "invalid_input", message: "Choose the installation the file is for" };
-  const requestHost = await resolveLocalFederationAuthorityUrl();
-  const result = await issueOrganizationJoinFile({ intendedPeer, requestHost });
-  if (!result.issued) return joinIssueFailure(result.reason, result.detail);
-  revalidatePath(CONNECTIONS_PATH);
-  return ok({ fileName: result.fileName, content: result.packageText, intendedPeer: result.intendedPeer, expiresAt: result.expiresAt });
-}
-
-export async function getOrganizationJoinActionStatusAction(actionKey: string): Promise<
-  | { ok: true; actionKey: string; actionType: string; status: string; approvalState: string; packageReady: boolean; evidence: Record<string, unknown> }
-  | OrganizationJoinActionFailure
-> {
-  const gate = await assertManagePlatform();
-  if (!gate.ok) return gate;
-  const row = await prisma.remoteAction.findUnique({
-    where: { actionKey },
-    select: { actionKey: true, actionType: true, status: true, approvalState: true, result: true, evidence: true },
-  });
-  if (!row || (row.actionType !== "organization.join.issue" && row.actionType !== "organization.join.import")) {
-    return { ok: false, error: "invalid_input", message: "Organization setup action was not found" };
-  }
-  return {
-    ok: true,
-    actionKey: row.actionKey,
-    actionType: row.actionType,
-    status: row.status,
-    approvalState: row.approvalState,
-    packageReady: isRecord(row.result) && typeof row.result.joinPackageEnc === "string",
-    evidence: sanitizeActionEvidence(isRecord(row.evidence) ? row.evidence : undefined),
-  };
-}
-
-export async function downloadIssuedJoinPackageAction(actionKey: string): Promise<
-  { ok: true; fileName: string; content: string; expiresAt: string } | OrganizationJoinActionFailure
-> {
-  const gate = await assertManagePlatform();
-  if (!gate.ok) return gate;
-  const result = await consumeIssuedJoinPackage(prisma as unknown as OrganizationJoinActionDb, actionKey);
-  if (!result.ok) return actionFailure(result.reason);
-  revalidatePath(CONNECTIONS_PATH);
-  return {
-    ok: true,
-    fileName: `organization-join-${actionKey}.dpfjoin`,
-    content: result.joinPackage,
-    expiresAt: result.expiresAt.toISOString(),
-  };
-}
-
-export async function cancelOrganizationJoinActionAction(actionKey: string): Promise<
-  { ok: true } | OrganizationJoinActionFailure
-> {
-  const gate = await assertManagePlatform();
-  if (!gate.ok) return gate;
-  const result = await cancelQueuedOrganizationJoinAction(prisma as unknown as OrganizationJoinActionDb, actionKey);
-  if (!result.ok) return actionFailure(result.reason);
-  revalidatePath(CONNECTIONS_PATH);
-  return result;
-}
-
-function actionFailure(reason: string): OrganizationJoinActionFailure {
-  switch (reason) {
-    case "operator-confirmation-required":
-      return { ok: false, error: "invalid_input", message: "Confirm the local change before continuing" };
-    case "wrong-host-role":
-      return { ok: false, error: "not_ready", message: "This installation cannot perform that organization setup step" };
-    case "action-not-allowlisted":
-    case "action-execute-capability-required":
-      return { ok: false, error: "not_ready", message: "Secure organization setup is not enabled for this installation" };
-    case "join-package-already-used":
-    case "action-already-dispatched":
-      return { ok: false, error: "conflict", message: "This organization setup request has already been used or started" };
-    case "join-package-expired":
-      return { ok: false, error: "invalid_input", message: "The join file has expired. Create a new one on the organization installation" };
-    case "join-package-intended-for-another-host":
-      return { ok: false, error: "invalid_input", message: "The join file was created for another installation" };
-    case "join-package-consumed":
-      return { ok: false, error: "conflict", message: "The join file has already been downloaded" };
-    default:
-      return { ok: false, error: "invalid_input", message: "The organization setup request is not valid" };
-  }
-}
 function joinIssueFailure(reason: string, detail?: string): OrganizationJoinActionFailure {
   switch (reason) {
     case "not-the-authority":
@@ -502,10 +125,4 @@ function joinImportFailure(reason: string, detail?: string): OrganizationJoinAct
     default:
       return { ok: false, error: "invalid_input", message: "This is not a valid DPF organization join file" };
   }
-}
-
-function edgeHostIdentity(value: unknown): string | null {
-  if (!isRecord(value)) return null;
-  if (typeof value.hostname === "string") return value.hostname;
-  return isRecord(value.host) && typeof value.host.hostname === "string" ? value.host.hostname : null;
 }

--- a/docs/ux-fit/2026-09-05-retire-edge-join-path.ux-fit.json
+++ b/docs/ux-fit/2026-09-05-retire-edge-join-path.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "two-acts-only-retire-edge-cards",
+  "decisionInteractionId": "DI-DE665E842CD3",
+  "scope": {
+    "files": [
+      "apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "two-acts-only-retire-edge-cards",
+      "keep-edge-cards-as-legacy-section"
+    ],
+    "note": "EP-ZERO-CONFIG-FEDERATION slice 3 (spec docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md §6.3). 'Connect your own installations' now shows exactly two acts, 'Create join file' and 'Join this installation', both portal-mediated since slices 1–2. The edge-node readiness cards ('Enable secure host actions' / 'Enable secure setup'), the host-action progress cards and their six unreachable server actions are removed; no control was added, the two forms are unchanged. The kernel scored the two-acts shape highest (composite 9.80, margin 5.55, confidence high) against keeping the retired cards under a disclosure."
+  }
+}

--- a/scripts/local-action-result-baseline.json
+++ b/scripts/local-action-result-baseline.json
@@ -4,5 +4,5 @@
   "expiry": "2026-11-16",
   "note": "One-ActionResult ratchet baseline (BI-1CED89B9). localAliases must stay empty; inlineOkTrueTotal is shrink-only — compose ok()/err() from lib/shared/action-result. Regenerate with: node scripts/check-no-local-action-result.mjs --update",
   "localAliases": [],
-  "inlineOkTrueTotal": 965
+  "inlineOkTrueTotal": 953
 }


### PR DESCRIPTION
Slice 3 of the portal-mediated membership spec (§6.3). Since slices 1 and 2
both acts are portal-mediated — the authority mints the join file itself and
the member certifies itself through the authority's portal — so nothing on the
page reached the edge-node readiness cards ("Enable secure host actions" /
"Enable secure setup"), the host-action progress cards, or the six server
actions behind them (node summaries, authorize, queue, status, download,
cancel). They are gone. "Connect your own installations" shows exactly
"Create join file" and "Join this installation".

The remote-action dispatch for organization.join.* stays (the edge node
binary still honours it); only the page and its session boundary drop the
path. readJoinPackageFacts keeps its script-era fallback so an installation
that joined by script is unaffected.

Tests: organization-join actions (session boundary, both portal-native
actions, every refusal mapping), OrganizationJoinPanel (two acts only, no
secure-setup copy, issue + import flows). One-ActionResult baseline
retightened (965 -> 953 inline sites).

## Verification
- organization-join action tests (session boundary, both portal-native actions, every refusal mapping) and OrganizationJoinPanel tests (two acts only, no secure-setup copy, issue + import flows) green; typecheck clean; UX-fit, design-grounding, clock-bomb, module-size, prose-lint, raw-error guards OK; one-ActionResult baseline retightened.
- Live: slices 1–2 already run on the development install; this slice removes unreachable UI only.

Design-Grounding-Decision: implements slice 3 (§6.3) of docs/superpowers/specs/2026-09-03-portal-mediated-organization-membership-design.md; code substrate apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx and apps/web/lib/actions/organization-join.ts; UX shape by principle_decide DI-DE665E842CD3
Docs-Impact-Decision: docs/user-guide/platform/index.md already describes the portal-mediated flow; no behaviour added

🤖 Generated with [Claude Code](https://claude.com/claude-code)