### PR TITLE
doc(verification): report what the depth binding would have decided (BI-30165EB4)

### DIFF
--- a/docs/superpowers/audits/2026-09-06-verification-depth-shadow-report.md
+++ b/docs/superpowers/audits/2026-09-06-verification-depth-shadow-report.md
@@ -1,0 +1,85 @@
+---
+status: active
+title: Verification-depth shadow report — what the depth binding would have decided
+---
+
+# Verification-Depth Shadow Report
+
+- **Date:** 2026-09-06
+- **Phase:** 2 of [`2026-08-28-verification-first-workroom-gates.md`](../plans/2026-08-28-verification-first-workroom-gates.md), step 2.3 (the report) and step 2.4 (the written decision per affected cell).
+- **Design:** [`2026-08-28-verification-first-workroom-gates-design.md`](../specs/2026-08-28-verification-first-workroom-gates-design.md) §4.1.
+- **Backlog:** BI-30165EB4 (Phase 2), BI-4FF872FB (the defect this report found).
+- **Source of truth:** the canonical runtime's `BuildActivity` ledger, `tool = 'verification-depth-shadow'`. Live query, not seed data.
+
+---
+
+## 1. The report
+
+Every shadow decision recorded since the seam landed (PR #4880, 2026-09-02) through 2026-09-06.
+
+**Total shadow decisions: 3. Distinct builds: 1. Distinct cells: 1.**
+
+Grouped by kind, processSize and declared depth, as the plan requires:
+
+| kind | processSize | declared depth | transition | decisions | would block | would *newly* block |
+| --- | --- | --- | --- | --- | --- | --- |
+| `feature` | `medium` | `deep` | `ideate->plan` | 3 | 3 | 3 |
+
+Every other cell is empty. No `shallow` decision was recorded. No decision was recorded at `plan->build`, `build->review` or `review->ship`.
+
+The single reason string, identical across all three:
+
+> `deep verification requires a passing typecheck.`
+
+All three carry `actualAllowed: true` — the live gate allowed the transition, as Phase 2 requires. **Zero verdicts changed.**
+
+## 2. Reading the numbers honestly
+
+The plan's §10 offers two falsification branches. This report matches **neither cleanly**, and saying which it is matters more than filing it under one.
+
+**It is not the "empty report" case.** §10 says an empty report means the depth derivation is not reaching real transitions, and the fix is upstream in `derive.ts`. The derivation *is* reaching real transitions. Depth resolved to `deep` on a live build through the stakes path — `deriveStakesBias` maps `deliverableSensitivity: "high"` to `deep`, and the ideate->plan gate evidence carries that sensitivity (`build-design-review-handler.ts:598`). The plumbing works end to end: posture resolved, requirement evaluated, decision recorded. No upstream fix is indicated.
+
+**It is not the "enormous report" case either** — but not because depth is rarely declared. The ledger is small because **the Build Studio phase pipeline is nearly dormant**, not because the binding is narrow:
+
+| Build phase | Builds |
+| --- | --- |
+| `abandoned` | 43 |
+| `ship` | 2 |
+| `failed` | 1 |
+| `build` | 1 |
+| `complete` | 1 |
+
+48 builds total, 43 abandoned. Over the same four days the ledger covers, `BuildActivity` recorded 2,041 `ideate_dispatch` and 1,743 `design_fix_loop` rows against just 3 phase-gate evaluations. Work is churning inside the ideate phase and almost never crossing a phase boundary.
+
+**So the sample is too small to calibrate the declaration, and that is itself the finding.** Three decisions from one build is not a blast radius measurement. The honest verdict on step 2.4's question — "is the block correct or is the declaration wrong?" — is answerable for the one observed cell, and unanswerable for the rest of the matrix because the matrix was never exercised.
+
+## 3. The decision on the one affected cell
+
+**The block is wrong, and the declaration is not wrong either. The requirement is being evaluated at a transition where its evidence cannot exist.**
+
+`checkVerificationDepthSatisfied` demands `verificationOut.typecheckPassed` and `testsFailed === 0` at *any* transition. But `verificationOut` is produced during the build phase. At `ideate->plan` — the transition all three records describe — no build has run, so `verificationOut` is structurally absent, and a `deep` declaration blocks on evidence that could not have been produced yet.
+
+The two halves that combine into this are each defensible alone:
+
+- the design's depth table (§4.1) reads as if the requirement is evaluated once, at ship time;
+- `evaluateVerificationDepthShadow` calls `checkRequirement` directly rather than through a policy cell's requirement list, so it runs on every transition.
+
+Together they manufacture a false positive.
+
+**This is why the report was worth running.** The moment Phase 3 adds this requirement to a policy cell, every high-sensitivity build deadlocks at its *first* transition, before it can ever produce the typecheck the gate is asking for. A shadow report that had simply been counted rather than read would have shown "3 blocks, small blast radius, safe to bind" — and binding it would have broken the deep path completely.
+
+Filed as **BI-4FF872FB** with two candidate fixes (scope the requirement to transitions at or after `build->review`, or make the check phase-aware). Which one is an operator decision, not an agent default.
+
+## 4. What this means for Phase 3
+
+**Phase 3 is not ready to start.** Two preconditions, neither of which is a code change to the gate:
+
+1. **BI-4FF872FB must land first.** Binding a check that false-positives on its most common transition is precisely the "gate people route around" failure the design's §4.2 ordering constraint exists to prevent.
+2. **The report needs a real sample.** Three decisions from one build cannot calibrate anything. Either the build pipeline needs to move work across phase boundaries again, or the shadow window needs to run long enough to observe `shallow` declarations and the later transitions. The 43-abandoned-of-48 build population is a separate health problem that this report surfaces but does not own.
+
+## 5. Method
+
+- Ledger read directly from the canonical runtime Postgres (`dpf-postgres-1`, database `dpf`), table `BuildActivity`, `tool = 'verification-depth-shadow'`. Read-only.
+- Phase distribution from `FeatureBuild`; room posture inputs from `WorkCapsule` (the `Workroom` Prisma model maps to that table).
+- Code substrate verified at `433d90325`: `build-process-matrix.ts`, `verification-depth-requirement.ts`, `verification-depth-shadow.ts`, `work-posture/verification-depth-gate.ts`, `work-posture/derive.ts`, `work-posture/resolve.ts`.
+- Acceptance re-run at the same SHA: 156 tests across 9 files, all passing, including the byte-identical back-compat invariant.

--- a/docs/superpowers/plans/2026-08-28-verification-first-workroom-gates.md
+++ b/docs/superpowers/plans/2026-08-28-verification-first-workroom-gates.md
@@ -11,14 +11,14 @@ title: Implementation plan — verification-first workroom gates
 
 ---
 
-## 0. Blocking precondition
+## 0. Blocking precondition — CLEARED 2026-09-06
 
-This plan must not start until two things are true:
+Both queries ran against live state on 2026-09-06. Full results in the design's §10.
 
-1. **Epic-overlap check against live state.** The DPF MCP server was unreachable for the authoring session, so no live epic or backlog query ran. `EP-WORK-CONVERGENCE`, `EP-1C37C089` (gate binding), `EP-QUALITY-RIGHTSIZING` and `EP-COWORKER-LIFECYCLE` are plausible existing owners of parts of this work. If one already covers a phase, that phase becomes an extension of it rather than new work.
-2. **`BI-4BD81F3B` status confirmed.** Its existence is cited from a code comment in `build-process-matrix.ts`. Phase 4 depends on it being closed; if it is already closed, Phase 4 moves earlier.
+1. **Epic-overlap check — done.** The owner is **`EP-WORK-POSTURE`**, which the original list did not name. `BI-13ED1BE1` (Slice E) already owns making `verificationDepth` load-bearing and shipped on 2026-08-23 at the *policy-envelope* enforcement point — five days before this plan was written. Of the four names guessed here: `EP-QUALITY-RIGHTSIZING` does not exist; `EP-1C37C089` is **not** "gate binding" but the TAK consequential-tool-use gate; `EP-WORK-CONVERGENCE` and `EP-COWORKER-LIFECYCLE` exist but own neither. Phase 2 was therefore filed as a sibling slice under `EP-WORK-POSTURE` (`BI-30165EB4`), not as new work.
+2. **`BI-4BD81F3B` — does not exist.** It returns `not_found` in the live backlog; it is cited only from a code comment. **Phase 4 is gated on an item that was never filed.** Filing it, or identifying what actually tracks non-vacuous browser-use results, is now a Phase 4 precondition.
 
-Both are single queries once MCP is reachable. Neither is a design question.
+**Phase 2 is delivered.** Code landed in PR #4880 (`48a7492bd`, 2026-09-02) — before either query ran, so it too was built without live coverage. Its report and the step 2.4 decision are at [`2026-09-06-verification-depth-shadow-report.md`](../audits/2026-09-06-verification-depth-shadow-report.md).
 
 ## 1. Sequencing rationale
 
@@ -67,6 +67,17 @@ flowchart TD
 **Do not skip 2.3.** The back-compat invariant in `build-process-matrix.ts` is explicit that the default cell must stay byte-identical; shadow mode is how that is proven rather than asserted.
 
 **Gate:** unit tests + `pnpm --filter web build`. No runtime behaviour changes in this phase, which is the point.
+
+### 3.1 Outcome — 2026-09-06
+
+All four steps are complete. `BI-30165EB4`.
+
+- **2.1–2.3 delivered** in PR #4880. Back-compat is proven byte-identically rather than asserted, comparing `JSON.stringify` of the verdict across kind × processSize × depth for the absent/default cell. 156 tests pass across 9 files at `433d90325`.
+- **2.4 delivered** in the [shadow report](../audits/2026-09-06-verification-depth-shadow-report.md).
+
+**The report found one affected cell, and the block is a false positive.** `feature`/`medium`/`deep` at `ideate->plan`, blocking because `verificationOut.typecheckPassed` is absent — at a transition that runs *before any build*, so that evidence cannot exist. Filed as `BI-4FF872FB`.
+
+**Phase 3 must not start yet.** Two preconditions: `BI-4FF872FB` lands first, and the ledger acquires a sample worth calibrating against (3 decisions from 1 build is not a blast radius). Binding the requirement as it stands would deadlock every high-sensitivity build at its first transition.
 
 ### Phase 2 execution record — 2026-08-29
 
@@ -170,4 +181,8 @@ Stated so it can be falsified rather than defended:
 
 - **If Phase 2's shadow report is empty**, then no live work declares `shallow` or `deep`, the posture layer's depth derivation is not reaching real transitions, and the first fix is upstream in `work-posture/derive.ts` — not at the gate. The plan would restart from there.
 - **If the report is enormous**, the depth derivation is over-declaring and needs calibration before any binding. Either way, Phase 2 is the measurement that decides, which is why it cannot be skipped.
+
+**What actually happened (2026-09-06): neither branch, and the binary was too coarse.** The report is tiny — 3 decisions, 1 build, 1 cell — but *not* for the reason the "empty" branch predicts. Depth derivation **is** reaching real transitions, through the stakes path (`deliverableSensitivity: "high"` → `deep`). No upstream `derive.ts` fix is indicated. The ledger is small because the build pipeline is nearly dormant: 43 of 48 builds abandoned, and 3 phase-gate evaluations against 2,041 `ideate_dispatch` rows over the same window.
+
+The lesson for the next phase that writes a falsification clause: **volume was the wrong axis.** Counting the report would have read "3 blocks, small blast radius, safe to bind" and been exactly wrong — the single cell is a false positive that would deadlock every deep build. Reading it found that. A falsification test should ask whether the observations are *sound*, not only how many there are.
 - **If `BI-4BD81F3B` turns out to be unfixable** with the current browser-use approach, Phase 4 does not proceed by lowering the bar. The correct response is to replace the UX verification mechanism, and that is a different design.

--- a/docs/superpowers/specs/2026-08-28-verification-first-workroom-gates-design.md
+++ b/docs/superpowers/specs/2026-08-28-verification-first-workroom-gates-design.md
@@ -25,7 +25,7 @@ Every row is code-verified against this branch, not inferred.
 | 1 | **Failing tests do not block a phase advance.** `verification-typecheck-passed` reads `evidence.verificationOut` and asserts only `typecheckPassed`. `testsFailed` is declared on the same inline type and never read. | `apps/web/lib/explore/build-process-matrix.ts` `checkRequirement`, case `verification-typecheck-passed` |
 | 2 | **UX verification cannot block.** `uxVerification-not-blocking` returns `allowed` for `complete`, `failed`, `skipped` and `null`. Only the transient `running` defers. The code comment records this as an operator decision of 2026-06-07 and names the open quality problem as `BI-4BD81F3B` — "browser-use agent producing genuine, non-vacuous results". | same file, case `uxVerification-not-blocking` |
 | 3 | **Acceptance is self-assessed.** `acceptance-evaluated` requires only that `evidence.acceptanceMet` be truthy. `acceptance-all-met-if-array` tightens this *only* when the value happens to be an array. A scalar truthy value passes unexamined. | same file, cases `acceptance-evaluated`, `acceptance-all-met-if-array` |
-| 4 | **`verificationDepth` is inert.** It is derived (`work-posture/derive.ts`), tightened through a floor (`work-posture/resolve.ts` `tightenVerificationDepth`), and rendered as chips. Its only consumers are display components. No gate reads it. | `WorkroomPosture.tsx`, `posture-display.ts`, `GoldenTriangleOutcomes.tsx`; already recorded as finding 5 of [`workroom-work-posture-design`](2026-08-22-workroom-work-posture-design.md) |
+| 4 | ~~**`verificationDepth` is inert.** It is derived (`work-posture/derive.ts`), tightened through a floor (`work-posture/resolve.ts` `tightenVerificationDepth`), and rendered as chips. Its only consumers are display components. No gate reads it.~~ **CORRECTED 2026-09-06 — this finding was already stale when written.** See §1.2. | `WorkroomPosture.tsx`, `posture-display.ts`, `GoldenTriangleOutcomes.tsx`; already recorded as finding 5 of [`workroom-work-posture-design`](2026-08-22-workroom-work-posture-design.md) |
 | 5 | **Nothing constrains the judge to be independent of the author.** No gate requirement, routing rule, or envelope check asserts that the model family judging an artifact differs from the family that produced it. | `GATE_REQUIREMENTS` (11 entries, none about judge identity); `apps/web/lib/model-selection` |
 | 6 | **Verification that runs on the real path exists — and is not gate-bound.** Golden journeys execute through the real coworker path (real persona, real tool surface, real routing) and are judged by five mechanical oracles (`ORACLE-FABRICATE`, `ORACLE-PURITY`, `ORACLE-REFUSAL`, `ORACLE-SURFACE`, `ORACLE-TOOL`). They run on a certification *sweep*. No phase gate or workroom transition consults their verdicts. | `coworker-lifecycle/golden-journeys.ts`, `certification-runner.ts`, `certification-oracles.ts` |
 | 7 | **There is no feature reachability map.** `apps/web/lib/ea/route-manifest.json` is a route *inventory* — `routePath`, `kind`, `segments`, `dynamicParams`, `file`. It carries nothing about how a *user* reaches a feature: no nav path, no entry point, no stable selector, no keyboard affordance. | `apps/web/lib/ea/route-manifest.json` |
@@ -39,6 +39,18 @@ Every one of those guards protects **the repository that builds the factory**.
 The **workroom** — where in-portal coworkers do customer work — has, at the runtime tier, exactly one hard check: the code compiles. Tests are informational, UX verification is advisory, acceptance is self-reported, and the declared verification depth is decorative.
 
 **DPF has hard gates on the code that builds the factory and soft gates on the work the factory does.** Findings 1–7 are that one sentence seen from seven angles.
+
+### 1.2 Correction to finding 4 — recorded 2026-09-06
+
+Finding 4 claimed no gate reads `verificationDepth`. That was **already false on the day this design was written**, and is now false twice over. Recorded here rather than silently edited, because the reason it was wrong is the reason §10's blocking precondition existed.
+
+1. **The action path was already bound, five days earlier.** `BI-13ED1BE1` (EP-WORK-POSTURE, Slice E) shipped in PR #4591 / `a5da024b4` on **2026-08-23**. `resolveVerificationRequirement` (`work-management/hitl-join.ts`) fuses the declared depth with `RiskClass.outbound-or-floor`, and `evaluateWorkCasePolicy` denies a consequential action by name — `missing_verification_evidence` — when verification is required and no evidence carries a `verifiedAt`. That item's own body states Defect 1 in the same terms this design's finding 4 uses. The design was authored without live backlog state (see §10), so it re-derived a problem the platform had already fixed at a different enforcement point.
+
+2. **The build phase gate is now bound in shadow.** PR #4880 / `48a7492bd` (2026-09-02) landed Change A per §4.1 — `verification-depth-satisfied` in `GATE_REQUIREMENTS`, evaluated on every transition and recorded to `BuildActivity`, changing no verdict.
+
+**What survives.** The two bindings enforce at *different points* and are not duplicates: BI-13ED1BE1 governs whether a coworker may take a consequential **action**; §4.1 governs whether a build may cross a **phase boundary**. The accurate form of finding 4 is narrower and still true as of `433d90325`: *the build-process phase gate did not read `verificationDepth`* — `GATE_REQUIREMENTS` carried 11 entries and none concerned depth.
+
+**What this costs the rest of the design.** §4.1's depth table and BI-13ED1BE1's requirement now define "deep" differently — a three-tier evidence ladder versus a binary requires-verification floor. Reconciling them is unowned work; until it is done, one declaration means two things. Before Phase 3 binds anything, that reconciliation is a precondition, not a cleanup.
 
 ## 2. Why this is a design problem, not seven bug fixes
 
@@ -196,6 +208,18 @@ Detail, task breakdown and rollback: [`2026-08-28-verification-first-workroom-ga
 
 Findings 1–7 are code-verified on this branch and cite the files.
 
-**Backlog coverage is absent.** The DPF MCP server was unreachable for this session (`DPF_MCP_BEARER_TOKEN` unset; connection refused), so live epic and backlog state could not be queried. Per [`live-state-over-seed-data`](../../professions/data-architect/wiki/live-state-over-seed-data.md) and the epic-overlap rule, this design is **not ready to implement** until an epic-overlap check runs against the live database — `EP-WORK-CONVERGENCE`, `EP-1C37C089`, `EP-QUALITY-RIGHTSIZING` and `EP-COWORKER-LIFECYCLE` are the likely neighbours and may already own parts of this. `BI-4BD81F3B` is cited from a source comment and its live status is unconfirmed.
+~~**Backlog coverage is absent.**~~ **RESOLVED 2026-09-06 — the epic-overlap check ran against live state.** Recorded below; the original text is preserved in git history.
 
-This document is a design proposal with verified problem statements, not an approved plan.
+The check the original §10 asked for was run against the live database on 2026-09-06 with `DPF_MCP_BEARER_TOKEN` set and the MCP server reachable. Results:
+
+| Named neighbour | Live state |
+| --- | --- |
+| `EP-WORK-CONVERGENCE` | Exists. Does not own depth binding. |
+| `EP-1C37C089` | Exists, but is **mislabelled in the plan as "gate binding"**. Its real title is *TAK alignment control surface — WWWD×WSID governance gate on consequential tool use*. Adjacent, not this. |
+| `EP-QUALITY-RIGHTSIZING` | **Does not exist.** No match across all 80 epics. |
+| `EP-COWORKER-LIFECYCLE` | Exists. Owns certification and oracles (finding 6), not depth binding. |
+| **`EP-WORK-POSTURE`** | **The actual owner, and not named in the original list.** Slice E, `BI-13ED1BE1`, owns making `verificationDepth` load-bearing — see §1.2. |
+
+**`BI-4BD81F3B` does not exist in the live backlog.** It returns `not_found`. It is cited only from a code comment in `build-process-matrix.ts`. §4.2 makes it the hard ordering precondition for Phase 4, so **Phase 4 is currently gated on a backlog item that was never filed.** Filing it — or replacing the reference with whatever really tracks non-vacuous browser-use results — is a precondition for Phase 4, not a formality.
+
+**Status of the design as a whole.** The problem statements remain code-verified apart from finding 4 (§1.2). Phase 2 is delivered (`BI-30165EB4`) and its report is at [`2026-09-06-verification-depth-shadow-report.md`](../audits/2026-09-06-verification-depth-shadow-report.md). Phases 3–6 remain proposals; Phase 3 has two open preconditions named in that report.


### PR DESCRIPTION
## What this is

Phase 2 of the [verification-first workroom gates plan](docs/superpowers/plans/2026-08-28-verification-first-workroom-gates.md) — **shadow mode**. Its code landed in #4880 with no backlog item and without the report the plan asks for. This delivers the report, the step 2.4 decision, and the backlog coverage.

**No code changes. No verdict changes. Zero policy cells list the requirement.**

## Design grounding

Grounded in [`2026-08-28-verification-first-workroom-gates-design.md`](docs/superpowers/specs/2026-08-28-verification-first-workroom-gates-design.md) §4.1 and its plan §3.

Code substrate read at `433d90325` before writing anything:
- `apps/web/lib/explore/build-process-matrix.ts` — `GATE_REQUIREMENTS`, `checkRequirement`, the byte-identical back-compat contract
- `apps/web/lib/explore/verification-depth-requirement.ts`, `verification-depth-shadow.ts`
- `apps/web/lib/work-posture/verification-depth-gate.ts` — the transition seam and its 9 call sites
- `apps/web/lib/work-posture/derive.ts`, `resolve.ts` — `deriveStakesBias`, `tightenVerificationDepth`
- `apps/web/lib/work-management/hitl-join.ts`, `policy-envelope.ts` — the *other* depth binding

Live state read from the canonical runtime: `BuildActivity`, `FeatureBuild`, `WorkCapsule`.

## The report

The whole shadow ledger, 2026-09-02 → 2026-09-06:

| kind | processSize | depth | transition | decisions | would block | would newly block |
| --- | --- | --- | --- | --- | --- | --- |
| `feature` | `medium` | `deep` | `ideate->plan` | 3 | 3 | 3 |

**The one affected cell is a false positive.** `checkVerificationDepthSatisfied` demands `verificationOut.typecheckPassed` at *any* transition, but `verificationOut` is produced during the build phase — at `ideate->plan` it cannot exist yet. Depth reaches that transition for real, via `deliverableSensitivity: "high" → deep`. So the moment Phase 3 binds this, **every high-sensitivity build deadlocks at its first transition**. Filed as `BI-4FF872FB`.

Counting the report would have said "3 blocks, small blast radius, safe to bind" and been exactly wrong. Reading it found the defect.

## Two corrections

Both recorded rather than silently edited.

1. **Design finding 4 was already stale when written.** It claims no gate reads `verificationDepth`. `BI-13ED1BE1` bound it at the policy envelope in #4591 on 2026-08-23 — five days *before* the design was authored. The two bindings are not duplicates (action vs. phase boundary), but they now define "deep" differently, and reconciling them is an unowned precondition for Phase 3.
2. **Plan §0's blocking precondition is cleared.** The epic-overlap check ran: the owner is `EP-WORK-POSTURE` (not named in the original list), `EP-QUALITY-RIGHTSIZING` does not exist, `EP-1C37C089` is the TAK tool-use gate rather than "gate binding", and **`BI-4BD81F3B` — which §4.2 makes the hard precondition for Phase 4 — was never filed.**

## Verification

- `pnpm --filter web exec vitest run lib/explore/build-process-matrix.test.ts lib/work-posture/` — **156 passed, 9 files**
- `pnpm --filter web build` — **exit 0**
- `check-doc-links`, `check-doc-anchor-existence`, `check-doc-reference-integrity`, `check-spec-status-frontmatter` — all OK

The back-compat invariant is **proven, not asserted**: `build-process-matrix.test.ts` compares `JSON.stringify(result)` against the pre-matrix verdict across kind {absent, feature} × processSize {absent, medium} × depth {absent, none}. Depth `none`/absent behaves exactly as today.

## Scope discipline

Untouched, as the phase requires: `uxVerification-not-blocking` (Phase 4, and its gating BI does not exist), `testsFailed` as a blocking input (Phase 3), judge independence (Phase 5 — a kernel-gap capture and a decision first). No table, migration, or new verification engine.

## Backlog

- `BI-30165EB4` — Phase 2, filed retroactively under `EP-WORK-POSTURE`
- `BI-4FF872FB` — the false-positive defect; **Phase 3 is blocked on it**

🤖 Generated with [Claude Code](https://claude.com/claude-code)