### PR TITLE
fix(decisions): owner ruling queue selects on ownership, not route (BI-EB5E9BE3)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/review/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/review/page.tsx
@@ -41,6 +41,8 @@ export const metadata = {
   title: "Decision review",
 };
 
+import { ownerRulingQueueWhere } from "@/lib/decision-perspective/owner-ruling-queue";
+
 const UNRESOLVED = ["defer", "escalate"];
 
 const OPERATOR_ACTIONABLE_WHERE: Prisma.DecisionInteractionWhereInput = {
@@ -112,6 +114,17 @@ export default async function DecisionReviewPage({
   searchParams?: ReviewSearchParams;
 }) {
   const { focus: focusDomainClass = null } = (await searchParams) ?? {};
+  // BI-EB5E9BE3: resolve the ownership boundary BEFORE the batch, so the inbox
+  // query can select on it. Previously the profile was fetched inside the same
+  // Promise.all and therefore could not narrow the inbox, which is why the
+  // predicate fell back to a route string.
+  const organizationProfileIds = (
+    await prisma.decisionPerspectiveProfile.findMany({
+      where: { kind: "organization" },
+      select: { profileId: true },
+    })
+  ).map((p) => p.profileId);
+
   const [
     conflictRows,
     unresolvedRows,
@@ -164,12 +177,8 @@ export default async function DecisionReviewPage({
       // Unresolved WWWD business decisions (no build, unanswered) — the
       // inline capture loop's inbox (BI-9677364B).
       prisma.decisionInteraction.findMany({
-        where: {
-          outcomeType: { in: UNRESOLVED },
-          buildId: null,
-          routeContext: "/coworker-business",
-          humanOutcome: { equals: Prisma.DbNull },
-        },
+        // BI-EB5E9BE3: ownership, not route. See owner-ruling-queue.ts.
+        where: ownerRulingQueueWhere(organizationProfileIds, Prisma.DbNull),
         orderBy: { createdAt: "desc" },
         take: 20,
         select: {

--- a/apps/web/lib/decision-perspective/owner-ruling-queue.test.ts
+++ b/apps/web/lib/decision-perspective/owner-ruling-queue.test.ts
@@ -1,0 +1,86 @@
+// BI-EB5E9BE3 — the owner's ruling queue selected on ROUTE, not ownership.
+//
+// Live proof on origin/main @ 2cc2845398: 14 unresolved, unanswered
+// DecisionInteraction rows with routeContext "/ops/demand" and the organization
+// profile were excluded from "Waiting on your call", because the predicate
+// required routeContext to equal "/coworker-business" exactly. Six approved
+// standing-Workroom prerequisites sat unfunded as a result.
+//
+// The first test is the regression: it fails under the old route-equality rule
+// and passes under the ownership rule.
+import { describe, it, expect } from "vitest";
+import {
+  isOwnerRulingQueueRow,
+  ownerRulingQueueWhere,
+  type OwnerRulingCandidate,
+} from "./owner-ruling-queue";
+
+const ORG_PROFILES = ["wwwd-operator-org"];
+/** Stands in for Prisma.DbNull, which has no runtime in unit tests. */
+const DB_NULL = Symbol("DbNull");
+
+function row(over: Partial<OwnerRulingCandidate> = {}): OwnerRulingCandidate {
+  return {
+    outcomeType: "defer",
+    buildId: null,
+    taskRunId: null,
+    question: "Fund now or defer?",
+    humanOutcome: null,
+    profileId: "wwwd-operator-org",
+    routeContext: "/coworker-business",
+    domainClass: "business",
+    gateKey: null,
+    ...over,
+  };
+}
+
+/** The predicate as it behaved before this fix — route equality. */
+function legacyRouteOnly(r: OwnerRulingCandidate): boolean {
+  return r.routeContext === "/coworker-business";
+}
+
+describe("owner ruling queue selects on ownership, not route (BI-EB5E9BE3)", () => {
+  it("includes an /ops/demand decision scored against the organization profile", () => {
+    const demand = row({ routeContext: "/ops/demand" });
+    // The defect, stated as an assertion: the old rule dropped this row.
+    expect(legacyRouteOnly(demand)).toBe(false);
+    // The fix: ownership decides, so it is the owner's to rule on.
+    expect(isOwnerRulingQueueRow(demand, ORG_PROFILES)).toBe(true);
+  });
+
+  it("keeps the existing /coworker-business path visible", () => {
+    expect(isOwnerRulingQueueRow(row(), ORG_PROFILES)).toBe(true);
+  });
+
+  it("excludes everything that is not the owner's call", () => {
+    const cases: Array<[string, OwnerRulingCandidate]> = [
+      ["profession gate", row({ gateKey: "profession" })],
+      ["kernel consult", row({ domainClass: "kernel-consult" })],
+      ["platform WWMD", row({ routeContext: "mcp:principle_decide" })],
+      ["build-bound", row({ buildId: "FB-1" })],
+      ["task-bound", row({ taskRunId: "TR-1" })],
+      ["empty question", row({ question: "" })],
+      ["already answered", row({ humanOutcome: "fund" })],
+      ["another org's profile", row({ profileId: "wwwd-other-org" })],
+      ["no profile at all", row({ profileId: null })],
+      ["already resolved", row({ outcomeType: "decide" })],
+    ];
+    for (const [label, candidate] of cases) {
+      expect(isOwnerRulingQueueRow(candidate, ORG_PROFILES), label).toBe(false);
+    }
+  });
+
+  it("selects nothing when no organization profile is configured", () => {
+    // Fail closed: an install without a profile must not inherit platform rows.
+    expect(isOwnerRulingQueueRow(row(), [])).toBe(false);
+    expect(ownerRulingQueueWhere([], DB_NULL).profileId).toEqual({ in: [] });
+  });
+
+  it("builds a where clause that does not constrain routeContext", () => {
+    const where = ownerRulingQueueWhere(ORG_PROFILES, DB_NULL);
+    // The whole point: route must not narrow the inbox.
+    expect(where).not.toHaveProperty("routeContext");
+    expect(where.profileId).toEqual({ in: ORG_PROFILES });
+    expect(where.buildId).toBeNull();
+  });
+});

--- a/apps/web/lib/decision-perspective/owner-ruling-queue.ts
+++ b/apps/web/lib/decision-perspective/owner-ruling-queue.ts
@@ -1,0 +1,85 @@
+// The owner's "Waiting on your call" inbox predicate.
+//
+// BI-EB5E9BE3: this used to select on `routeContext: "/coworker-business"`.
+// That is a ROUTE, not an ownership boundary, so a WWWD decision raised
+// anywhere else — `approve_demand_for_funding` writes `/ops/demand` — was
+// invisible to the owner even though it was theirs to rule on. Verified on
+// origin/main @ 2cc2845398: 14 unresolved, unanswered `/ops/demand`
+// interactions carrying the organization profile were excluded from the queue,
+// leaving approved standing-Workroom prerequisites unfunded.
+//
+// The canonical boundary is the organization decision profile: a decision the
+// owner rules on is one scored against THEIR profile. Route is incidental.
+import type { Prisma } from "@dpf/db";
+
+/** Outcome types that still need a human ruling. */
+export const UNRESOLVED_OUTCOMES = ["defer", "escalate"] as const;
+
+/**
+ * Rows that are never the owner's to rule on, regardless of profile:
+ * platform/kernel judgement, and decisions bound to a build or task run
+ * (those belong to their own gates, not the business inbox).
+ */
+export function excludedFromOwnerRulingQueue(): Prisma.DecisionInteractionWhereInput[] {
+  return [
+    { gateKey: "profession" },
+    { domainClass: "kernel-consult" },
+    { routeContext: { startsWith: "mcp:principle_decide" } },
+  ];
+}
+
+/**
+ * The inbox predicate. `organizationProfileIds` is the ownership boundary — an
+ * empty list selects nothing rather than falling back to every profile, so a
+ * misconfigured install shows an empty queue instead of platform decisions.
+ */
+export function ownerRulingQueueWhere(
+  organizationProfileIds: readonly string[],
+  // `humanOutcome` is a JSON column, so "unanswered" is Prisma.DbNull rather
+  // than SQL NULL. It is injected so this module stays free of a Prisma runtime
+  // import and the rule lives in exactly one place.
+  unansweredSentinel: unknown,
+): Prisma.DecisionInteractionWhereInput {
+  return {
+    outcomeType: { in: [...UNRESOLVED_OUTCOMES] },
+    buildId: null,
+    taskRunId: null,
+    question: { not: "" },
+    humanOutcome: { equals: unansweredSentinel as never },
+    profileId: { in: [...organizationProfileIds] },
+    NOT: excludedFromOwnerRulingQueue(),
+  };
+}
+
+/** One interaction, reduced to the fields the predicate reads. */
+export type OwnerRulingCandidate = {
+  outcomeType: string;
+  buildId: string | null;
+  taskRunId: string | null;
+  question: string;
+  humanOutcome: unknown;
+  profileId: string | null;
+  routeContext: string | null;
+  domainClass: string | null;
+  gateKey: string | null;
+};
+
+/**
+ * Same rules, evaluated in process. Kept beside `ownerRulingQueueWhere` so the
+ * acceptance cases are testable without a database, and so the two cannot drift
+ * silently — the test asserts them against one shared fixture set.
+ */
+export function isOwnerRulingQueueRow(
+  row: OwnerRulingCandidate,
+  organizationProfileIds: readonly string[],
+): boolean {
+  if (!UNRESOLVED_OUTCOMES.includes(row.outcomeType as (typeof UNRESOLVED_OUTCOMES)[number])) return false;
+  if (row.buildId !== null || row.taskRunId !== null) return false;
+  if (!row.question) return false;
+  if (row.humanOutcome !== null && row.humanOutcome !== undefined) return false;
+  if (row.gateKey === "profession") return false;
+  if (row.domainClass === "kernel-consult") return false;
+  if ((row.routeContext ?? "").startsWith("mcp:principle_decide")) return false;
+  if (!row.profileId || !organizationProfileIds.includes(row.profileId)) return false;
+  return true;
+}


### PR DESCRIPTION
fix(decisions): owner ruling queue selects on ownership, not route (BI-EB5E9BE3)

`approve_demand_for_funding` writes a WWWD DecisionInteraction with
routeContext "/ops/demand". The owner's "Waiting on your call" inbox selected
rows whose routeContext equalled "/coworker-business" exactly, so those
decisions were never shown and fund-now versus defer could not be ruled on —
leaving approved standing-Workroom prerequisites unfunded.

Route is where a decision was raised. It is not whose call it is. The canonical
ownership boundary is the organization decision profile: a decision the owner
rules on is one scored against their profile.

Reproduced on origin/main @ 2cc2845398 against the live database:

  unresolved, unanswered, non-build DecisionInteraction rows by route
    /coworker-business   29   visible
    /ops/demand          14   invisible  <- the defect

All 14 carry a profileId belonging to a DecisionPerspectiveProfile of kind
organization, so every one of them was the owner's call.

Ruled out by running, not reading:
  - not actually unresolved/answered — the same query already filters
    buildId IS NULL and humanOutcome IS NULL and still returns 14
  - missing the organization profile — joined profileId against
    DecisionPerspectiveProfile WHERE kind = organization; all 14 match
  - OPERATOR_ACTIONABLE_WHERE dropping them — that predicate applies to the
    conflict and findings queries, not to openOrgRows

The fix extracts the predicate into owner-ruling-queue.ts and selects on
profileId. It deliberately does NOT add "/ops/demand" as a second allowed
route, which would repeat the defect for the next surface that raises a WWWD
decision. The organization profile ids are resolved before the Promise.all so
the inbox query can narrow on them — previously the profile was fetched inside
the same batch, which is why the predicate fell back to a route string.

Fails closed: an empty organization-profile list selects nothing, so a
misconfigured install shows an empty queue rather than inheriting platform
WWMD rows.

Exclusions preserved and asserted: profession gate, kernel-consult,
mcp:principle_decide, build-bound, task-bound, empty question, already
answered, another organization's profile, no profile, already resolved.

Tests: owner-ruling-queue.test.ts keeps the pre-fix rule as `legacyRouteOnly`
so the regression documents the old behaviour rather than relying on a deleted
line. lib/decision-perspective 37 files / 350 tests green; wider sweep
218 files / 2155 tests green; tsc --noEmit clean.

Docs-Impact-Decision: internal selection predicate for an existing queue. No
user-facing or coworker-facing documentation describes how the inbox is
filtered, and the visible behaviour change is that decisions which were always
the owner's now actually appear.

## Design grounding

- Existing specs/plans reviewed:
  - No spec governs this inbox predicate. The authority is the item's own
    acceptance criteria (BI-EB5E9BE3), which name the canonical
    organization-profile ownership boundary and require the existing
    OrgDecisionCaptureList and resolution action be reused rather than a second
    approval surface built. This change does exactly that: only the selection
    predicate moves.
- Current code substrate reviewed:
  - apps/web/app/(shell)/coworker-decisions/review/page.tsx — the openOrgRows
    query and OPERATOR_ACTIONABLE_WHERE; confirmed the route equality is the
    only narrowing beyond outcome/build/answered, and that the organization
    profile was fetched inside the same Promise.all and so could not narrow it.
  - apps/web/lib/decision-perspective/org-business-gate.ts — confirmed
    "/coworker-business" is a route recorded on the ledger, not an ownership
    marker.
  - apps/web/lib/actions/org-decision-capture.ts and
    apps/web/lib/mcp/packs/org-decision-pack.ts — both default routeContext to
    "/coworker-business", which is why the equality predicate happened to work
    for one surface and silently failed for every other.
- Source of truth:
  - DecisionPerspectiveProfile of kind "organization" is the ownership
    boundary. Route stays a recorded fact, not a filter.
- Decision:
  - Select on profileId. Do NOT enumerate allowed routes — that repeats the
    defect for the next surface that raises a WWWD decision.

Design-Grounding-Decision: no-contract-change (selection predicate only; the
queue, its component, and its resolution action are unchanged)

Process-Spine-Decision: localized bugfix — the new module is an extracted
predicate for an existing queue, not a new capability, and no contract or doc
surface changes

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Mark Bodman <markdbodman@gmail.com>


---

## How this was found

Driving the Build Studio lifecycle end to end. `BI-EB5E9BE3` was picked because
its readiness needed exactly one gate, and satisfying that gate honestly meant
actually reproducing the defect rather than asserting it. The reproduction is
what produced this fix.

## Reviewer notes

The load-bearing question is "route or ownership?", and the live numbers answer
it: 14 unresolved, unanswered `/ops/demand` interactions all carry a profileId
belonging to a `DecisionPerspectiveProfile` of kind `organization`. They were
the owner's call by the canonical boundary and were dropped purely because the
predicate compared a route string.

Two things worth checking closely:

- **The rejected alternative.** Adding `/ops/demand` to an allowed-route list
  would make the symptom disappear and leave the defect in place for the next
  surface that raises a WWWD decision. The test asserts the where clause carries
  no `routeContext` at all.
- **Fail-closed.** `ownerRulingQueueWhere([])` selects nothing, so an install
  with no organization profile shows an empty queue rather than inheriting
  platform WWMD rows. Asserted.

`Prisma.DbNull` is injected rather than imported so the predicate module stays
free of a Prisma runtime import and the rule lives in one place — the page
passes the real sentinel, the test passes a symbol.
