### PR TITLE
fix(review): stop a success condition from reading as a blocker (BI-8E1FD1BD)

### DIFF
--- a/apps/web/lib/tak/terminal-tool-policy.test.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.test.ts
@@ -359,6 +359,46 @@ describe("terminal tool policy", () => {
       result: { error: "terminal_writer_phase_reader_refused" },
     });
   });
+
+  // Observed on BI-8E1FD1BD spec-approval, 2026-09-06. The reviewer had already
+  // read the artifact successfully. It then hit this refusal six times and told
+  // a human "BLOCKED - immutable evidence unavailable; all six evidence-reader
+  // attempts failed" - the exact inverse of what the refusal says - and answered
+  // with prose instead of its verdict, so the run ended with no receipt. The
+  // refusal is a SUCCESS condition wearing an error's clothes, so its wording is
+  // load-bearing: it must not contain anything a model can hear as "missing",
+  // and it must say what happens if the writer is not called.
+  it("phrases the writer-phase reader refusal so it cannot be read as missing evidence", () => {
+    const resumed = enterTerminalWriterPhase(policy);
+    const refusal = resolveTerminalToolCall(resumed, [], "read_source_at_version");
+    expect(refusal.kind).toBe("refuse");
+    const message = refusal.kind === "refuse" ? refusal.result.message : "";
+
+    // States the true state before the instruction.
+    expect(message).toMatch(/SUCCESS, NOT A FAILURE/);
+    expect(message).toMatch(/persisted/);
+    expect(message).toMatch(/[Nn]othing is missing/);
+    // Names the consequence of answering with prose.
+    expect(message).toMatch(new RegExp(policy.writerToolName));
+    expect(message).toMatch(/NO receipt/);
+    // Both verdicts are legitimate, so a reviewer does not read the nudge as
+    // pressure to pass.
+    expect(message).toMatch(/fail/i);
+    // The words that caused the inversion must not appear.
+    expect(message).not.toMatch(/\bunavailable\b/i);
+    expect(message).not.toMatch(/\bblocked\b/i);
+  });
+
+  it("phrases the evidence-complete nudge the same way", () => {
+    const resumed = enterTerminalWriterPhase(policy);
+    const nudge = resolveTerminalTextExit(resumed, [], 0);
+    expect(nudge.kind).toBe("nudge");
+    const message = nudge.kind === "nudge" ? nudge.message : "";
+    expect(message).toMatch(/succeeded|complete/);
+    expect(message).toMatch(/[Nn]othing is missing/);
+    expect(message).toMatch(/NO receipt/);
+    expect(message).not.toMatch(/\bunavailable\b/i);
+  });
 });
 
 describe("agent loop terminal writer integration", () => {

--- a/apps/web/lib/tak/terminal-tool-policy.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.ts
@@ -317,12 +317,25 @@ export function resolveTerminalToolCall(
     };
   }
   if (policy.terminalPhase === "writer-only" && policy.readerToolNames.includes(toolName)) {
+    // BI-69BBC446 follow-up. This refusal used to read "Immutable evidence is
+    // already persisted. Call <writer> now." A reviewer took six refusals in a
+    // row and reported to a human: "BLOCKED - immutable evidence unavailable;
+    // all six evidence-reader attempts failed" - the exact inverse of what the
+    // refusal said. It then wrote prose instead of its verdict, and the run
+    // ended with no receipt. A success condition phrased as an error is read as
+    // an error, so this states the state first, the consequence second, and
+    // never uses a word the model can hear as "missing".
     return {
       kind: "refuse",
       result: {
         success: false,
         error: "terminal_writer_phase_reader_refused",
-        message: `Immutable evidence is already persisted. Call ${policy.writerToolName} now.`,
+        message:
+          `SUCCESS, NOT A FAILURE: you already read the bound artifact in full and it is persisted for this `
+          + `turn. Nothing is missing and there is nothing left to retrieve. Re-reading is declined only `
+          + `because it would be redundant. You have everything you need to judge. `
+          + `Call ${policy.writerToolName} now with your assessment - a pass and a fail are equally valid. `
+          + `If you answer with prose instead, this run ends with NO receipt recorded and your review is lost.`,
       },
     };
   }
@@ -473,6 +486,10 @@ export function resolveTerminalTextExit(
   return {
     kind: "nudge",
     allowedToolNames: [policy.writerToolName],
-    message: `Evidence retrieval is complete. Call ${policy.writerToolName} now with your independent assessment; do not respond with prose first.`,
+    message:
+      `Evidence retrieval is complete and succeeded - nothing is missing and you have everything you need to `
+      + `judge. Call ${policy.writerToolName} now with your independent assessment; a pass and a fail are `
+      + `equally valid outcomes. Answering with prose instead of the tool call ends this run with NO receipt `
+      + `recorded.`,
   };
 }


### PR DESCRIPTION
A reviewer in the bounded writer phase had already read its bound artifact in full. Every further read is declined by design, with:

> "Immutable evidence is already persisted. Call `<writer>` now."

On BI-8E1FD1BD spec-approval it took that refusal six times and reported to a human:

> **"BLOCKED — immutable evidence unavailable; all six evidence-reader attempts failed"**

The exact inverse of what the refusal said. It then answered with prose instead of recording its verdict, so the run ended `input-required` with no receipt — and it told the operator the receipt was *"waiting for your approval as an approval card"* when the system had already logged **"No receipt was created."**

A human was handed a false blocker and a false receipt, from a review that had actually succeeded at every step except the last one.

## Why the wording is the fix

The refusal is a **success condition wearing an error's clothes**: `success: false`, an error code, and a message whose first clause is a negation. A model reading it under nudge pressure resolves the ambiguity toward failure. Both that refusal and the evidence-complete nudge now:

- state the true state first — *"you already read the bound artifact in full and it is persisted"*, *"nothing is missing"*
- say plainly there is nothing left to retrieve
- name the consequence of answering with prose — **NO receipt recorded**
- say a pass and a fail are **equally valid**, so the nudge is not read as pressure to approve
- contain no word a model can hear as *missing*

That last point is load-bearing and I got it wrong first: my initial draft said *"do NOT report the artifact as unavailable"*, and the new test rejected it for containing the word at all. Negation is exactly the construction that failed here, so the test bans the trigger words outright rather than trusting the negation to survive.

Nothing about the phase machine, tool surface or receipt semantics changes.

## Verification

- 1499 tests across 134 suites pass (`lib/tak`), including two new cases pinning the wording of both messages
- `pnpm --filter web build` exits 0
- Guard parity preflight passes

## Gate status, stated honestly

Local-CI returned **BLOCKED (child signal death)** on three consecutive runs — the build child killed by SIGTERM under host memory pressure, at 1:29 and then 0:19. The gate's own text says this is infrastructure evidence, not a product build failure, and its typecheck stage recorded `classification=passed` before the kill. Pushed under `operator-emergency` with that reason recorded; the cloud merge queue runs the full build.

## Design grounding

**specs/plans reviewed:** `docs/superpowers/specs/2026-09-01-statutory-rate-acquisition-design.md` is the artifact the failing review was bound to; the governed-review contract it runs under lives in `apps/web/lib/mcp-task-review-contract.ts`.

**code substrate:** `apps/web/lib/tak/terminal-tool-policy.ts` holds the phase machine (`enterTerminalWriterPhase`, `resolveTerminalToolCall`, `resolveTerminalTextExit`); `apps/web/lib/mcp-task-execution.ts` applies it per dispatch; `apps/web/lib/mcp-task-review-contract.ts` pins the reader arguments. Only the two message strings change.

Design-Grounding-Decision: no-contract-change (message wording only on an existing governed review path)

Docs-Impact-Decision: agent-facing tool-refusal copy on an existing governed path. No route, contract or user-guide surface changes.

Process-Spine-Decision: no new capability — corrects the copy of two existing messages; the durable record of why lives in BI-8E1FD1BD.