### PR TITLE
feat(work): project coworker engagements into work cases

### DIFF
--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -264,9 +264,40 @@ describe("WorkCaseDetailView", () => {
     );
 
     expect(html).toContain("<details");
+    expect(html).toContain("Share an update");
     expect(html).toContain("Room details");
     expect(html.indexOf("Room details")).toBeLessThan(html.indexOf("A2A status"));
     expect(html.indexOf("Room details")).toBeLessThan(html.indexOf("BK-1"));
+  });
+
+  it("does not render a WorkItem comment form for source-only coworker engagements", () => {
+    const coworkerRoom: WorkroomView = {
+      ...room,
+      roomKey: "coworker-engagement%3ACE-1",
+      caseRef: {
+        caseId: "coworker-engagement:CE-1",
+        sourceType: "coworker-engagement",
+        sourceId: "CE-1",
+      },
+      title: "Prepare launch readiness.",
+      sourceRefs: [{ kind: "coworker-engagement", id: "CE-1", status: "needs-approval" }],
+    };
+    const html = renderToStaticMarkup(
+      <WorkroomBodyContent
+        detail={{
+          ...detail,
+          room: coworkerRoom,
+          workItemId: null,
+          workItemTitle: null,
+        }}
+        room={coworkerRoom}
+        mode="detail"
+        onModeChange={() => {}}
+      />,
+    );
+
+    expect(html).not.toContain("Share an update");
+    expect(html).toContain("Room details");
   });
 
   it("renders detailed activity kinds with distinct accessible labels", () => {

--- a/apps/web/components/workspace/workroom/WorkroomBody.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomBody.tsx
@@ -259,9 +259,11 @@ function WorkroomDetailsContent({ detail, room }: Props) {
             </details>
           ) : null}
 
-          <div className="border-t border-[var(--dpf-border)] p-4">
-            <WorkItemCommentBox workItemId={detail.workItemId} caseKey={room.roomKey} />
-          </div>
+          {detail.workItemId ? (
+            <div className="border-t border-[var(--dpf-border)] p-4">
+              <WorkItemCommentBox workItemId={detail.workItemId} caseKey={room.roomKey} />
+            </div>
+          ) : null}
         </section>
 
         <aside aria-label="Work Room context" className="space-y-3">

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1149,6 +1149,9 @@
       "docs/architecture/work-shapes-and-the-decision-gate.md",
       "docs/user-guide/ai-workforce/how-governed-work-runs.md"
     ],
+    "apps/web/lib/work-management/coworker-engagement-case-projection.ts": [
+      "docs/user-guide/workspace/work-rooms.md"
+    ],
     "apps/web/lib/work-management/room-channel-continuity.ts": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
@@ -3153,6 +3156,7 @@
       "apps/web/components/workspace/WorkCaseDetailView.tsx",
       "apps/web/components/workspace/workroom/WorkroomCycles.tsx",
       "apps/web/components/workspace/workroom/WorkroomParticipants.tsx",
+      "apps/web/lib/work-management/coworker-engagement-case-projection.ts",
       "apps/web/lib/work-management/room-channel-continuity.ts",
       "apps/web/lib/work-management/room-channel-ingress.ts",
       "apps/web/lib/work-management/room-participation.ts",

--- a/apps/web/lib/work-management/case-read-model.test.ts
+++ b/apps/web/lib/work-management/case-read-model.test.ts
@@ -77,4 +77,43 @@ describe("Work Case read model", () => {
       "evidence",
     ]);
   });
+
+  it("projects coworker engagements without requiring a WorkItem anchor", () => {
+    const detail = buildWorkCaseDetail({
+      source: { sourceType: "coworker-engagement", sourceId: "CE-1", status: "needs-approval" },
+      coworkerEngagement: {
+        engagementId: "CE-1",
+        requestedOutcome: "Prepare the municipal launch readiness packet.",
+        status: "needs-approval",
+        priority: "high",
+        providerDisplayName: "Launch Readiness Coworker",
+      },
+      evidence: [{
+        evidenceId: "coworker-engagement:CE-1:approval-context",
+        kind: "approval-context",
+        summary: "Paid provider approval is required before work begins.",
+      }],
+    });
+
+    expect(detail.summary).toMatchObject({
+      caseId: "coworker-engagement:CE-1",
+      title: "Prepare the municipal launch readiness packet.",
+      sourceLabel: "Coworker engagement",
+      state: "awaiting-decision",
+      nextAction: "Resolve pending decision",
+      attention: {
+        required: true,
+        reason: expect.stringContaining("approval"),
+      },
+    });
+    expect(detail.summary.sourceRefs).toContainEqual({
+      kind: "coworker-engagement",
+      id: "CE-1",
+      status: "needs-approval",
+    });
+    expect(detail.timeline.map((event) => event.sourceRef.kind)).toEqual([
+      "coworker-engagement",
+      "evidence",
+    ]);
+  });
 });

--- a/apps/web/lib/work-management/case-read-model.ts
+++ b/apps/web/lib/work-management/case-read-model.ts
@@ -51,9 +51,19 @@ export interface WorkCaseReadModelEvidenceInput {
   summary: string;
 }
 
+export interface WorkCaseReadModelCoworkerEngagementInput {
+  engagementId: string;
+  requestedOutcome: string;
+  status: string;
+  priority?: string | null;
+  providerDisplayName?: string | null;
+  workCapsuleId?: string | null;
+}
+
 export interface BuildWorkCaseReadModelInput {
   source: WorkCaseReadModelSourceInput;
   workItem?: WorkCaseReadModelWorkItemInput | null;
+  coworkerEngagement?: WorkCaseReadModelCoworkerEngagementInput | null;
   capsule?: WorkCaseReadModelCapsuleInput | null;
   runtimeVerification?: WorkCaseReadModelVerificationInput | null;
   capsules?: readonly WorkCaseReadModelCapsuleInput[];
@@ -124,6 +134,19 @@ function sourceRefsForInput(input: BuildWorkCaseReadModelInput): WorkCaseSourceR
       status: input.workItem.status,
     });
   }
+  if (input.coworkerEngagement) {
+    refs.push({
+      kind: "coworker-engagement",
+      id: input.coworkerEngagement.engagementId,
+      status: input.coworkerEngagement.status,
+    });
+    if (input.coworkerEngagement.workCapsuleId) {
+      refs.push({
+        kind: "work-capsule",
+        id: input.coworkerEngagement.workCapsuleId,
+      });
+    }
+  }
   if (input.capsule) {
     refs.push({
       kind: "work-capsule",
@@ -156,6 +179,12 @@ export function buildWorkCaseSummary(
     workItem: input.workItem
       ? { itemId: input.workItem.itemId, status: input.workItem.status }
       : null,
+    coworkerEngagement: input.coworkerEngagement
+      ? {
+          engagementId: input.coworkerEngagement.engagementId,
+          status: input.coworkerEngagement.status,
+        }
+      : null,
     capsule: input.capsule ?? input.capsules?.[0] ?? null,
     decision: primaryDecision ?? null,
     runtimeVerification: input.runtimeVerification ?? null,
@@ -164,18 +193,36 @@ export function buildWorkCaseSummary(
 
   return {
     caseId: buildCaseId(input),
-    title: input.workItem?.title ?? `${sourceEntry?.displayLabel ?? input.source.sourceType} ${input.source.sourceId}`,
+    title: input.workItem?.title
+      ?? input.coworkerEngagement?.requestedOutcome
+      ?? `${sourceEntry?.displayLabel ?? input.source.sourceType} ${input.source.sourceId}`,
     sourceLabel: sourceEntry?.displayLabel ?? input.source.sourceType,
     state: projection.state,
     stateReason: projection.reason,
     a2aStatus: projection.a2aStatus,
     terminal: projection.terminal,
     nextAction: nextActionForState(projection.state),
-    urgency: input.workItem?.urgency,
+    urgency: input.workItem?.urgency ?? input.coworkerEngagement?.priority ?? undefined,
     dueAt: iso(input.workItem?.dueAt),
     assignedToUserId: input.workItem?.assignedToUserId ?? null,
     attention: attentionForProjection(projection),
     sourceRefs: sourceRefsForInput(input),
+  };
+}
+
+function coworkerEngagementTimelineEvent(
+  engagement: WorkCaseReadModelCoworkerEngagementInput,
+): WorkCaseTimelineEvent {
+  return {
+    eventId: `coworker-engagement:${engagement.engagementId}`,
+    label: engagement.providerDisplayName
+      ? `${engagement.providerDisplayName}: ${engagement.requestedOutcome}`
+      : engagement.requestedOutcome,
+    sourceRef: {
+      kind: "coworker-engagement",
+      id: engagement.engagementId,
+      status: engagement.status,
+    },
   };
 }
 
@@ -233,6 +280,7 @@ export function buildWorkCaseDetail(
     decisions,
     evidence,
     timeline: [
+      ...(input.coworkerEngagement ? [coworkerEngagementTimelineEvent(input.coworkerEngagement)] : []),
       ...capsules.map(capsuleTimelineEvent),
       ...decisions.map(decisionTimelineEvent),
       ...evidence.map(evidenceTimelineEvent),

--- a/apps/web/lib/work-management/case-types.ts
+++ b/apps/web/lib/work-management/case-types.ts
@@ -78,6 +78,7 @@ export type WorkCaseSourceRefKind =
   | "source"
   | "work-item"
   | "work-capsule"
+  | "coworker-engagement"
   | "task-run"
   | "task-artifact"
   | "decision-interaction"

--- a/apps/web/lib/work-management/coworker-engagement-case-projection.ts
+++ b/apps/web/lib/work-management/coworker-engagement-case-projection.ts
@@ -1,0 +1,260 @@
+import { encodeWorkCaseKey } from "./case-key";
+import {
+  buildWorkCaseDetail,
+  buildWorkCaseSummary,
+  type WorkCaseReadModelEvidenceInput,
+} from "./case-read-model";
+import { buildWorkroomView } from "./room-read-model";
+import type { WorkroomParticipantView } from "./room-types";
+import type {
+  WorkspaceRoomAuthContext,
+  WorkspaceWorkCaseDetailView,
+  WorkspaceWorkCaseListItem,
+} from "./workspace-case-loader";
+
+export const CLOSED_COWORKER_ENGAGEMENT_STATUSES = ["completed", "cancelled", "rejected"];
+
+const COWORKER_ENGAGEMENT_PRIORITY_URGENCY: Record<string, string> = {
+  emergency: "emergency",
+  urgent: "urgent",
+  high: "priority",
+  normal: "routine",
+  medium: "routine",
+  low: "routine",
+};
+
+const COWORKER_ENGAGEMENT_URGENCY_LABELS: Record<string, string> = {
+  emergency: "Emergency",
+  urgent: "Urgent",
+  priority: "Priority",
+  routine: "Routine",
+};
+
+export type WorkspaceCoworkerEngagementRecord = {
+  id: string;
+  engagementId: string;
+  offerId: string;
+  serviceId: string;
+  providerAgentId: string;
+  requestedByUserId: string | null;
+  requestedByAgentId: string | null;
+  requestedOutcome: string;
+  priority: string;
+  status: string;
+  approvalContext: unknown;
+  auditRefs: unknown;
+  metadata: unknown;
+  workCapsuleId: string | null;
+  toolExecutionId: string | null;
+  createdAt: Date | string;
+  updatedAt?: Date | string;
+  completedAt?: Date | string | null;
+  provider?: { displayName: string | null; name: string | null } | null;
+  offer?: { offerId: string; name: string } | null;
+  service?: { serviceId: string; name: string } | null;
+};
+
+export type CoworkerEngagementCasePrismaClient = {
+  coworkerEngagement?: {
+    findMany(args: unknown): Promise<WorkspaceCoworkerEngagementRecord[]>;
+    findFirst(args: unknown): Promise<WorkspaceCoworkerEngagementRecord | null>;
+  };
+};
+
+function sourceForEngagement(engagement: WorkspaceCoworkerEngagementRecord): {
+  sourceType: string;
+  sourceId: string;
+} {
+  return { sourceType: "coworker-engagement", sourceId: engagement.engagementId };
+}
+
+function urgencyForEngagement(engagement: WorkspaceCoworkerEngagementRecord): string {
+  return COWORKER_ENGAGEMENT_PRIORITY_URGENCY[engagement.priority] ?? "routine";
+}
+
+export function toCoworkerEngagementListItem(
+  engagement: WorkspaceCoworkerEngagementRecord,
+  userId: string,
+): WorkspaceWorkCaseListItem {
+  const source = sourceForEngagement(engagement);
+  const urgency = urgencyForEngagement(engagement);
+  const providerName = engagement.provider?.displayName ?? engagement.provider?.name ?? engagement.providerAgentId;
+  const summary = buildWorkCaseSummary({
+    source: { ...source, status: engagement.status },
+    coworkerEngagement: {
+      engagementId: engagement.engagementId,
+      requestedOutcome: engagement.requestedOutcome,
+      status: engagement.status,
+      priority: urgency,
+      providerDisplayName: providerName,
+      workCapsuleId: engagement.workCapsuleId,
+    },
+  });
+  const urgentAttention = urgency === "emergency" || urgency === "urgent";
+  const urgencyLabel = COWORKER_ENGAGEMENT_URGENCY_LABELS[urgency] ?? urgency;
+  return {
+    caseId: summary.caseId,
+    href: `/workspace/cases/${encodeWorkCaseKey(source)}`,
+    title: summary.title,
+    sourceLabel: summary.sourceLabel,
+    state: summary.state,
+    stateReason: summary.stateReason,
+    a2aStatus: summary.a2aStatus,
+    terminal: summary.terminal,
+    nextAction: summary.nextAction,
+    urgency,
+    urgencyLabel,
+    effortLabel: engagement.service?.name ?? engagement.offer?.name ?? "Coworker service",
+    dueAt: null,
+    assignmentLabel: engagement.requestedByUserId === userId
+      ? "Requested by you"
+      : engagement.requestedByAgentId
+        ? "Requested by coworker"
+        : "Requested",
+    attentionRequired: summary.attention.required || urgentAttention,
+    attentionReason: summary.attention.reason ?? (urgentAttention ? `${urgencyLabel} priority.` : null),
+    description: engagement.offer?.name ?? engagement.service?.name ?? null,
+    sourceRefs: summary.sourceRefs,
+  };
+}
+
+function recordHasContent(value: unknown): boolean {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0);
+}
+
+function evidenceFromCoworkerEngagement(
+  engagement: WorkspaceCoworkerEngagementRecord,
+): WorkCaseReadModelEvidenceInput[] {
+  const evidence: WorkCaseReadModelEvidenceInput[] = [];
+  if (recordHasContent(engagement.approvalContext)) {
+    evidence.push({
+      evidenceId: `coworker-engagement:${engagement.engagementId}:approval-context`,
+      kind: "approval-context",
+      summary: "Approval context is attached to the coworker engagement.",
+    });
+  }
+  if (recordHasContent(engagement.auditRefs)) {
+    evidence.push({
+      evidenceId: `coworker-engagement:${engagement.engagementId}:audit-refs`,
+      kind: "audit-refs",
+      summary: "Audit references are attached to the coworker engagement.",
+    });
+  }
+  if (recordHasContent(engagement.metadata)) {
+    evidence.push({
+      evidenceId: `coworker-engagement:${engagement.engagementId}:metadata`,
+      kind: "metadata",
+      summary: "Metadata is attached to the coworker engagement.",
+    });
+  }
+  return evidence;
+}
+
+function coworkerParticipant(
+  engagement: WorkspaceCoworkerEngagementRecord,
+): WorkroomParticipantView {
+  const providerName = engagement.provider?.displayName ?? engagement.provider?.name ?? engagement.providerAgentId;
+  return {
+    principalRef: engagement.providerAgentId,
+    displayName: providerName,
+    kind: "agent",
+    roles: ["contributor"],
+    workState: engagement.status === "in-progress" ? "working" : "waiting",
+    presence: "unknown",
+    currentWorkSummary: engagement.requestedOutcome,
+    enteredReason: "Requested through a coworker service engagement.",
+    sponsorPrincipalRef: engagement.requestedByUserId ?? engagement.requestedByAgentId ?? null,
+    authoritySummary: "Runs under the coworker service offer and engagement approval context.",
+    sourceRefs: [{
+      kind: "coworker-engagement",
+      id: engagement.engagementId,
+      status: engagement.status,
+    }],
+    assignmentSource: "explicit",
+    coordinatorSource: "none",
+  };
+}
+
+export async function loadCoworkerEngagementDetail({
+  prismaClient,
+  sourceId,
+  userId,
+  authContext,
+  caseKey,
+  now,
+}: {
+  prismaClient: CoworkerEngagementCasePrismaClient;
+  sourceId: string;
+  userId: string;
+  authContext?: WorkspaceRoomAuthContext;
+  caseKey: string;
+  now: Date;
+}): Promise<WorkspaceWorkCaseDetailView | null> {
+  if (!prismaClient.coworkerEngagement) return null;
+  const engagement = await prismaClient.coworkerEngagement.findFirst({
+    where: authContext?.isSuperuser
+      ? { engagementId: sourceId }
+      : { engagementId: sourceId, requestedByUserId: userId },
+    include: {
+      provider: { select: { displayName: true, name: true } },
+      offer: { select: { offerId: true, name: true } },
+      service: { select: { serviceId: true, name: true } },
+    },
+  });
+  if (!engagement) return null;
+  if (!authContext?.isSuperuser && engagement.requestedByUserId !== userId) return null;
+
+  const source = sourceForEngagement(engagement);
+  const providerName = engagement.provider?.displayName ?? engagement.provider?.name ?? engagement.providerAgentId;
+  const detail = buildWorkCaseDetail({
+    source: { ...source, status: engagement.status },
+    coworkerEngagement: {
+      engagementId: engagement.engagementId,
+      requestedOutcome: engagement.requestedOutcome,
+      status: engagement.status,
+      priority: urgencyForEngagement(engagement),
+      providerDisplayName: providerName,
+      workCapsuleId: engagement.workCapsuleId,
+    },
+    evidence: evidenceFromCoworkerEngagement(engagement),
+  });
+  const sourceRefs = detail.summary.sourceRefs;
+  const room = buildWorkroomView({
+    caseKey,
+    detail,
+    boundary: {
+      purpose: engagement.requestedOutcome,
+      outcome: engagement.requestedOutcome,
+      scopeIncluded: [
+        engagement.offer?.name ?? engagement.service?.name ?? "Coworker service engagement",
+      ],
+      sourceRefs,
+    },
+    participants: [coworkerParticipant(engagement)],
+    activities: [{
+      sourceEventId: engagement.engagementId,
+      kind: engagement.status === "needs-approval" ? "ask" : "external-event",
+      occurredAt: engagement.createdAt,
+      actorRef: { actorKind: "agent", actorId: engagement.providerAgentId, displayName: providerName },
+      summary: engagement.status === "needs-approval"
+        ? "Approval is required before this coworker engagement can continue."
+        : engagement.requestedOutcome,
+      sourceRef: { kind: "coworker-engagement", id: engagement.engagementId, status: engagement.status },
+    }],
+    context: {
+      refs: sourceRefs,
+      digest: engagement.service?.name ?? engagement.offer?.name ?? null,
+      sensitivityCeiling: null,
+    },
+    now,
+  });
+
+  return {
+    summary: toCoworkerEngagementListItem(engagement, userId),
+    evidenceTimeline: detail.timeline,
+    sourceRefs,
+    workItemId: null,
+    workItemTitle: null,
+    room,
+  };
+}

--- a/apps/web/lib/work-management/source-registry.test.ts
+++ b/apps/web/lib/work-management/source-registry.test.ts
@@ -24,6 +24,29 @@ describe("Work Case source registry", () => {
     );
   });
 
+  it("registers coworker service engagements as company-work source definitions", () => {
+    const entry = getWorkCaseSourceEntry("coworker-engagement");
+
+    expect(entry).toMatchObject({
+      sourceKey: "coworker-engagement",
+      displayLabel: "Coworker engagement",
+      owningArea: "ai-workforce",
+      domainCategory: "coworker-service",
+      defaultDecisionScope: "wwwd",
+      accountResolverKey: null,
+      roomProjection: { mode: "finite" },
+    });
+    expect(entry?.receiptPolicy).toEqual({
+      defaultReceiptKind: "governed-action",
+      receiptRequiredForConsequentialTransition: true,
+    });
+    expect(getWorkroomDefinitionIdentity("coworker-engagement")).toMatchObject({
+      definitionId: "workroom-definition:coworker-engagement",
+      label: "Coworker engagement",
+      decisionScope: "wwwd",
+    });
+  });
+
   it("documents routing, decision, transition, and receipt defaults for every source", () => {
     for (const entry of WORK_CASE_SOURCE_REGISTRY) {
       expect(entry.displayLabel.length).toBeGreaterThan(0);

--- a/apps/web/lib/work-management/source-registry.ts
+++ b/apps/web/lib/work-management/source-registry.ts
@@ -329,6 +329,20 @@ export const WORK_CASE_SOURCE_REGISTRY = [
     receiptPolicy: OBSERVED_RECEIPT_POLICY,
     roomProjection: FINITE_ROOM_PROJECTION,
   },
+  {
+    sourceKey: "coworker-engagement",
+    definitionVersion: 1,
+    displayLabel: "Coworker engagement",
+    owningArea: "ai-workforce",
+    domainCategory: "coworker-service",
+    defaultDecisionScope: "wwwd",
+    accountResolverKey: null,
+    titleProjection: "Use the requested outcome for the coworker service engagement.",
+    summaryProjection: "Use the coworker service, provider, approval context, and engagement status.",
+    supportedTransitions: STANDARD_TRANSITIONS,
+    receiptPolicy: GOVERNED_RECEIPT_POLICY,
+    roomProjection: FINITE_ROOM_PROJECTION,
+  },
   // ─── Employment lifecycle (EP-862820FD, BI-28EFA338) ────────────────────────
   //
   // The employment lifecycle is registry entries, not a workflow engine.

--- a/apps/web/lib/work-management/status-projection.test.ts
+++ b/apps/web/lib/work-management/status-projection.test.ts
@@ -68,6 +68,39 @@ describe("Work Case status projection", () => {
     });
   });
 
+  it("projects coworker service engagement approval and terminal states", () => {
+    expect(
+      projectWorkCaseState({
+        coworkerEngagement: { engagementId: "CE-1", status: "needs-approval" },
+      }),
+    ).toMatchObject({
+      state: "awaiting-decision",
+      a2aStatus: "input-required",
+      blockingActorKind: "decision",
+      sourceRef: { kind: "coworker-engagement", id: "CE-1", status: "needs-approval" },
+    });
+
+    expect(
+      projectWorkCaseState({
+        coworkerEngagement: { engagementId: "CE-2", status: "completed" },
+      }),
+    ).toMatchObject({
+      state: "resolved",
+      a2aStatus: "completed",
+      terminal: true,
+    });
+
+    expect(
+      projectWorkCaseState({
+        coworkerEngagement: { engagementId: "CE-3", status: "rejected" },
+      }),
+    ).toMatchObject({
+      state: "cancelled",
+      a2aStatus: "rejected",
+      terminal: true,
+    });
+  });
+
   it("prioritizes capsule and verification states over a still-open queue item", () => {
     expect(
       projectWorkCaseState({

--- a/apps/web/lib/work-management/status-projection.ts
+++ b/apps/web/lib/work-management/status-projection.ts
@@ -33,6 +33,10 @@ export interface WorkCaseStatusProjectionInput {
     verificationId: string;
     status: string;
   } | null;
+  coworkerEngagement?: {
+    engagementId: string;
+    status: string;
+  } | null;
   source?: {
     sourceType: string;
     sourceId: string;
@@ -305,6 +309,66 @@ function projectTaskRun(taskRun: { taskRunId: string; status: string }): WorkCas
   });
 }
 
+function projectCoworkerEngagement(
+  engagement: NonNullable<WorkCaseStatusProjectionInput["coworkerEngagement"]>,
+): WorkCaseStateProjection | null {
+  const status = normalized(engagement.status);
+  const sourceRef = ref("coworker-engagement", engagement.engagementId, engagement.status);
+  if (status === "needs-approval") {
+    return projection({
+      state: "awaiting-decision",
+      reason: "Coworker engagement is waiting for approval before work can continue.",
+      sourceRef,
+      blockingActorKind: "decision",
+      a2aStatus: "input-required",
+    });
+  }
+  if (status === "requested") {
+    return projection({
+      state: "intake",
+      reason: "Coworker engagement has been requested.",
+      sourceRef,
+    });
+  }
+  if (status === "accepted") {
+    return projection({
+      state: "triage",
+      reason: "Coworker engagement has been accepted and is ready to start.",
+      sourceRef,
+    });
+  }
+  if (status === "in-progress") {
+    return projection({
+      state: "active",
+      reason: "Coworker engagement is in progress.",
+      sourceRef,
+    });
+  }
+  if (status === "completed") {
+    return projection({
+      state: "resolved",
+      reason: "Coworker engagement completed.",
+      sourceRef,
+    });
+  }
+  if (status === "rejected") {
+    return projection({
+      state: "cancelled",
+      reason: "Coworker engagement was rejected.",
+      sourceRef,
+      a2aStatus: "rejected",
+    });
+  }
+  if (status === "cancelled" || status === "canceled") {
+    return projection({
+      state: "cancelled",
+      reason: "Coworker engagement was cancelled.",
+      sourceRef,
+    });
+  }
+  return null;
+}
+
 /** Single projection entry point for every registered durable work carrier. */
 export function projectWorkUnitState(workUnit: WorkUnit): WorkCaseStateProjection {
   const { carrier, carrierId } = workUnit.identity;
@@ -314,6 +378,9 @@ export function projectWorkUnitState(workUnit: WorkUnit): WorkCaseStateProjectio
   }
   if (carrier === "work-item") {
     return projectWorkCaseState({ workItem: { itemId: carrierId, status } });
+  }
+  if (carrier === "coworker-engagement") {
+    return projectWorkCaseState({ coworkerEngagement: { engagementId: carrierId, status } });
   }
   return projectTaskRun({ taskRunId: carrierId, status });
 }
@@ -336,6 +403,10 @@ export function projectWorkCaseState(
   if (input.workItem) {
     const workItemProjection = projectWorkItem(input.workItem);
     if (workItemProjection) return workItemProjection;
+  }
+  if (input.coworkerEngagement) {
+    const engagementProjection = projectCoworkerEngagement(input.coworkerEngagement);
+    if (engagementProjection) return engagementProjection;
   }
   if (input.source) {
     return projection({

--- a/apps/web/lib/work-management/work-unit.test.ts
+++ b/apps/web/lib/work-management/work-unit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isSameWorkCase,
   toWorkUnitFromCapsule,
+  toWorkUnitFromCoworkerEngagement,
   toWorkUnitFromWorkItem,
   toWorkUnitFromTaskRun,
 } from "./work-unit";
@@ -79,6 +80,28 @@ describe("WorkUnit adapters", () => {
       contributorRefs: ["ops-coordinator"],
     });
     expect(unit.currentState.status).toBe("input-required");
+  });
+
+  it("adapts a CoworkerEngagement without inventing a second lifecycle", () => {
+    const unit = toWorkUnitFromCoworkerEngagement({
+      engagementId: "CE-1",
+      requestedOutcome: "Prepare launch readiness.",
+      status: "needs-approval",
+      requestedByUserId: "user-1",
+      providerAgentId: "agent-launch",
+    });
+
+    expect(unit.identity).toMatchObject({
+      carrier: "coworker-engagement",
+      carrierId: "CE-1",
+      title: "Prepare launch readiness.",
+      caseRef: { sourceType: "coworker-engagement", sourceId: "CE-1" },
+      workItemId: null,
+    });
+    expect(unit.participants).toEqual({
+      accountableRef: "user-1",
+      contributorRefs: ["agent-launch"],
+    });
   });
 
   it("recognizes a capsule and a work-item as the same case via the shared anchor", () => {

--- a/apps/web/lib/work-management/work-unit.ts
+++ b/apps/web/lib/work-management/work-unit.ts
@@ -10,7 +10,11 @@
  * Design: docs/superpowers/specs/2026-08-12-work-model-convergence-addendum-common-work-formula-design.md
  */
 
-export type WorkUnitCarrierKind = "work-capsule" | "work-item" | "task-run";
+export type WorkUnitCarrierKind =
+  | "work-capsule"
+  | "work-item"
+  | "task-run"
+  | "coworker-engagement";
 
 /** The case a unit projects into, addressed by (sourceType, sourceId). */
 export interface WorkUnitCaseRef {
@@ -55,6 +59,7 @@ export const WORK_UNIT_CARRIER_REGISTRY = [
   { carrier: "work-capsule", adapter: "toWorkUnitFromCapsule", addressableSourceType: "work-capsule" },
   { carrier: "work-item", adapter: "toWorkUnitFromWorkItem", addressableSourceType: "work-item" },
   { carrier: "task-run", adapter: "toWorkUnitFromTaskRun", addressableSourceType: "task-run" },
+  { carrier: "coworker-engagement", adapter: "toWorkUnitFromCoworkerEngagement", addressableSourceType: "coworker-engagement" },
 ] as const satisfies ReadonlyArray<{
   carrier: WorkUnitCarrierKind;
   adapter: string;
@@ -151,6 +156,31 @@ export function toWorkUnitFromWorkItem(input: WorkItemWorkUnitInput): WorkUnit {
       : { sourceType: "work-item", sourceId: input.id },
     workItemId: input.id,
     backlogItemId: input.sourceType === "backlog-item" ? input.sourceId : null,
+    stage: input.status,
+  });
+}
+
+export interface CoworkerEngagementWorkUnitInput {
+  engagementId: string;
+  requestedOutcome: string;
+  status: string;
+  requestedByUserId?: string | null;
+  requestedByAgentId?: string | null;
+  providerAgentId?: string | null;
+  workCapsuleId?: string | null;
+}
+
+/** Adapter: a requested coworker service engagement -> WorkUnit. */
+export function toWorkUnitFromCoworkerEngagement(input: CoworkerEngagementWorkUnitInput): WorkUnit {
+  return unit({
+    carrier: "coworker-engagement",
+    carrierId: input.engagementId,
+    title: input.requestedOutcome,
+    status: input.status,
+    caseRef: { sourceType: "coworker-engagement", sourceId: input.engagementId },
+    workItemId: null,
+    accountableRef: input.requestedByUserId ?? input.requestedByAgentId ?? null,
+    contributorRefs: [input.providerAgentId, input.workCapsuleId],
     stage: input.status,
   });
 }

--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -9,6 +9,8 @@ import {
 } from "./workspace-case-loader";
 
 type WorkItemFixture = Awaited<ReturnType<WorkspaceCasePrismaClient["workItem"]["findMany"]>>[number];
+type CoworkerEngagementFixture =
+  Awaited<ReturnType<NonNullable<WorkspaceCasePrismaClient["coworkerEngagement"]>["findMany"]>>[number];
 
 const baseItem = {
   id: "row-1",
@@ -52,6 +54,30 @@ function prismaFor(items: WorkItemFixture[], detail: WorkItemFixture | null = it
   };
 }
 
+const baseEngagement: CoworkerEngagementFixture = {
+  id: "eng-row-1",
+  engagementId: "CE-1",
+  offerId: "OFFER-1",
+  serviceId: "SVC-1",
+  providerAgentId: "agent-launch",
+  requestedByUserId: "user-1",
+  requestedByAgentId: null,
+  requestedOutcome: "Prepare the municipal launch readiness packet.",
+  priority: "high",
+  status: "needs-approval",
+  approvalContext: { required: true, reasons: ["paid-provider:funding-context-missing"] },
+  auditRefs: { source: "town-informed-exercise" },
+  metadata: { exercise: "municipal-launch-readiness" },
+  workCapsuleId: null,
+  toolExecutionId: null,
+  createdAt: new Date("2026-09-06T01:00:00.000Z"),
+  updatedAt: new Date("2026-09-06T01:05:00.000Z"),
+  completedAt: null,
+  provider: { displayName: "Launch Readiness Coworker", name: "launch-readiness" },
+  offer: { offerId: "OFFER-1", name: "Launch readiness" },
+  service: { serviceId: "SVC-1", name: "Municipal portal readiness" },
+};
+
 describe("workspace Work Case loader", () => {
   it("projects queued work as attention-first Work Cases", async () => {
     const dashboard = await loadWorkspaceWorkCaseLens({
@@ -93,6 +119,80 @@ describe("workspace Work Case loader", () => {
 
     expect(key).toBe("manual-task%3AWI%3A42");
     expect(decodeWorkCaseKey(key)).toEqual({ sourceType: "manual-task", sourceId: "WI:42" });
+  });
+
+  it("merges coworker service engagements into the attention-first Work Case lens", async () => {
+    const prismaClient: WorkspaceCasePrismaClient = {
+      ...prismaFor([{ ...baseItem, status: "in-progress", urgency: "routine" }]),
+      coworkerEngagement: {
+        findMany: async () => [baseEngagement],
+        findFirst: async () => baseEngagement,
+      },
+    };
+
+    const dashboard = await loadWorkspaceWorkCaseLens({
+      prismaClient,
+      userId: "user-1",
+      now: new Date("2026-09-06T01:10:00.000Z"),
+    });
+
+    expect(dashboard.cases.map((item) => item.caseId)).toEqual([
+      "coworker-engagement:CE-1",
+      "booking:BK-1",
+    ]);
+    expect(dashboard.cases[0]).toMatchObject({
+      title: "Prepare the municipal launch readiness packet.",
+      sourceLabel: "Coworker engagement",
+      state: "awaiting-decision",
+      href: "/workspace/cases/coworker-engagement%3ACE-1",
+      assignmentLabel: "Requested by you",
+      attentionRequired: true,
+    });
+  });
+
+  it("loads coworker engagement details without a WorkItem comment target", async () => {
+    const prismaClient: WorkspaceCasePrismaClient = {
+      ...prismaFor([], null),
+      coworkerEngagement: {
+        findMany: async () => [baseEngagement],
+        findFirst: async () => baseEngagement,
+      },
+    };
+
+    const detail = await loadWorkspaceWorkCaseDetail({
+      prismaClient,
+      caseKey: encodeWorkCaseKey({ sourceType: "coworker-engagement", sourceId: "CE-1" }),
+      userId: "user-1",
+      now: new Date("2026-09-06T01:10:00.000Z"),
+    });
+
+    expect(detail?.summary).toMatchObject({
+      caseId: "coworker-engagement:CE-1",
+      sourceLabel: "Coworker engagement",
+      state: "awaiting-decision",
+      attentionRequired: true,
+    });
+    expect(detail?.workItemId).toBeNull();
+    expect(detail?.sourceRefs).toContainEqual({
+      kind: "coworker-engagement",
+      id: "CE-1",
+      status: "needs-approval",
+    });
+    expect(detail?.room).toMatchObject({
+      roomKey: "coworker-engagement%3ACE-1",
+      title: "Prepare the municipal launch readiness packet.",
+      purpose: "Prepare the municipal launch readiness packet.",
+      state: "awaiting-decision",
+      work: {
+        nextAction: "Resolve pending decision",
+        attentionRequired: true,
+      },
+    });
+    expect(detail?.room?.participants).toContainEqual(expect.objectContaining({
+      displayName: "Launch Readiness Coworker",
+      kind: "agent",
+      roles: ["contributor"],
+    }));
   });
 
   // BI-2310EEE1 — the list and the room must derive one state. A queued WorkItem

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -37,6 +37,12 @@ import {
   readWorkspaceRoomPolicy,
   type WorkspaceRoomPolicyParticipant,
 } from "./workspace-room-access";
+import {
+  CLOSED_COWORKER_ENGAGEMENT_STATUSES,
+  loadCoworkerEngagementDetail,
+  toCoworkerEngagementListItem,
+  type CoworkerEngagementCasePrismaClient,
+} from "./coworker-engagement-case-projection";
 
 export { decodeWorkCaseKey, encodeWorkCaseKey } from "./case-key";
 
@@ -143,7 +149,7 @@ export type WorkspaceCasePrismaClient = {
   workroomActivity: {
     findMany(args: unknown): Promise<WorkspaceWorkroomActivityRecord[]>;
   };
-};
+} & CoworkerEngagementCasePrismaClient;
 
 export type WorkspaceRoomAuthContext = {
   principalId: string | null;
@@ -225,8 +231,8 @@ export type WorkspaceWorkCaseDetailView = {
   sourceRefs: WorkCaseSourceRef[];
   // BI-B416B12A: the underlying WorkItem id/title, so the detail surface can post
   // a comment (WorkItemMessage.workItemId) with @mention notification.
-  workItemId: string;
-  workItemTitle: string;
+  workItemId: string | null;
+  workItemTitle: string | null;
   // Transitional compatibility seam. The loader always returns the room
   // projection; the optional marker lets the existing detail component remain
   // unchanged until BI-32E26F62 replaces its composition on the same route.
@@ -365,19 +371,37 @@ export async function loadWorkspaceWorkCaseLens({
   }
 
   const cases = items
-    .map((item) => toListItem(item, userId, now, item.id ? capsulesByItem.get(item.id) ?? [] : []))
-    .sort(sortCases);
+    .map((item) => toListItem(item, userId, now, item.id ? capsulesByItem.get(item.id) ?? [] : []));
+  const coworkerEngagements = prismaClient.coworkerEngagement
+    ? await prismaClient.coworkerEngagement.findMany({
+        where: {
+          requestedByUserId: userId,
+          status: { notIn: CLOSED_COWORKER_ENGAGEMENT_STATUSES },
+        },
+        include: {
+          provider: { select: { displayName: true, name: true } },
+          offer: { select: { offerId: true, name: true } },
+          service: { select: { serviceId: true, name: true } },
+        },
+        orderBy: [{ createdAt: "asc" }],
+        take: limit,
+      })
+    : [];
+  const sortedCases = [
+    ...cases,
+    ...coworkerEngagements.map((engagement) => toCoworkerEngagementListItem(engagement, userId)),
+  ].sort(sortCases).slice(0, limit);
 
   return {
     generatedAt: now.toISOString(),
     stats: {
-      total: cases.length,
-      needsAttention: cases.filter((item) => item.attentionRequired).length,
-      active: cases.filter((item) => item.state === "active" || item.state === "verifying").length,
-      unassigned: cases.filter((item) => item.assignmentLabel === "Unassigned").length,
-      dueSoon: cases.filter((item) => dueSoon(item.dueAt, now)).length,
+      total: sortedCases.length,
+      needsAttention: sortedCases.filter((item) => item.attentionRequired).length,
+      active: sortedCases.filter((item) => item.state === "active" || item.state === "verifying").length,
+      unassigned: sortedCases.filter((item) => item.assignmentLabel === "Unassigned").length,
+      dueSoon: sortedCases.filter((item) => dueSoon(item.dueAt, now)).length,
     },
-    cases,
+    cases: sortedCases,
   };
 }
 
@@ -542,6 +566,16 @@ export async function loadWorkspaceWorkCaseDetail({
 }): Promise<WorkspaceWorkCaseDetailView | null> {
   const decoded = decodeWorkCaseKey(caseKey);
   if (!decoded) return null;
+  if (decoded.sourceType === "coworker-engagement") {
+    return loadCoworkerEngagementDetail({
+      prismaClient,
+      sourceId: decoded.sourceId,
+      userId,
+      authContext,
+      caseKey,
+      now,
+    });
+  }
 
   const item = await prismaClient.workItem.findFirst({
     where: {

--- a/docs/superpowers/evidence/2026-09-06-town-informed-company-work-loop-exercise.md
+++ b/docs/superpowers/evidence/2026-09-06-town-informed-company-work-loop-exercise.md
@@ -1,0 +1,122 @@
+# Town-Informed Company Work Loop Exercise
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-09-06 |
+| Governing spec | docs/superpowers/specs/2026-07-24-town-informed-company-work-loop-design.md |
+| Governing plan | docs/superpowers/plans/2026-07-24-town-informed-company-work-loop.md |
+| Governing epic | EP-WORK-CONVERGENCE |
+| Historic backlog label | historic-F309BB95 (does not resolve in this install) |
+| Live backlog item | BI-0EA09322 |
+| Exercise mode | source-grounded dry run |
+| Runtime limitation | Live runtime was not used; findings are valid for source/schema/read-model/UI planning and are not a claim that live event routing has been exercised. |
+
+## Initial Broad Request
+
+Capture one company outcome as a Work Case: prepare a launch-readiness package for a small municipal services portal that accepts resident service requests, routes them to the right team, exposes status safely, and names the owner decisions required before public launch.
+
+## Current Town.com Research Snapshot
+
+Town's current public product framing is an AI assistant that handles repeated busywork through routines, integrations, and human review points. The company-use lesson for DPF is not a personal assistant clone; it is that repeated work should be packaged as observable routines, run against existing systems, and pause for review before consequential action.
+
+Sources reviewed on 2026-09-06:
+
+- Town homepage: https://www.town.com/
+- Town routine library: https://www.town.com/routines
+- Post-meeting debrief drafts: https://www.town.com/routines/post-meeting-debrief-drafts
+- Stalled deal re-engagement: https://www.town.com/routines/stalled-deal-re-engagement
+- Closed-lost win-back: https://www.town.com/routines/closed-lost-win-back
+- Pipeline hygiene alerts: https://www.town.com/routines/pipeline-hygiene-alerts
+- Town pricing for teams: https://www.town.com/pricing?audience=teams
+
+DPF adopts the routine and review-loop pattern, rejects a standalone assistant/inbox, and lands the company setting inside Work Case, Workroom, CoworkerOffer/CoworkerEngagement, AuthorityBinding, receipts, and the existing Needs You surface.
+
+## Compact Turn-By-Turn Summary
+
+| Step | Work Case movement | Result |
+| --- | --- | --- |
+| 1 | Broad company request enters as one launch-readiness outcome. | Work Case remains the company object; no personal assistant surface is introduced. |
+| 2 | Strategy/COO defines stakeholders, success criteria, launch risk, and the decision owner. | Business-facing brief is enough for coworker packet creation. |
+| 3 | Architecture checks current source substrate. | Work Case, Workroom, CoworkerEngagement, TaskRun, WorkUnit, DecisionInteraction, and evidence/receipts already exist. |
+| 4 | Compliance names privacy, retention, public-sector accessibility, and approval constraints. | Consequential commitments belong in Needs You through approval/decision waits. |
+| 5 | Storefront/Product defines resident request lifecycle and candidate Build Studio brief. | Build work remains gated until readiness evidence is clear. |
+| 6 | Finance identifies fees, procurement, refunds, and paid-provider approval needs. | A paid-provider coworker service engagement can require approval before work starts. |
+| 7 | Operations/Dispatcher defines routing, assignment, SLA, and exception handling. | These are Work Case context and candidate future routines, not a second dashboard. |
+| 8 | QA/Assurance defines launch checklist and acceptance evidence. | Verification receipts attach to the same Work Case. |
+| 9 | Source/code verification checks whether coworker service engagements appear in Work Case. | Gap proven: CoworkerEngagement is persisted and typed, but Work Case source registry/read-model/loader did not project it. |
+
+## Work Case Identity
+
+| Field | Value |
+| --- | --- |
+| Proposed case id | coworker-engagement:CE-MUNI-LAUNCH |
+| Source type | coworker-engagement |
+| Source id | CE-MUNI-LAUNCH |
+| Sponsor | Requesting user or requesting agent recorded on CoworkerEngagement |
+| Provider | CoworkerEngagement.providerAgentId |
+| Owning decision scope | WWWD for the municipality/customer's launch decision; WWMD only if platform substrate changes |
+
+## Coworker Contribution Packets
+
+| Coworker | Source reference | Expected output packet | Approval trigger | Evidence/receipt required | Result |
+| --- | --- | --- | --- | --- | --- |
+| Strategy / COO | Work Case business brief | Launch goal, stakeholders, success criteria, risks | Scope changes that affect launch commitment | Operator note or governed action receipt | Recorded |
+| Enterprise Architect | Architecture evidence | Primitive reuse and boundary review | WWMD if DPF substrate changes | Architecture evidence note | Recorded |
+| Compliance / Legal | Compliance packet | Privacy, retention, accessibility, and approval constraints | WWWD/WSID when obligations alter launch posture | DecisionInteraction or compliance evidence | Recorded |
+| Storefront / Product | Portal flow source | Resident request lifecycle and Build Studio brief | WWWD for resident-facing process commitments | Product packet evidence | Recorded |
+| Finance | Finance packet | Fees, refunds, payments, procurement concerns | Funding or paid-provider approval | ApprovalContext and finance evidence | Recorded |
+| Operations / Dispatcher | Dispatch source mapping | Routing, assignment, SLA, field exception path | Operational policy exception | Dispatch evidence note | Recorded |
+| Build Studio | Work Capsule reference | Implementation scope only after gates are clear | WWMD for platform build scope | Work Capsule/evidence link | Recorded |
+| QA / Assurance | Verification source | Launch checklist and acceptance tests | Release readiness decision | Verification receipt | Recorded |
+
+## Required Needs You Decision
+
+Needs You item: approve or decline starting a paid/high-risk launch-readiness coworker service engagement.
+
+Why it belongs in Needs You: CoworkerEngagement.status = needs-approval represents a consequential decision about funding, authority, or risk before work can continue. It should project to Work Case state awaiting-decision with A2A status input-required.
+
+Why technical recovery stays out: a failed runtime verification, provider outage, or missing source bridge is system work. It may block the Work Case, but it should not inflate the owner's decision count unless a real business/authority decision is required.
+
+## Evidence And Receipts
+
+| Evidence | Source | Result |
+| --- | --- | --- |
+| Schema substrate | packages/db/prisma/schema/ai-coworker.prisma model CoworkerEngagement | CoworkerEngagement already persists engagementId, requested outcome, priority, status, approval context, work capsule/tool references, audit refs, and timestamps. |
+| Status vocabulary | apps/web/lib/coworker-service-catalog/types.ts | Engagement statuses are requested, needs-approval, accepted, rejected, in-progress, completed, cancelled. |
+| Creation path | apps/web/lib/coworker-service-catalog/engagements.ts | Approval-required offers create CoworkerEngagement rows with status needs-approval and approval context. |
+| Work Case source registry | apps/web/lib/work-management/source-registry.ts before this branch | No coworker-engagement source entry existed. |
+| Work Case source refs | apps/web/lib/work-management/case-types.ts before this branch | No coworker-engagement source-ref kind existed. |
+| Status projection | apps/web/lib/work-management/status-projection.ts before this branch | No CoworkerEngagement projection existed; source fallback could only show intake with low confidence. |
+| Workspace lens/detail loader | apps/web/lib/work-management/workspace-case-loader.ts before this branch | Loader queried WorkItem/Workroom only, so a direct CoworkerEngagement could not appear as one company Work Case. |
+| WorkUnit formula | apps/web/lib/work-management/work-unit.ts before this branch | WorkUnit carriers were WorkCapsule, WorkItem, and TaskRun; CoworkerEngagement had no adapter. |
+
+Receipt status: source-grounded evidence only. No live runtime receipt is claimed here.
+
+## Delivery Gate Observation
+
+During delivery verification on 2026-09-06, the local-CI production-build stage failed before product code ran because a stale managed BuildKit container for slot-0 carried a GPU device request and Docker Desktop invoked `nvidia-container-runtime-hook`, which crashed while opening NVML. A disposable DPF-shaped BuildKit builder booted without a GPU request, so the stale managed builders were removed and the gate was retried against a fresh tree identity. Treat that earlier local-CI record as infrastructure evidence, not a product defect in the CoworkerEngagement Work Case projection.
+
+## Gap Results
+
+| Hypothesis | Result | Evidence | Follow-up |
+| --- | --- | --- | --- |
+| CoworkerEngagement as Work Case source | Proven | Existing CoworkerEngagement rows cannot be addressed by Work Case source registry/read model without a coworker-engagement source key. | Implemented under BI-0EA09322 on this branch. |
+| Multi-coworker session rollup | Partly proven | Workroom participant projection exists for WorkItem-backed rooms; this exercise only proves the requested coworker service must enter the room first. | No separate BI filed. |
+| Routine promotion edge | Not proven | One dry-run scenario is insufficient recurrence evidence. | None found. |
+| Needs You source coherence | Proven for approval status only | needs-approval should become awaiting-decision/input-required; technical recovery remains system-facing. | Implemented in status projection under BI-0EA09322. |
+| Memory and Commons boundary | Not proven | The dry run produced no new durable memory/commons rule beyond the existing spec. | None found. |
+| Work Case read-model coverage | Proven | buildWorkCaseSummary/buildWorkCaseDetail accepted WorkItem/Capsule/Decision/Evidence but not CoworkerEngagement. | Implemented under BI-0EA09322 on this branch. |
+
+## Explicit None Found Entries
+
+- Follow-on backlog items: BI-0EA09322 filed for the proven projection gap; no additional item filed from the dry run.
+- Repeated-work/routine candidates: none found; one exercise does not prove a repeatable offer.
+- Memory/commons candidates: none found; existing Work Case and evidence-bound learning doctrine covers the lesson.
+- Implementation gaps: CoworkerEngagement as Work Case source and Work Case read-model coverage.
+
+## Planning Decision
+
+- Gate result: source-level implementation may proceed
+- Live-runtime dependency: no
+- Implementation gap selected: CoworkerEngagement as Work Case source
+- Reason: The implementation is source-level projection work over existing persisted CoworkerEngagement records, not live event routing. Current source proves the missing registry, source-ref, status projection, WorkUnit adapter, and workspace loader coverage. A live runtime exercise remains required before claiming end-to-end automatic delivery from service request to Needs You, but it is not required to implement and test this projection gap.

--- a/docs/superpowers/plans/2026-07-24-town-informed-company-work-loop.md
+++ b/docs/superpowers/plans/2026-07-24-town-informed-company-work-loop.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Town-Informed Company Work Loop Implementation Plan
 
 > **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -15,13 +19,15 @@
 >
 > - Tracked by `BI-3B01B725` (recovered tail designs). Read it before acting on this document.
 > - Preserved implementation: `doc/town-company-work-loop` @ `d903bac20cad8297e68ae5e54f010805c68719d5`, pinned at `refs/salvage/2026-08-15/doc/town-company-work-loop` and listed in `~/dpf-deleted-remote-branch-tips-2026-08-15.txt`. Restore with `git push origin d903bac20cad8297e68ae5e54f010805c68719d5:refs/heads/doc/town-company-work-loop`.
-> - Backlog ids cited below that do **not** resolve in this install: `BI-F309BB95`. Treat them as labels, not links.
+> - Backlog labels cited below that do **not** resolve in this install: `historic-F309BB95`. Treat them as historic labels, not links.
+> - Live implementation item for the current branch: `BI-0EA09322` (Project coworker service engagements into Work Case company work).
+> - Current exercise evidence: `docs/superpowers/evidence/2026-09-06-town-informed-company-work-loop-exercise.md`.
 > - No coverage receipt is recorded and none should be until a thread actually starts — a receipt bound to unstarted work would be fiction. This document is deliberately outside the plan-backlog-coverage gate (it carries no bolded backlog-item metadata line).
 
 ## File Structure
 
 - Create: `docs/superpowers/evidence/2026-07-24-town-informed-company-work-loop-exercise.md`
-  - Responsibility: one human-readable exercise record for BI-F309BB95, including coworker packets, Needs You decision, evidence, "none found" entries, and proven gaps.
+  - Responsibility: one human-readable exercise record for the historic-F309BB95 exercise label, including coworker packets, Needs You decision, evidence, "none found" entries, and proven gaps.
 - Modify: `apps/web/lib/work-management/source-registry.ts`
   - Responsibility: register `coworker-engagement` as a Work Case source only if Chunk 1 proves the source is needed.
 - Modify: `apps/web/lib/work-management/source-registry.test.ts`
@@ -82,7 +88,7 @@ Use this exact section structure:
 | Date | 2026-07-24 |
 | Governing spec | docs/superpowers/specs/2026-07-24-town-informed-company-work-loop-design.md |
 | Governing epic | EP-2984B02B |
-| Primary backlog item | BI-F309BB95 |
+| Primary backlog item | BI-0EA09322 |
 | Exercise mode | source-grounded dry run |
 | Runtime limitation | Live runtime was not used; findings are valid only for source/schema/read-model/UI planning. |
 
@@ -1113,7 +1119,7 @@ Call `mcp__dpf__record_external_development_evidence` after final verification a
   "provider": "codex",
   "externalSessionId": "town-company-work-loop-implementation",
   "routeContext": "/build",
-  "backlogItemId": "BI-F309BB95",
+  "backlogItemId": "BI-0EA09322",
   "branchName": "doc/town-company-work-loop",
   "worktreePath": "D:/DPF-worktrees/town-company-work-loop",
   "summary": "Town-informed company Work Case loop implementation and verification handoff.",

--- a/docs/superpowers/specs/2026-07-24-town-informed-company-work-loop-design.md
+++ b/docs/superpowers/specs/2026-07-24-town-informed-company-work-loop-design.md
@@ -1,12 +1,16 @@
+---
+status: active
+---
+
 # Town-Informed Company Work Loop
 
 | Field | Value |
 | --- | --- |
-| Status | Design approved for spec; implementation not started |
+| Status | Design approved; implementation resumed 2026-09-06 under live BI-0EA09322 |
 | Date | 2026-07-24 |
 | Trigger | Founder asked to research Town.com-style assistant/workflow lessons and land the useful parts in DPF company scope, not as a standalone prototype. |
 | Governing epic | EP-2984B02B - Work Case / Company Work Management |
-| Primary backlog | BI-F309BB95 - Exercise multi-coworker Work Case capture with municipal services launch-readiness scenario |
+| Primary backlog | BI-0EA09322 - Project coworker service engagements into Work Case company work |
 | Related surfaces | Workspace, Needs You inbox, Work Case, Work Capsule, Coworker Service Catalog, coworker memory, Authority/Audit |
 | Extends | 2026-06-27-work-management-architecture-design.md; 2026-06-23-human-attention-surface-design.md; 2026-06-29-layer-scoped-work-capsules-design.md; 2026-06-30-coworker-service-offer-catalog-design.md; 2026-07-21-memory-trust-and-evidence-currency-design.md |
 
@@ -15,7 +19,9 @@
 >
 > - Tracked by `BI-3B01B725` (recovered tail designs). Read it before acting on this document.
 > - Preserved implementation: `doc/town-company-work-loop` @ `d903bac20cad8297e68ae5e54f010805c68719d5`, pinned at `refs/salvage/2026-08-15/doc/town-company-work-loop` and listed in `~/dpf-deleted-remote-branch-tips-2026-08-15.txt`. Restore with `git push origin d903bac20cad8297e68ae5e54f010805c68719d5:refs/heads/doc/town-company-work-loop`.
-> - Backlog ids cited below that do **not** resolve in this install: `BI-F309BB95`. Treat them as labels, not links.
+> - Backlog labels cited below that do **not** resolve in this install: `historic-F309BB95`. Treat them as historic labels, not links.
+> - Live implementation item for the DPF-native projection gap: `BI-0EA09322` (Project coworker service engagements into Work Case company work).
+> - Current exercise evidence: `docs/superpowers/evidence/2026-09-06-town-informed-company-work-loop-exercise.md`.
 > - No coverage receipt is recorded and none should be until a thread actually starts — a receipt bound to unstarted work would be fiction. This document is deliberately outside the plan-backlog-coverage gate (it carries no bolded backlog-item metadata line).
 
 ## 1. Thesis
@@ -52,7 +58,7 @@ The previous standalone prototype was correctly rejected because it created a se
 
 The right question is not "Where do we put a Townie?" It is "Can one DPF company outcome stay coherent while multiple coworkers, routines, approvals, memory notes, and build work all contribute?"
 
-BI-F309BB95 is the right proof point because it already asks for a multi-coworker municipal services launch-readiness exercise with strategy, architecture, compliance, storefront, finance, operations, Build Studio, and QA coworkers. That is a company setting, not a personal productivity setting.
+The historic-F309BB95 exercise label is the right proof point because it already asks for a multi-coworker municipal services launch-readiness exercise with strategy, architecture, compliance, storefront, finance, operations, Build Studio, and QA coworkers. That is a company setting, not a personal productivity setting.
 
 ## 3. Non-Goals
 
@@ -122,7 +128,7 @@ Reject:
 
 ## 5. DPF Landing Decision
 
-Land Town.com-style lessons as **an exercise-backed Work Case addendum** under EP-2984B02B and BI-F309BB95.
+Land Town.com-style lessons as **an exercise-backed Work Case addendum** under EP-2984B02B and BI-0EA09322.
 
 The municipal services launch-readiness exercise becomes the proving run:
 
@@ -357,7 +363,7 @@ No implementation should begin until the exercise has converted "possible gaps" 
 The design is successful when:
 
 1. Town.com research is captured as lessons mapped to DPF primitives, not as a standalone assistant.
-2. BI-F309BB95 has a concrete exercise path grounded in the Work Case architecture.
+2. BI-0EA09322 has a concrete exercise path grounded in the Work Case architecture.
 3. The municipal services scenario can be described as one Work Case with multiple coworker contributions.
 4. Needs You remains the only owner decision surface.
 5. Repeat work is routed toward coworker service offers/playbooks, not new dashboard widgets.

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -9,6 +9,7 @@ relatedCode:
   - apps/web/components/workspace/WorkCaseDetailView.tsx
   - apps/web/components/workspace/workroom/WorkroomCycles.tsx
   - apps/web/components/workspace/workroom/WorkroomParticipants.tsx
+  - apps/web/lib/work-management/coworker-engagement-case-projection.ts
   - apps/web/lib/work-management/room-channel-continuity.ts
   - apps/web/lib/work-management/room-channel-ingress.ts
   - apps/web/lib/work-management/room-participation.ts
@@ -23,6 +24,8 @@ relatedCode:
 A Workroom is not an unbounded chat channel. It has a work boundary: purpose, outcome, scope, accountability, authority, sensitivity, measures, timing, and a closure rule. The platform keeps the underlying governed Work Case and its evidence; the room presents that structure in language suited to doing the work.
 
 From **Platform > Workrooms**, select a room ID to open this same canonical Workroom. Rooms tied to backlog work open that backlog case; rooms without a backlog item open their Work Capsule case, so the inventory never leads to a dead route.
+
+Coworker service engagements can also appear as Work Cases. When a requested coworker service needs approval, is accepted, or is in progress, the room opens around the engagement itself: the requested outcome is the room boundary, the provider coworker appears as a contributor, and approval context or audit references stay attached as evidence. These rooms do not show the WorkItem comment box until a WorkItem exists, because there is no task message thread to post into yet.
 
 ## What You See First
 


### PR DESCRIPTION
## Summary

- Captures the Town.com company-work-loop research as DPF-native evidence and updates the existing Town-informed spec/plan instead of creating a standalone assistant app.
- Projects `CoworkerEngagement` into the canonical Work Case/Workroom/WorkUnit path, including `needs-approval` as owner-facing `awaiting-decision` work.
- Keeps source-only coworker engagement rooms from rendering a WorkItem comment form when no WorkItem exists.

## Verification

- `pnpm --filter web exec vitest run lib/work-management/source-registry.test.ts lib/work-management/status-projection.test.ts lib/work-management/case-read-model.test.ts lib/work-management/workspace-case-loader.test.ts lib/work-management/work-unit.test.ts components/workspace/WorkCaseDetailView.test.tsx` — 6 files, 59 tests passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm run pregate:preflight` — 64 guards clean.
- `pnpm run pregate` — local-CI gate passed for `a9756902a67955171479967e0f269956de313cb0`.

## Notes

Earlier local-CI evidence `cmtpf057l09cd01p7tyse4opi` was a stale BuildKit/Docker Desktop NVIDIA hook infrastructure failure before product code ran. The branch evidence now records that observation, the stale managed builders were removed, and the final gate passed on a fresh run.

Linked backlog: BI-0EA09322
Local-CI-Evidence: cmtpg5ans0avv01p7cpw54xlq (feat/town-company-work-loop-delivery@a9756902a67955171479967e0f269956de313cb0)
