### PR TITLE
fix(workrooms): observe squash-safe PR delivery (BI-9FF39058)

### DIFF
--- a/apps/web/lib/contributor-change-lanes/github-rest-reader.test.ts
+++ b/apps/web/lib/contributor-change-lanes/github-rest-reader.test.ts
@@ -129,6 +129,7 @@ describe("readGithubPullRequests", () => {
     }
     // First fetch carried no If-None-Match (initial etag from prior run is empty {})
     const firstCallHeaders = fetchImpl.mock.calls[0]?.[1].headers as Record<string, string>;
+    expect(fetchImpl.mock.calls[0]?.[0]).toContain("state=all");
     expect(firstCallHeaders["If-None-Match"]).toBeUndefined();
     expect(firstCallHeaders.Authorization).toBe("Bearer ghp_decrypted_xxxxxxxxx");
     // Etag persisted to metadata, preserving sibling keys
@@ -137,6 +138,61 @@ describe("readGithubPullRequests", () => {
         data: { metadata: { other: "preserved", githubPrEtag: '"new-etag-abc"' } },
       }),
     );
+  });
+
+  it("persists exact authored-head and squash-merge provenance", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:xxx",
+      status: "active",
+    });
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      makeResponse([
+        makeRawPr(5090, {
+          state: "closed",
+          head: { ref: "fix/squash", sha: "a".repeat(40) },
+          merge_commit_sha: "b".repeat(40),
+          merged_at: "2026-09-06T04:00:00.000Z",
+          updated_at: "2026-09-06T04:00:01.000Z",
+        }),
+      ]),
+    );
+
+    const result = await readGithubPullRequests({
+      fetchImpl: fetchImpl as never,
+      now: () => new Date("2026-09-06T04:01:00.000Z"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows[0]).toMatchObject({
+      sourceKey: "5090",
+      payload: {
+        repositoryFullName: "o/r",
+        number: 5090,
+        state: "merged",
+        headSha: "a".repeat(40),
+        mergeCommitSha: "b".repeat(40),
+        mergedAt: "2026-09-06T04:00:00.000Z",
+        providerUpdatedAt: "2026-09-06T04:00:01.000Z",
+        observedAt: "2026-09-06T04:01:00.000Z",
+        providerApiVersion: "github-rest/2022-11-28",
+        observationFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    });
+  });
+
+  it("drops an unknown provider state instead of projecting it as open", async () => {
+    mocks.credentialFindUnique.mockResolvedValueOnce({
+      secretRef: "enc:xxx",
+      status: "active",
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse([makeRawPr(5092, { state: "future-state" })]));
+
+    const result = await readGithubPullRequests({ fetchImpl: fetchImpl as never });
+
+    expect(result).toMatchObject({ ok: true, rows: [] });
   });
 
   it("sends If-None-Match from ScheduledJob.metadata.githubPrEtag on the first page", async () => {
@@ -245,15 +301,19 @@ describe("parseRepoFromUrl", () => {
   });
 });
 
-function makeRawPr(n: number) {
+function makeRawPr(n: number, overrides: Record<string, unknown> = {}) {
   return {
     number: n,
     html_url: `https://github.com/o/r/pull/${n}`,
     title: `PR ${n}`,
-    head: { ref: `feat/branch-${n}` },
+    head: { ref: `feat/branch-${n}`, sha: n.toString(16).padStart(40, "0") },
     state: "open",
     draft: false,
     mergeable_state: "CLEAN",
+    updated_at: "2026-09-06T03:00:00.000Z",
+    merged_at: null,
+    merge_commit_sha: null,
+    ...overrides,
   };
 }
 

--- a/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
+++ b/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
@@ -16,6 +16,10 @@
 
 import { createOffThreadpoolFetchTransport } from "@/lib/network/off-threadpool-fetch";
 
+import {
+  createPullRequestObservation,
+  parseVerifiedPullRequestObservation,
+} from "./pull-request-observation";
 import type { PullRequestSnapshot } from "./types";
 
 const GITHUB_PR_CREDENTIAL_PROVIDER_ID = "github-pr-sync";
@@ -47,6 +51,8 @@ export type GithubReaderResult =
 export type GithubReaderDeps = {
   /** Injection point so tests don't fetch real URLs. */
   fetchImpl?: typeof fetch;
+  /** One operation timestamp, injected so every page in a sync is comparable. */
+  now?: () => Date;
 };
 
 /** Resolved repo coordinates `{owner}/{repo}`. */
@@ -76,7 +82,7 @@ export async function cancelGithubResponseBody(response: Response): Promise<void
 }
 
 /**
- * Production GitHub PR reader. Returns the rows for the open-PR list,
+ * Production GitHub PR reader. Returns the rows for the open and terminal PR list,
  * tagged with sourceKey = PR number as string. The pure runner in
  * contributor-inventory-sync.ts wraps this into a SyncSourceResult.
  */
@@ -85,6 +91,7 @@ export async function readGithubPullRequests(
 ): Promise<GithubReaderResult> {
   const { prisma } = await import("@dpf/db");
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const observedAt = (deps.now ?? (() => new Date()))().toISOString();
 
   const token = await resolveGithubToken(prisma);
   if (!token) {
@@ -100,7 +107,7 @@ export async function readGithubPullRequests(
   const previousEtag = await loadEtag(prisma);
 
   try {
-    const result = await fetchOpenPullRequests(fetchImpl, repo, token, previousEtag);
+    const result = await fetchPullRequests(fetchImpl, repo, token, previousEtag, observedAt);
     if (result.kind === "not-modified") {
       return {
         ok: true,
@@ -254,11 +261,12 @@ type FetchOutcome =
   | { kind: "not-modified"; rateLimitRemaining?: number; rateLimitResetAt?: Date | null }
   | { kind: "error"; error: string };
 
-async function fetchOpenPullRequests(
+async function fetchPullRequests(
   fetchImpl: typeof fetch,
   repo: RepoIdentity,
   token: string,
   ifNoneMatch: string | null,
+  observedAt: string,
 ): Promise<FetchOutcome> {
   const rows: SnapshotRowPayload[] = [];
   let etag: string | null = null;
@@ -266,7 +274,7 @@ async function fetchOpenPullRequests(
   let rateLimitResetAt: Date | null | undefined;
 
   for (let page = 1; page <= DEFAULT_MAX_PAGES; page++) {
-    const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls?state=open&per_page=${DEFAULT_PER_PAGE}&page=${page}`;
+    const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls?state=all&sort=updated&direction=desc&per_page=${DEFAULT_PER_PAGE}&page=${page}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",
@@ -312,7 +320,7 @@ async function fetchOpenPullRequests(
 
     const json = (await res.json()) as RawPullRequest[];
     for (const pr of json) {
-      const parsed = parsePullRequest(pr);
+      const parsed = parsePullRequest(pr, repo, observedAt);
       if (parsed) {
         rows.push({ sourceKey: String(parsed.number), payload: parsed });
       }
@@ -348,27 +356,52 @@ type RawPullRequest = {
   url?: string;
   html_url?: string;
   title?: string;
-  head?: { ref?: string };
+  head?: { ref?: string; sha?: string };
   state?: string;
   draft?: boolean;
   mergeable_state?: string;
+  merge_commit_sha?: string | null;
+  merged_at?: string | null;
+  updated_at?: string;
 };
 
-function parsePullRequest(pr: RawPullRequest): PullRequestSnapshot | null {
-  if (typeof pr.number !== "number" || !pr.head?.ref || !pr.html_url) return null;
-  return {
+function parsePullRequest(
+  pr: RawPullRequest,
+  repo: RepoIdentity,
+  observedAt: string,
+): PullRequestSnapshot | null {
+  if (
+    typeof pr.number !== "number" ||
+    !pr.head?.ref ||
+    !pr.head.sha ||
+    !pr.html_url ||
+    !pr.updated_at
+  ) {
+    return null;
+  }
+  const state = normalizeState(pr);
+  if (!state) return null;
+  const observation = createPullRequestObservation({
+    repositoryFullName: `${repo.owner}/${repo.name}`,
     number: pr.number,
     url: pr.html_url,
     title: pr.title ?? "",
     headBranch: pr.head.ref,
-    state: normalizeState(pr.state),
+    headSha: pr.head.sha,
+    state,
     isDraft: pr.draft === true,
     mergeStateStatus: pr.mergeable_state ?? null,
-  };
+    mergeCommitSha: state === "merged" ? pr.merge_commit_sha ?? null : null,
+    mergedAt: state === "merged" ? pr.merged_at ?? null : null,
+    providerUpdatedAt: pr.updated_at,
+    observedAt,
+  });
+  return parseVerifiedPullRequestObservation(observation);
 }
 
-function normalizeState(s: string | undefined): PullRequestSnapshot["state"] {
-  if (s === "open") return "open";
-  if (s === "closed") return "closed";
-  return "open";
+function normalizeState(pr: RawPullRequest): PullRequestSnapshot["state"] | null {
+  if (pr.merged_at) return "merged";
+  if (pr.state === "open") return "open";
+  if (pr.state === "closed") return "closed";
+  return null;
 }

--- a/apps/web/lib/contributor-change-lanes/pull-request-observation.test.ts
+++ b/apps/web/lib/contributor-change-lanes/pull-request-observation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPullRequestObservation,
+  parseVerifiedPullRequestObservation,
+  selectLatestExactPullRequestObservation,
+} from "./pull-request-observation";
+
+const REPO = "OpenDigitalProductFactory/opendigitalproductfactory";
+
+function observation(
+  overrides: Partial<Parameters<typeof createPullRequestObservation>[0]> = {},
+) {
+  return createPullRequestObservation({
+    repositoryFullName: REPO,
+    number: 5090,
+    url: `https://github.com/${REPO}/pull/5090`,
+    title: "Delivery observation",
+    headBranch: "fix/delivery-observation",
+    headSha: "a".repeat(40),
+    state: "open",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    mergeCommitSha: null,
+    mergedAt: null,
+    providerUpdatedAt: "2026-09-06T04:00:00.000Z",
+    observedAt: "2026-09-06T04:01:00.000Z",
+    ...overrides,
+  });
+}
+
+describe("verified pull-request observations", () => {
+  it("round-trips an authenticated repository/PR/head observation", () => {
+    const value = observation({ providerUpdatedAt: "2026-09-06T04:00:00Z" });
+
+    expect(parseVerifiedPullRequestObservation(value)).toEqual(value);
+    expect(value.observationFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(value.providerApiVersion).toBe("github-rest/2022-11-28");
+  });
+
+  it("rejects tampered, legacy, or incomplete payloads", () => {
+    const value = observation();
+    expect(
+      parseVerifiedPullRequestObservation({ ...value, headSha: "b".repeat(40) }),
+    ).toBeNull();
+    expect(
+      parseVerifiedPullRequestObservation({
+        number: 5090,
+        state: "merged",
+        headBranch: "fix/delivery-observation",
+      }),
+    ).toBeNull();
+    expect(
+      parseVerifiedPullRequestObservation(
+        observation({ url: `https://github.com/${REPO}/pull/5091` }),
+      ),
+    ).toBeNull();
+  });
+
+  it("binds repository, PR and authored head exactly", () => {
+    const value = observation({
+      state: "merged",
+      mergeCommitSha: "c".repeat(40),
+      mergedAt: "2026-09-06T04:00:00Z",
+    });
+
+    expect(
+      selectLatestExactPullRequestObservation([value], {
+        repositoryFullName: REPO,
+        pullRequestNumber: 5090,
+        headSha: "a".repeat(40),
+      }),
+    ).toEqual(value);
+    expect(
+      selectLatestExactPullRequestObservation([value], {
+        repositoryFullName: REPO,
+        pullRequestNumber: 5090,
+        headSha: "d".repeat(40),
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps a matching merge monotonic across duplicate or out-of-order rows", () => {
+    const merged = observation({
+      state: "merged",
+      mergeCommitSha: "c".repeat(40),
+      mergedAt: "2026-09-06T04:00:00.000Z",
+      providerUpdatedAt: "2026-09-06T04:00:00.000Z",
+    });
+    const outOfOrderOpen = observation({
+      state: "open",
+      providerUpdatedAt: "2026-09-06T04:02:00.000Z",
+      observedAt: "2026-09-06T04:03:00.000Z",
+    });
+
+    expect(
+      selectLatestExactPullRequestObservation([outOfOrderOpen, merged], {
+        repositoryFullName: REPO,
+        pullRequestNumber: 5090,
+        headSha: "a".repeat(40),
+      }),
+    ).toEqual(merged);
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/pull-request-observation.ts
+++ b/apps/web/lib/contributor-change-lanes/pull-request-observation.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+
+export const PULL_REQUEST_OBSERVATION_VERSION = "github-rest/2022-11-28" as const;
+
+export type PullRequestObservation = {
+  repositoryFullName: string;
+  number: number;
+  url: string;
+  title: string;
+  headBranch: string;
+  headSha: string;
+  state: "open" | "merged" | "closed";
+  isDraft: boolean;
+  mergeStateStatus: string | null;
+  mergeCommitSha: string | null;
+  mergedAt: string | null;
+  providerUpdatedAt: string;
+  observedAt: string;
+  providerApiVersion: typeof PULL_REQUEST_OBSERVATION_VERSION;
+  observationFingerprint: string;
+};
+
+export type PullRequestObservationInput = Omit<
+  PullRequestObservation,
+  "providerApiVersion" | "observationFingerprint"
+>;
+
+export type PullRequestObservationIdentity = {
+  repositoryFullName: string;
+  pullRequestNumber: number;
+  headSha: string;
+};
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const FINGERPRINT_PATTERN = /^[a-f0-9]{64}$/;
+const REPOSITORY_PATTERN = /^[^/\s]+\/[^/\s]+$/;
+
+function canonicalFingerprintPayload(
+  value: Omit<PullRequestObservation, "observationFingerprint" | "observedAt">,
+): string {
+  return JSON.stringify({
+    providerApiVersion: value.providerApiVersion,
+    repositoryFullName: value.repositoryFullName,
+    number: value.number,
+    url: value.url,
+    title: value.title,
+    headBranch: value.headBranch,
+    headSha: value.headSha.toLowerCase(),
+    state: value.state,
+    isDraft: value.isDraft,
+    mergeStateStatus: value.mergeStateStatus,
+    mergeCommitSha: value.mergeCommitSha?.toLowerCase() ?? null,
+    mergedAt: value.mergedAt,
+    providerUpdatedAt: value.providerUpdatedAt,
+  });
+}
+
+function fingerprint(
+  value: Omit<PullRequestObservation, "observationFingerprint" | "observedAt">,
+): string {
+  return createHash("sha256").update(canonicalFingerprintPayload(value), "utf8").digest("hex");
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  return (
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(value) &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function hasMatchingPullRequestUrl(
+  url: string,
+  repositoryFullName: string,
+  number: number,
+): boolean {
+  return url.toLowerCase() === `https://github.com/${repositoryFullName}/pull/${number}`.toLowerCase();
+}
+
+/**
+ * Build the authenticated provider fact stored by the GitHub inventory reader.
+ * The fingerprint intentionally excludes observedAt: two polls that see the same
+ * provider state are duplicates, while providerUpdatedAt changes with real state.
+ */
+export function createPullRequestObservation(
+  input: PullRequestObservationInput,
+): PullRequestObservation {
+  const withoutFingerprint = {
+    ...input,
+    providerApiVersion: PULL_REQUEST_OBSERVATION_VERSION,
+  };
+  return {
+    ...withoutFingerprint,
+    observationFingerprint: fingerprint(withoutFingerprint),
+  };
+}
+
+/**
+ * Verify a stored provider payload before it can influence Workroom lifecycle.
+ * Legacy and partially populated snapshots remain visible as inventory history,
+ * but they are not authority for either "open" or "delivered" classification.
+ */
+export function parseVerifiedPullRequestObservation(
+  value: unknown,
+): PullRequestObservation | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (
+    row.providerApiVersion !== PULL_REQUEST_OBSERVATION_VERSION ||
+    typeof row.repositoryFullName !== "string" ||
+    !REPOSITORY_PATTERN.test(row.repositoryFullName) ||
+    typeof row.number !== "number" ||
+    !Number.isSafeInteger(row.number) ||
+    row.number <= 0 ||
+    typeof row.url !== "string" ||
+    !hasMatchingPullRequestUrl(row.url, row.repositoryFullName, row.number) ||
+    typeof row.title !== "string" ||
+    typeof row.headBranch !== "string" ||
+    row.headBranch.length === 0 ||
+    typeof row.headSha !== "string" ||
+    !SHA_PATTERN.test(row.headSha) ||
+    !["open", "merged", "closed"].includes(String(row.state)) ||
+    typeof row.isDraft !== "boolean" ||
+    !isNullableString(row.mergeStateStatus) ||
+    !isNullableString(row.mergeCommitSha) ||
+    (row.mergeCommitSha !== null && !SHA_PATTERN.test(row.mergeCommitSha)) ||
+    !(row.mergedAt === null || isIsoTimestamp(row.mergedAt)) ||
+    !isIsoTimestamp(row.providerUpdatedAt) ||
+    !isIsoTimestamp(row.observedAt) ||
+    typeof row.observationFingerprint !== "string" ||
+    !FINGERPRINT_PATTERN.test(row.observationFingerprint)
+  ) {
+    return null;
+  }
+  const parsed = row as PullRequestObservation;
+  if (
+    (parsed.state === "merged" &&
+      (parsed.mergedAt === null || parsed.mergeCommitSha === null)) ||
+    (parsed.state !== "merged" &&
+      (parsed.mergedAt !== null || parsed.mergeCommitSha !== null))
+  ) {
+    return null;
+  }
+  const expected = fingerprint(parsed);
+  return expected === parsed.observationFingerprint ? parsed : null;
+}
+
+function compareNewest(a: PullRequestObservation, b: PullRequestObservation): number {
+  const providerDelta = Date.parse(a.providerUpdatedAt) - Date.parse(b.providerUpdatedAt);
+  if (providerDelta !== 0) return providerDelta;
+  const observationDelta = Date.parse(a.observedAt) - Date.parse(b.observedAt);
+  if (observationDelta !== 0) return observationDelta;
+  return a.observationFingerprint.localeCompare(b.observationFingerprint);
+}
+
+/**
+ * Select one exact provider fact without letting a late/out-of-order open event
+ * undo a merge already observed for the same repository, PR, and authored head.
+ */
+export function selectLatestExactPullRequestObservation(
+  payloads: readonly unknown[],
+  identity: PullRequestObservationIdentity,
+): PullRequestObservation | null {
+  const matching = payloads
+    .map(parseVerifiedPullRequestObservation)
+    .filter((row): row is PullRequestObservation => Boolean(row))
+    .filter(
+      (row) =>
+        row.repositoryFullName.toLowerCase() === identity.repositoryFullName.toLowerCase() &&
+        row.number === identity.pullRequestNumber &&
+        row.headSha.toLowerCase() === identity.headSha.toLowerCase(),
+    );
+  const merged = matching.filter((row) => row.state === "merged");
+  const candidates = merged.length > 0 ? merged : matching;
+  return candidates.sort(compareNewest).at(-1) ?? null;
+}

--- a/apps/web/lib/contributor-change-lanes/types.ts
+++ b/apps/web/lib/contributor-change-lanes/types.ts
@@ -167,13 +167,21 @@ export type GitBranchSnapshot = {
 };
 
 export type PullRequestSnapshot = {
+  repositoryFullName?: string;
   number: number;
   url: string;
   title: string;
   headBranch: string;
+  headSha?: string;
   state: "open" | "merged" | "closed";
   isDraft: boolean;
   mergeStateStatus: string | null;
+  mergeCommitSha?: string | null;
+  mergedAt?: string | null;
+  providerUpdatedAt?: string;
+  observedAt?: string;
+  providerApiVersion?: string;
+  observationFingerprint?: string;
 };
 
 export type LaneProjectionInput = {

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
@@ -216,6 +216,21 @@ describe("runContributorInventorySync", () => {
     expect(result.perSourceResult["github-pr"].state).toBe("not-configured");
   });
 
+  it("records a provider not-modified response so consumers can renew prior observations", async () => {
+    const result = await runContributorInventorySync({
+      now: FIXED_NOW,
+      readers: fakeReaders({
+        githubPr: async () => ({ ok: true, rows: [], unchanged: true }),
+      }),
+    });
+
+    expect(result.perSourceResult["github-pr"]).toMatchObject({
+      ok: true,
+      count: 0,
+      unchanged: true,
+    });
+  });
+
   it("stuck-run reaper: when reapStuckRuns=true, marks pre-existing running rows older than the threshold as failed before the new run", async () => {
     mocks.syncRunUpdateMany.mockResolvedValue({ count: 2 });
 

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.ts
@@ -56,7 +56,7 @@ const NOTIFICATION_CRON_SUBJECT = "contributor-inventory-sync";
 export type SyncSourceKey = "git-worktree" | "git-branch" | "github-pr";
 
 export type SyncSourceResult =
-  | { ok: true; rows: SnapshotRowPayload[] }
+  | { ok: true; rows: SnapshotRowPayload[]; unchanged?: boolean }
   | { ok: false; error: string; state?: "not-configured" | "error" };
 
 export type SnapshotRowPayload = {
@@ -108,6 +108,8 @@ export type PerSourceSummary = {
   count: number;
   error: string | null;
   state?: "ok" | "not-configured" | "error";
+  /** The provider authenticated that its previously stored representation is current. */
+  unchanged?: boolean;
 };
 
 /**
@@ -508,7 +510,13 @@ async function syncStaleCronNotification(
 
 function summarize(res: SyncSourceResult): PerSourceSummary {
   if (res.ok) {
-    return { ok: true, count: res.rows.length, error: null, state: "ok" };
+    return {
+      ok: true,
+      count: res.rows.length,
+      error: null,
+      state: "ok",
+      ...(res.unchanged ? { unchanged: true } : {}),
+    };
   }
   return {
     ok: false,
@@ -580,7 +588,7 @@ async function createDefaultReaders(): Promise<SyncSourceReaders> {
       if (!result.ok) {
         return { ok: false, error: result.error, state: result.state };
       }
-      return { ok: true, rows: result.rows };
+      return { ok: true, rows: result.rows, unchanged: result.unchanged };
     },
   };
 }

--- a/apps/web/lib/work-capsules/liveness.test.ts
+++ b/apps/web/lib/work-capsules/liveness.test.ts
@@ -182,7 +182,7 @@ describe("classifyWorkCapsuleLiveness", () => {
     expect(v).toMatchObject({ liveness: "recovery-required", isLive: false, isReapable: false });
   });
 
-  it("treats an open PR as live even after the authoring lease lapsed", () => {
+  it("does not treat a stored PR identity as observed open state", () => {
     const v = classifyWorkCapsuleLiveness(
       row({
         executorKind: "codex-desktop",
@@ -191,9 +191,42 @@ describe("classifyWorkCapsuleLiveness", () => {
       }),
       NOW,
     );
+    expect(v.liveness).toBe("lease-expired");
+    expect(v.isReapable).toBe(true);
+  });
+
+  it("treats only a fresh explicit open observation as live", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: "codex-desktop",
+        leaseExpiresAt: new Date("2026-08-04T00:00:00.000Z"),
+        pullRequestNumber: 4055,
+        pullRequestObservation: {
+          state: "open",
+          observedAt: new Date("2026-08-05T14:50:00.000Z"),
+        },
+      }),
+      NOW,
+    );
     expect(v.liveness).toBe("live");
     expect(v.isReapable).toBe(false);
     expect(v.reason).toContain("#4055");
+  });
+
+  it("does not keep a room live from a stale open observation", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: "codex-desktop",
+        leaseExpiresAt: new Date("2026-08-04T00:00:00.000Z"),
+        pullRequestNumber: 4055,
+        pullRequestObservation: {
+          state: "open",
+          observedAt: new Date("2026-08-05T14:00:00.000Z"),
+        },
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("lease-expired");
   });
 
   it("marks a capsule dead when its linked build is terminal (zombie BS capsule)", () => {

--- a/apps/web/lib/work-capsules/liveness.ts
+++ b/apps/web/lib/work-capsules/liveness.ts
@@ -96,6 +96,10 @@ const REAPABLE_LIVENESS = new Set<WorkCapsuleLiveness>([
  *  DELIVERED (merged) room bypasses the grace: it need not resume. */
 export const WORK_CAPSULE_PAUSE_GRACE_MS = 24 * 60 * 60 * 1000;
 
+/** Provider "open" is a renewable liveness fact, not a permanent property. */
+export const WORK_CAPSULE_OPEN_PR_FRESHNESS_MS = 20 * 60 * 1000;
+const PROVIDER_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
 export type CapsuleLivenessInput = {
   status: string;
   executorKind: string | null;
@@ -104,6 +108,11 @@ export type CapsuleLivenessInput = {
   updatedAt: Date;
   pullRequestUrl: string | null;
   pullRequestNumber?: number | null;
+  /** Verified provider state for this exact repository/PR/authored-head tuple. */
+  pullRequestObservation?: {
+    state: "open" | "merged" | "closed";
+    observedAt: Date;
+  } | null;
   /**
    * Snapshot of the linked Build Studio FeatureBuild, when this capsule is a
    * build-studio capsule and the caller has loaded it. `phase` drives the
@@ -115,10 +124,9 @@ export type CapsuleLivenessInput = {
   taskRun?: { status: string | null; updatedAt: Date | null } | null;
   durableWait?: { state: "queued" | "active"; signaledAt: Date | null } | null;
   /**
-   * Whether this capsule's work is DELIVERED, computed by the caller from LOCAL
-   * git reachability (branch head reachable from the trunk = merged) — never the
-   * GitHub PR API and never an LLM. When `merged` is true the room is closed out
-   * as delivered regardless of lease state. Absent/null when not computed.
+   * Whether this capsule's work is DELIVERED, computed by the caller from a
+   * verified provider observation or positive local git reachability — never an
+   * LLM. When `merged` is true the room is closed out regardless of lease state.
    */
   deliveredSignal?: { merged: boolean } | null;
 };
@@ -145,8 +153,16 @@ export type CapsuleLivenessVerdict = {
   trueLivenessAt: Date | null;
 };
 
-function hasOpenPr(input: CapsuleLivenessInput): boolean {
-  return Boolean(input.pullRequestUrl) || (input.pullRequestNumber ?? 0) > 0;
+function hasOpenPr(input: CapsuleLivenessInput, now: Date): boolean {
+  if (
+    !input.pullRequestObservation ||
+    input.pullRequestObservation.state !== "open" ||
+    (!input.pullRequestUrl && (input.pullRequestNumber ?? 0) <= 0)
+  ) {
+    return false;
+  }
+  const age = now.getTime() - input.pullRequestObservation.observedAt.getTime();
+  return age >= -PROVIDER_CLOCK_SKEW_MS && age <= WORK_CAPSULE_OPEN_PR_FRESHNESS_MS;
 }
 
 function humanAge(ms: number): string {
@@ -201,10 +217,8 @@ export function classifyWorkCapsuleLiveness(
     return verdict("terminal", `Capsule already ${input.status}.`, null);
   }
 
-  // DELIVERED wins over every liveness signal: if the branch head is reachable
-  // from the trunk (merged — computed locally, no GitHub API, no LLM) the work
-  // is done and the session need not resume, so close out as delivered rather
-  // than waiting on a lease or mislabelling it abandoned.
+  // DELIVERED wins over every liveness signal. The caller may prove it from an
+  // exact authenticated provider merge or positive local trunk reachability.
   if (input.deliveredSignal?.merged) {
     return verdict(
       "delivered",
@@ -215,9 +229,13 @@ export function classifyWorkCapsuleLiveness(
 
   // An open PR is the live artifact even if the authoring session's lease has
   // since lapsed — the work is in review / the merge queue, not abandoned.
-  if (hasOpenPr(input)) {
+  if (hasOpenPr(input, now)) {
     const label = input.pullRequestNumber ? `PR #${input.pullRequestNumber}` : "an open PR";
-    return verdict("live", `Parked in review as ${label}.`, input.lastSyncedAt ?? null);
+    return verdict(
+      "live",
+      `Parked in review as ${label} (verified provider observation).`,
+      input.pullRequestObservation?.observedAt ?? null,
+    );
   }
 
   const taskRun = input.taskRun ?? null;

--- a/apps/web/lib/work-capsules/work-capsule-reaper.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-reaper.test.ts
@@ -14,6 +14,7 @@ const { prismaMock } = vi.hoisted(() => ({
 vi.mock("@dpf/db", () => ({ prisma: prismaMock }));
 
 import {
+  annotateProviderDeliverySignals,
   annotateDeliveredSignals,
   reconcileTerminalCapsuleBacklogs,
   reapStaleWorkCapsules,
@@ -121,6 +122,7 @@ function capsule(overrides: Record<string, unknown> = {}) {
     updatedAt: NOW,
     pullRequestUrl: null,
     pullRequestNumber: null,
+    repositoryFullName: null,
     headBranch: null,
     headSha: null,
     worktreePath: null,
@@ -141,7 +143,12 @@ describe("selectReapCandidates", () => {
       capsule({ capsuleId: "WC-ZOMBIE", featureBuildId: "fb-abandoned" }),
       capsule({ capsuleId: "WC-BUILDING", featureBuildId: "fb-building" }),
       capsule({ capsuleId: "WC-FROZEN14", updatedAt: new Date("2026-08-02T14:00:00.000Z") }),
-      capsule({ capsuleId: "WC-PR", pullRequestNumber: 4055, leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z") }),
+      capsule({
+        capsuleId: "WC-PR",
+        pullRequestNumber: 4055,
+        leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+        pullRequestObservation: { state: "open", observedAt: new Date("2026-08-05T14:55:00.000Z") },
+      }),
       capsule({ capsuleId: "WC-DONE", status: "complete", updatedAt: new Date("2026-06-01T00:00:00.000Z") }),
       capsule({ capsuleId: "WC-NEW", updatedAt: new Date("2026-08-05T14:45:00.000Z") }),
     ];
@@ -219,6 +226,84 @@ describe("annotateDeliveredSignals (procedural, local git — no LLM, no GitHub 
   });
 });
 
+describe("annotateProviderDeliverySignals (BI-9FF39058)", () => {
+  const merged = {
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    number: 5090,
+    url: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5090",
+    title: "Squash-safe delivery",
+    headBranch: "fix/squash",
+    headSha: "a".repeat(40),
+    state: "merged",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    mergeCommitSha: "b".repeat(40),
+    mergedAt: "2026-08-05T14:50:00.000Z",
+    providerUpdatedAt: "2026-08-05T14:50:00.000Z",
+    observedAt: "2026-08-05T14:51:00.000Z",
+    providerApiVersion: "github-rest/2022-11-28",
+    observationFingerprint: "fixture-is-replaced-by-helper",
+  };
+
+  it("marks a source-free squash merge delivered only for the exact authored head", async () => {
+    const { createPullRequestObservation } = await import(
+      "../contributor-change-lanes/pull-request-observation"
+    );
+    const payload = createPullRequestObservation(merged as never);
+    const rows = [
+      capsule({
+        capsuleId: "WC-MATCH",
+        repositoryFullName: merged.repositoryFullName,
+        pullRequestNumber: 5090,
+        headSha: merged.headSha,
+      }),
+      capsule({
+        capsuleId: "WC-LATER-HEAD",
+        repositoryFullName: merged.repositoryFullName,
+        pullRequestNumber: 5090,
+        headSha: "c".repeat(40),
+      }),
+    ] as any[];
+
+    await annotateProviderDeliverySignals(rows, [payload], NOW);
+
+    expect(rows[0].deliveredSignal).toEqual({ merged: true });
+    expect(rows[1].deliveredSignal).toBeUndefined();
+  });
+
+  it("projects a fresh matching open observation, but not a stale one", async () => {
+    const { createPullRequestObservation } = await import(
+      "../contributor-change-lanes/pull-request-observation"
+    );
+    const open = createPullRequestObservation({
+      ...merged,
+      state: "open",
+      mergeCommitSha: null,
+      mergedAt: null,
+    } as never);
+    const fresh = capsule({
+      repositoryFullName: merged.repositoryFullName,
+      pullRequestNumber: 5090,
+      headSha: merged.headSha,
+    }) as any;
+    const stale = capsule({
+      repositoryFullName: merged.repositoryFullName,
+      pullRequestNumber: 5090,
+      headSha: merged.headSha,
+    }) as any;
+
+    await annotateProviderDeliverySignals([fresh], [open], NOW);
+    await annotateProviderDeliverySignals(
+      [stale],
+      [open],
+      new Date("2026-08-05T16:00:00.000Z"),
+    );
+
+    expect(fresh.pullRequestObservation?.state).toBe("open");
+    expect(stale.pullRequestObservation).toBeUndefined();
+  });
+});
+
 function makeDb() {
   const db = {
     workroom: {
@@ -230,6 +315,7 @@ function makeDb() {
     },
     workroomActivity: { create: vi.fn() },
     featureBuild: { findMany: vi.fn() },
+    contributorInventorySyncRun: { findFirst: vi.fn().mockResolvedValue(null) },
     $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(db)),
   };
   return db;
@@ -322,6 +408,97 @@ describe("reapStaleWorkCapsules", () => {
 
     expect(result.candidates).toHaveLength(1);
     expect(result.candidates[0]!.liveness).toBe("build-terminal");
+  });
+
+  it("loads the latest successful provider inventory to close a source-free squash merge", async () => {
+    const { createPullRequestObservation } = await import(
+      "../contributor-change-lanes/pull-request-observation"
+    );
+    const merged = createPullRequestObservation({
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      number: 5090,
+      url: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5090",
+      title: "Squash-safe delivery",
+      headBranch: "fix/squash",
+      headSha: "a".repeat(40),
+      state: "merged",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      mergeCommitSha: "b".repeat(40),
+      mergedAt: "2026-08-05T14:50:00.000Z",
+      providerUpdatedAt: "2026-08-05T14:50:00.000Z",
+      observedAt: "2026-08-05T14:51:00.000Z",
+    });
+    db.workroom.findMany.mockResolvedValueOnce([
+      capsule({
+        capsuleId: "WC-SQUASHED",
+        repositoryFullName: merged.repositoryFullName,
+        pullRequestNumber: merged.number,
+        headSha: merged.headSha,
+        leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+      }),
+    ]);
+    db.contributorInventorySyncRun.findFirst.mockResolvedValueOnce({
+      snapshots: [{ payload: merged }],
+    });
+    db.featureBuild.findMany.mockResolvedValueOnce([]);
+
+    const result = await reapStaleWorkCapsules({ db: db as never, now: NOW });
+
+    expect(db.contributorInventorySyncRun.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { perSourceResult: { path: ["github-pr", "ok"], equals: true } },
+        orderBy: { startedAt: "desc" },
+      }),
+    );
+    expect(result.candidates).toEqual([
+      expect.objectContaining({ capsuleId: "WC-SQUASHED", disposition: "delivered" }),
+    ]);
+  });
+
+  it("renews prior open observations when GitHub confirms the inventory is unchanged", async () => {
+    const { createPullRequestObservation } = await import(
+      "../contributor-change-lanes/pull-request-observation"
+    );
+    const priorOpen = createPullRequestObservation({
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      number: 5091,
+      url: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5091",
+      title: "Still in review",
+      headBranch: "fix/reviewing",
+      headSha: "c".repeat(40),
+      state: "open",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      mergeCommitSha: null,
+      mergedAt: null,
+      providerUpdatedAt: "2026-08-05T14:00:00.000Z",
+      observedAt: "2026-08-05T14:00:00.000Z",
+    });
+    db.workroom.findMany.mockResolvedValueOnce([
+      capsule({
+        capsuleId: "WC-STILL-OPEN",
+        repositoryFullName: priorOpen.repositoryFullName,
+        pullRequestNumber: priorOpen.number,
+        pullRequestUrl: priorOpen.url,
+        headSha: priorOpen.headSha,
+        leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+      }),
+    ]);
+    db.contributorInventorySyncRun.findFirst
+      .mockResolvedValueOnce({
+        startedAt: new Date("2026-08-05T14:59:00.000Z"),
+        completedAt: new Date("2026-08-05T14:59:30.000Z"),
+        perSourceResult: { "github-pr": { ok: true, unchanged: true } },
+        snapshots: [],
+      })
+      .mockResolvedValueOnce({ snapshots: [{ payload: priorOpen }] });
+    db.featureBuild.findMany.mockResolvedValueOnce([]);
+
+    const result = await reapStaleWorkCapsules({ db: db as never, now: NOW });
+
+    expect(result.candidates).toHaveLength(0);
+    expect(db.contributorInventorySyncRun.findFirst).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/web/lib/work-capsules/work-capsule-reaper.ts
+++ b/apps/web/lib/work-capsules/work-capsule-reaper.ts
@@ -22,8 +22,10 @@
 // Worktree removal is a separate, explicitly-gated step (dpf-worktree-hygiene).
 
 import { WORK_CAPSULE_IDLE_STALE_MS } from "@/lib/work-capsules";
+import { selectLatestExactPullRequestObservation } from "../contributor-change-lanes/pull-request-observation";
 import {
   classifyWorkCapsuleLiveness,
+  WORK_CAPSULE_OPEN_PR_FRESHNESS_MS,
   type CapsuleLivenessInput,
   type WorkCapsuleDisposition,
   type WorkCapsuleLiveness,
@@ -121,7 +123,7 @@ export type ReapCandidate = {
 /** The linked-build snapshot the reaper joins onto build-studio capsules. */
 export type ReaperBuildSnapshot = { phase: string | null; lastActivityAt: Date | null };
 
-type ReaperCapsuleRow = CapsuleLivenessInput & {
+export type ReaperCapsuleRow = CapsuleLivenessInput & {
   capsuleId: string;
   title: string;
   source: string;
@@ -129,6 +131,7 @@ type ReaperCapsuleRow = CapsuleLivenessInput & {
   headSha: string | null;
   worktreePath: string | null;
   featureBuildId: string | null;
+  repositoryFullName: string | null;
 };
 
 /**
@@ -184,6 +187,9 @@ type ReaperDb = CapsuleDb & {
   backlogItemActivity?: {
     count(args: unknown): Promise<number>;
     create(args: unknown): Promise<any>;
+  };
+  contributorInventorySyncRun?: {
+    findFirst(args: unknown): Promise<any>;
   };
 };
 
@@ -300,7 +306,12 @@ export async function annotateDeliveredSignals(
   const hasTrunk = deps.hasTrunk ?? trunkRefExists;
   const reachable = deps.reachable ?? isReachableFromTrunk;
 
-  const withSha = rows.filter((r) => Boolean(r.headSha));
+  const withSha = rows.filter(
+    (row) =>
+      Boolean(row.headSha) &&
+      !row.deliveredSignal?.merged &&
+      !row.pullRequestObservation,
+  );
   if (withSha.length === 0) return;
   if (!(await hasTrunk(repoRoot))) return; // repo-less runtime → skip; null everywhere.
 
@@ -311,6 +322,107 @@ export async function annotateDeliveredSignals(
     } catch {
       // Best-effort: a single git failure never aborts the sweep.
     }
+  }
+}
+
+/**
+ * Project verified provider observations onto Workroom rows. A merge is a
+ * durable monotonic fact. An open PR is only a bounded liveness observation;
+ * stale/closed/unknown payloads grant no liveness and no reaper authority.
+ */
+export async function annotateProviderDeliverySignals(
+  rows: ReaperCapsuleRow[],
+  payloads: readonly unknown[],
+  now: Date = new Date(),
+  confirmedAt: Date | null = null,
+): Promise<void> {
+  for (const row of rows) {
+    if (!row.repositoryFullName || !row.pullRequestNumber || !row.headSha) continue;
+    const observation = selectLatestExactPullRequestObservation(payloads, {
+      repositoryFullName: row.repositoryFullName,
+      pullRequestNumber: row.pullRequestNumber,
+      headSha: row.headSha,
+    });
+    if (!observation) continue;
+    if (observation.state === "merged") {
+      row.deliveredSignal = { merged: true };
+      continue;
+    }
+    const observedAt = confirmedAt ?? new Date(observation.observedAt);
+    const age = now.getTime() - observedAt.getTime();
+    if (observation.state === "open" && age >= 0 && age <= WORK_CAPSULE_OPEN_PR_FRESHNESS_MS) {
+      row.pullRequestObservation = { state: "open", observedAt };
+    }
+  }
+}
+
+type ProviderObservationBatch = {
+  payloads: unknown[];
+  confirmedAt: Date | null;
+};
+
+function githubInventoryWasUnchanged(perSourceResult: unknown): boolean {
+  if (!perSourceResult || typeof perSourceResult !== "object") return false;
+  const github = (perSourceResult as Record<string, unknown>)["github-pr"];
+  return Boolean(
+    github &&
+      typeof github === "object" &&
+      (github as Record<string, unknown>).unchanged === true,
+  );
+}
+
+async function loadLatestSuccessfulProviderPayloads(
+  db: ReaperDb,
+): Promise<ProviderObservationBatch> {
+  if (!db.contributorInventorySyncRun) return { payloads: [], confirmedAt: null };
+  try {
+    const row = await db.contributorInventorySyncRun.findFirst({
+      where: { perSourceResult: { path: ["github-pr", "ok"], equals: true } },
+      orderBy: { startedAt: "desc" },
+      select: {
+        startedAt: true,
+        completedAt: true,
+        perSourceResult: true,
+        snapshots: {
+          where: { source: "github-pr" },
+          select: { payload: true },
+        },
+      },
+    });
+    if (!row) return { payloads: [], confirmedAt: null };
+    if (Array.isArray(row.snapshots) && row.snapshots.length > 0) {
+      return {
+        payloads: row.snapshots.map((snapshot: { payload?: unknown }) => snapshot.payload),
+        confirmedAt: null,
+      };
+    }
+    if (!githubInventoryWasUnchanged(row.perSourceResult)) {
+      return { payloads: [], confirmedAt: null };
+    }
+    const prior = await db.contributorInventorySyncRun.findFirst({
+      where: {
+        AND: [
+          { perSourceResult: { path: ["github-pr", "ok"], equals: true } },
+          { snapshots: { some: { source: "github-pr" } } },
+        ],
+      },
+      orderBy: { startedAt: "desc" },
+      select: {
+        snapshots: {
+          where: { source: "github-pr" },
+          select: { payload: true },
+        },
+      },
+    });
+    return {
+      payloads: Array.isArray(prior?.snapshots)
+        ? prior.snapshots.map((snapshot: { payload?: unknown }) => snapshot.payload)
+        : [],
+      confirmedAt: row.completedAt ?? row.startedAt,
+    };
+  } catch {
+    // Provider unavailability is unknown, never evidence that a PR is closed.
+    return { payloads: [], confirmedAt: null };
   }
 }
 
@@ -346,6 +458,7 @@ export async function reapStaleWorkCapsules(args: {
       updatedAt: true,
       pullRequestUrl: true,
       pullRequestNumber: true,
+      repositoryFullName: true,
       headBranch: true,
       headSha: true,
       worktreePath: true,
@@ -354,11 +467,19 @@ export async function reapStaleWorkCapsules(args: {
     take: 500,
   });
 
-  // DELIVERED detection — PROCEDURAL, LOCAL, no LLM, no GitHub API: a room whose
-  // branch head is reachable from the trunk has merged and is closed out as
-  // delivered (not abandoned). Reads git objects only (never a worktree), so it
-  // is junction-safe; degrades gracefully to null (→ lease/grace logic) wherever
-  // the local repo or the trunk ref is unavailable.
+  // Provider facts are the source-free/squash-safe path. Only verified exact
+  // repository/PR/authored-head observations can affect lifecycle; a previous
+  // successful inventory remains available while later provider syncs fail.
+  const providerObservations = await loadLatestSuccessfulProviderPayloads(args.db);
+  await annotateProviderDeliverySignals(
+    capsules,
+    providerObservations.payloads,
+    now,
+    providerObservations.confirmedAt,
+  );
+
+  // Positive local ancestry remains a fallback for source checkouts. It never
+  // overwrites an exact provider merge with a negative/indeterminate result.
   await annotateDeliveredSignals(capsules);
 
   // Batch-load the linked FeatureBuild snapshot for the build-studio capsules

--- a/docs/superpowers/plans/2026-09-06-squash-safe-delivery-observation.md
+++ b/docs/superpowers/plans/2026-09-06-squash-safe-delivery-observation.md
@@ -1,0 +1,45 @@
+---
+status: draft
+---
+
+# Squash-safe delivery observation implementation plan
+
+**Backlog item:** `BI-9FF39058`  
+**Workroom:** `WC-162C6AAD`  
+**Design:** [Squash-safe delivery observation](../specs/2026-09-06-squash-safe-delivery-observation-design.md)
+
+## Scope and coverage
+
+This is one atomic delivery slice from the delivery-closeout program. It changes
+only GitHub inventory observation and Workroom liveness/reaping. Durable closeout,
+host acknowledgement, acceptance execution, queue cancellation, and cost metrics
+remain with their filed backlog items.
+
+| Deliverable | Backlog item | Acceptance |
+| --- | --- | --- |
+| Immutable authenticated PR observation | BI-9FF39058 | AC-9FF-1 |
+| Exact repository/PR/head merge selection | BI-9FF39058 | AC-9FF-2, AC-9FF-3 |
+| Fresh-open and outage-safe merged semantics | BI-9FF39058 | AC-9FF-3, AC-9FF-4 |
+| Shared classifier/reaper integration and fallback | BI-9FF39058 | AC-9FF-5 |
+
+## TDD sequence
+
+1. Red: prove the reader still requests only open PRs and drops head/merge/provider
+   provenance. Green: emit the complete, fingerprinted `state=all` payload.
+2. Red: prove URL/number presence falsely keeps a stale room live. Green: require a
+   fresh exact-bound `open` observation.
+3. Red: prove a source-free squash merge is missed and an older merge can attach to
+   a later head. Green: select a matching provider merge only, retaining the latest
+   monotonic observation per PR.
+4. Regression: mismatched repository/PR/head, legacy/malformed payloads,
+   stale-open, closed, duplicate/out-of-order observations, provider outage, and
+   local positive ancestry fallback.
+
+## Verification and delivery
+
+Run the affected GitHub reader, liveness, reaper, inventory/read-model and lane
+projection tests; run web typecheck, style drift and pregate preflight. Request the
+exact-tree local gate only if capacity admits immediately; otherwise record the
+operator-authorized infrastructure result as `INCONCLUSIVE`/non-PASS. Commit with
+DCO, publish normally, open one protected PR, and require every protected PR and
+merge-group check. This slice does not authorize release or live upgrade.

--- a/docs/superpowers/plans/2026-09-06-squash-safe-delivery-observation.md
+++ b/docs/superpowers/plans/2026-09-06-squash-safe-delivery-observation.md
@@ -8,6 +8,24 @@ status: draft
 **Workroom:** `WC-162C6AAD`  
 **Design:** [Squash-safe delivery observation](../specs/2026-09-06-squash-safe-delivery-observation-design.md)
 
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-9FF39058`
+- Receipt: blocked-by: the immutable plan must be committed before the governed coverage recorder can bind it
+- Rationale: The observation schema, exact selector, freshness semantics, and
+  reaper consumer form one safety invariant. Shipping any phase independently
+  would either lose squash-merge delivery or allow stale or mismatched provider
+  evidence to close the wrong Workroom.
+- Dependencies: none
+
+| Key | Requirement refs | Contract refs | Flow refs | Verification refs |
+| --- | --- | --- | --- | --- |
+| provider-observation | OBJ-9FF-1 | contract:provider-pr-observation-v1 | flow:github-reader-to-inventory | AC-9FF-1 |
+| exact-merge-selection | OBJ-9FF-2 | contract:exact-pr-head-selection | flow:provider-observation-selection | AC-9FF-2 |
+| freshness-reconciliation | OBJ-9FF-2, OBJ-9FF-3 | contract:fresh-open-monotonic-merge | flow:inventory-to-liveness | AC-9FF-3, AC-9FF-4 |
+| reaper-integration | OBJ-9FF-4 | contract:workroom-liveness-reaper | flow:liveness-to-reaper | AC-9FF-5 |
+
 ## Scope and coverage
 
 This is one atomic delivery slice from the delivery-closeout program. It changes

--- a/docs/superpowers/plans/2026-09-06-squash-safe-delivery-observation.md
+++ b/docs/superpowers/plans/2026-09-06-squash-safe-delivery-observation.md
@@ -12,7 +12,7 @@ status: draft
 
 - Decision: atomic
 - Parent: `BI-9FF39058`
-- Receipt: blocked-by: the immutable plan must be committed before the governed coverage recorder can bind it
+- Receipt: `cmtpex02m096t01p76d75uhb2`
 - Rationale: The observation schema, exact selector, freshness semantics, and
   reaper consumer form one safety invariant. Shipping any phase independently
   would either lose squash-merge delivery or allow stale or mismatched provider

--- a/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
+++ b/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
@@ -57,13 +57,21 @@ state because they lack the immutable head binding.
 
 ## Acceptance criteria
 
-| Acceptance | Objectives | Statement |
-| --- | --- | --- |
-| **AC-9FF-1** | OBJ-9FF-1 | Authenticated inventory stores `state=all` observations with the exact repository, head SHA, merge SHA/time, provider update time/API version, and a stable fingerprint. |
-| **AC-9FF-2** | OBJ-9FF-2 | A merged provider observation whose repository, PR number, and head all match produces `delivered`, including on a runtime without Git. |
-| **AC-9FF-3** | OBJ-9FF-2, OBJ-9FF-3 | A newer Workroom head, mismatched repository/PR, closed PR, stale open PR, malformed legacy payload, or missing provider snapshot does not produce delivered or open-PR liveness. |
-| **AC-9FF-4** | OBJ-9FF-3 | A prior matching merge remains usable from the latest successful snapshot when a later provider sync fails; an open observation expires from liveness after the freshness window. |
-| **AC-9FF-5** | OBJ-9FF-4 | Existing local positive ancestry remains a fallback, dry-run remains the default, and no filesystem mutation is added to the reaper. |
+- **AC-9FF-1:** [OBJ-9FF-1] Authenticated inventory stores `state=all`
+  observations with the exact repository, head SHA, merge SHA/time, provider
+  update time/API version, and a stable fingerprint.
+- **AC-9FF-2:** [OBJ-9FF-2] A merged provider observation whose repository, PR
+  number, and head all match produces `delivered`, including on a runtime
+  without Git.
+- **AC-9FF-3:** [OBJ-9FF-2, OBJ-9FF-3] A newer Workroom head, mismatched
+  repository/PR, closed PR, stale open PR, malformed legacy payload, or missing
+  provider snapshot does not produce delivered or open-PR liveness.
+- **AC-9FF-4:** [OBJ-9FF-3] A prior matching merge remains usable from the latest
+  successful snapshot when a later provider sync fails; an authenticated
+  not-modified response renews the prior open observation, and an unconfirmed
+  open observation expires after the freshness window.
+- **AC-9FF-5:** [OBJ-9FF-4] Existing local positive ancestry remains a fallback,
+  dry-run remains the default, and no filesystem mutation is added to the reaper.
 
 ## Failure and compatibility behavior
 

--- a/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
+++ b/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
@@ -6,6 +6,7 @@ status: draft
 
 **Backlog item:** `BI-9FF39058`  
 **Workroom:** `WC-162C6AAD`  
+**Readiness profile:** `feature`  
 **Parent design:** [Delivery closeout and cost efficiency](2026-09-04-delivery-closeout-cost-efficiency-design.md)
 
 ## Problem and evidence

--- a/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
+++ b/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
@@ -1,0 +1,102 @@
+---
+status: draft
+---
+
+# Squash-safe delivery observation
+
+**Backlog item:** `BI-9FF39058`  
+**Workroom:** `WC-162C6AAD`  
+**Parent design:** [Delivery closeout and cost efficiency](2026-09-04-delivery-closeout-cost-efficiency-design.md)
+
+## Problem and evidence
+
+The Workroom liveness projector currently treats a stored pull-request URL or
+number as proof that the PR is open. The reaper separately asks a local Git
+checkout whether the authored head is reachable from the trunk. Neither fact is
+portable: an installed runtime has no source checkout, a stored PR identity says
+nothing about its current state, and a squash merge deliberately does not make the
+authored head an ancestor of the merge commit.
+
+The existing contributor-inventory job already performs authenticated GitHub
+reads and keeps the latest successful snapshot through provider outages. It is
+the right observation source; adding another provider client or persistence model
+would duplicate authority.
+
+## Decision
+
+Extend the existing GitHub PR snapshot with repository, authored head, merge
+commit, provider timestamps, API version, and a deterministic observation
+fingerprint. The inventory reader requests open and terminal PRs. The Workroom
+reaper reads the latest successful provider snapshot and accepts it only when
+repository, PR number, and authored head all match the Workroom.
+
+A matching `merged` observation is monotonic delivery evidence and remains valid
+when the latest sync later fails. A matching `open` observation is liveness only
+while the successful sync is fresh. `closed`, stale-open, malformed, mismatched,
+and unavailable observations are explicit unknowns for liveness: they neither
+keep a room alive nor authorize abandonment by themselves. Local Git ancestry
+remains a positive fallback for non-squash delivery when available; it is not the
+portable source of PR state.
+
+No schema migration is required. Contributor inventory payloads are JSON and new
+fields are additive; old snapshots remain readable but cannot prove provider
+state because they lack the immutable head binding.
+
+## Objectives
+
+- **OBJ-9FF-1:** A provider observation identifies repository, PR, authored head,
+  state, merge commit, provider timestamps/version, and a deterministic
+  fingerprint.
+- **OBJ-9FF-2:** A squash-merged PR closes only the Workroom whose immutable head
+  it observed; a later unmerged head cannot inherit delivery.
+- **OBJ-9FF-3:** Provider outage, stale open state, malformed legacy payloads, and
+  a source-free install remain honest unknowns rather than imaginary open or
+  abandoned states.
+- **OBJ-9FF-4:** Provider and local-git observations share the existing liveness
+  classifier and reaper, without a second closeout controller.
+
+## Acceptance criteria
+
+| Acceptance | Objectives | Statement |
+| --- | --- | --- |
+| **AC-9FF-1** | OBJ-9FF-1 | Authenticated inventory stores `state=all` observations with the exact repository, head SHA, merge SHA/time, provider update time/API version, and a stable fingerprint. |
+| **AC-9FF-2** | OBJ-9FF-2 | A merged provider observation whose repository, PR number, and head all match produces `delivered`, including on a runtime without Git. |
+| **AC-9FF-3** | OBJ-9FF-2, OBJ-9FF-3 | A newer Workroom head, mismatched repository/PR, closed PR, stale open PR, malformed legacy payload, or missing provider snapshot does not produce delivered or open-PR liveness. |
+| **AC-9FF-4** | OBJ-9FF-3 | A prior matching merge remains usable from the latest successful snapshot when a later provider sync fails; an open observation expires from liveness after the freshness window. |
+| **AC-9FF-5** | OBJ-9FF-4 | Existing local positive ancestry remains a fallback, dry-run remains the default, and no filesystem mutation is added to the reaper. |
+
+## Failure and compatibility behavior
+
+Parsing is fail closed. Missing or non-string repository/head fields, invalid PR
+numbers/states, or invalid timestamps do not become observations. Duplicate rows
+for one PR resolve deterministically by provider update time and then fingerprint;
+an older/out-of-order row cannot replace a newer fact. Existing payloads lacking
+the new fields continue to drive the contributor UI but cannot drive closeout.
+
+The reaper still needs its existing independent stale/dead signal before acting.
+Provider `closed` is not abandonment authority. Rollback removes provider
+annotation and returns to local positive ancestry; all inventory data remains
+readable.
+
+## Research and alternatives
+
+- GitHub's pull-request API exposes authored head, state, merge commit and
+  provider timestamps. DPF adopts those authenticated facts and rejects URL
+  presence as state.
+- Kubernetes controllers distinguish observed state from desired state and keep
+  last-known durable facts across transient read failures. DPF adopts that
+  reconciliation shape rather than making provider availability a correctness
+  dependency.
+- Event-sourced consumers reject stale/out-of-order observations by version or
+  timestamp. DPF applies the same monotonic selection locally and rejects a new
+  event bus because contributor inventory already owns polling and persistence.
+
+## Ordered implementation sequence
+
+1. Extend and test the GitHub inventory payload and `state=all` read.
+2. Add exact-bound, monotonic provider-observation selection to Workroom
+   reconciliation.
+3. Make explicit fresh-open state the only PR liveness signal and preserve local
+   positive ancestry fallback.
+4. Run affected tests, typecheck, policy guards, DCO, and protected PR checks;
+   record unavailable local capacity as inconclusive rather than a product PASS.

--- a/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
+++ b/docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md
@@ -57,21 +57,13 @@ state because they lack the immutable head binding.
 
 ## Acceptance criteria
 
-- **AC-9FF-1:** [OBJ-9FF-1] Authenticated inventory stores `state=all`
-  observations with the exact repository, head SHA, merge SHA/time, provider
-  update time/API version, and a stable fingerprint.
-- **AC-9FF-2:** [OBJ-9FF-2] A merged provider observation whose repository, PR
-  number, and head all match produces `delivered`, including on a runtime
-  without Git.
-- **AC-9FF-3:** [OBJ-9FF-2, OBJ-9FF-3] A newer Workroom head, mismatched
-  repository/PR, closed PR, stale open PR, malformed legacy payload, or missing
-  provider snapshot does not produce delivered or open-PR liveness.
-- **AC-9FF-4:** [OBJ-9FF-3] A prior matching merge remains usable from the latest
-  successful snapshot when a later provider sync fails; an authenticated
-  not-modified response renews the prior open observation, and an unconfirmed
-  open observation expires after the freshness window.
-- **AC-9FF-5:** [OBJ-9FF-4] Existing local positive ancestry remains a fallback,
-  dry-run remains the default, and no filesystem mutation is added to the reaper.
+| Acceptance | Objectives | Statement |
+| --- | --- | --- |
+| AC-9FF-1 | OBJ-9FF-1 | Authenticated inventory stores `state=all` observations with the exact repository, head SHA, merge SHA/time, provider update time/API version, and a stable fingerprint. |
+| AC-9FF-2 | OBJ-9FF-2 | A merged provider observation whose repository, PR number, and head all match produces `delivered`, including on a runtime without Git. |
+| AC-9FF-3 | OBJ-9FF-2, OBJ-9FF-3 | A newer Workroom head, mismatched repository/PR, closed PR, stale open PR, malformed legacy payload, or missing provider snapshot does not produce delivered or open-PR liveness. |
+| AC-9FF-4 | OBJ-9FF-3 | A prior matching merge remains usable from the latest successful snapshot when a later provider sync fails; an authenticated not-modified response renews the prior open observation, and an unconfirmed open observation expires after the freshness window. |
+| AC-9FF-5 | OBJ-9FF-4 | Existing local positive ancestry remains a fallback, dry-run remains the default, and no filesystem mutation is added to the reaper. |
 
 ## Failure and compatibility behavior
 


### PR DESCRIPTION
## Summary

- persist an explicit, schema-validated GitHub pull-request observation with exact repository, PR, authored head, provider state, timestamps, API version, and stable fingerprint
- use exact provider-observed merges to close Workrooms as delivered even when squash merging makes the authored SHA unreachable from `main`
- make provider-observed open PR liveness renewable and time-bounded, while retaining positive local ancestry as a source-checkout fallback

## Design grounding

Implements BI-9FF39058 from the asynchronous long-running agent-interaction delivery design. The canonical design and ordered plan are:

- `docs/superpowers/specs/2026-09-06-squash-safe-delivery-observation-design.md`
- `docs/superpowers/plans/2026-09-06-squash-safe-delivery-observation.md`

Genuine readiness evidence is recorded for design, spec baseline, research, architecture, atomic plan coverage, and plan review. Current plan-review receipt: `initiative-3dbbe91c-ceb2-4d9f-95e0-b61ab9d1a638` on same TaskRun recovery.

## Verification

- TDD RED: 4 files / 57 tests, 6 intended failures and 51 passes.
- TDD GREEN: 12 files / 151 tests passed.
- `pnpm --filter web typecheck`: passed.
- pre-commit scoped typecheck and gitleaks: passed.
- `pnpm run pregate:preflight`: 64/64 guards passed.
- DCO sign-off and clean pushed branch: verified.
- Exact-tree local integration gate was not admitted during the shared deployment quiescence window and is explicitly INCONCLUSIVE/non-PASS under the operator-authorized bypass. The underperforming `pnpm pr:ready` wrapper was stopped after more than two minutes with no output and is also recorded INCONCLUSIVE. All protected PR and merge-group checks remain mandatory.

## Safety and rollback

Only authenticated, exact-bound, schema-valid provider observations can influence liveness or delivery. Closed/stale/malformed/mismatched observations grant no authority; GitHub or database failure degrades to unknown. A merge observation is monotonic, 304 responses renew only a previously stored valid open observation, and pages from unrelated sync attempts are never synthesized. Revert this PR to restore local-ancestry-only delivery classification.

Local-CI-Override: operator-emergency; shared deployment quiescence withheld the local integration slot, with 151 affected tests, typecheck, 64 preflight guards, DCO and protected CI retained.
