### PR TITLE
fix(decision): provision the fallback decision profile's version so the kernel ledger can record (BI-218EC195)

### DIFF
--- a/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.test.ts
+++ b/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.test.ts
@@ -79,13 +79,24 @@ describe("ensureOrgDecisionPerspectiveProfile", () => {
         status: "active",
       }),
     ]);
+    // BI-218EC195: the fallback profile is a governing profile in its own
+    // right, so it carries a version too — the ledger refuses to record
+    // against a profile with no version.
     expect(fake.versions).toEqual([
+      expect.objectContaining({
+        versionId: `${ORG_PERSPECTIVE_FALLBACK_PROFILE_ID}-v1`,
+        profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+        versionNumber: 1,
+      }),
       expect.objectContaining({
         versionId: result.versionId,
         profileId: result.profileId,
         versionNumber: 1,
       }),
     ]);
+    expect(fake.profiles[0]).toEqual(
+      expect.objectContaining({ currentVersionId: `${ORG_PERSPECTIVE_FALLBACK_PROFILE_ID}-v1` }),
+    );
   });
 
   it("replays idempotently with the same profile and version", async () => {
@@ -101,6 +112,6 @@ describe("ensureOrgDecisionPerspectiveProfile", () => {
 
     expect(second).toEqual(first);
     expect(fake.profiles).toHaveLength(2);
-    expect(fake.versions).toHaveLength(1);
+    expect(fake.versions).toHaveLength(2); // fallback v1 + org v1 (BI-218EC195)
   });
 });

--- a/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.ts
+++ b/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.ts
@@ -4,6 +4,15 @@ import { DECISION_DOMAIN_CLASSES } from "@/lib/decision-perspective/types";
 
 /** Platform fallback our organization profiles chain to (material.ts:14). */
 export const ORG_PERSPECTIVE_FALLBACK_PROFILE_ID = "dpf-organizational-principles";
+/**
+ * The fallback profile's own version row. The kernel-consult ledger records a
+ * decision only when the governing profile has BOTH a profile row and a
+ * version row; the fallback used to be ensured as a profile alone, so every
+ * WWWD `principle_decide` on an install that resolved to it returned
+ * `ledger.recorded=false, reason: profile-not-provisioned` — a ruling nobody
+ * could cite (BI-218EC195). Mirrors DPF_ORGANIZATIONAL_PRINCIPLES_PROFILE.
+ */
+export const ORG_PERSPECTIVE_FALLBACK_VERSION_ID = `${ORG_PERSPECTIVE_FALLBACK_PROFILE_ID}-v1`;
 
 const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness";
 const DEFAULT_AUTONOMY_POLICY = {
@@ -65,6 +74,22 @@ export async function ensureOrgDecisionPerspectiveProfile(
       autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
       status: "active",
     },
+  });
+
+  await db.decisionPerspectiveProfileVersion.upsert({
+    where: { versionId: ORG_PERSPECTIVE_FALLBACK_VERSION_ID },
+    update: {},
+    create: {
+      versionId: ORG_PERSPECTIVE_FALLBACK_VERSION_ID,
+      profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      versionNumber: 1,
+      materialFingerprint: `seed:${ORG_PERSPECTIVE_FALLBACK_PROFILE_ID}:v1`,
+      changeSummary: "Initial organizational principle fallback profile.",
+    },
+  });
+  await db.decisionPerspectiveProfile.update({
+    where: { profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID },
+    data: { currentVersionId: ORG_PERSPECTIVE_FALLBACK_VERSION_ID },
   });
 
   await db.decisionPerspectiveProfile.upsert({

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
@@ -144,8 +144,9 @@ describe("seedOrgWwwdCorpus", () => {
     });
 
     // Version v1
-    expect(fake.versions).toHaveLength(1);
-    expect(fake.versions[0]).toMatchObject({ versionId: result.versionId, versionNumber: 1 });
+    // Fallback profile v1 + org v1 (BI-218EC195: the fallback carries its own version).
+    expect(fake.versions).toHaveLength(2);
+    expect(fake.versions[1]).toMatchObject({ versionId: result.versionId, versionNumber: 1 });
 
     // Thirteen materials across all four decision classes (BI-70ADC71F + the
     // workstream-B excellence page in plan-readiness).
@@ -219,7 +220,7 @@ describe("seedOrgWwwdCorpus", () => {
 
     // Fallback + org profile, each upserted once (no duplicates on re-run).
     expect(fake.profiles).toHaveLength(2);
-    expect(fake.versions).toHaveLength(1);
+    expect(fake.versions).toHaveLength(2);
     expect(fake.materials).toHaveLength(13);
     expect(fake.wikiPages).toHaveLength(10);
     // Body unchanged on the 2nd run → no extra revision, no re-embed

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -10,6 +10,6 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 |---|---:|---|
 | Prisma models | 625 | `packages/db/prisma/schema/` |
 | Prisma enums | 85 | `packages/db/prisma/schema/` |
-| Migrations | 566 | `packages/db/prisma/migrations/` |
+| Migrations | 567 | `packages/db/prisma/migrations/` |
 | Kernel principles | 100 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 659 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/data-impact/2026-09-05-fallback-decision-profile-version.data-impact.json
+++ b/docs/data-impact/2026-09-05-fallback-decision-profile-version.data-impact.json
@@ -1,0 +1,39 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-governance",
+  "affectedCopies": [
+    "Kernel-consult ledger (DecisionInteraction rows now record against the fallback profile)",
+    "Decision-perspective profile readers that resolve currentVersionId for dpf-organizational-principles"
+  ],
+  "migration": {
+    "name": "20260905020000_backfill_fallback_decision_profile_version",
+    "backfill": "Inserts the single DecisionPerspectiveProfileVersion row dpf-organizational-principles-v1 (versionNumber 1, materialFingerprint seed:dpf-organizational-principles:v1) where the fallback profile exists without it, and sets the profile's currentVersionId to it where null. Idempotent; no-op where the version already exists or the profile is absent. Nothing is deleted or rewritten."
+  },
+  "tests": [
+    "apps/web/lib/onboarding/ensure-org-decision-perspective-profile.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:decision-perspective-profile-version",
+      "prismaModel": "DecisionPerspectiveProfileVersion",
+      "lifecycleDisposition": "Seed-provisioned governance version; retained for the life of the profile it versions and never age-purged, because sealed decision records cite it.",
+      "fields": [
+        {
+          "fieldId": "data:decision-perspective-profile-version#versionId",
+          "resolution": "inherited",
+          "reason": "Stable seed identity mirroring DPF_ORGANIZATIONAL_PRINCIPLES_PROFILE.currentVersion; no new field, one new row.",
+          "provenance": "BI-218EC195; apps/web/lib/decision-perspective/default-profile.ts",
+          "flags": []
+        },
+        {
+          "fieldId": "data:decision-perspective-profile-version#materialFingerprint",
+          "resolution": "inherited",
+          "reason": "Seed fingerprint string; carries no personal or sensitive data.",
+          "provenance": "BI-218EC195",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260905020000_backfill_fallback_decision_profile_version/migration.sql
+++ b/packages/db/prisma/migrations/20260905020000_backfill_fallback_decision_profile_version/migration.sql
@@ -1,0 +1,24 @@
+-- BI-218EC195: the WWWD fallback decision profile shipped as a profile row with
+-- no version row on installs seeded before the version was ensured. The
+-- kernel-consult ledger refuses to record a decision against a profile with no
+-- version, so every principle_decide that resolved to the fallback returned
+-- ledger.recorded=false (profile-not-provisioned). Backfill the v1 version and
+-- point the profile at it. Idempotent: no-op where the version already exists
+-- or the profile is absent.
+INSERT INTO "DecisionPerspectiveProfileVersion" ("id", "versionId", "profileId", "versionNumber", "materialFingerprint", "changeSummary", "createdAt")
+SELECT
+  'dppv_' || substr(md5(random()::text || clock_timestamp()::text), 1, 24),
+  'dpf-organizational-principles-v1',
+  'dpf-organizational-principles',
+  1,
+  'seed:dpf-organizational-principles:v1',
+  'Initial organizational principle fallback profile.',
+  now()
+WHERE EXISTS (SELECT 1 FROM "DecisionPerspectiveProfile" WHERE "profileId" = 'dpf-organizational-principles')
+  AND NOT EXISTS (SELECT 1 FROM "DecisionPerspectiveProfileVersion" WHERE "versionId" = 'dpf-organizational-principles-v1');
+
+UPDATE "DecisionPerspectiveProfile"
+SET "currentVersionId" = 'dpf-organizational-principles-v1'
+WHERE "profileId" = 'dpf-organizational-principles'
+  AND "currentVersionId" IS NULL
+  AND EXISTS (SELECT 1 FROM "DecisionPerspectiveProfileVersion" WHERE "versionId" = 'dpf-organizational-principles-v1');


### PR DESCRIPTION
## Why

Every `principle_decide` on Arcamanus DEV returned `ledger: { recorded: false, reason: "profile-not-provisioned" }` (five calls while ratifying the work-shape spec, all with a resolved governing profile and strong structured coverage). The governing profile `dpf-organizational-principles` existed as a row but had **no `DecisionPerspectiveProfileVersion`**. `ensureOrgDecisionPerspectiveProfile` ensured the fallback profile only as a foreign-key target and never minted its v1 version, while the ledger writer requires both a profile and a version before it seals anything. The kernel could rule but nothing could cite the ruling, which is the precondition for WWMD automating approvals. BI-218EC195.

## What

- `ensureOrgDecisionPerspectiveProfile` now upserts the fallback profile's v1 version (mirroring `DPF_ORGANIZATIONAL_PRINCIPLES_PROFILE` in `default-profile.ts`) and points the profile's `currentVersionId` at it. Idempotent on replay.
- Forward-only migration `20260905020000_backfill_fallback_decision_profile_version` backfills the version and the pointer on installs seeded before this, guarded so it is a no-op where the version already exists or the profile is absent.

Not in this PR: routing `in_platform_coworker` decisions to the organization's own perspective profile (`org-perspective-<orgId>`) instead of the fallback constant. That is the BI-HDLEMP-01 decision-domain routing question and stays on BI-218EC195 as the second half.

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md` (ring scope / decision record), BI-44526F3E (the WWWD fallback constant with no DB row) as recorded in `kernel-consult-ledger.ts`.
- Current code substrate reviewed: `apps/web/lib/decision/kernel-consult-ledger.ts:243-262`, `apps/web/lib/onboarding/ensure-org-decision-perspective-profile.ts`, `apps/web/lib/decision-perspective/default-profile.ts`, `apps/web/lib/decision/caller-context.ts` (profile resolution), `packages/db/prisma/schema/decision-governance.prisma` (`DecisionPerspectiveProfileVersion`).
- Source of truth: the profile + version pair is what the ledger keys on; the fallback profile is a governing profile in its own right and must be provisioned like one.
- Decision: complete the existing provisioning path; no new substrate.

Design-Grounding-Decision: no-contract-change (completes the existing fallback-profile provisioning; no route, schema, enum, or tool surface changes)
Docs-Impact-Decision: internal decision-ledger provisioning repair; no user-guide page describes profile versions.

## Verification
- `ensure-org-decision-perspective-profile.test.ts`: provisioning creates the fallback v1 and the org v1 and sets the pointer; replay stays idempotent (two versions, two profiles).
- `pnpm --filter web typecheck` clean; `lib/decision` suites green (675 tests).
- Migration applies cleanly against the live data state: verified by the local-CI gate on the branch, and the live install currently holds exactly the pre-condition the backfill targets (profile row present, `currentVersionId` null, no version row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
