### PR TITLE
fix(gate): a parked claim says whether the pool is closed, not just queued (BI-D908DA0A, BI-ECAE03F7)

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -573,6 +573,21 @@ that durable record; do not infer the refusal from process residency, cancel
 and recreate a healthy FIFO claim, or conflate Docker model residency and GPU
 VRAM with Windows physical-memory telemetry.
 
+**A queue and a closed pool are two different waits, and the gate says which.**
+When the host rollback contracts the pool to `effectiveCapacity: 0`
+(`host-stage-headroom-low`, `host-memory-low`, `host-observation-stale`, ...),
+no slot can admit anyone, yet the claim is still parked with
+`admission.status: "queued"`. The waiting line then reads
+`local-CI pool is CLOSED (<rollbackReason>)` instead of `queued at position N`,
+the queued lease event and the durable-wait record carry `poolClosedReason`,
+and `pnpm run pregate:status` names host pressure rather than "the gate did not
+run". Behind a queue you wait; behind a closed pool you free host memory (on a
+Windows host, usually the WSL page cache held by `vmmemWSL`) or wait for the
+pressure to pass. Waiting in line does nothing for a closed pool
+(BI-D908DA0A). A fenced run likewise records *which* fence fired
+(`fence reason: lease-authority-deadline`, ...) in its gate record, so a
+self-fence never reads as a reasonless failure of the diff (BI-ECAE03F7).
+
 Typecheck writes a separate `web-typecheck` receipt before `next typegen &&
 tsc --noEmit` starts, heartbeats the compiler descendant tree, memory, and a
 bounded output tail, and records real compiler exits separately from opaque

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -256,6 +256,8 @@ test("durable queue observation reuses claimKey and grants a fresh admitted TTL"
           data: {
             lease: { leaseId: "NPEL-QUEUE-TEST" },
             admission: { status: "queued", queuePosition: 2, waitAgeMs: 20 },
+            // BI-D908DA0A: a closed pool parks the claim on the same wire shape.
+            poolPolicy: { effectiveCapacity: 0, rollbackReason: "host-stage-headroom-low" },
           },
         }
         : tool === "claim_nonprod_environment_lease"
@@ -311,7 +313,7 @@ test("durable queue observation reuses claimKey and grants a fresh admitted TTL"
     );
     const grantedMs = Date.parse(claims[1].args.expiresAt) - claims[1].receivedAt;
     assert.ok(grantedMs >= 2_800, `expected a fresh ~3s TTL, got ${grantedMs}ms`);
-    assert.match(result.output, /queued at position 2/);
+    assert.match(result.output, /pool is CLOSED \(host-stage-headroom-low\).*position 2/);
   } finally {
     server.closeAllConnections();
     await new Promise((resolve) => server.close(resolve));

--- a/scripts/gate-worktree-pool-closed.test.mjs
+++ b/scripts/gate-worktree-pool-closed.test.mjs
@@ -1,0 +1,49 @@
+// BI-D908DA0A — a queued claim and a CLOSED pool arrive on the same wire shape
+// (`admission.status: "queued"`), but they call for different responses. Guards
+// the distinction the gate now makes in its waiting line and its parked record.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { describeQueuedAdmission, poolClosedReason } from "./gate-worktree.mjs";
+
+test("a pool at effectiveCapacity 0 is CLOSED, named by its rollback reason", () => {
+  assert.equal(
+    poolClosedReason({ effectiveCapacity: 0, rollbackReason: "host-stage-headroom-low" }),
+    "host-stage-headroom-low",
+  );
+  assert.equal(poolClosedReason({ effectiveCapacity: 0, rollbackReason: null }), "capacity-zero");
+});
+
+test("a pool with any admissible slot is a queue, not a closure", () => {
+  assert.equal(poolClosedReason({ effectiveCapacity: 1, rollbackReason: "host-build-capacity-one" }), null);
+  assert.equal(poolClosedReason({ effectiveCapacity: 2, rollbackReason: null }), null);
+  assert.equal(poolClosedReason(null), null);
+  assert.equal(poolClosedReason(undefined), null);
+});
+
+test("the waiting line says CLOSED and why when nobody can be admitted", () => {
+  const line = describeQueuedAdmission({
+    admission: { queuePosition: 1 },
+    poolPolicy: { effectiveCapacity: 0, rollbackReason: "host-stage-headroom-low" },
+    delayMs: 12_400,
+  });
+  assert.match(line, /pool is CLOSED \(host-stage-headroom-low\)/);
+  assert.match(line, /not behind other work/);
+  assert.match(line, /observing again in 12\.4s/);
+  assert.doesNotMatch(line, /admission queued at position/);
+});
+
+test("the waiting line stays a plain queue position when a slot exists", () => {
+  const line = describeQueuedAdmission({
+    admission: { queuePosition: 3 },
+    poolPolicy: { effectiveCapacity: 1, rollbackReason: "host-build-capacity-one" },
+    delayMs: 9_800,
+  });
+  assert.equal(line, "local-CI admission queued at position 3; observing again in 9.8s...");
+});
+
+test("a missing policy is treated as a queue, never as a closure", () => {
+  const line = describeQueuedAdmission({ admission: { queuePosition: 2 }, poolPolicy: null, delayMs: 1_000 });
+  assert.match(line, /^local-CI admission queued at position 2/);
+});

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -129,6 +129,36 @@ export function executionPressureFenceReason(poolPolicy) {
     : null;
 }
 
+// BI-D908DA0A: a queued claim and a CLOSED pool look identical on the wire. Both
+// come back `admission.status === "queued"`, because a pool whose host rollback
+// contracted capacity to 0 has no slot to admit anyone into, so every claim is
+// parked. But they are different situations with different responses: behind a
+// queue you wait; behind a closed pool you free host memory (or wait for the
+// pressure to pass), and no amount of waiting in line helps. Observed live on
+// 2026-09-06: `effectiveCapacity: 0, rollbackReason: host-stage-headroom-low`
+// printed as "queued at position 1", which read as contention and cost a full
+// misdiagnosis. The policy carries the fact; the gate just never said it.
+export function poolClosedReason(poolPolicy) {
+  if (!poolPolicy || poolPolicy.effectiveCapacity !== 0) return null;
+  return typeof poolPolicy.rollbackReason === "string" && poolPolicy.rollbackReason
+    ? poolPolicy.rollbackReason
+    : "capacity-zero";
+}
+
+/** The one line an operator sees while a claim is parked. Says WHICH kind of wait. */
+export function describeQueuedAdmission({ admission, poolPolicy, delayMs }) {
+  const position = admission?.queuePosition ?? "?";
+  const again = Number.isFinite(delayMs)
+    ? `; observing again in ${(delayMs / 1000).toFixed(1)}s...`
+    : "";
+  const closed = poolClosedReason(poolPolicy);
+  if (closed) {
+    return `local-CI pool is CLOSED (${closed}): no slot can admit anyone until the host recovers, `
+      + `so this claim is parked at position ${position} behind host pressure, not behind other work${again}`;
+  }
+  return `local-CI admission queued at position ${position}${again}`;
+}
+
 function die(message) {
   process.stderr.write(`gate-worktree: ${message}\n`);
   process.exit(1);
@@ -1403,12 +1433,14 @@ async function main() {
     if (claimResponse?.success === true && admission?.status === "queued") {
       leaseId = canonicalLeaseId || claimResponse.entityId || leaseId;
       queuedClaimInterruptedByQuiescence = false;
+      const closedReason = poolClosedReason(claimResponse?.data?.poolPolicy);
       leaseEvents.push({
         type: "queued",
         at: new Date().toISOString(),
         queuePosition: admission.queuePosition ?? null,
         waitAgeMs: admission.waitAgeMs ?? null,
         expiresAt,
+        ...(closedReason ? { poolClosedReason: closedReason } : {}),
       });
       writeState(stateFile, {
         branch,
@@ -1444,6 +1476,7 @@ async function main() {
           claimKey,
           queuePosition: admission.queuePosition ?? null,
           resumeMode: "durable-task",
+          ...(closedReason ? { poolClosedReason: closedReason } : {}),
         }) + "\n");
         process.exit(75);
       }
@@ -1453,7 +1486,11 @@ async function main() {
       }
       const delayMs = retryDelayMs({ attempt: claimAttempt, pollSeconds: options.pollSeconds });
       claimAttempt += 1;
-      waiting(`local-CI admission queued at position ${admission.queuePosition}; observing again in ${(delayMs / 1000).toFixed(1)}s...`);
+      waiting(describeQueuedAdmission({
+        admission,
+        poolPolicy: claimResponse?.data?.poolPolicy,
+        delayMs,
+      }));
       await sleep(Math.min(delayMs, Math.max(10, deadline - Date.now())));
       continue;
     }
@@ -1825,6 +1862,9 @@ async function main() {
     for (const [signal, handler] of Object.entries(runSignalHandlers)) process.removeListener(signal, handler);
   }
   const runResult = supervised.result;
+  // BI-ECAE03F7: a fenced run must record WHICH fence fired, or pregate:status
+  // reports a reasonless failure against the diff.
+  const fenceReason = supervised.status === "fenced" ? String(supervised.reason || "fenced") : "";
   if (supervised.status === "fenced") {
     runResult.status = 75;
     runResult.output = `${runResult.output}\ngate-worktree: lease fenced (${supervised.reason}); child process tree terminated\n`;
@@ -2061,10 +2101,12 @@ async function main() {
 
   const capturedFailureCount = (failureSummary?.failedTests?.length || 0)
     + (failureSummary?.failedChecks?.length || 0);
-  const persistedReason = outcome.summary
-    || (capturedFailureCount === 0 && runResult.status
-      ? `no stage failed; child exited ${runResult.status} after the last completed stage`
-      : "");
+  const persistedReason = fenceReason
+    ? `${outcome.summary || "local-CI gate blocked: the lease was fenced"} (fence reason: ${fenceReason})`
+    : outcome.summary
+      || (capturedFailureCount === 0 && runResult.status
+        ? `no stage failed; child exited ${runResult.status} after the last completed stage`
+        : "");
   writeState(stateFile, {
     branch,
     sha,

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -105,6 +105,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       // liveness test above: in ci-policy-test-inventory-allowlist.txt it would
       // never run.
       node("--test", "scripts/gate-worktree-lease-timeout.test.mjs"),
+      // BI-D908DA0A: a parked claim says whether it waits behind work or behind
+      // a closed pool; the two used to print identically.
+      node("--test", "scripts/gate-worktree-pool-closed.test.mjs"),
       // BI-24D5D7C2: the control-plane watchdog aborts a 13-minute build after
       // two consecutive probe failures, and an inner mcpCall deadline was
       // classified as "request-failed" — an operator reads that as a broken

--- a/scripts/lib/pregate-status.mjs
+++ b/scripts/lib/pregate-status.mjs
@@ -49,6 +49,27 @@ export const PREGATE_VERDICTS = Object.freeze([
 const UNFINISHED_GATE_STATUSES = new Set(["queued", "cancelled"]);
 
 /**
+ * The pool policy the gate recorded with a parked claim (BI-D908DA0A). Read from
+ * the admission snapshot first, then the queued lease event, so an older record
+ * that carries only one of them still answers.
+ */
+export function poolClosedReasonFromState(state) {
+  const policy = state?.admission?.poolPolicy;
+  if (policy && policy.effectiveCapacity === 0) {
+    return typeof policy.rollbackReason === "string" && policy.rollbackReason
+      ? policy.rollbackReason
+      : "capacity-zero";
+  }
+  const events = Array.isArray(state?.leaseEvents) ? state.leaseEvents : [];
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    if (events[i]?.type === "queued" && typeof events[i].poolClosedReason === "string") {
+      return events[i].poolClosedReason;
+    }
+  }
+  return null;
+}
+
+/**
  * BI-8392DA16 / BI-2AB94B5A. A `blocked_*` status is infrastructure evidence —
  * the child was killed, the sandbox drifted, or the control plane starved.
  * FAIL is a claim about the diff. These must never share a headline.
@@ -229,6 +250,16 @@ export function classifySlotRecord({ state, metadata, headSha, headBranch = "", 
       };
     }
     if (UNFINISHED_GATE_STATUSES.has(status)) {
+      // BI-D908DA0A: a claim parked because the pool had NO admissible slot is
+      // host pressure, not a queue. Say so, or the operator waits behind nobody.
+      const closed = poolClosedReasonFromState(state);
+      if (closed) {
+        return {
+          ...base,
+          verdict: "INCONCLUSIVE",
+          reason: `gate record status ${status} — the local-CI pool was CLOSED (${closed}) when this claim was parked: no slot could admit anyone, so this is host pressure, not a queue and not a failure of the diff. Free host memory or wait for the pressure to pass, then re-run pregate.`,
+        };
+      }
       return {
         ...base,
         verdict: "INCONCLUSIVE",

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -10,6 +10,7 @@ import {
   classifySlotRecord,
   exitCodeForVerdict,
   formatStatusReport,
+  poolClosedReasonFromState,
   reconcileSlots,
 } from "./pregate-status.mjs";
 
@@ -158,6 +159,53 @@ test("a run that gave up while queued reads INCONCLUSIVE, not PASS (BI-8392DA16)
   assert.equal(r.verdict, "INCONCLUSIVE");
   assert.match(r.reason, /blocked_quiescence/);
   assert.match(r.reason, /infrastructure, not a product verdict/i);
+});
+
+test("a claim parked behind a CLOSED pool names the host pressure, not a queue (BI-D908DA0A)", () => {
+  const r = classifySlotRecord({
+    state: passingState({
+      gatePassed: false,
+      status: "queued",
+      evidenceRecordId: "",
+      admission: {
+        queuePosition: 1,
+        poolPolicy: { effectiveCapacity: 0, rollbackReason: "host-stage-headroom-low" },
+      },
+    }),
+    metadata: null,
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.match(r.reason, /pool was CLOSED \(host-stage-headroom-low\)/);
+  assert.match(r.reason, /not a queue and not a failure of the diff/);
+});
+
+test("an older parked record carries the closure on its queued lease event", () => {
+  assert.equal(
+    poolClosedReasonFromState({
+      leaseEvents: [{ type: "queued", queuePosition: 2, poolClosedReason: "host-memory-low" }],
+    }),
+    "host-memory-low",
+  );
+  assert.equal(poolClosedReasonFromState({ admission: { poolPolicy: { effectiveCapacity: 1 } } }), null);
+  assert.equal(poolClosedReasonFromState(null), null);
+});
+
+test("a claim queued behind a live slot still reads as a plain queue", () => {
+  const r = classifySlotRecord({
+    state: passingState({
+      gatePassed: false,
+      status: "queued",
+      evidenceRecordId: "",
+      admission: { queuePosition: 2, poolPolicy: { effectiveCapacity: 1, rollbackReason: "host-build-capacity-one" } },
+    }),
+    metadata: null,
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.doesNotMatch(r.reason, /CLOSED/);
 });
 
 test("PENDING when the gate passed but evidence publication is unfinished", () => {


### PR DESCRIPTION
## What

A claim behind a queue and a claim behind a **closed** pool arrive on the same wire shape (`admission.status: "queued"`). When the host rollback contracts the local-CI pool to `effectiveCapacity: 0` (`host-stage-headroom-low`, `host-memory-low`, ...), nobody can be admitted, yet the gate printed `queued at position 1` and `pregate:status` said "the gate did not run". Both read as contention. The real response is to free host memory. Observed live on Arcamanus DEV on 2026-09-06; it cost a full misdiagnosis.

- `scripts/gate-worktree.mjs`: the waiting line reads `local-CI pool is CLOSED (<rollbackReason>)`; the queued lease event and the durable-wait (exit 75) record carry `poolClosedReason`.
- `scripts/lib/pregate-status.mjs`: a parked record behind a closed pool names host pressure, not a queue and not a failure of the diff.
- `scripts/gate-worktree.mjs`: a fenced run persists **which** fence fired (`fence reason: lease-authority-deadline`) in its recorded failure reason. Closes BI-ECAE03F7 acceptance 3.
- `docs/testing/pre-pr-gate.md`: documents the two kinds of wait.

## Why the pool is at 1 slot, and why that is not the bug

BI-D908DA0A's seeding shipped in #4869 (the installation profile derives `requestedCapacity: 2`). Measured on the live box: Docker VM 25.2 GB, `MemAvailable` ~20.2 GiB, two builder slots reserve 2 × 10 GiB. `host-build-capacity-one` is an honest reading that flips with the VM page cache, and slot-1 has admitted on this host before. `host-stage-headroom-low` (capacity 0) is Windows free memory at 9.2 GiB against a 4 GiB floor plus a 6 GiB stage reserve, caused by the WSL page cache. The residual defect was that capacity 0 was invisible. This PR makes it visible.

## Verification

- `node --test scripts/gate-worktree-pool-closed.test.mjs scripts/lib/pregate-status.test.mjs scripts/gate-worktree-lease-timeout.test.mjs`: 46 pass. Both new test files fail against the unfixed tree (proved by restoring the origin/main copies).
- `node --test --test-name-pattern="durable queue observation" scripts/gate-worktree-lease.test.mjs`: pass, now asserting the CLOSED line end to end.
- `node scripts/ci-policy-guards.mjs --profile pull-request`: all 7 pass.
- `--profile source`: 63/64; the one failure (Janitor Tests) is three pre-existing Windows-host cases (`gate-worktree.sh` variants, `local-ci-runner.mjs unshallows`, `isEntryModule` symlink EPERM) that fail identically on origin/main. Their `.mjs` twins pass.
- New test file registered in `scripts/lib/ci-policy-guards.mjs` (gate-executor-liveness guard).

Backlog: BI-D908DA0A (item 2 of the proposed work), BI-ECAE03F7 (acceptance 3). Evidence recorded on both items.

Docs-Impact-Decision: docs/testing/pre-pr-gate.md is updated in this PR; the ci-policy-guards.mjs change only registers a new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
