### PR TITLE
feat(ux): add delegate interaction step role

### DIFF
--- a/apps/web/lib/ea/interaction-shape.test.ts
+++ b/apps/web/lib/ea/interaction-shape.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INTERACTION_STEP_ROLES,
+  isDelegationNode,
+  isInteractionStepRole,
+  measureInteractionFlowLoad,
+  type InteractionShapeNode,
+} from "./interaction-shape";
+
+describe("interaction shape step-role contract", () => {
+  it("keeps delegate in the closed step-role set", () => {
+    expect(INTERACTION_STEP_ROLES).toEqual([
+      "entry",
+      "progress",
+      "decide",
+      "delegate",
+      "complete",
+      "reference",
+    ]);
+    expect(isInteractionStepRole("delegate")).toBe(true);
+    expect(isInteractionStepRole("delegated")).toBe(false);
+  });
+
+  it("identifies delegation nodes as their own role", () => {
+    expect(isDelegationNode({ stepRole: "delegate" })).toBe(true);
+    expect(isDelegationNode({ stepRole: "progress" })).toBe(false);
+  });
+});
+
+describe("measureInteractionFlowLoad", () => {
+  it("stops the human traversal at a delegate node", () => {
+    const nodes: InteractionShapeNode[] = [
+      {
+        key: "entry",
+        label: "Marketing",
+        jobLane: "owner-marketing",
+        stepRole: "entry",
+        continuesTo: ["draft"],
+      },
+      {
+        key: "draft",
+        label: "Draft campaign",
+        jobLane: "owner-marketing",
+        stepRole: "progress",
+        continuesTo: ["handoff"],
+      },
+      {
+        key: "handoff",
+        label: "Ask marketing coworker",
+        jobLane: "owner-marketing",
+        stepRole: "delegate",
+        continuesTo: ["coworker-marketing"],
+      },
+      {
+        key: "coworker-marketing",
+        label: "Marketing coworker lane",
+        jobLane: "coworker-marketing",
+        stepRole: "complete",
+      },
+    ];
+
+    expect(measureInteractionFlowLoad(nodes, "entry")).toEqual({
+      entryKey: "entry",
+      jobLane: "owner-marketing",
+      terminalRole: "delegate",
+      stepsToOutcome: 3,
+      traversedNodeKeys: ["entry", "draft", "handoff"],
+      delegatedTo: ["coworker-marketing"],
+      deadEndNodeKeys: [],
+      missingContinuationKeys: [],
+    });
+  });
+
+  it("counts a normal complete path without changing existing semantics", () => {
+    const nodes: InteractionShapeNode[] = [
+      { key: "entry", label: "Start", jobLane: "owner", stepRole: "entry", continuesTo: ["finish"] },
+      { key: "finish", label: "Done", jobLane: "owner", stepRole: "complete" },
+    ];
+
+    expect(measureInteractionFlowLoad(nodes, "entry")).toMatchObject({
+      terminalRole: "complete",
+      stepsToOutcome: 2,
+      traversedNodeKeys: ["entry", "finish"],
+      delegatedTo: [],
+    });
+  });
+
+  it("reports progress and decision nodes without continuations as dead ends", () => {
+    const nodes: InteractionShapeNode[] = [
+      { key: "entry", label: "Start", jobLane: "owner", stepRole: "entry", continuesTo: ["decide"] },
+      { key: "decide", label: "Choose", jobLane: "owner", stepRole: "decide" },
+    ];
+
+    expect(measureInteractionFlowLoad(nodes, "entry")).toMatchObject({
+      terminalRole: "dead-end",
+      stepsToOutcome: null,
+      deadEndNodeKeys: ["decide"],
+    });
+  });
+
+  it("returns a stable missing-entry result for callers that reference a stale node", () => {
+    expect(measureInteractionFlowLoad([], "missing")).toEqual({
+      entryKey: "missing",
+      jobLane: null,
+      terminalRole: "missing-entry",
+      stepsToOutcome: null,
+      traversedNodeKeys: [],
+      delegatedTo: [],
+      deadEndNodeKeys: [],
+      missingContinuationKeys: ["missing"],
+    });
+  });
+});

--- a/apps/web/lib/ea/interaction-shape.ts
+++ b/apps/web/lib/ea/interaction-shape.ts
@@ -1,0 +1,149 @@
+// apps/web/lib/ea/interaction-shape.ts
+//
+// Pure contract and measurement helpers for the human-interaction shape graph.
+// This stays beside navigation-extract because the shape graph composes the same
+// route/navigation facts; it is not a second route inventory.
+
+export const INTERACTION_STEP_ROLES = [
+  "entry",
+  "progress",
+  "decide",
+  "delegate",
+  "complete",
+  "reference",
+] as const;
+
+export type InteractionStepRole = (typeof INTERACTION_STEP_ROLES)[number];
+
+export interface InteractionShapeNode {
+  key: string;
+  label: string;
+  jobLane: string;
+  stepRole: InteractionStepRole;
+  continuesTo?: readonly string[];
+  path?: string;
+  spineStage?: string;
+}
+
+export type InteractionTerminalRole =
+  | "complete"
+  | "delegate"
+  | "dead-end"
+  | "cycle"
+  | "missing-entry";
+
+export interface InteractionFlowLoad {
+  entryKey: string;
+  jobLane: string | null;
+  terminalRole: InteractionTerminalRole;
+  /** Human-visible nodes traversed from entry to `complete` or `delegate`. */
+  stepsToOutcome: number | null;
+  traversedNodeKeys: string[];
+  /** For `delegate`, the receiving job lane(s), not additional human steps. */
+  delegatedTo: string[];
+  deadEndNodeKeys: string[];
+  missingContinuationKeys: string[];
+}
+
+const STEP_ROLE_SET: ReadonlySet<string> = new Set(INTERACTION_STEP_ROLES);
+const DEAD_END_ROLES: ReadonlySet<InteractionStepRole> = new Set(["progress", "decide"]);
+
+export function isInteractionStepRole(value: string): value is InteractionStepRole {
+  return STEP_ROLE_SET.has(value);
+}
+
+export function isDelegationNode(
+  node: Pick<InteractionShapeNode, "stepRole">,
+): boolean {
+  return node.stepRole === "delegate";
+}
+
+/**
+ * Measures the operator's traversal from one entry node.
+ *
+ * `delegate` is terminal for the human path. Its `continuesTo` values name the
+ * receiving job lane(s), so following them as more surface steps would recreate
+ * the very cognitive-load inversion BI-5A1A3C13 exists to prevent.
+ */
+export function measureInteractionFlowLoad(
+  nodes: readonly InteractionShapeNode[],
+  entryKey: string,
+): InteractionFlowLoad {
+  const byKey = new Map(nodes.map((node) => [node.key, node]));
+  const entry = byKey.get(entryKey);
+
+  if (!entry) {
+    return {
+      entryKey,
+      jobLane: null,
+      terminalRole: "missing-entry",
+      stepsToOutcome: null,
+      traversedNodeKeys: [],
+      delegatedTo: [],
+      deadEndNodeKeys: [],
+      missingContinuationKeys: [entryKey],
+    };
+  }
+
+  const queue: Array<{ key: string; path: string[] }> = [{ key: entryKey, path: [entryKey] }];
+  const visitedShortestPath = new Map<string, number>();
+  const deadEndNodeKeys = new Set<string>();
+  const missingContinuationKeys = new Set<string>();
+  let sawCycle = false;
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const node = byKey.get(current.key);
+
+    if (!node) {
+      missingContinuationKeys.add(current.key);
+      continue;
+    }
+
+    const previousLength = visitedShortestPath.get(current.key);
+    if (previousLength !== undefined && previousLength <= current.path.length) {
+      continue;
+    }
+    visitedShortestPath.set(current.key, current.path.length);
+
+    if (node.stepRole === "complete" || node.stepRole === "delegate") {
+      return {
+        entryKey,
+        jobLane: entry.jobLane,
+        terminalRole: node.stepRole,
+        stepsToOutcome: current.path.length,
+        traversedNodeKeys: current.path,
+        delegatedTo: node.stepRole === "delegate" ? [...(node.continuesTo ?? [])] : [],
+        deadEndNodeKeys: [...deadEndNodeKeys],
+        missingContinuationKeys: [...missingContinuationKeys],
+      };
+    }
+
+    const nextKeys = node.continuesTo ?? [];
+    if (nextKeys.length === 0) {
+      if (DEAD_END_ROLES.has(node.stepRole)) {
+        deadEndNodeKeys.add(node.key);
+      }
+      continue;
+    }
+
+    for (const nextKey of nextKeys) {
+      if (current.path.includes(nextKey)) {
+        sawCycle = true;
+        continue;
+      }
+      queue.push({ key: nextKey, path: [...current.path, nextKey] });
+    }
+  }
+
+  return {
+    entryKey,
+    jobLane: entry.jobLane,
+    terminalRole: deadEndNodeKeys.size > 0 ? "dead-end" : sawCycle ? "cycle" : "dead-end",
+    stepsToOutcome: null,
+    traversedNodeKeys: [entryKey],
+    delegatedTo: [],
+    deadEndNodeKeys: [...deadEndNodeKeys],
+    missingContinuationKeys: [...missingContinuationKeys],
+  };
+}

--- a/apps/web/lib/ea/navigation-extract.test.ts
+++ b/apps/web/lib/ea/navigation-extract.test.ts
@@ -47,6 +47,31 @@ describe("buildNavigationModel", () => {
     expect(model.relTypeSlugs).toContain("traces");
   });
 
+  it("emits interaction-shape metadata when supplied by the shape extractor", () => {
+    const m = buildNavigationModel({
+      entries: [{
+        key: "marketing_delegate",
+        label: "Ask marketing coworker",
+        path: "/customer/marketing",
+        domain: "business",
+        targetDomain: "business",
+        jobLane: "owner-marketing",
+        stepRole: "delegate",
+        continuesTo: ["coworker-marketing"],
+        spineStage: "market-and-sell",
+      }],
+      routePaths: ["/customer/marketing"],
+    });
+
+    const entry = m.elements.find((e) => e.sysmlKey === "navigation:entry:marketing_delegate");
+    expect(entry?.properties).toMatchObject({
+      jobLane: "owner-marketing",
+      stepRole: "delegate",
+      continuesTo: ["coworker-marketing"],
+      spineStage: "market-and-sell",
+    });
+  });
+
   it("flags real routes with no canonical nav entry as an orphan conformance finding, excluding dynamic routes", () => {
     const orphan = model.conformanceIssues?.find((c) => c.issueType === "route-not-in-canonical-nav");
     expect(orphan?.onKey).toBe(NAVIGATION_PACKAGE_KEY);

--- a/apps/web/lib/ea/navigation-extract.ts
+++ b/apps/web/lib/ea/navigation-extract.ts
@@ -35,6 +35,7 @@
 
 import type { SysmlDesiredModel, SysmlDesiredConformanceIssue } from "./sysml-model-seed";
 import type { PortalNavRecord } from "../navigation/portal-navigation-model";
+import type { InteractionStepRole } from "./interaction-shape";
 
 export const NAVIGATION_PACKAGE_KEY = "navigation:pkg";
 
@@ -58,6 +59,14 @@ export interface NavSourceEntry {
   /** True when the target domain is reached by following a redirect shim rather than the
    *  href directly — the teleport the parity engine's href-only check used to miss. */
   viaRedirect?: boolean;
+  /** Optional interaction-shape lane when a richer extractor has already resolved it. */
+  jobLane?: string;
+  /** Optional role of this surface inside a human job path. Includes `delegate`. */
+  stepRole?: InteractionStepRole;
+  /** Next surface keys, or for `delegate`, the receiving job lane(s). */
+  continuesTo?: readonly string[];
+  /** Optional operational value-stream stage this entry serves. */
+  spineStage?: string;
 }
 
 /** A map of redirect-shim route path → its destination route path (query stripped),
@@ -150,6 +159,10 @@ export function buildNavigationModel(input: NavigationModelInput): SysmlDesiredM
         targetPath: entry.path,
         targetDomain: entry.targetDomain,
         ...(entry.viaRedirect ? { viaRedirect: true, effectivePath: entry.effectivePath } : {}),
+        ...(entry.jobLane ? { jobLane: entry.jobLane } : {}),
+        ...(entry.stepRole ? { stepRole: entry.stepRole } : {}),
+        ...(entry.continuesTo?.length ? { continuesTo: [...entry.continuesTo] } : {}),
+        ...(entry.spineStage ? { spineStage: entry.spineStage } : {}),
       },
     });
     relationships.push({ fromKey: surfaceKey, toKey: entryKey, relSlug: "contains" });

--- a/docs/superpowers/plans/2026-09-05-interaction-shape-delegate-role.md
+++ b/docs/superpowers/plans/2026-09-05-interaction-shape-delegate-role.md
@@ -1,0 +1,49 @@
+---
+status: active
+---
+
+# BI-5A1A3C13 - Delegate step-role implementation plan
+
+**Backlog item:** `BI-5A1A3C13`
+**Epic:** `EP-4FF5273F` - Vertical Integration Inward
+**Workroom:** `WC-06901F51`
+**Branch:** `feat/interaction-shape-delegate-role`
+**Spec:** `docs/superpowers/specs/2026-08-15-interaction-shape-graph-and-design-shaping-design.md` sections 3.2, 4, and 11
+
+## Outcome
+
+`delegate` becomes a first-class interaction-shape step role before any flow-load baseline can freeze the wrong behavior. A human handoff to a coworker now terminates the human traversal for `stepsToOutcome`; the receiving coworker lane remains visible as delegation metadata instead of being counted as another operator step.
+
+## Research and current substrate
+
+- `origin/main` contains the amended interaction-shape spec and the recovered backlog bundle, but no implementation symbols for `stepRole`, `StepRole`, `stepsToOutcome`, `jobLane`, or `continuesTo` outside docs/recovery.
+- The existing navigation substrate is `apps/web/lib/ea/navigation-extract.ts`: it already projects navigation entries into SysML elements, records route trace edges, and reports navigation conformance findings. This is the right extension point for shape metadata pass-through; a second route or UX analyzer would duplicate the existing graph.
+- The route audience and page purpose registries already classify who a route serves and what kind of destination it is. This slice does not fork them; later shape extractors can feed their resolved `jobLane`, `stepRole`, `continuesTo`, and `spineStage` values into the existing navigation projection.
+- Code graph freshness was high-trust at the time of planning, with the caveat that `EXPOSES_TOOL` relationships were absent. Direct `git grep origin/main` confirmed the implementation gap.
+
+## UX fit
+
+No user-facing route changes in this slice. The UX value is measurement correctness: delegation is the platform's main cognitive-load reduction move, so the graph must not score delegation as extra human work. The navigation projection remains the source of truth for route reachability; shape metadata rides on that projection.
+
+## Phases
+
+1. **Contract and measurement.** Add `apps/web/lib/ea/interaction-shape.ts` with the closed `InteractionStepRole` set including `delegate`, a pure `InteractionShapeNode` contract, and a `measureInteractionFlowLoad` helper that stops on `delegate` or `complete`.
+2. **Projection pass-through.** Extend `NavSourceEntry` and `buildNavigationModel` so upstream shape extractors can emit `jobLane`, `stepRole`, `continuesTo`, and `spineStage` into the SysML element properties. This keeps navigation and interaction shape coupled without creating a parallel graph.
+3. **Regression coverage.** Add colocated tests proving `delegate` is in the closed role set, delegation stops `stepsToOutcome`, normal complete paths still count, dead-end detection remains explicit, and navigation entries emit supplied shape metadata.
+4. **Verification and handoff.** Run targeted EA tests and the style drift guard where dependencies are available. Because this worktree started source-only, any unrun dependency-bound gate must be reported as unrun rather than green.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-5A1A3C13`
+- Receipt: blocked-by: repository provider cannot resolve the immutable plan commit until this branch is published; MCP record_plan_backlog_coverage refused HTTP 422 while the reviewed commit existed only locally.
+- Dependencies: none
+- Rationale: This slice implements one independently shippable outcome, `BI-5A1A3C13`; the contract, measurement helper, projection pass-through, and tests are one behavioral unit. It does not deliver the later `prerequisitesToEntry` or `spine-stage-inert` work.
+
+| Deliverable | BI | Requirement refs | Contract refs | Flow refs | Verification refs |
+|---|---|---|---|---|---|
+| `delegate-step-role` | `BI-5A1A3C13` | `OBJ-ISG-DELEGATE` | `CT-ISG-STEPROLE`, `CT-ISG-FLOWLOAD` | `FLOW-ISG-HUMAN-TRAVERSAL` | `AC-DELEGATE-ROLE`, `AC-DELEGATE-STOPS-STEPS`, `AC-DELEGATE-EMITTED` |
+
+## Risk and rollback
+
+Risk is low because the new module is pure and `navigation-extract` only emits optional properties when callers supply them. Rollback is one commit revert; existing navigation conformance behavior remains unchanged when no interaction-shape metadata is present.


### PR DESCRIPTION
## Summary

Adds the missing interaction-shape `delegate` step role so delegation is modeled as the point where human-visible `stepsToOutcome` stops, while the delegated coworker path remains visible as metadata. This is the substrate slice for simplifying the platform UX without creating a second UX analyzer.

## Changes

- Adds `apps/web/lib/ea/interaction-shape.ts` with the closed `InteractionStepRole` set, delegation detection, and pure flow-load measurement.
- Adds regression tests for role validation, delegate termination, complete paths, dead ends, and missing entries.
- Extends `NavSourceEntry`/`buildNavigationModel` to pass through `jobLane`, `stepRole`, `continuesTo`, and `spineStage` properties.
- Adds the atomic implementation plan for `BI-5A1A3C13` under the inward UX simplification epic.

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] `pnpm --filter web typecheck`
  - [x] `pnpm --filter web exec vitest run lib/ea/interaction-shape.test.ts lib/ea/navigation-extract.test.ts lib/ea/navigation-conformance.test.ts`

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the governed shared nonprod env (lease id: `NPEL-74B34CF4FE`, finalized evidence below)
  - [x] Evidence captured below

- [x] **Verification-harness limitation acknowledged**: plan backlog coverage receipt cannot be minted until `BI-5A1A3C13` has an initiative scope baseline from an independent spec-approval gate.

### Verification evidence

- Targeted Vitest passed: `pnpm --filter web exec vitest run lib/ea/interaction-shape.test.ts lib/ea/navigation-extract.test.ts lib/ea/navigation-conformance.test.ts`.
- Typecheck passed: `pnpm --filter web typecheck`.
- Style drift guard passed: `node scripts/check-style-drift.mjs`.
- Doc/plan guards passed: doc index check, doc links, doc anchors, spec status frontmatter, spec/plan/doc gate, and plan backlog-coverage static gate.
- Exact-tree local-CI: `pnpm run pregate`; portal quiescence deferred evidence publication, then `pnpm run pregate -- --finalize-evidence`; authoritative status `pnpm run pregate:status -- --json` returned `PASS` for `18f172bc24e75f34e1812cf2024209dc80fa7a01`, evidence `cmtp6mc5k001201medeatnoax`.
- Semantic review: fresh receipt for `18f172bc24e75f34e1812cf2024209dc80fa7a01`, result `inconclusive` due `local-ci-active-capacity-reservation`, policy mode `shadow`, `mayPublish=true`, gate `bcefcb19a64e5ffd4dbc495ff6b22b6a3e9867876c68d216eed79d4c1c36370d`.
- Plan coverage MCP write after push: `record_plan_backlog_coverage` returned `traceability-incomplete` because no initiative scope baseline exists for `BI-5A1A3C13`; Workroom evidence recorded that blocker.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` before opening this PR

Local-CI-Evidence: cmtp6mc5k001201medeatnoax (feat/interaction-shape-delegate-role@18f172bc24e75f34e1812cf2024209dc80fa7a01)

## Related issues / Epic

Backlog: `BI-5A1A3C13`
Epic: `EP-4FF5273F` - Vertical Integration Inward
Workroom: `WC-06901F51`

## Epic / Backlog linkage (for multi-BI work)

Parent: `EP-4FF5273F` - Vertical Integration Inward
This PR covers: `BI-5A1A3C13` only. It does not implement the sibling `prerequisitesToEntry` or `spine-stage-inert` items.

## Overlap sweep

`gh pr list --state open --limit 50 --json number,title,headRefName,author,url` found one open PR: `#5090 docs: define reviewer recovery and Workroom shape evolution` on `doc/reviewer-recovery-shape`. `gh pr view 5090 --json files` showed no path overlap with this branch.

## Notes for the reviewer

This is intentionally a substrate change: it creates the small, reusable interaction-shape contract that later UX simplification work can consume, instead of adding another portal-specific analyzer. The branch may trail a fast-moving `origin/main`, but local-CI admitted and finalized a PASS for this exact head; PR health and required checks remain authoritative after GitHub opens the PR.

