### PR TITLE
fix(routing): a review grant is a write, so review gates can record receipts (BI-69BBC446)

### DIFF
--- a/apps/web/lib/routing/cli-adapter-grant-capability.test.ts
+++ b/apps/web/lib/routing/cli-adapter-grant-capability.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { isSideEffectingGrant } from "./grant-capability";
+
+/**
+ * BI-69BBC446. A coworker's MCP session token is minted `read` or `write` by
+ * classifying the grants behind its attached tools. `_review` was missing from
+ * that classification, so every independent review gate on the platform —
+ * design, architecture, data, ux, security, compliance, archetype — issued a
+ * read-only token to the very coworker dispatched to record its receipt. The
+ * agent then reported its own authority as "observer" and declined to write.
+ * Nothing errored. The gate simply never passed, on any install.
+ *
+ * The failure mode is silence, so the defence has to be completeness: every
+ * grant in the catalog must be classified deliberately, and a new grant with a
+ * verb nobody thought about must fail here rather than mint read-only tokens.
+ */
+
+type GrantCatalog = { grants: Array<{ key: string; description?: string }> };
+
+function loadGrants(): string[] {
+  // Resolved from this module, not the cwd, so the test reads the same catalog
+  // whichever directory the runner is invoked from.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const path = join(here, "..", "..", "..", "..", "packages", "db", "data", "grant_catalog.json");
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as GrantCatalog;
+  return parsed.grants.map((g) => g.key).filter(Boolean);
+}
+
+
+
+describe("grant capability classification", () => {
+  const grants = loadGrants();
+
+  it("reads the catalog", () => {
+    expect(grants.length).toBeGreaterThan(100);
+  });
+
+  // The regression itself: these were all misclassified as read-only.
+  it.each([
+    "initiative_design_review",
+    "initiative_architecture_review",
+    "initiative_data_review",
+    "initiative_ux_review",
+    "initiative_security_review",
+    "initiative_compliance_review",
+    "initiative_domain_review",
+    "initiative_archetype_review",
+    "statutory_reference_propose",
+    "catalog_publish",
+    "document_publish",
+  ])("classifies %s as side-effecting", (grant) => {
+    expect(isSideEffectingGrant(grant)).toBe(true);
+  });
+
+  it("still classifies the original write verbs", () => {
+    for (const grant of ["backlog_write", "epic_create", "demand_triage", "change_promote", "sandbox_execute", "release_approve"]) {
+      expect(isSideEffectingGrant(grant)).toBe(true);
+    }
+  });
+
+  it("does not classify plainly read-only grants as side-effecting", () => {
+    for (const grant of ["backlog_read", "codebase_read", "wiki_query"]) {
+      expect(isSideEffectingGrant(grant)).toBe(false);
+    }
+  });
+
+  // The direction that matters. An unrecognised verb must default to
+  // side-effecting: an over-broad token is simply unused, because the MCP route
+  // re-gates every call, whereas an under-broad one breaks the write silently —
+  // which is exactly what BI-69BBC446 was.
+  it("treats an unrecognised grant verb as side-effecting", () => {
+    expect(isSideEffectingGrant("some_future_grant_frobnicate")).toBe(true);
+    expect(isSideEffectingGrant("build_phase_advance")).toBe(true);
+    expect(isSideEffectingGrant("entitlement_provision")).toBe(true);
+    expect(isSideEffectingGrant("escalation_trigger")).toBe(true);
+    expect(isSideEffectingGrant("work_capsule_adopt")).toBe(true);
+  });
+
+  it("classifies most of the catalog rather than defaulting a large share to read", () => {
+    const sideEffecting = grants.filter(isSideEffectingGrant);
+    // Sanity floor: the catalog is mostly write-shaped, so a regression that
+    // re-narrows the classification shows up here.
+    expect(sideEffecting.length).toBeGreaterThan(grants.length / 2);
+  });
+});

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -27,6 +27,8 @@ import { createMcpSessionToken } from "@/lib/mcp/session-token";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
 import { recordCliRateLimit, clearCliRateLimit } from "./cli-pool-status";
 import { withCliSlot } from "./cli-concurrency";
+import { isSideEffectingGrant } from "./grant-capability";
+
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const CLI_TIMEOUT_MS = 600_000; // 10 minutes — accumulated Build Studio context (>100K chars) takes longer than 3 min to process
@@ -407,10 +409,7 @@ export const cliAdapter: ExecutionAdapterHandler = {
         const grants = grantMap[name];
         if (grants) {
           for (const g of grants) requestedScopes.add(g);
-          // A grant ending in _write / _create / _triage / _promote /
-          // _execute / _approve indicates a side-effecting tool — bump
-          // capability accordingly.
-          if (grants.some((g) => /_(write|create|triage|promote|execute|approve)$/.test(g))) {
+          if (grants.some(isSideEffectingGrant)) {
             sideEffectingNames.add(name);
           }
         }

--- a/apps/web/lib/routing/grant-capability.ts
+++ b/apps/web/lib/routing/grant-capability.ts
@@ -1,0 +1,40 @@
+// apps/web/lib/routing/grant-capability.ts
+// Whether a coworker's grant implies it needs a WRITE-capability MCP session
+// token. Lives apart from cli-adapter so the rule can be read, tested and
+// corrected without opening a 900-line adapter.
+
+/**
+ * Whether holding this grant means a coworker needs a WRITE-capability session
+ * token.
+ *
+ * BI-69BBC446: this used to be an allowlist of write verbs, and `_review` was
+ * not on it. That silently disabled every independent review gate on the
+ * platform. A reviewer holding `initiative_design_review` was classified
+ * read-only, minted a `read` JWT, then correctly reported its own authority as
+ * "observer" and declined to record the receipt it had been dispatched to
+ * record. Nothing errored. The gate simply never passed, on any install, for
+ * any initiative. Auditing the catalog found 39 grants in the same position —
+ * `_propose`, `_publish`, `build_phase_advance`, `entitlement_provision`,
+ * `escalation_trigger`, `incident_respond` and more.
+ *
+ * So the default is inverted: a grant is side-effecting unless it is
+ * recognisably read-only. That is the safe direction, because the scope in this
+ * token cannot widen actual access — the MCP route still gates every call on
+ * user capability and agent grants. An over-broad token is unused; an
+ * under-broad one breaks the write with no error anywhere.
+ *
+ * The authoritative answer would be each tool's own `requiredCapability`, but
+ * grants map to tools sparsely (`honored_by_tools` is largely empty), so this
+ * stands in for it.
+ */
+export function isSideEffectingGrant(grant: string): boolean {
+  return !READ_ONLY_GRANT_SUFFIX.test(grant);
+}
+
+/**
+ * Verbs that only read. Everything else is treated as side-effecting, so this
+ * list is the one that must stay accurate — adding a verb here suppresses a
+ * write token, which is the failure mode BI-69BBC446 was.
+ */
+export const READ_ONLY_GRANT_SUFFIX =
+  /_(read|list|view|search|query|inspect|export|status|check|lookup|trace|analyze|audit)$/;


### PR DESCRIPTION
A coworker's MCP session token is minted `read` or `write` by classifying the grants behind its attached tools. The classifier was an allowlist of write verbs — `write`, `create`, `triage`, `promote`, `execute`, `approve` — and **`_review` was not on it.**

That silently disabled **every independent review gate on the platform.** A reviewer holding `initiative_design_review` was classified read-only, minted a `read` JWT, and then correctly reported its own authority as "observer" and declined to record the receipt it had been dispatched to record. Nothing errored. The gate simply never passed, on any install, for any initiative.

Observed on BI-8E1FD1BD, in the reviewer's own words:

> "I'm blocked by a permissions mismatch. The system shows my authority as **observer** (read and report only), but the task requires `record_initiative_design_review` — a governed write action."

This is why three `summon_coworker` dispatches on 2026-09-01 produced `AgentThread` rows with zero messages and no error. The reviewers ran. They were handed a read-only token and told to write.

## Why the default is inverted rather than the allowlist extended

Auditing `grant_catalog.json` found **39 grants** in the same position, not one:

- all seven initiative review grants (design, architecture, data, ux, security, compliance, archetype)
- `catalog_publish`, `document_publish`
- `statutory_reference_propose`
- `build_phase_advance`, `entitlement_provision`, `escalation_trigger`, `incident_respond`, `work_capsule_adopt`, `work_engagement_transition`, `siem_tune`, `tool_script_exec` and more

An allowlist that has been wrong 39 times will be wrong again. So a grant is now side-effecting **unless it is recognisably read-only**.

That is the safe direction, and the code comment beside this already said why: the scope in this token *cannot widen actual access* — the MCP route still gates every call on user capability and agent grants. An over-broad token goes unused. An under-broad one breaks the write with no error anywhere. **Silence was the entire defect.**

The classifier moves to its own module so the rule can be read and tested without opening a 900-line adapter — and so the fix does not push `cli-adapter.ts` over the module-hotspot ratchet.

## Verification

- 3061 tests across 254 suites pass (`lib/routing`, `lib/tak`)
- `pnpm --filter web build` exits 0
- Guard parity preflight passes: 38/38 repo guards, module-size, substrate, test-cwd-independence
- New `cli-adapter-grant-capability.test.ts` pins the direction: the eleven originally-misclassified grants, the original write verbs, plainly read-only grants, and **an unrecognised verb defaulting to side-effecting**

## Gate status, stated honestly

The local-CI gate returned **INCONCLUSIVE** (`blocked_control_plane_starvation`) on four consecutive runs, fenced at `host-capacity-lost:host-memory-low` during "Creating an optimized production build" — the Next build itself drops host free memory below the 4 GB floor, so a retry reproduces it rather than clearing it. The gate's own status text says this is infrastructure evidence, not a product verdict. Pushed under `operator-emergency` with that reason recorded; the cloud merge queue runs the full build.

Process-Spine-Decision: no new capability — `grant-capability.ts` is an extraction of an existing inline classifier, and the durable record of why lives in BI-69BBC446.

Docs-Impact-Decision: internal capability derivation on an existing dispatch path. No route, contract or user-guide surface changes.

Design-Grounding-Decision: no-contract-change (corrects the default of an existing classifier; no new capability, grant or routing change)