### PR TITLE
fix(guards): a plan merges when it names why its coverage receipt is blocked; the receipt is enforced at the claim (BI-B5C8FEFC)

### DIFF
--- a/scripts/check-plan-backlog-coverage.mjs
+++ b/scripts/check-plan-backlog-coverage.mjs
@@ -24,8 +24,19 @@ export function validatePlanText(path, text) {
 
   if (!decision) errors.push(`${path}: coverage Decision must be atomic or decomposed.`);
   if (parent !== itemId) errors.push(`${path}: coverage Parent must match umbrella ${itemId}.`);
+  // A plan is durable knowledge; its merge must not depend on reviewer capacity.
+  // The coverage receipt is enforced where it governs work — at the implementation
+  // claim (initiative-readiness PLAN_COVERAGE_REQUIRED) — so this gate accepts a
+  // plan that states, in the open, WHY the receipt could not be minted yet. A
+  // bare "pending" still fails: the condition must be named so the next reader
+  // can act on it rather than rediscover it (founder ruling 2026-09-05).
+  const blockedBy = receipt?.match(/^blocked-by:\s*(.+)$/i)?.[1]?.trim() ?? "";
   if (!receipt || /^(?:pending|none|n\/a)\b/i.test(receipt)) {
-    errors.push(`${path}: a live MCP coverage Receipt is required; "pending" and Markdown-only evidence are invalid.`);
+    errors.push(
+      `${path}: a live MCP coverage Receipt is required, or "Receipt: blocked-by: <the concrete condition>" naming why it cannot be minted yet; bare "pending" is not a condition.`,
+    );
+  } else if (/^blocked-by:/i.test(receipt) && blockedBy.length < 30) {
+    errors.push(`${path}: "Receipt: blocked-by:" must name the concrete blocking condition (at least 30 characters).`);
   }
   if (!dependencies) errors.push(`${path}: dependencies must be recorded explicitly (use "none" when empty).`);
 

--- a/scripts/check-plan-backlog-coverage.test.mjs
+++ b/scripts/check-plan-backlog-coverage.test.mjs
@@ -51,3 +51,29 @@ test("allows mappings to existing BIs and requires dependency recording", () => 
 - Receipt: receipt-mapped-1`));
   assert.deepEqual(result, { ok: true, errors: [] });
 });
+
+test("accepts a plan whose receipt names the concrete blocking condition (merge does not wait on reviewer capacity)", () => {
+  const result = validatePlanText(
+    "docs/superpowers/plans/blocked.md",
+    header(`- Decision: decomposed
+- Parent: \`BI-PARENT\`
+- Receipt: blocked-by: no initiative scope baseline exists for BI-PARENT (spec-approval receipt not yet recorded)
+- Rationale: each child is one clean revert.
+- Dependencies: slice-a -> \`BI-A\` (none); slice-b -> \`BI-B\` (BI-A)`),
+  );
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ok, true);
+});
+
+test("rejects a blocked-by receipt that names no real condition", () => {
+  const result = validatePlanText(
+    "docs/superpowers/plans/blocked-vague.md",
+    header(`- Decision: decomposed
+- Parent: \`BI-PARENT\`
+- Receipt: blocked-by: later
+- Rationale: each child is one clean revert.
+- Dependencies: slice-a -> \`BI-A\` (none)`),
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join(" "), /concrete blocking condition/);
+});


### PR DESCRIPTION
The plan-coverage CI gate refused to merge any plan document without a
live record_plan_backlog_coverage receipt. That receipt needs an
independently approved spec baseline, which needs reviewer capacity, so
a plan's MERGE depended on whether an AI reviewer could finish reading
the spec that day. The same requirement is already enforced where it
governs work — initiative-readiness refuses an implementation claim
without PLAN_COVERAGE_REQUIRED — so the doc-merge copy added no
protection and starved the commons: the work-shape plan (PR #5059) sat
red for a day with all its code merged.

The gate now accepts "Receipt: blocked-by: <concrete condition>" (30+
characters) so the next reader can act on the condition instead of
rediscovering it. A bare "pending" still fails.

Founder ruling 2026-09-05: durable knowledge merges; governance binds at
the claim, not at the document.

Design-Grounding-Decision: no-contract-change (CI guard accepts a named blocking condition; the readiness policy and receipt contract are unchanged)
Docs-Impact-Decision: guard behaviour documented in its own header and tests; no user-guide page describes the plan-coverage gate.
Process-Spine-Decision: localized guard correction with tests; no new capability.

Unblocks #5059. Guard tests: 5/5. Local-CI gate: PASS on this SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)