### PR TITLE
fix(federation): the organization named at setup is an estate-name tier; members report the authority's real refusal

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -237,6 +237,8 @@ export default async function ShellLayout({ children }: { children: React.ReactN
           installationBadge={await loadInstallationBadge({
             readConfig: async (key) =>
               (await prisma.platformConfig.findUnique({ where: { key } }))?.value ?? null,
+            // The badge falls back to the organization named at setup (BI-CA54ACC8).
+            readOrganizationName: async () => organization?.name ?? null,
           })}
         />
         <div className="flex flex-1 flex-col lg:flex-row">

--- a/apps/web/app/(shell)/ops/installation/page.tsx
+++ b/apps/web/app/(shell)/ops/installation/page.tsx
@@ -60,7 +60,11 @@ export default async function InstallationIdentityPage() {
     <div className="mx-auto w-full max-w-4xl">
       <InstallationIdentityPanel view={view} />
       <div className="px-4 pb-6 sm:px-6">
-        <EstateNameField estateName={estate.estateName} badgePreview={badgePreview} />
+        <EstateNameField
+          estateName={estate.tier === "organization-name" ? null : estate.estateName}
+          badgePreview={badgePreview}
+          organizationFallback={estate.tier === "organization-name" ? estate.estateName : null}
+        />
       </div>
     </div>
   );

--- a/apps/web/app/.well-known/dpf-federation.json/route.test.ts
+++ b/apps/web/app/.well-known/dpf-federation.json/route.test.ts
@@ -15,6 +15,8 @@ vi.mock("@/lib/federation/demand-identity", () => ({
 }));
 vi.mock("@/lib/install/estate-identity", () => ({
   loadEstateNameResolution: mockEstate,
+  // BI-CA54ACC8: the route composes its store through this builder.
+  prismaEstateIdentityStore: vi.fn(() => ({ readConfig: async () => null, readOrganizationName: async () => null })),
 }));
 
 import { GET } from "./route";

--- a/apps/web/app/.well-known/dpf-federation.json/route.ts
+++ b/apps/web/app/.well-known/dpf-federation.json/route.ts
@@ -26,7 +26,7 @@ import {
   federationAdvertisingEnabled,
 } from "@/lib/federation/discovery-advertisement";
 import { resolveFederationIdentity } from "@/lib/federation/demand-identity";
-import { loadEstateNameResolution } from "@/lib/install/estate-identity";
+import { loadEstateNameResolution, prismaEstateIdentityStore } from "@/lib/install/estate-identity";
 
 export const dynamic = "force-dynamic";
 
@@ -45,11 +45,7 @@ export async function GET(): Promise<NextResponse> {
   try {
     const [identity, estate] = await Promise.all([
       resolveFederationIdentity(prisma),
-      loadEstateNameResolution({
-        readConfig: async (key: string) =>
-          (await prisma.platformConfig.findUnique({ where: { key }, select: { value: true } }))
-            ?.value ?? null,
-      }),
+      loadEstateNameResolution(prismaEstateIdentityStore(prisma)),
     ]);
     advertisement = buildFederationAdvertisement({
       projectionSecret: identity.projectionSecret,

--- a/apps/web/app/api/v1/federation/enroll/organization/route.test.ts
+++ b/apps/web/app/api/v1/federation/enroll/organization/route.test.ts
@@ -10,7 +10,11 @@ const { mockAccept, mockSelfUrl, mockEstate } = vi.hoisted(() => ({
 vi.mock("@dpf/db", () => ({ prisma: { platformConfig: { findUnique: vi.fn().mockResolvedValue(null) } } }));
 vi.mock("@/lib/federation/organization-membership", () => ({ acceptOrganizationEnrolment: mockAccept }));
 vi.mock("@/lib/federation/self-authority", () => ({ resolveLocalFederationAuthorityUrl: mockSelfUrl }));
-vi.mock("@/lib/install/estate-identity", () => ({ loadEstateNameResolution: mockEstate }));
+vi.mock("@/lib/install/estate-identity", () => ({
+  loadEstateNameResolution: mockEstate,
+  // BI-CA54ACC8: the route composes its store through this builder.
+  prismaEstateIdentityStore: vi.fn(() => ({ readConfig: async () => null, readOrganizationName: async () => null })),
+}));
 
 import { POST } from "./route";
 

--- a/apps/web/app/api/v1/federation/enroll/organization/route.ts
+++ b/apps/web/app/api/v1/federation/enroll/organization/route.ts
@@ -19,7 +19,7 @@ import { prisma } from "@dpf/db";
 import { apiErrorResponse } from "@/lib/api/error";
 import { acceptOrganizationEnrolment, type MembershipDb } from "@/lib/federation/organization-membership";
 import { resolveLocalFederationAuthorityUrl } from "@/lib/federation/self-authority";
-import { loadEstateNameResolution } from "@/lib/install/estate-identity";
+import { loadEstateNameResolution, prismaEstateIdentityStore } from "@/lib/install/estate-identity";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let body: unknown;
@@ -32,9 +32,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!localAuthorityUrl) {
     return apiErrorResponse("SELF_AUTHORITY_UNKNOWN", "This installation does not know its own reachable address.", 503);
   }
-  const estate = await loadEstateNameResolution({
-    readConfig: async (key: string) => (await prisma.platformConfig.findUnique({ where: { key }, select: { value: true } }))?.value ?? null,
-  });
+  const estate = await loadEstateNameResolution(prismaEstateIdentityStore(prisma));
   const result = await acceptOrganizationEnrolment(prisma as unknown as MembershipDb, {
     envelope: body,
     localAuthorityUrl,

--- a/apps/web/components/workspace/EstateNameField.tsx
+++ b/apps/web/components/workspace/EstateNameField.tsx
@@ -18,10 +18,17 @@ import { declareEstateName } from "@/lib/actions/installation-estate-name";
 export function EstateNameField({
   estateName,
   badgePreview,
+  organizationFallback = null,
 }: {
   estateName: string | null;
   /** The role word the badge will pair the name with, e.g. `DEV`. Null on production. */
   badgePreview: string | null;
+  /**
+   * The setup-time organization name in force because nobody named the
+   * operator here (BI-CA54ACC8). The field stays empty so what the operator
+   * types is a real declaration, and the hint says what applies meanwhile.
+   */
+  organizationFallback?: string | null;
 }) {
   const router = useRouter();
   const [value, setValue] = useState(estateName ?? "");
@@ -75,7 +82,11 @@ export function EstateNameField({
           }}
           optional
           autoComplete="off"
-          hint="Leave it empty if you would rather not name it yet."
+          hint={
+            organizationFallback
+              ? `Until you name it, the organization from setup applies: ${organizationFallback}.`
+              : "Leave it empty if you would rather not name it yet."
+          }
           disabled={isPending}
         />
         <div className="text-xs text-[var(--dpf-muted)]">

--- a/apps/web/lib/federation/organization-membership.test.ts
+++ b/apps/web/lib/federation/organization-membership.test.ts
@@ -204,7 +204,34 @@ describe("enrolWithOrganizationAuthority + reconcile", () => {
 
     const old = vi.fn(async () => ({ ok: false, status: 404 }));
     expect(await enrolWithOrganizationAuthority(member.db, { material: memberMaterial, authorityUrls: ["http://192.168.0.152:3000"], localAuthorityUrl: "http://m", displayName: "D", now, post: old as never }))
-      .toMatchObject({ enrolled: false, reason: "peer responded 404" });
+      .toMatchObject({ enrolled: false, reason: "peer responded 404 (http://192.168.0.152:3000)" });
+  });
+
+  // BI-39C06F70: on the live pair the authority's 403 (no-local-organization)
+  // was hidden behind the https fallback URL's socket error for four ticks.
+  it("reports the authority's refusal reason, stops at it, and never lets a fallback URL's socket error hide it", async () => {
+    const member = installation("member");
+    const refusing = vi.fn(async ({ peerAuthorityUrl }: { peerAuthorityUrl: string }) =>
+      peerAuthorityUrl.startsWith("https://")
+        ? { ok: false, status: 0, error: "fetch failed" }
+        : { ok: false, status: 403, body: { code: "MEMBERSHIP_PROOF_REFUSED", details: { reason: "no-local-organization" } } });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(await enrolWithOrganizationAuthority(member.db, { material: memberMaterial, authorityUrls: ["http://192.168.0.152:3000", "https://192.168.0.152"], localAuthorityUrl: "http://m", displayName: "D", now, post: refusing as never }))
+        .toEqual({ enrolled: false, reason: "authority refused: no-local-organization (http://192.168.0.152:3000)" });
+      expect(refusing).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("no-local-organization"));
+    } finally {
+      warn.mockRestore();
+    }
+
+    // A non-definitive answer (500) still beats the fallback's socket error.
+    const flaky = vi.fn(async ({ peerAuthorityUrl }: { peerAuthorityUrl: string }) =>
+      peerAuthorityUrl.startsWith("https://") ? { ok: false, status: 0, error: "fetch failed" } : { ok: false, status: 500, body: { code: "INTERNAL" } });
+    expect(await enrolWithOrganizationAuthority(member.db, { material: memberMaterial, authorityUrls: ["http://192.168.0.152:3000", "https://192.168.0.152"], localAuthorityUrl: "http://m", displayName: "D", now, post: flaky as never }))
+      .toEqual({ enrolled: false, reason: "peer responded 500 (http://192.168.0.152:3000)" });
+    expect(flaky).toHaveBeenCalledTimes(2);
+    expect(member.created).toHaveLength(0);
   });
 
   it("reconcile: not a member without material; already linked when a trusted link to the authority host exists", async () => {

--- a/apps/web/lib/federation/organization-membership.ts
+++ b/apps/web/lib/federation/organization-membership.ts
@@ -72,12 +72,21 @@ export interface MembershipDb extends FederationIdentityDb {
   remoteAction?: {
     findFirst(args: unknown): Promise<{ parameters: unknown } | null>;
   };
+  organization?: {
+    findFirst(args: unknown): Promise<{ name: string } | null>;
+  };
   $transaction<T>(fn: (tx: Parameters<typeof createFederationLinkRow>[0]) => Promise<T>): Promise<T>;
 }
 
 async function localOrganizationRef(db: MembershipDb, env?: Record<string, string | undefined>): Promise<string | null> {
   const resolution = await loadEstateNameResolution(
-    { readConfig: async (key: string) => (await db.platformConfig.findUnique({ where: { key }, select: { value: true } }))?.value ?? null },
+    {
+      readConfig: async (key: string) => (await db.platformConfig.findUnique({ where: { key }, select: { value: true } }))?.value ?? null,
+      // The setup-time organization name is the lowest tier (BI-CA54ACC8): an
+      // authority that was named at install but never on the installation page
+      // still has an organization to compare.
+      readOrganizationName: async () => (await db.organization?.findFirst({ select: { name: true } }))?.name ?? null,
+    },
     env ? { env } : {},
   );
   return normalizeOrganizationRef(resolution.estateName);
@@ -300,7 +309,19 @@ export async function enrolWithOrganizationAuthority(
 ): Promise<{ enrolled: true; linkId: string; authorityUrl: string } | { enrolled: false; reason: string }> {
   const callback = generateLinkToken();
   const post = input.post ?? postToPeer;
-  let last: PeerPostResult | null = null;
+  // The failure the operator sees is the most informative one across the
+  // derived URLs, not the last one tried (BI-39C06F70): an authority's answer
+  // beats a fallback URL's socket error, and a definitive refusal ends the loop
+  // because no other URL can change that verdict.
+  let last: (PeerPostResult & { authorityUrl: string }) | null = null;
+  const remember = (res: PeerPostResult, authorityUrl: string) => {
+    const informative = (r: PeerPostResult | null) => (r ? (r.status > 0 ? (r.body ? 2 : 1) : 0) : -1);
+    if (informative(res) >= informative(last)) last = { ...res, authorityUrl };
+  };
+  const refusalReason = (res: PeerPostResult): string | null => {
+    const details = (res.body as { details?: { reason?: unknown } } | undefined)?.details;
+    return res.status === 403 && typeof details?.reason === "string" ? details.reason : null;
+  };
   for (const authorityUrl of input.authorityUrls) {
     const built = await buildMembershipProof(db, {
       material: input.material,
@@ -314,10 +335,17 @@ export async function enrolWithOrganizationAuthority(
     });
     if ("error" in built) return { enrolled: false, reason: built.error };
     const res = await post({ peerAuthorityUrl: authorityUrl, linkToken: "dpflink_organization-proof", path: ORGANIZATION_ENROLL_PATH, cloudEvent: built, sameOrgLan: true });
-    last = res;
-    if (!res.ok) continue;
+    if (!res.ok) {
+      remember(res, authorityUrl);
+      const reason = refusalReason(res);
+      if (reason) {
+        console.warn(`[federation] the organization authority at ${authorityUrl} refused this installation's membership proof: ${reason}`);
+        return { enrolled: false, reason: `authority refused: ${reason} (${authorityUrl})` };
+      }
+      continue;
+    }
     const body = res.body as { linkId?: string; linkToken?: string; proof?: unknown } | undefined;
-    if (typeof body?.linkToken !== "string" || !body.linkToken.startsWith("dpflink_")) { last = { ok: false, status: res.status, error: "malformed-response" }; continue; }
+    if (typeof body?.linkToken !== "string" || !body.linkToken.startsWith("dpflink_")) { remember({ ok: false, status: res.status, body: res.body, error: "malformed-response" }, authorityUrl); continue; }
     // Verify the authority's own proof when it sent one.
     let peerStatement: MembershipStatement | null = null;
     let peerChain: ChainVerification | null = null;
@@ -357,7 +385,9 @@ export async function enrolWithOrganizationAuthority(
     });
     return { enrolled: true, linkId, authorityUrl };
   }
-  return { enrolled: false, reason: last ? `peer responded ${last.status}${last.error ? `: ${last.error}` : ""}` : "no-authority-url" };
+  // `last` is only assigned inside `remember`, which the narrowing above cannot see.
+  const failure = last as (PeerPostResult & { authorityUrl: string }) | null;
+  return { enrolled: false, reason: failure ? `peer responded ${failure.status}${failure.error ? `: ${failure.error}` : ""} (${failure.authorityUrl})` : "no-authority-url" };
 }
 
 /**

--- a/apps/web/lib/federation/organization-trust-anchor-store.ts
+++ b/apps/web/lib/federation/organization-trust-anchor-store.ts
@@ -55,6 +55,10 @@ export interface TrustAnchorStoreDb {
       { value: unknown } | null
     >;
   };
+  /** The Organization row named at setup — the lowest estate-name tier (BI-CA54ACC8). */
+  organization?: {
+    findFirst(args: { select: { name: true } }): Promise<{ name: string } | null>;
+  };
 }
 
 /**
@@ -89,6 +93,8 @@ export function createOrganizationTrustAnchorStore(
           readConfig: async (key: string) =>
             (await db.platformConfig.findUnique({ where: { key }, select: { value: true } }))?.value ??
             null,
+          readOrganizationName: async () =>
+            (await db.organization?.findFirst({ select: { name: true } }))?.name ?? null,
         },
         options,
       );

--- a/apps/web/lib/install/estate-identity-contract.test.ts
+++ b/apps/web/lib/install/estate-identity-contract.test.ts
@@ -146,6 +146,25 @@ describe("precedence", () => {
     expect(resolved.tier).toBe("unset");
   });
 
+  // BI-CA54ACC8: production refused every membership proof with
+  // no-local-organization although its banner said "Fabrikam" — the
+  // Organization row named at setup was never an estate-name tier.
+  it("falls back to the organization named at setup, below every explicit tier", () => {
+    const resolved = resolveEstateNamePrecedence({ organizationName: "  Fabrikam " });
+    expect(resolved.estateName).toBe("Fabrikam");
+    expect(resolved.tier).toBe("organization-name");
+    expect(resolved.organizationNameValue).toBe("Fabrikam");
+
+    const declared = resolveEstateNamePrecedence({ organizationName: "Fabrikam", portalDeclaration: declaration() });
+    expect(declared.estateName).toBe("Northwind");
+    expect(declared.tier).toBe("portal-declaration");
+    expect(declared.organizationNameValue).toBe("Fabrikam");
+
+    const malformed = resolveEstateNamePrecedence({ organizationName: "   " });
+    expect(malformed.tier).toBe("unset");
+    expect(malformed.organizationNameValue).toBeUndefined();
+  });
+
   it("reports a shadowed declaration so an operator learns why theirs is not in force", () => {
     const resolved = resolveEstateNamePrecedence({
       installerState: "FromInstaller",

--- a/apps/web/lib/install/estate-identity-contract.ts
+++ b/apps/web/lib/install/estate-identity-contract.ts
@@ -44,6 +44,7 @@ export const ESTATE_NAME_TIERS = [
   "process-override",
   "installer-state",
   "portal-declaration",
+  "organization-name",
   "unset",
 ] as const;
 export type EstateNameTier = (typeof ESTATE_NAME_TIERS)[number];
@@ -148,6 +149,8 @@ export interface EstateNameResolution {
   tier: EstateNameTier;
   /** The installer-state value, when installer state supplied one. */
   installerStateValue?: string;
+  /** The Organization row's name, when setup recorded one (BI-CA54ACC8). */
+  organizationNameValue?: string;
   /** The portal declaration, whether or not it is the value in force. */
   portalDeclaration?: PortalEstateIdentityDeclarationV1;
   /**
@@ -197,14 +200,23 @@ export function resolveEstateNamePrecedence(input: {
   processOverride?: string | null;
   installerState?: string | null;
   portalDeclaration?: PortalEstateIdentityDeclarationV1 | null;
+  /**
+   * The Organization row's name — the answer the operator gave at setup. The
+   * lowest speaking tier (BI-CA54ACC8): an install that predates the estate
+   * name, or never opened the installation page, is still the company it was
+   * set up as, and its peers compare that name.
+   */
+  organizationName?: string | null;
 }): EstateNameResolution {
   const portalDeclaration = input.portalDeclaration ?? undefined;
   const override = normalizeEstateName(input.processOverride);
   const installerState = normalizeEstateName(input.installerState);
+  const organizationName = normalizeEstateName(input.organizationName);
 
   const base = {
     ...(installerState ? { installerStateValue: installerState } : {}),
     ...(portalDeclaration ? { portalDeclaration } : {}),
+    ...(organizationName ? { organizationNameValue: organizationName } : {}),
   };
 
   const shadowedBy = (
@@ -245,6 +257,10 @@ export function resolveEstateNamePrecedence(input: {
       tier: "portal-declaration",
       ...base,
     };
+  }
+
+  if (organizationName) {
+    return { estateName: organizationName, tier: "organization-name", ...base };
   }
 
   return { estateName: null, tier: "unset", ...base };

--- a/apps/web/lib/install/estate-identity.test.ts
+++ b/apps/web/lib/install/estate-identity.test.ts
@@ -63,6 +63,23 @@ describe("readInstallEstateName", () => {
 });
 
 describe("loadEstateNameResolution", () => {
+  // BI-CA54ACC8: a store that can read the Organization row supplies the
+  // lowest tier; a failing read drops only that tier.
+  it("falls back to the organization named at setup, and drops that tier alone when its read fails", async () => {
+    const resolved = await loadEstateNameResolution(
+      { readConfig: async () => null, readOrganizationName: async () => "Fabrikam" },
+      { env: {}, readText: async () => "{}" },
+    );
+    expect(resolved).toMatchObject({ estateName: "Fabrikam", tier: "organization-name", organizationNameValue: "Fabrikam" });
+
+    const failing = await loadEstateNameResolution(
+      { readConfig: async () => declaration(), readOrganizationName: async () => { throw new Error("db down"); } },
+      { env: {}, readText: async () => "{}" },
+    );
+    expect(failing).toMatchObject({ estateName: "Northwind", tier: "portal-declaration" });
+    expect(failing.organizationNameValue).toBeUndefined();
+  });
+
   it("resolves the portal declaration when it is the only tier", async () => {
     const resolved = await loadEstateNameResolution(storeOf(declaration()), {
       env: {},

--- a/apps/web/lib/install/estate-identity.ts
+++ b/apps/web/lib/install/estate-identity.ts
@@ -52,6 +52,12 @@ export async function readInstallEstateName(options: {
 /** The read this module needs from PlatformConfig, kept Prisma-free. */
 export interface EstateIdentityStore {
   readConfig(key: string): Promise<unknown>;
+  /**
+   * The Organization row's name from setup, the lowest speaking tier
+   * (BI-CA54ACC8). Optional so a store that only carries PlatformConfig keeps
+   * working; such a store simply cannot fall back to the organization name.
+   */
+  readOrganizationName?(): Promise<string | null>;
 }
 
 /**
@@ -85,11 +91,37 @@ export async function loadEstateNameResolution(
     portalDeclaration = null;
   }
 
+  let organizationName: string | null = null;
+  if (store.readOrganizationName) {
+    try {
+      organizationName = await store.readOrganizationName();
+    } catch {
+      organizationName = null;
+    }
+  }
+
   return resolveEstateNamePrecedence({
     processOverride: env[ESTATE_NAME_ENV_VAR],
     installerState,
     portalDeclaration,
+    organizationName,
   });
+}
+
+/**
+ * The reads every Prisma-backed caller composes: the PlatformConfig declaration
+ * and the Organization row's name. One builder so no surface forgets the
+ * organization tier and answers "unnamed" for an installation that was named at
+ * setup (BI-CA54ACC8).
+ */
+export function prismaEstateIdentityStore(prisma: {
+  platformConfig: { findUnique(args: { where: { key: string }; select: { value: true } }): Promise<{ value: unknown } | null> };
+  organization: { findFirst(args: { select: { name: true } }): Promise<{ name: string } | null> };
+}): EstateIdentityStore {
+  return {
+    readConfig: async (key) => (await prisma.platformConfig.findUnique({ where: { key }, select: { value: true } }))?.value ?? null,
+    readOrganizationName: async () => (await prisma.organization.findFirst({ select: { name: true } }))?.name ?? null,
+  };
 }
 
 /**

--- a/apps/web/lib/install/instance-stance.ts
+++ b/apps/web/lib/install/instance-stance.ts
@@ -117,6 +117,8 @@ export function holdsIrreplaceableWork(input: {
 /** Minimal store shape so callers can pass Prisma without this module importing it. */
 export interface InstanceStanceStore {
   readConfig(key: string): Promise<unknown>;
+  /** The Organization row's name from setup — the lowest estate-name tier (BI-CA54ACC8). */
+  readOrganizationName?(): Promise<string | null>;
   countBacklogItemsByStatus(statuses: readonly string[]): Promise<number>;
   /**
    * Most recent create/update across items in those statuses, or null when
@@ -144,11 +146,14 @@ export interface InstanceStanceStore {
  * a different set of rows.
  */
 export function prismaInstanceStanceStore(
-  prisma: Pick<PrismaClient, "platformConfig" | "backlogItem" | "federationLink">,
+  prisma: Pick<PrismaClient, "platformConfig" | "backlogItem" | "federationLink" | "organization">,
 ): InstanceStanceStore {
   return {
     readConfig: async (key) =>
       (await prisma.platformConfig.findUnique({ where: { key } }))?.value ?? null,
+    // Lowest estate-name tier: the organization named at setup (BI-CA54ACC8).
+    readOrganizationName: async () =>
+      (await prisma.organization.findFirst({ select: { name: true } }))?.name ?? null,
     countBacklogItemsByStatus: (statuses) =>
       prisma.backlogItem.count({ where: { status: { in: [...statuses] } } }),
     latestBacklogChangeByStatus: async (statuses) => {

--- a/apps/web/lib/mcp/initialize.ts
+++ b/apps/web/lib/mcp/initialize.ts
@@ -66,6 +66,9 @@ async function composeInstallationIdentity(): Promise<
     const store = {
       readConfig: async (key: string) =>
         (await prisma.platformConfig.findUnique({ where: { key } }))?.value ?? null,
+      // Lowest estate-name tier: the organization named at setup (BI-CA54ACC8).
+      readOrganizationName: async () =>
+        (await prisma.organization.findFirst({ select: { name: true } }))?.name ?? null,
     };
 
     const [environment, estate, shortDeviceId] = await Promise.all([

--- a/docs/superpowers/specs/2026-08-25-installation-estate-identity-design.md
+++ b/docs/superpowers/specs/2026-08-25-installation-estate-identity-design.md
@@ -308,3 +308,9 @@ a living document and is now behind the decision.
 - **Fix the gate, not just the sentence.** Rewriting one headline leaves the
   incentive that produced it. The readability cap stays; what changes is that
   satisfying it with fragments stops being the cheapest path.
+
+## Addendum 2026-09-06: the organization named at setup is the lowest tier (BI-CA54ACC8)
+
+Found on the live pair while proving EP-ZERO-CONFIG-FEDERATION: production showed its Organization name in the banner yet refused every membership proof with `no-local-organization`, because the membership statement compares the estate name and nothing had ever moved an existing install forward onto it (the installer never writes `estateName`, no migration seeded it, and the operator had not opened the installation page).
+
+The precedence gains one more speaking tier below `portal-declaration`: `organization-name`, the Organization row the setup wizard created. `resolveEstateNamePrecedence` takes `organizationName`, reports `organizationNameValue`, and `EstateIdentityStore.readOrganizationName` (optional) supplies it; `prismaEstateIdentityStore` is the one builder Prisma-backed callers use. The installation page keeps the Operator name field empty while this tier is in force and says which organization applies meanwhile (kernel decision DI-0B1E2E643EB3), so a typed name remains a real declaration. `unset` still exists: an install with no Organization row and no declaration is unnamed, and says so.

--- a/docs/ux-fit/2026-09-06-estate-name-organization-fallback.ux-fit.json
+++ b/docs/ux-fit/2026-09-06-estate-name-organization-fallback.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "empty-field-hint-names-fallback",
+  "decisionInteractionId": "DI-0B1E2E643EB3",
+  "scope": {
+    "files": [
+      "apps/web/components/workspace/EstateNameField.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "empty-field-hint-names-fallback",
+      "prefill-field-with-organization-name",
+      "silent-fallback-no-copy-change"
+    ],
+    "note": "BI-CA54ACC8 (EP-ZERO-CONFIG-FEDERATION). The estate name gains a lowest tier that falls back to the Organization row named at setup. On /ops/installation the Operator name field stays empty when that tier is in force and its hint reads 'Until you name it, the organization from setup applies: <name>.' so what the operator types stays a real declaration. The kernel scored this shape highest (composite 8.65, margin 3.11, confidence high) against pre-filling the field and against a silent fallback."
+  }
+}

--- a/scripts/check-doc-anchor-existence.mjs
+++ b/scripts/check-doc-anchor-existence.mjs
@@ -141,7 +141,12 @@ export function isTruncatedListing(body) {
     return true; // unparseable is not proof of completeness
   }
   const text = JSON.stringify(parsed?.result ?? parsed ?? null);
-  if (/"truncated"\s*:\s*true/.test(text)) return true;
+  // Two truncation shapes: the tool's own `truncated: true` page marker, and
+  // the MCP server's per-call context budget, which replaces a large result
+  // with `structuredContent._truncated: true` plus a `_preview` holding only
+  // the first few rows. A 222-epic catalog came back as a 6 KB preview naming
+  // four epics, and every other correctly cited epic read as "missing".
+  if (/"_?truncated"\s*:\s*true/.test(text)) return true;
   const total = text.match(/"total"\s*:\s*(\d+)/);
   const fetched = text.match(/"fetched"\s*:\s*(\d+)/);
   if (total && fetched && Number(fetched[1]) < Number(total[1])) return true;

--- a/scripts/check-doc-anchor-existence.test.mjs
+++ b/scripts/check-doc-anchor-existence.test.mjs
@@ -242,3 +242,23 @@ test("fetched short of total counts as truncated even without the flag", () => {
 test("an unparseable listing is never treated as a complete one", () => {
   assert.equal(isTruncatedListing("<html>gateway timeout</html>"), true);
 });
+
+// Seen live 2026-09-06: a 222-epic catalog came back from the MCP server's
+// per-call context budget as a 6 KB `structuredContent._preview` naming four
+// epics, with `_truncated: true` (underscore) — and every other correctly
+// cited epic was declared missing.
+test("the MCP server's context-budget preview (_truncated) counts as truncated", () => {
+  const budgeted = JSON.stringify({
+    result: {
+      content: [{ type: "text", text: "{\"success\":true,\"message\":\"Listed 222 epic(s) (222 of 222 fetched)…\"}" }],
+      isError: false,
+      structuredContent: {
+        _truncated: true,
+        _note: "Result exceeded the per-call context budget; re-call with filter/pagination/range parameters to narrow it.",
+        _originalChars: 132349,
+        _preview: "{\"epics\":[{\"epicId\":\"EP-AAAA1111\"},{\"epicId\":\"EP-BBBB2222\"}",
+      },
+    },
+  });
+  assert.equal(isTruncatedListing(budgeted), true);
+});


### PR DESCRIPTION
## Summary

Two defects found while proving EP-ZERO-CONFIG-FEDERATION on the live pair (BI-105BB8B2), both filed with reproduction:

**BI-CA54ACC8 — the organization named at setup was never an estate-name tier.** Production showed its operator name in the banner (the Organization row the setup wizard creates) yet its federation authority refused every membership proof with `no-local-organization`, because the membership statement compares the *estate* name: a separate record #4662 added on 08-26 with no forward-move step (the installer never writes `estateName`, no migration seeded it, and #5004 started comparing it a week later). Development passed only because someone had declared the name on its installation page.

Fix: `resolveEstateNamePrecedence` gains the lowest speaking tier `organization-name`, fed by an optional `EstateIdentityStore.readOrganizationName`, reported as `organizationNameValue`. Every Prisma-backed caller supplies it (membership authority, enrol route and federation advertisement via the new `prismaEstateIdentityStore`, trust-anchor store, MCP handshake, shell badge, installation page via `prismaInstanceStanceStore`). The Operator name field stays empty while that tier is in force and its hint names the organization that applies meanwhile (kernel DI-0B1E2E643EB3, `docs/ux-fit/2026-09-06-estate-name-organization-fallback.ux-fit.json`), so a typed name remains a real declaration. `unset` still exists for an install with neither.

**BI-39C06F70 — the member reported the fallback URL's socket error instead of the authority's answer.** `enrolWithOrganizationAuthority` tried `http://host:3000` then `https://host` and kept the *last* failure, so four ticks said `peer responded 0: fetch failed` while production had answered 403 `no-local-organization` on the first URL. Now an authority's answer beats a transport error, the URL is named, and a definitive 403 with a reason ends the loop with `authority refused: <reason> (<url>)` plus a warn log line.

## Design grounding

Extends `docs/superpowers/specs/2026-08-25-installation-estate-identity-design.md` (addendum 2026-09-06 added) and `docs/superpowers/specs/2026-09-02-zero-configuration-organization-federation-design.md` (the membership statement carries the normalised organization ref). Code substrate: `apps/web/lib/install/estate-identity-contract.ts`, `apps/web/lib/install/estate-identity.ts`, `apps/web/lib/federation/organization-membership.ts`, `apps/web/components/workspace/EstateNameField.tsx`.

## Tests

- `estate-identity-contract.test.ts`: new tier below every explicit tier; a malformed organization name leaves `unset`.
- `estate-identity.test.ts`: the organization read supplies the tier; a failing read drops only that tier.
- `organization-membership.test.ts`: refusal reason surfaced and the loop stops after one call; a 500 still beats the fallback's socket error; the 404 message names the URL.
- `apps/web` typecheck clean; 72 tests across the touched files pass.

Test fixtures use a placeholder organization name per the repo identity-hygiene rule.

Pushed with the recorded pre-push override because the local-CI pool is dead-parked (exit 75). CI enforces every gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Also carries a guard-parity fix: `check-doc-anchor-existence.mjs` now treats the MCP server context-budget preview (`structuredContent._truncated: true`) as a truncated epic catalog instead of declaring every epic past the preview missing (test added with the live payload shape).
