### PR TITLE
fix(deliberation): one owner for a bootstrapped TaskRun; never resurrect a settled run (BI-D208E70C)

### DIFF
--- a/apps/web/lib/change-review/build-studio-semantic-review.test.ts
+++ b/apps/web/lib/change-review/build-studio-semantic-review.test.ts
@@ -8,6 +8,7 @@ const db = vi.hoisted(() => ({
   taskRunFindUnique: vi.fn(),
   taskRunCreate: vi.fn(),
   taskRunUpdate: vi.fn(),
+  taskRunUpdateMany: vi.fn(async (..._args: unknown[]) => ({ count: 1 })),
 }));
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -21,6 +22,7 @@ vi.mock("@dpf/db", () => ({
       findUnique: (...args: unknown[]) => db.taskRunFindUnique(...args),
       create: (...args: unknown[]) => db.taskRunCreate(...args),
       update: (...args: unknown[]) => db.taskRunUpdate(...args),
+      updateMany: (...args: unknown[]) => db.taskRunUpdateMany(...args),
     },
   },
 }));

--- a/apps/web/lib/coworker/authority-approval-envelope.ts
+++ b/apps/web/lib/coworker/authority-approval-envelope.ts
@@ -26,7 +26,7 @@ type AuthorityApprovalDb = {
   taskRun: { updateMany(args: unknown): Promise<unknown> };
 };
 
-type MarkTaskWorking = (taskRunId: string) => Promise<void>;
+type MarkTaskWorking = (taskRunId: string) => Promise<boolean | void>;
 
 function activeEnvelopeWhere(
   approvalBindingFingerprint: string,

--- a/apps/web/lib/deliberation/bootstrapped-task-run.ts
+++ b/apps/web/lib/deliberation/bootstrapped-task-run.ts
@@ -1,0 +1,16 @@
+// apps/web/lib/deliberation/bootstrapped-task-run.ts
+//
+// Identity of a TaskRun the deliberation orchestrator created because the
+// caller supplied none. Exactly one writer settles such a run (BI-D208E70C):
+// the orchestrator when it dispatched the branches itself, otherwise the async
+// runner (queue/functions/deliberation-run.ts) — whatever routeContext the
+// caller passed. Before this, the orchestrator settled the run, the runner
+// re-marked it working, and only closed it again when routeContext was
+// literally "deliberation"; every /build review deliberation leaked.
+
+/** Business-id prefix the orchestrator stamps on a run it bootstrapped. */
+export const BOOTSTRAPPED_TASK_RUN_PREFIX = "deliberation-";
+
+export function isBootstrappedDeliberationTaskRunId(taskRunId: string): boolean {
+  return taskRunId.startsWith(BOOTSTRAPPED_TASK_RUN_PREFIX);
+}

--- a/apps/web/lib/deliberation/orchestrator.test.ts
+++ b/apps/web/lib/deliberation/orchestrator.test.ts
@@ -217,7 +217,9 @@ describe("orchestrateDeliberation — review pattern", () => {
       decision: "escalate",
       confidence: 0,
     }));
-    expect(mocks.taskRunUpdateMany).toHaveBeenCalledWith(
+    // BI-D208E70C: no dispatcher → the async runner owns completion, so the
+    // orchestrator must NOT settle the bootstrapped TaskRun it just created.
+    expect(mocks.taskRunUpdateMany).not.toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ taskRunId: "taskrun-1" }),
         data: expect.objectContaining({ status: "completed" }),

--- a/apps/web/lib/deliberation/orchestrator.ts
+++ b/apps/web/lib/deliberation/orchestrator.ts
@@ -43,6 +43,7 @@ import {
   type ConsensusDecision,
 } from "./consensus";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { BOOTSTRAPPED_TASK_RUN_PREFIX } from "./bootstrapped-task-run";
 
 /* -------------------------------------------------------------------------- */
 /* Public shapes                                                              */
@@ -367,7 +368,7 @@ export async function orchestrateDeliberation(
   } else {
     const created = await prisma.taskRun.create({
       data: {
-        taskRunId: `deliberation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        taskRunId: `${BOOTSTRAPPED_TASK_RUN_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         userId: input.userId,
         threadId: input.threadId ?? null,
         buildId: input.buildId ?? null,
@@ -715,9 +716,8 @@ export async function orchestrateDeliberation(
     await applyConsensusOutcome(buildId, consensusDecision, branchVotes, prisma);
   }
 
-  // BI-132FC1B9: settle bootstrapped TaskRuns so a failed/timeout caller cannot
-  // leave them in working forever and trip the self-upgrade quiescence drain.
-  if (taskRunBootstrapped && taskRunId) {
+  // BI-132FC1B9 settle; BI-D208E70C only when THIS call dispatched — see bootstrapped-task-run.ts.
+  if (taskRunBootstrapped && taskRunId && input.dispatcher) {
     await settleBootstrapTaskRun(taskRunId, "completed");
   }
 

--- a/apps/web/lib/mcp-task-submit-approval-recovery.test.ts
+++ b/apps/web/lib/mcp-task-submit-approval-recovery.test.ts
@@ -390,10 +390,10 @@ describe("submitRemoteCoworkerTask approval recovery", () => {
         },
       },
     });
-    expect(db.update).toHaveBeenCalledWith({
-      where: { taskRunId: "TR-MCP-APPROVED" },
+    expect(db.updateMany).toHaveBeenCalledWith(expect.objectContaining({ // guarded working transition (BI-D208E70C)
+      where: expect.objectContaining({ taskRunId: "TR-MCP-APPROVED" }),
       data: { status: "working", lastHeartbeatAt: expect.any(Date) },
-    });
+    }));
     expect(db.update).toHaveBeenCalledWith({
       where: { taskRunId: "TR-MCP-APPROVED" },
       data: {

--- a/apps/web/lib/mcp-task-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer.test.ts
@@ -321,10 +321,10 @@ describe("terminal writer resumption", () => {
         }),
       },
     });
-    expect(db.update).toHaveBeenCalledWith({
-      where: { taskRunId: "TR-MCP-SAME-WRITER-RUN" },
+    expect(db.updateMany).toHaveBeenCalledWith(expect.objectContaining({ // guarded working transition (BI-D208E70C)
+      where: expect.objectContaining({ taskRunId: "TR-MCP-SAME-WRITER-RUN" }),
       data: { status: "working", lastHeartbeatAt: expect.any(Date) },
-    });
+    }));
     expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
       taskRunId: "TR-MCP-SAME-WRITER-RUN",
       threadId: "thread-external",

--- a/apps/web/lib/mcp/packs/change-review-pack.test.ts
+++ b/apps/web/lib/mcp/packs/change-review-pack.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
       findUnique: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
   },
   recordExternalEvidence: vi.fn(),
@@ -62,6 +63,17 @@ describe("change-review MCP pack", () => {
       if (!row) throw new Error("missing TaskRun");
       Object.assign(row, data);
       return row;
+    });
+    // markTaskRunWorking is a guarded updateMany (BI-D208E70C): move the row
+    // only from a working-entry state, and report how many rows moved.
+    mocks.prisma.taskRun.updateMany.mockImplementation(async ({ where, data }) => {
+      const allowed: string[] = where.status?.in ?? [];
+      const row = taskRows.find(
+        (candidate) => candidate.taskRunId === where.taskRunId && allowed.includes(String(candidate.status)),
+      );
+      if (!row) return { count: 0 };
+      Object.assign(row, data);
+      return { count: 1 };
     });
   });
 

--- a/apps/web/lib/observability/heartbeat.test.ts
+++ b/apps/web/lib/observability/heartbeat.test.ts
@@ -61,13 +61,24 @@ describe("heartbeat()", () => {
 });
 
 describe("markTaskRunWorking()", () => {
-  it("sets status='working' and lastHeartbeatAt atomically", async () => {
-    mockUpdate.mockResolvedValue({});
-    await markTaskRunWorking("TR-3");
-    expect(mockUpdate).toHaveBeenCalledWith({
-      where: { taskRunId: "TR-3" },
+  it("sets status='working' and lastHeartbeatAt atomically, only from a non-terminal state (BI-D208E70C)", async () => {
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    const moved = await markTaskRunWorking("TR-3");
+    expect(moved).toBe(true);
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: {
+        taskRunId: "TR-3",
+        status: { in: ["submitted", "queued", "running", "active", "working", "input-required", "auth-required"] },
+      },
       data: { status: "working", lastHeartbeatAt: expect.any(Date) },
     });
+  });
+
+  it("returns false and leaves a completed run completed (never resurrects a settled run)", async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+    const moved = await markTaskRunWorking("TR-done");
+    expect(moved).toBe(false);
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/observability/heartbeat.ts
+++ b/apps/web/lib/observability/heartbeat.ts
@@ -48,11 +48,34 @@ export async function heartbeat(taskRunId: string): Promise<boolean> {
   }
 }
 
-export async function markTaskRunWorking(taskRunId: string): Promise<void> {
-  await prisma.taskRun.update({
-    where: { taskRunId },
+/**
+ * States a TaskRun can be moved INTO `working` from. Anything else is terminal
+ * or parked and stays where it is: a completed run must never be resurrected
+ * by a late worker that did not know it was already settled (BI-D208E70C — the
+ * async deliberation runner re-marked runs the orchestrator had completed,
+ * and 295 of them ended up "stalled" on the live install).
+ */
+export const TASK_RUN_WORKING_ENTRY_STATES = [
+  "submitted",
+  "queued",
+  "running",
+  "active",
+  "working",
+  "input-required",
+  "auth-required",
+] as const;
+
+/**
+ * Returns whether the row transitioned (or was already working). A false
+ * result means the run is terminal or parked and the caller must not treat
+ * itself as its owner.
+ */
+export async function markTaskRunWorking(taskRunId: string): Promise<boolean> {
+  const result = await prisma.taskRun.updateMany({
+    where: { taskRunId, status: { in: [...TASK_RUN_WORKING_ENTRY_STATES] } },
     data: { status: "working", lastHeartbeatAt: new Date() },
   });
+  return result.count > 0;
 }
 
 /**

--- a/apps/web/lib/queue/functions/brand-extract.test.ts
+++ b/apps/web/lib/queue/functions/brand-extract.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   createTaskArtifact: vi.fn(),
   designSystemToThemeTokens: vi.fn(),
   taskRunUpdate: vi.fn(),
+  taskRunUpdateMany: vi.fn(),
   organizationUpdate: vi.fn(),
   brandingConfigUpsert: vi.fn(),
   agentMessageCreate: vi.fn(),
@@ -33,7 +34,7 @@ vi.mock("@/lib/brand/apply", () => ({
 
 vi.mock("@dpf/db", () => ({
   prisma: {
-    taskRun: { update: mocks.taskRunUpdate },
+    taskRun: { update: mocks.taskRunUpdate, updateMany: mocks.taskRunUpdateMany },
     organization: { update: mocks.organizationUpdate },
     brandingConfig: { upsert: mocks.brandingConfigUpsert },
     agentMessage: { create: mocks.agentMessageCreate },
@@ -106,6 +107,7 @@ describe("runBrandExtraction (core handler)", () => {
     mocks.agentAttachmentFindMany.mockReset();
 
     mocks.taskRunUpdate.mockResolvedValue({});
+    mocks.taskRunUpdateMany.mockReset().mockResolvedValue({ count: 1 });
     mocks.organizationUpdate.mockResolvedValue({});
     mocks.brandingConfigUpsert.mockResolvedValue({});
     mocks.agentMessageCreate.mockResolvedValue({});
@@ -174,21 +176,21 @@ describe("runBrandExtraction (core handler)", () => {
       sources: { url: "https://example.com" },
     });
 
-    expect(mocks.taskRunUpdate).toHaveBeenNthCalledWith(
-      1,
+    // The working transition is the guarded updateMany (BI-D208E70C).
+    expect(mocks.taskRunUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { taskRunId: "run-1" },
+        where: expect.objectContaining({ taskRunId: "run-1" }),
         data: expect.objectContaining({ status: "working" }),
       }),
     );
     expect(mocks.taskRunUpdate).toHaveBeenNthCalledWith(
-      2,
+      1,
       expect.objectContaining({
         where: { taskRunId: "run-1" },
         data: expect.objectContaining({ status: "completed" }),
       }),
     );
-    expect(mocks.taskRunUpdate.mock.calls[1]![0].data).not.toHaveProperty("state");
+    expect(mocks.taskRunUpdate.mock.calls[0]![0].data).not.toHaveProperty("state");
     expect(mocks.createTaskArtifact).toHaveBeenCalledWith(
       expect.objectContaining({
         taskRunId: "run-1",
@@ -227,19 +229,18 @@ describe("runBrandExtraction (core handler)", () => {
       }),
     ).rejects.toThrow("URL timeout");
 
-    expect(mocks.taskRunUpdate).toHaveBeenNthCalledWith(
-      1,
+    expect(mocks.taskRunUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ status: "working" }),
       }),
     );
     expect(mocks.taskRunUpdate).toHaveBeenNthCalledWith(
-      2,
+      1,
       expect.objectContaining({
         data: expect.objectContaining({ status: "failed" }),
       }),
     );
-    expect(mocks.taskRunUpdate.mock.calls[1]![0].data).not.toHaveProperty("state");
+    expect(mocks.taskRunUpdate.mock.calls[0]![0].data).not.toHaveProperty("state");
     expect(mocks.createTaskMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         taskRunId: "run-1",

--- a/apps/web/lib/queue/functions/deliberation-run.test.ts
+++ b/apps/web/lib/queue/functions/deliberation-run.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mocks = vi.hoisted(() => ({
   transaction: vi.fn(),
   taskRunUpdate: vi.fn(),
+  taskRunUpdateMany: vi.fn(),
   taskRunFindUnique: vi.fn(),
   deliberationRunFindUnique: vi.fn(),
   deliberationRunUpdate: vi.fn(),
@@ -35,7 +36,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@dpf/db", () => ({
   prisma: {
     $transaction: mocks.transaction,
-    taskRun: { update: mocks.taskRunUpdate, findUnique: mocks.taskRunFindUnique },
+    taskRun: {
+      update: mocks.taskRunUpdate,
+      updateMany: mocks.taskRunUpdateMany,
+      findUnique: mocks.taskRunFindUnique,
+    },
     deliberationRun: {
       findUnique: mocks.deliberationRunFindUnique,
       update: mocks.deliberationRunUpdate,
@@ -78,7 +83,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.transaction.mockImplementation(async (callback: (client: unknown) => unknown) =>
     callback({
-      taskRun: { update: mocks.taskRunUpdate, findUnique: mocks.taskRunFindUnique },
+      taskRun: {
+      update: mocks.taskRunUpdate,
+      updateMany: mocks.taskRunUpdateMany,
+      findUnique: mocks.taskRunFindUnique,
+    },
       deliberationRun: {
         findUnique: mocks.deliberationRunFindUnique,
         update: mocks.deliberationRunUpdate,
@@ -275,6 +284,52 @@ describe("runDeliberation", () => {
       (c) => c[0].data.status === "completed",
     );
     expect(completedUpdate).toBeDefined();
+  });
+
+  it("completes an orchestrator-bootstrapped TaskRun even when routeContext is /build (BI-D208E70C)", async () => {
+    runWithBranches([
+      { id: "n1", workerRole: "reviewer", status: "queued" },
+      { id: "n2", workerRole: "summarizer", status: "queued" },
+    ]);
+    mocks.taskRunFindUnique.mockResolvedValue({ routeContext: "/build" });
+
+    await runDeliberation({
+      userId: "u1",
+      deliberationRunId: "delib-1",
+      taskRunId: "deliberation-1788372027063-9vjla0",
+      threadId: null,
+    });
+
+    const completedUpdate = mocks.taskRunUpdate.mock.calls.find(
+      (c) => c[0].data.status === "completed",
+    );
+    expect(completedUpdate).toBeDefined();
+    // The start-of-run transition is the guarded one, never a bare update to working.
+    expect(mocks.taskRunUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "working" }) }),
+    );
+    expect(
+      mocks.taskRunUpdate.mock.calls.find((c) => c[0].data.status === "working"),
+    ).toBeUndefined();
+  });
+
+  it("does not complete a caller-owned TaskRun whose routeContext is not deliberation", async () => {
+    runWithBranches([
+      { id: "n1", workerRole: "reviewer", status: "queued" },
+      { id: "n2", workerRole: "summarizer", status: "queued" },
+    ]);
+    mocks.taskRunFindUnique.mockResolvedValue({ routeContext: "/build" });
+
+    await runDeliberation({
+      userId: "u1",
+      deliberationRunId: "delib-1",
+      taskRunId: "TR-CALLER-OWNED",
+      threadId: null,
+    });
+
+    expect(
+      mocks.taskRunUpdate.mock.calls.find((c) => c[0].data.status === "completed"),
+    ).toBeUndefined();
   });
 
   it("returns early when DeliberationRun doesn't exist — no crash", async () => {

--- a/apps/web/lib/queue/functions/deliberation-run.ts
+++ b/apps/web/lib/queue/functions/deliberation-run.ts
@@ -59,7 +59,13 @@ export async function runDeliberation(input: RunDeliberationInput): Promise<void
   // still caught because the watchdog accepts both values.
   try {
     const { markTaskRunWorking } = await import("@/lib/observability/heartbeat");
-    await markTaskRunWorking(input.taskRunId);
+    const moved = await markTaskRunWorking(input.taskRunId);
+    if (!moved) {
+      // Terminal or parked already — never resurrect it (BI-D208E70C).
+      console.warn(
+        `[deliberation-run] TaskRun ${input.taskRunId} is not in a working-entry state; leaving its status untouched`,
+      );
+    }
   } catch (err) {
     console.warn(
       "[deliberation-run] failed to mark TaskRun working",
@@ -347,13 +353,22 @@ export async function runDeliberation(input: RunDeliberationInput): Promise<void
     consensusState: compactSummary.consensusState,
   });
 
-  // Mark TaskRun completed when the deliberation is its only work.
+  // Mark TaskRun completed when the deliberation is its only work: a run the
+  // orchestrator bootstrapped for this deliberation (whatever routeContext the
+  // caller passed — the /build review path passes "/build", BI-D208E70C), or a
+  // caller-owned run whose routeContext says deliberation is all it does.
   try {
+    const { isBootstrappedDeliberationTaskRunId } = await import(
+      "@/lib/deliberation/bootstrapped-task-run"
+    );
     const tr = await prisma.taskRun.findUnique({
       where: { taskRunId: input.taskRunId },
       select: { routeContext: true },
     });
-    if (tr?.routeContext === "deliberation") {
+    if (
+      tr?.routeContext === "deliberation" ||
+      isBootstrappedDeliberationTaskRunId(input.taskRunId)
+    ) {
       await prisma.taskRun.update({
         where: { taskRunId: input.taskRunId },
         data: { status: "completed", completedAt: new Date() },


### PR DESCRIPTION
## Why

A deliberation started through `startDeliberation` had two owners of its TaskRun. The orchestrator bootstrapped the run, dispatched nothing (no dispatcher: the async runner does the work), and settled the run to `completed` on exit. The runner then called `markTaskRunWorking()`, an unguarded `update` that flipped the completed row back to `working`, and only marked it completed again when `routeContext` was literally `"deliberation"`. The `/build` review path passes `"/build"`. BI-D208E70C.

Live on Arcamanus DEV: every review deliberation ended `working` with `completedAt` already set. 295 of them were later reaped to `stalled` by the watchdog (whose comments call this a "known leak" and route around it), and the survivors sat under Platform work in flight on Right Now after #4999 made them visible.

## What

- `markTaskRunWorking` is now a guarded transition. It moves a run to `working` only from a non-terminal entry state (`submitted | queued | running | active | working | input-required | auth-required`) and returns whether it did. A completed run stays completed whoever calls it; the ten existing callers keep their semantics.
- The orchestrator settles a bootstrapped run only when it dispatched the branches itself. Without a dispatcher the async runner owns completion. The failure path still settles, since no runner follows a throw.
- The runner completes any orchestrator-bootstrapped run (business-id prefix `deliberation-`, now exported from the orchestrator as `BOOTSTRAPPED_TASK_RUN_PREFIX`) regardless of `routeContext`, and still leaves caller-owned runs alone. If the guarded transition refuses, it logs and does not touch the row.

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-05-19-build-studio-stall-detection.md` (§5.6 heartbeat substrate, §6.1 watchdog); BI-132FC1B9 (settle bootstrapped runs) as recorded in the orchestrator.
- Current code substrate reviewed: `apps/web/lib/observability/heartbeat.ts`, `apps/web/lib/deliberation/orchestrator.ts` (`settleBootstrapTaskRun`), `apps/web/lib/actions/deliberation.ts` (`startDeliberation` → inngest), `apps/web/lib/queue/functions/deliberation-run.ts`, `apps/web/lib/queue/functions/taskrun-watchdog.ts` and `observability/watchdog-detect.ts` (the "leaked deliberation run" guard).
- Source of truth: TaskRun status is owned by exactly one writer per run; the runner for async deliberations, the orchestrator for synchronous ones.
- Decision: single-owner correction inside the existing lifecycle; no schema, tool, or route change.

Design-Grounding-Decision: no-contract-change (single-owner correction inside the existing deliberation TaskRun lifecycle; no route, schema, enum, or tool surface changes)
Docs-Impact-Decision: internal TaskRun lifecycle correction; no user-guide page describes the deliberation runner's status writes.

## Verification
- `heartbeat.test.ts`: guard moves from entry states and refuses a terminal row.
- `orchestrator.test.ts`: no settle without a dispatcher.
- `deliberation-run.test.ts`: completes a bootstrapped `/build` run; leaves a caller-owned `/build` run untouched; the start-of-run transition is the guarded one.
- Three unrelated test doubles (`mcp-task-submit`, `build-studio-semantic-review`, `brand-extract`) updated for the guarded write; 2789 tests across `lib/build`, `lib/queue`, `lib/deliberation`, `lib/observability`, `lib/change-review`, `lib/mcp-task-submit` green.
- `pnpm --filter web typecheck` clean.
- Local-CI gate: see pregate record on the branch.

Not in this PR: the 295 already-stalled rows stay as they are (they are terminal and harmless); the two currently `working` leaked rows will be reaped by the watchdog as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
