### PR TITLE
fix(promoter): keep a pre-existing install's LAN exposure through the portal swap

### DIFF
--- a/.github/workflows/self-upgrade-acceptance.yml
+++ b/.github/workflows/self-upgrade-acceptance.yml
@@ -127,6 +127,13 @@ jobs:
         run: |
           node --test scripts/promote-install-state-rollback.test.mjs \
             | tee "$DPF_N1_EVIDENCE/signed-promotion-rollback.tap"
+      - name: Promotion keeps a pre-existing install's LAN exposure through the portal swap
+        # BI-55A30F8B: the portal is recreated before the installer writes
+        # DPF_HOST_BIND_ADDRESS; the promoter must carry the pre-existing
+        # exposure itself or a LAN install goes dark mid-upgrade.
+        run: |
+          node --test scripts/promote-host-bind-address.test.mjs \
+            | tee "$DPF_N1_EVIDENCE/promotion-host-bind-address.tap"
       - name: Resolve N-1 baseline
         id: baseline
         # BI-9E5E6063: prefer a live merge-base over a potentially stale

--- a/docs/superpowers/specs/2026-09-05-portal-bind-posture-design.md
+++ b/docs/superpowers/specs/2026-09-05-portal-bind-posture-design.md
@@ -36,6 +36,7 @@ Candidate causes ruled out by running them:
 4. `apps/web/app/api/automation/sign-in/route.ts`: build the redirect from `getPortalUrl()`.
 5. `docs/install/*` and `docs/user-guide` (whichever guide the docs-impact gate maps): default exposure statement and the opt-in line.
 6. Follow-up for the remaining 58 `request.nextUrl.origin` call sites: BI-48092F3A.
+7. `scripts/promote.sh` (BI-55A30F8B, found on the first production self-upgrade after step 2 shipped): the promoter recreates the portal in its step 4, but step 3 above only runs in its step 7, so the first promotion binds every port to loopback with the old `.env` and a LAN install goes dark. Before any compose command, when the compose env file predates the key, the promoter exports `DPF_HOST_BIND_ADDRESS=0.0.0.0` (process environment wins over `--env-file`) and emits `step=host-bind-address-preserved`. An env file that carries the key, or an operator-set variable, is left alone. Test `promote-host-bind-address.test.mjs`, registered in the self-upgrade acceptance workflow.
 
 ## Boundaries
 

--- a/scripts/ci-policy-test-inventory-allowlist.txt
+++ b/scripts/ci-policy-test-inventory-allowlist.txt
@@ -130,6 +130,7 @@ scripts/nonprod-environment-admission.test.mjs
 scripts/pr-readiness.test.mjs
 scripts/pregate.test.mjs
 scripts/probes/marketing-media/gemini-tts-response.test.mjs
+scripts/promote-host-bind-address.test.mjs
 scripts/promote-install-state-rollback.test.mjs
 scripts/promoter-build-context.test.mjs
 scripts/promoter-contract.test.mjs

--- a/scripts/promote-host-bind-address.test.mjs
+++ b/scripts/promote-host-bind-address.test.mjs
@@ -1,0 +1,115 @@
+// BI-55A30F8B: the promoter recreates the portal (step 4) before the installer
+// writes DPF_HOST_BIND_ADDRESS into the install .env (step 7). Compose then
+// binds every published port to 127.0.0.1 and a LAN-serving install goes dark
+// for the rest of the promotion. promote.sh must mirror the installer's
+// pre-existing-install rule (BI-FEE77B68) before any compose command runs.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+const root = resolve(new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+const bash = process.platform === "win32" ? "C:\\Program Files\\Git\\bin\\bash.exe" : "bash";
+const bashPath = (path) => process.platform === "win32"
+  ? resolve(path).replace(/^([A-Za-z]):\\/, (_, drive) => `/${drive.toLowerCase()}/`).replaceAll("\\", "/")
+  : resolve(path);
+
+async function fixture() {
+  const dir = await mkdtemp(join(tmpdir(), "dpf-promote-bind-"));
+  const source = join(dir, "source");
+  const stateDir = join(dir, "state");
+  const bin = join(dir, "bin");
+  await Promise.all([mkdir(join(source, "scripts", "lib"), { recursive: true }), mkdir(stateDir), mkdir(bin)]);
+  await writeFile(join(source, "scripts/lib/resolve-capability-compose-profiles.mjs"),
+    `process.stdout.write(JSON.stringify({composeProfiles:[],requiredServices:[]}) + "\\n");\n`);
+  await writeFile(join(stateDir, "install-state.json"), `${JSON.stringify({
+    schemaVersion: 1, installerVersion: "acceptance-v1", platform: "linux", arch: "amd64",
+    installPath: "/opt/dpf", stateDir: "/dpf-state", composeProjectName: "dpf",
+  })}\n`);
+  // The same node shim the rollback acceptance uses: Git Bash hands POSIX
+  // paths to a Windows node, which cannot open them.
+  await writeFile(join(bin, "node"), `#!/usr/bin/env bash
+converted=()
+for arg in "$@"; do
+  case "$arg" in /[a-zA-Z]/*) arg="$(cygpath -w "$arg")" ;; esac
+  converted+=("$arg")
+done
+if [[ "\${DPF_PROMOTER_STATE_DIR:-}" == /[a-zA-Z]/* ]]; then export DPF_PROMOTER_STATE_DIR="$(cygpath -w "$DPF_PROMOTER_STATE_DIR")"; fi
+exec '${bashPath(process.execPath)}' "\${converted[@]}"
+`);
+  await chmod(join(bin, "node"), 0o755);
+  spawnSync("git", ["init", "-q", source]);
+  spawnSync("git", ["-C", source, "config", "user.email", "test@example.com"]);
+  spawnSync("git", ["-C", source, "config", "user.name", "Test"]);
+  spawnSync("git", ["-C", source, "add", "."]);
+  spawnSync("git", ["-C", source, "commit", "-q", "-m", "fixture"]);
+  const sha = spawnSync("git", ["-C", source, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
+  // Source the promoter in dry-run mode, then report the bind address the
+  // compose commands would have inherited. Dry-run runs every resolution
+  // step and touches no Docker.
+  const harnessPath = join(dir, "harness.sh");
+  await writeFile(harnessPath, `source "$1" --self-upgrade --dry-run\nprintf 'bind=%s\\n' "\${DPF_HOST_BIND_ADDRESS:-unset}"\n`);
+  return { dir, source, stateDir, bin, sha, harnessPath };
+}
+
+async function promote(f, { envFile, processEnv } = {}) {
+  const env = {
+    ...process.env,
+    PATH: `${bashPath(f.bin)}:/usr/local/bin:/usr/bin:/bin`,
+    DPF_PROMOTER_STATE_DIR: bashPath(f.stateDir),
+    PROMOTE_SOURCE: bashPath(f.source),
+    PROMOTE_TARGET_SHA: f.sha,
+    PROMOTE_BACKUP_PATH: bashPath(join(f.dir, "backup")),
+    PROMOTE_HEALTH_URL: "http://acceptance.invalid/api/health",
+    PROMOTE_COMPOSE_PROJECT: "dpf-bind-acceptance",
+    ...processEnv,
+  };
+  delete env.DPF_HOST_BIND_ADDRESS;
+  if (processEnv?.DPF_HOST_BIND_ADDRESS) env.DPF_HOST_BIND_ADDRESS = processEnv.DPF_HOST_BIND_ADDRESS;
+  if (envFile !== undefined) {
+    const path = join(f.dir, "install.env");
+    await writeFile(path, envFile);
+    env.PROMOTE_COMPOSE_ENV_FILE = bashPath(path);
+  }
+  const result = spawnSync(bash, [bashPath(f.harnessPath), bashPath(join(root, "scripts/promote.sh"))], { cwd: root, env, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const bind = result.stdout.match(/^bind=(.*)$/m)?.[1];
+  return { bind, preserved: /step=host-bind-address-preserved/.test(result.stdout) };
+}
+
+test("an install .env that predates DPF_HOST_BIND_ADDRESS keeps its LAN exposure through the portal swap", async () => {
+  const f = await fixture();
+  try {
+    const run = await promote(f, { envFile: "DPF_IMAGE_TAG=v2026.09.05-previous.1\nGHCR_OWNER=opendigitalproductfactory\n" });
+    assert.equal(run.bind, "0.0.0.0");
+    assert.equal(run.preserved, true, "the promoter must say it preserved the exposure");
+  } finally { await rm(f.dir, { recursive: true, force: true }); }
+});
+
+test("an install .env that already carries DPF_HOST_BIND_ADDRESS is respected as written", async () => {
+  const f = await fixture();
+  try {
+    const run = await promote(f, { envFile: "DPF_IMAGE_TAG=v1\nDPF_HOST_BIND_ADDRESS=127.0.0.1\n" });
+    assert.equal(run.bind, "unset", "compose reads the value from --env-file; the promoter must not override it");
+    assert.equal(run.preserved, false);
+  } finally { await rm(f.dir, { recursive: true, force: true }); }
+});
+
+test("an operator-set DPF_HOST_BIND_ADDRESS in the promoter environment wins", async () => {
+  const f = await fixture();
+  try {
+    const run = await promote(f, { envFile: "DPF_IMAGE_TAG=v1\n", processEnv: { DPF_HOST_BIND_ADDRESS: "127.0.0.1" } });
+    assert.equal(run.bind, "127.0.0.1");
+    assert.equal(run.preserved, false);
+  } finally { await rm(f.dir, { recursive: true, force: true }); }
+});
+
+test("no env file, or an empty one, is a fresh install and keeps the compose loopback default", async () => {
+  const f = await fixture();
+  try {
+    assert.deepEqual(await promote(f), { bind: "unset", preserved: false });
+    assert.deepEqual(await promote(f, { envFile: "\n" }), { bind: "unset", preserved: false });
+  } finally { await rm(f.dir, { recursive: true, force: true }); }
+});

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -458,6 +458,24 @@ if [[ -n "${PROMOTE_COMPOSE_ENV_FILE:-}" ]]; then
   _env_args+=(--env-file "$PROMOTE_COMPOSE_ENV_FILE")
 fi
 
+# BI-55A30F8B: compose publishes every host port through DPF_HOST_BIND_ADDRESS
+# (default 127.0.0.1, BI-FEE77B68). The portal is recreated in step 4, but the
+# installer only writes the key into the install .env in step 7, so the first
+# promotion after that change served a LAN install on loopback only and the
+# host went dark for every peer (production, 2026-09-05). Mirror the installer
+# rule here, before any compose command runs: an env file that predates the key
+# keeps the all-interfaces exposure it already has. Process environment wins
+# over --env-file in compose interpolation, and an operator who already set the
+# variable, or an env file that carries it, is left alone.
+if [[ -z "${DPF_HOST_BIND_ADDRESS:-}" && -n "${PROMOTE_COMPOSE_ENV_FILE:-}" ]] \
+  && grep -q '[^[:space:]]' "$PROMOTE_COMPOSE_ENV_FILE" \
+  && ! grep -q '^DPF_HOST_BIND_ADDRESS=' "$PROMOTE_COMPOSE_ENV_FILE"; then
+  export DPF_HOST_BIND_ADDRESS=0.0.0.0
+  _host_bind_preserved=1
+else
+  _host_bind_preserved=0
+fi
+
 # Emit a tagged step line; always prints in both dry-run and real modes.
 # Only the step name and target SHA are printed — never source/backup/health
 # paths — so logs are safe to surface to operators.
@@ -468,6 +486,9 @@ emit_step() {
     printf 'step=%s target=%s\n' "$1" "$PROMOTE_TARGET_SHA"
   fi
 }
+if [[ $_host_bind_preserved -eq 1 ]]; then
+  emit_step host-bind-address-preserved
+fi
 
 # BET-5 (BI-A1E864A5): does this Postgres container's IMAGE provide the pgvector
 # extension? Image-agnostic — query pg_available_extensions (which reflects the

--- a/scripts/self-upgrade-sensitive-paths.test.mjs
+++ b/scripts/self-upgrade-sensitive-paths.test.mjs
@@ -73,6 +73,10 @@ test("acceptance workflow is path-sensitive, nightly, least-privilege, bounded, 
   assert.match(workflow, /Build candidate promoter with immutable contract identity/);
   assert.match(workflow, /Signed promotion rollback restores exact legacy state/);
   assert.match(workflow, /promote-install-state-rollback\.test\.mjs/);
+  // BI-55A30F8B: the promoter must keep a pre-existing install's LAN exposure
+  // through the portal swap, which happens before the installer writes the key.
+  assert.match(workflow, /Promotion keeps a pre-existing install's LAN exposure through the portal swap/);
+  assert.match(workflow, /promote-host-bind-address\.test\.mjs/);
   assert.match(workflow, /Invalid state refuses before quiescence/);
   assert.match(workflow, /\.quiescenceBegan == false/);
   // BI-AA6FBAD0: readiness must be proven against the shape every live install


### PR DESCRIPTION
## Summary

BI-55A30F8B. Production (192.168.0.152) self-upgraded at 2026-09-05 20:47Z and has been dark on the LAN since: the host pings, every published port refuses, and the development install's work sync reports `fetch failed`.

Cause: since #5067 `docker-compose.yml` publishes every host port through `${DPF_HOST_BIND_ADDRESS:-127.0.0.1}`. The installer (`install-release-assets.mjs`) writes `DPF_HOST_BIND_ADDRESS=0.0.0.0` into a pre-existing install's `.env` (BI-FEE77B68), but `promote.sh` runs that installer in its step 7, after it already recreated the portal in step 4 with the old `--env-file`. The first promotion after #5067 therefore bound the portal to loopback.

Fix: before any compose command, when the compose env file has content and lacks the key, the promoter exports `DPF_HOST_BIND_ADDRESS=0.0.0.0` (process environment wins over `--env-file` in compose interpolation) and emits `step=host-bind-address-preserved`. An env file that carries the key, an operator-set variable, a missing env file, or an empty one are left alone, so a fresh install keeps the loopback default.

## Tests

- `scripts/promote-host-bind-address.test.mjs` sources the promoter in dry-run mode under the acceptance harness and checks all four cases. It fails on the unpatched script (verified by swapping in `origin/main:scripts/promote.sh`).
- Registered in `.github/workflows/self-upgrade-acceptance.yml`; asserted by `self-upgrade-sensitive-paths.test.mjs`; allowlisted in the CI policy inventory like its sibling rollback test.
- `promote-install-state-rollback.test.mjs` still passes.

Spec `docs/superpowers/specs/2026-09-05-portal-bind-posture-design.md` gains fix-sequence step 7.

Pushed with the recorded pre-push override because the local-CI pool is dead-parked (exit 75). CI enforces every gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
