### PR TITLE
fix(review): rotate required-writer providers

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -62,13 +62,12 @@ import {
 import {
   applyTerminalToolSurface,
   buildTerminalToolReminder,
-  normalizeTerminalToolArguments,
+  normalizeTerminalToolArguments, rotateTerminalWriterProvider,
   resolveTerminalTextExit,
   resolveTerminalToolCall,
   selectTerminalToolSurface,
   type TerminalToolPolicy,
 } from "./terminal-tool-policy";
-// Re-export for importers (certification-oracles, tests) that pull from agentic-loop.
 export { detectToolRefusedDespiteAvailability } from "./tool-refused-recovery";
 
 // Safety ceiling — the loop exits naturally when the model responds with text-only
@@ -1757,6 +1756,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
           return completeResult(result.content, result);
         }
         if (exit.kind === "nudge") {
+          rotateTerminalWriterProvider(routeOptions, result.providerId);
           terminalToolNudges++;
           terminalToolSurfaceOverride = exit.allowedToolNames;
           messages = [...messages, { role: "assistant", content: result.content }, { role: "user", content: exit.message }];

--- a/apps/web/lib/tak/terminal-tool-policy.test.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.test.ts
@@ -527,6 +527,23 @@ describe("agent loop terminal writer integration", () => {
     expect(vi.mocked(routeAndCall)).toHaveBeenCalledTimes(3);
   });
 
+  it("routes the terminal-writer retry away from a provider that returned prose", async () => {
+    vi.mocked(routeAndCall)
+      .mockResolvedValueOnce(response("", [{ id: "read", name: "read_source_at_version", arguments: {} }]) as never)
+      .mockResolvedValueOnce(response("The evidence is sufficient for a judgment.") as never)
+      .mockResolvedValueOnce({ ...response("", [{ id: "writer", name: policy.writerToolName, arguments: {} }]), providerId: "anthropic-sub" } as never)
+      .mockResolvedValueOnce(response("The governed writer rejected the assessment, so no receipt exists.") as never);
+
+    await runAgenticLoop(params);
+
+    const retryOptions = vi.mocked(routeAndCall).mock.calls[2]![3] as {
+      deniedProviders?: string[];
+      preferredProviderId?: string;
+    };
+    expect(retryOptions.deniedProviders).toEqual(["local"]);
+    expect(retryOptions.preferredProviderId).toBeUndefined();
+  });
+
   it("returns a missing-writer failure when the review budget expires after a successful read", async () => {
     const now = vi.spyOn(Date, "now")
       .mockReturnValueOnce(0)

--- a/apps/web/lib/tak/terminal-tool-policy.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.ts
@@ -8,6 +8,26 @@ export type TerminalToolPolicy = {
   persistedEvidenceAvailable?: boolean;
 };
 
+type TerminalProviderRoute = {
+  deniedProviders?: string[];
+  preferredProviderId?: string;
+};
+
+/** Route a bounded required-writer retry away from the provider that returned prose. */
+export function rotateTerminalWriterProvider(
+  options: TerminalProviderRoute,
+  providerId: string,
+): void {
+  const noncompliantProvider = providerId.trim();
+  if (!noncompliantProvider || noncompliantProvider === "unknown") return;
+  options.deniedProviders = [
+    ...new Set([...(options.deniedProviders ?? []), noncompliantProvider]),
+  ];
+  if (options.preferredProviderId === noncompliantProvider) {
+    delete options.preferredProviderId;
+  }
+}
+
 export type ImmutableReaderArguments = {
   repositoryFullName: string;
   path: string;

--- a/docs/superpowers/plans/2026-09-06-required-terminal-writer-enforcement.md
+++ b/docs/superpowers/plans/2026-09-06-required-terminal-writer-enforcement.md
@@ -63,6 +63,12 @@ remains frozen and is not a test target.
 
 - `apps/web/lib/inference/ai-inference.ts`
 - `apps/web/lib/inference/ai-inference.call-provider.test.ts`
+
+## Provider noncompliance closeout
+
+1. Reproduce a successful immutable read followed by a required-writer prose response.
+2. Carry the noncompliant provider into the next in-turn route as a deny-only constraint, clearing a matching preference without selecting or pinning its replacement.
+3. Prove the same TaskRun reaches an alternate provider's actual writer call, while the no-alternative case remains a typed refusal and no receipt is inferred.
 - `apps/web/lib/routing/fallback.ts`
 - `apps/web/lib/routing/fallback.test.ts`
 - `apps/web/lib/tak/inference-dead-ends.ts`

--- a/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
+++ b/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
@@ -231,6 +231,10 @@ After reservation, the server invokes the already-governed `read_source_at_versi
 
 This is orchestration recovery, not an alternate evidence model. It changes no request identity, approval semantics, writer arguments, provider routing, tool grants, or receipt rules. WWMD decision `DI-6A51BE456F49` selected this repair over a replacement review identity because it preserves the immutable audit chain and makes the platform's existing resumability promise true.
 
+### Provider noncompliance rotation
+
+A required-writer provider that returns prose has demonstrated noncompliance for that bounded turn. The same TaskRun keeps its immutable binding, evidence, grants, and approval boundary, while the next in-turn writer nudge denies only that provider and lets the canonical router select another eligible endpoint. The platform never pins a replacement provider and never converts prose into a decision. If no alternative is eligible, the existing typed fail-closed refusal remains authoritative.
+
 ### Named-reference research
 
 - Source reference: `fix/initiative-review-terminal-writer-resume` at `c6c1380e828a65ca9552806d057c66833fb6c403`.


### PR DESCRIPTION
## Outcome
- rotate a governed required-writer retry away from a provider that returned prose
- preserve the same TaskRun, immutable evidence, grants, and approval boundary
- keep canonical routing responsible for selecting any eligible alternative

## Verification
- `terminal-tool-policy.test.ts`: 31/31 PASS
- `pnpm --filter web typecheck`: PASS
- module-size ratchet and diff check: PASS
- pregate preflight: 64/64 clean
- exact-tree local integration lease: skipped under the operator-authorized occupied/underperforming gate boundary; no PASS inferred

## Design grounding
- Existing specs/plans reviewed: immutable source review traversal design; required-terminal-writer enforcement plan
- Current code substrate reviewed: agentic-loop terminal text exit and canonical denied-provider routing
- Source of truth: terminal-tool-policy owns the bounded retry constraint; the canonical router selects the replacement
- Decision: a prose-returning provider is denied only for the next bounded writer retry

Docs-Impact-Decision: internal governed reviewer routing behavior only; no user-facing route, control, or workflow instructions change
Design-Grounding-Decision: extend the immutable source review traversal design and required-terminal-writer plan; agentic-loop and terminal-tool-policy remain the source of truth