### PR TITLE
fix(mcp): the design-review writer schema states its contract before the writer refuses it (BI-9E522F11)

### DIFF
--- a/apps/web/lib/mcp/packs/initiative-readiness-pack.test.ts
+++ b/apps/web/lib/mcp/packs/initiative-readiness-pack.test.ts
@@ -221,3 +221,21 @@ describe("initiative readiness reviewer tools", () => {
     }));
   });
 });
+
+describe("the writer schema states its contract before the writer refuses it (BI-9E522F11)", () => {
+  // Measured 2026-09-06 on the reference install: four spec-approval attempts
+  // in one hour ended malformed-receipt ("A passing spec approval cannot
+  // introduce findings"), one CLASSIFICATION_REQUIRED (profile copied from the
+  // spec header), one finding-resolution-invalid. Every rule was enforced on
+  // the server and stated nowhere the reviewer could read before calling.
+  it("tells the reviewer that a pass carries no findings, what profile to name, and what a resolution may cite", () => {
+    const tool = initiativeReadinessPack.definitions.find((definition) => definition.name === "record_initiative_design_review");
+    const properties = (tool?.inputSchema as { properties: Record<string, { description?: string }> }).properties;
+    expect(properties.decision?.description).toMatch(/NO findings/);
+    expect(properties.findings?.description).toMatch(/ONLY on a failing receipt/);
+    expect(properties.findings?.description).toMatch(/malformed-receipt/);
+    expect(properties.profile?.description).toMatch(/authoritative classification/);
+    expect(properties.profile?.description).toMatch(/CLASSIFICATION_REQUIRED/);
+    expect(properties.resolvedFindingRefs?.description).toMatch(/finding-resolution-invalid/);
+  });
+});

--- a/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
+++ b/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
@@ -34,11 +34,21 @@ function inputSchemaFor(name: string, lane: Lane): ToolDefinition["inputSchema"]
     properties: {
       itemId: { type: "string", description: "Governed BacklogItem ID (BI-*)." },
       gate: { type: "string", enum: [...lane.gates] },
-      decision: { type: "string", enum: ["pass", "fail", "not-applicable"] },
+      decision: {
+        type: "string",
+        enum: ["pass", "fail", "not-applicable"],
+        description:
+          "pass records the gate as satisfied at this exact artifact and carries NO findings; fail records the gate as unmet and carries at least one finding. Advisory observations that do not block belong in reason, never in findings on a pass.",
+      },
       artifactRef: artifactRefSchema,
-      reason: { type: "string" },
+      reason: {
+        type: "string",
+        description: "Why the gate passed or failed, citing the artifact. Non-blocking observations go here on a pass.",
+      },
       findings: {
         type: "array",
+        description:
+          "Blocking defects, and ONLY on a failing receipt: a passing receipt with findings is refused as malformed-receipt. Pass an empty array on pass. Each finding gets a server-minted id; the caller never supplies one.",
         items: {
           type: "object",
           properties: {
@@ -48,9 +58,23 @@ function inputSchemaFor(name: string, lane: Lane): ToolDefinition["inputSchema"]
           required: ["issue", "severity"],
         },
       },
-      resolvedFindingRefs: { type: "array", items: { type: "string" } },
-      profile: { type: "string", enum: ["doc-only", "fix", "feature", "cross-domain", "archetype"] },
-      artifactRole: { type: "string", enum: ["design-spec", "problem-statement", "documentation-scope"] },
+      resolvedFindingRefs: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Ids of findings currently OPEN on this item that this receipt resolves (from earlier failing receipts, IF-* ids). Pass an empty array when none; naming an id that is not open is refused as finding-resolution-invalid.",
+      },
+      profile: {
+        type: "string",
+        enum: ["doc-only", "fix", "feature", "cross-domain", "archetype"],
+        description:
+          "Required on a passing spec-approval. The item's own authoritative classification (the profile the readiness decision reports for the item, derived from its work type), NOT the reach of the design: a spec whose policy spans domains still names the item's profile. A mismatch is refused as CLASSIFICATION_REQUIRED.",
+      },
+      artifactRole: {
+        type: "string",
+        enum: ["design-spec", "problem-statement", "documentation-scope"],
+        description: "Required on a passing spec-approval: what the reviewed artifact is.",
+      },
       expectedCurrentBaselineId: { type: ["string", "null"] },
       supersessionDispositions: {
         type: "array",


### PR DESCRIPTION
## Why

Measured 2026-09-06 on the reference install while minting the BI-B5C8FEFC baseline: four spec-approval attempts in one hour ended `malformed-receipt` ("A passing spec approval cannot introduce findings"), one ended `CLASSIFICATION_REQUIRED` because the reviewer copied the profile from the spec header instead of naming the item's own classification, and one ended `finding-resolution-invalid` for citing a finding that was not open. Every rule is enforced on the server and was stated nowhere the reviewer could read: `decision`, `findings`, `resolvedFindingRefs`, `profile` and `artifactRole` carried no description.

## What

Descriptions on those five fields of `record_initiative_design_review` (and the sibling lanes sharing the schema) stating the contract. No behaviour change; the writer refuses exactly as before.

## Verification

- `initiative-readiness-pack.test.ts` asserts the descriptions carry the contract; pack suite 9/9.
- Web typecheck clean; local-CI gate PASS at f5a429b1f50a (evidence cmtpy6ude0ax601qm72hq1tu4).

Backlog: BI-9E522F11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)