### PR TITLE
fix(ci): let the security-sweep App token carry the installation's granted permissions (BI-3E6AFF04)

### DIFF
--- a/.github/workflows/audit-stale-overrides.yml
+++ b/.github/workflows/audit-stale-overrides.yml
@@ -62,9 +62,10 @@ jobs:
         with:
           app-id: ${{ secrets.SECURITY_SWEEP_APP_ID }}
           private-key: ${{ secrets.SECURITY_SWEEP_APP_PRIVATE_KEY }}
-          permission-dependabot-alerts: read
-          permission-secret-scanning-alerts: read
-          permission-security-events: read
+          # No permission-* inputs: the token carries exactly what the installation
+          # grants (Dependabot, Secret scanning, Code scanning alerts: read). Naming
+          # them here failed with 422 "permissions not granted" on the first live run
+          # because the API key for Dependabot alerts is vulnerability_alerts.
 
       - name: Audit stale overrides
         # On scheduled/manual runs require the API (a silent skip would hide that

--- a/.github/workflows/security-findings-watch.yml
+++ b/.github/workflows/security-findings-watch.yml
@@ -72,9 +72,10 @@ jobs:
         with:
           app-id: ${{ secrets.SECURITY_SWEEP_APP_ID }}
           private-key: ${{ secrets.SECURITY_SWEEP_APP_PRIVATE_KEY }}
-          permission-dependabot-alerts: read
-          permission-secret-scanning-alerts: read
-          permission-security-events: read
+          # No permission-* inputs: the token carries exactly what the installation
+          # grants (Dependabot, Secret scanning, Code scanning alerts: read). Naming
+          # them here failed with 422 "permissions not granted" on the first live run
+          # because the API key for Dependabot alerts is vulnerability_alerts.
 
       - name: Sweep all three security surfaces
         env:

--- a/docs/runbooks/2026-09-05-security-sweep-credential.md
+++ b/docs/runbooks/2026-09-05-security-sweep-credential.md
@@ -4,7 +4,7 @@ status: active
 
 # Security sweep credential: read all three alert surfaces
 
-**Backlog item:** BI-3E6AFF04 · **Workflows:** `security-findings-watch.yml`, `audit-stale-overrides.yml` · **Standing report:** issue #4389
+**Owner:** the production installation that stewards the open-source project, as steward of the open-source project (founder, 2026-09-05) · **Backlog item:** BI-3E6AFF04 · **Workflows:** `security-findings-watch.yml`, `audit-stale-overrides.yml` · **Standing report:** issue #4389
 
 ## Symptom
 

--- a/docs/superpowers/specs/2026-09-05-security-sweep-app-token-design.md
+++ b/docs/superpowers/specs/2026-09-05-security-sweep-app-token-design.md
@@ -31,3 +31,7 @@ At main `961ef9c8cf`, `.github/workflows/security-findings-watch.yml:64` and `au
 ## Rollback
 
 Delete the two secrets; the step is skipped and the fallback chain is what runs today.
+
+## Live-run correction (2026-09-05)
+
+The first run with the App secrets (run 33975611589) failed at the mint step with 422 "The permissions requested are not granted to this installation": the explicit `permission-*` inputs named Dependabot alerts by a key the API does not use (`vulnerability_alerts` is the real key). The inputs are removed; the token now carries exactly the installation's granted set. Credential owner: the production installation that stewards the open-source project, as steward of the open-source project (founder direction, 2026-09-05).


### PR DESCRIPTION
## Why

The first live run of the security sweep with the new GitHub App secrets (run 33975611589) failed at the token mint step:

```
422 The permissions requested are not granted to this installation.
```

The explicit `permission-*` inputs added in #5073 named Dependabot alerts by a key the API does not use (`vulnerability_alerts` is the real key), so GitHub refused the token even though the installation grants exactly the permissions the sweep needs. BI-3E6AFF04.

## What changed

- **Both workflows** (`security-findings-watch.yml`, `audit-stale-overrides.yml`): the three `permission-*` inputs are removed. The token now carries exactly what the installation grants: Dependabot alerts, Secret scanning alerts, Code scanning alerts, metadata, all read-only. A comment records why.
- **Runbook and spec**: record the credential owner (the production installation that stewards the open-source project) and the live-run correction.

## Design grounding

- Spec: `docs/superpowers/specs/2026-09-05-security-sweep-app-token-design.md` (section "Live-run correction")
- Code: `.github/workflows/security-findings-watch.yml`, `.github/workflows/audit-stale-overrides.yml`

## Verification

- Both workflows parse; no `permission-` inputs remain.
- The App (ID 4841607) is installed on this repository with the three read permissions; both secrets exist. After merge, `security-findings-watch.yml` is re-run and #4389's header must no longer report unreadable surfaces.

## Rollback

Revert this commit; the mint step then fails the same way as run 33975611589 and the sweep degrades to `GITHUB_TOKEN`.

Local-CI-Evidence: cmtoktauo03rt01up0mol8hoe
Docs-Impact-Decision: updated
Design-Grounding-Decision: no-contract-change (removes three workflow inputs; no product surface or schema touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
