### PR TITLE
fix(mcp): immutable reader pages carry a whole document so governed reviewers reach their receipt (BI-8B8731EE)

### DIFF
--- a/apps/web/lib/mcp/packs/version-history-pack.test.ts
+++ b/apps/web/lib/mcp/packs/version-history-pack.test.ts
@@ -162,6 +162,31 @@ describe("version-history pack — handler behavior (delegation preserved)", () 
     expect(gitUtils.gitShow).toHaveBeenCalledWith({ ref: "v1.0.0", path: "apps/web/x.ts" });
   });
 
+  it("read_source_at_version default page carries a 25 KB design spec in three reads or fewer (BI-8B8731EE)", async () => {
+    // A governed reviewer has six bounded reads before it must write its
+    // receipt. The old 40-line / 3,000-char default spent all six on a
+    // 25 KB spec and never reached the writer.
+    const line = "- gate row: requirement, evidence, reviewer, stop condition, budget.\n";
+    const content = line.repeat(Math.ceil(25_000 / line.length));
+    gitUtils.gitShow.mockResolvedValue({ content });
+    let cursor: string | undefined;
+    let reads = 0;
+    let assembled = "";
+    do {
+      const page = await versionHistoryPack.handlers.read_source_at_version(
+        { path: "docs/superpowers/specs/big.md", ...(cursor ? { cursor } : {}) },
+        "u1",
+      );
+      reads += 1;
+      const data = page.data as { content: string; hasMore: boolean; nextCursor: string | null };
+      assembled += data.content;
+      cursor = data.nextCursor ?? undefined;
+      if (!data.hasMore) break;
+    } while (reads < 10);
+    expect(assembled).toBe(content);
+    expect(reads).toBeLessThanOrEqual(3);
+  });
+
   it("read_source_at_version cursor makes progress through a line longer than maxChars", async () => {
     gitUtils.gitShow.mockResolvedValue({ content: "abcdefghij\nlast\n" });
     const first = await versionHistoryPack.handlers.read_source_at_version(

--- a/apps/web/lib/mcp/packs/version-history-pack.ts
+++ b/apps/web/lib/mcp/packs/version-history-pack.ts
@@ -15,10 +15,17 @@ import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import { createHash } from "node:crypto";
 
-const DEFAULT_READ_MAX_LINES = 40;
-const MAX_READ_LINES = 200;
-const DEFAULT_READ_MAX_CHARS = 3_000;
-const MAX_READ_CHARS = 3_200;
+// BI-8B8731EE: a governed reviewer gets a bounded number of immutable reads
+// (terminal-tool-policy maximumReaderCalls = 6) before it must write its
+// receipt. At 40 lines / 3,000 chars a page that is ~19 KB of artifact, and a
+// 25 KB design spec ran every reviewer out of budget four times in one night
+// without a verdict. A default page now carries a whole medium document, and
+// the cap allows a long one in two or three reads. Pages stay bounded: this
+// is still a paged reader, not a whole-file dump.
+const DEFAULT_READ_MAX_LINES = 200;
+const MAX_READ_LINES = 400;
+const DEFAULT_READ_MAX_CHARS = 12_000;
+const MAX_READ_CHARS = 16_000;
 const DEFAULT_SEARCH_RESULTS = 20;
 const MAX_SEARCH_RESULTS = 50;
 const MAX_SEARCH_OFFSET = 2_000;


### PR DESCRIPTION
## Why

A governed reviewer gets six bounded immutable reads before it must write its receipt (`terminal-tool-policy` `maximumReaderCalls`). `read_source_at_version` defaulted to 40 lines / 3,000 characters a page with a 3,200-character cap, so a reviewer could read about 19 KB before its budget ended. The 24.9 KB work-shape spec ran the Change Reviewer, Enterprise Architect and Portfolio Advisor out of budget four times on 2026-09-05; not one wrote a verdict, and the plan behind it (#5059) could not get its coverage receipt. BI-8B8731EE, third independent reproduction.

The kernel was consulted on how to proceed (`principle_decide`, elevated stakes): fix the reviewer's reading limit first, high confidence; relaxing the plan gate was rejected.

## What

Defaults become 200 lines / 12,000 characters a page; caps 400 / 16,000. A default page now carries a medium document whole and a long one in two or three reads. The reader stays paged and bounded, the cursor contract and tool schema are unchanged, and the tool description derives its numbers from the constants.

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md`, `2026-09-01-completion-readiness-recovery-design.md`.
- Current code substrate reviewed: `apps/web/lib/mcp/packs/version-history-pack.ts` (reader), `apps/web/lib/tak/terminal-tool-policy.ts` (`maximumReaderCalls: 6`, `readerBudgetExhausted`), `apps/web/lib/mcp-task-terminal-writer-escalation.ts`.
- Source of truth: the reader's page bounds are what size the reviewer's effective budget; the policy's call count is unchanged.
- Decision: change the page defaults and caps, not the policy count, so the budget still bounds work but is no longer smaller than one artifact.

Design-Grounding-Decision: no-contract-change (tool parameter defaults and caps only; schema, names and cursor contract unchanged)
Docs-Impact-Decision: the tool description derives its numbers from the constants; no user-guide page states the old page size.

## Verification
- New test: a 25 KB spec assembles in three default reads or fewer.
- `version-history-pack.test.ts` + `terminal-tool-policy.test.ts`: 46 tests green; `pnpm --filter web typecheck` clean.
- Local-CI gate: PASS on this SHA (pregate record on the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
