### PR TITLE
fix(review): reconcile dispositions and persisted readiness

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/baseline-repository.ts
+++ b/apps/web/lib/backlog/initiative-readiness/baseline-repository.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { validateInitiativeDisposition } from "./disposition-contract";
 
 import { Prisma, prisma } from "@dpf/db";
 
@@ -229,6 +230,8 @@ export async function recordInitiativeSpecApproval(args: {
   authorityDecisionId: string | null;
   tokenScope: string | null;
 }): Promise<RecordInitiativeSpecApprovalResult> {
+  const dispositionError = validateInitiativeDisposition("pass", [], args.resolvedFindingRefs);
+  if (dispositionError) return { ok: false, code: "malformed-receipt", error: dispositionError };
   if (!args.reviewerAgentId || !args.authorityDecisionId || !args.tokenScope) {
     return { ok: false, code: "AUTHORIZATION_DENIED", error: "Authenticated reviewer, authority decision, and token scope are required." };
   }

--- a/apps/web/lib/backlog/initiative-readiness/disposition-contract.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/disposition-contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { findingEvidenceMatchesRead, validateInitiativeDisposition } from "./disposition-contract";
+
+describe("canonical initiative disposition", () => {
+  it("rejects new findings on pass while preserving existing finding resolutions", () => {
+    expect(validateInitiativeDisposition("pass", [], [])).toBeNull();
+    expect(validateInitiativeDisposition("pass", ["Positive observation"], [])).not.toBeNull();
+    expect(validateInitiativeDisposition("pass", [], ["IF-open"])).toBeNull();
+  });
+  it("allows findings only with fail", () => {
+    expect(validateInitiativeDisposition("fail", ["Missing test"], [])).toBeNull();
+    expect(validateInitiativeDisposition("not-applicable", ["Missing test"], [])).not.toBeNull();
+  });
+  const page = { blobId: "blob", startLine: 10, endLine: 12,
+    content: "## Existing substrate and ownership boundary\nBI-6CB35411 is a conditional hard prerequisite.\nIts source paths are excluded." };
+  const evidence = { blobId: "blob", startLine: 11, endLine: 11, quote: "BI-6CB35411 is a conditional hard prerequisite." };
+  it("accepts exact immutable line evidence", () => {
+    expect(findingEvidenceMatchesRead(evidence, page, "blob")).toBe(true);
+  });
+  it.each([
+    { ...evidence, blobId: "other" },
+    { ...evidence, startLine: 9 },
+    { ...evidence, endLine: 13 },
+    { ...evidence, quote: "BI-6CB35411 is not a prerequisite." },
+    { ...evidence, startLine: 12, endLine: 12 },
+  ])("rejects mismatched or contradicted citation %j", (candidate) => {
+    expect(findingEvidenceMatchesRead(candidate, page, "blob")).toBe(false);
+  });
+});

--- a/apps/web/lib/backlog/initiative-readiness/disposition-contract.ts
+++ b/apps/web/lib/backlog/initiative-readiness/disposition-contract.ts
@@ -1,0 +1,46 @@
+/** Shared by reviewer instructions, provider schemas, and receipt validation. */
+export const INITIATIVE_DISPOSITION_GUIDANCE =
+  "Pass requires findings=[]. Positive observations belong in reason. Resolve only existing open finding IDs; otherwise use resolvedFindingRefs=[]. "
+  + "Only fail may introduce findings. Cite the bound immutable artifact's blob and lines for each finding, "
+  + "and check that the artifact does not contradict the finding. Never discard a finding to obtain approval. "
+  + "A receipt satisfies only its own gate; current readiness determines whether implementation may proceed.";
+
+export function validateInitiativeDisposition(
+  decision: string,
+  findings: readonly unknown[],
+  _resolvedFindingRefs: readonly string[],
+): string | null {
+  if (decision === "pass" && findings.length > 0) {
+    return `A passing receipt requires empty findings. ${INITIATIVE_DISPOSITION_GUIDANCE}`;
+  }
+  if (decision !== "fail" && findings.length > 0) {
+    return "Only a failing receipt can introduce findings. Put positive observations in reason.";
+  }
+  return null;
+}
+
+export const INITIATIVE_WRITER_CORRECTION_LIMIT = 2;
+export const INITIATIVE_CORRECTABLE_ERRORS = new Set([
+  "malformed-receipt", "reason-required", "finding-resolution-invalid",
+]);
+
+export type InitiativeFindingEvidence = {
+  blobId: string;
+  startLine: number;
+  endLine: number;
+  quote: string;
+};
+
+export function findingEvidenceMatchesRead(
+  evidence: InitiativeFindingEvidence,
+  page: Record<string, unknown>,
+  blobId: string,
+): boolean {
+  if (evidence.blobId !== blobId || page.blobId !== blobId
+    || typeof page.content !== "string" || typeof page.startLine !== "number" || typeof page.endLine !== "number"
+    || !Number.isSafeInteger(evidence.startLine) || !Number.isSafeInteger(evidence.endLine)
+    || evidence.startLine < page.startLine || evidence.endLine > page.endLine || evidence.endLine < evidence.startLine
+    || typeof evidence.quote !== "string" || !evidence.quote.trim()) return false;
+  const cited = page.content.split("\n").slice(evidence.startLine - page.startLine, evidence.endLine - page.startLine + 1).join("\n");
+  return cited.includes(evidence.quote);
+}

--- a/apps/web/lib/backlog/initiative-readiness/receipt-schema.ts
+++ b/apps/web/lib/backlog/initiative-readiness/receipt-schema.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { validateInitiativeDisposition } from "./disposition-contract";
 
 import type { InitiativeSubject } from "./types";
 import type { ReadinessProfile } from "./types";
@@ -236,9 +237,8 @@ export function validateInitiativeGateReceiptDraft(
   if (draft.findingRefs.some((finding) => draft.resolvedFindingRefs.includes(finding))) {
     return reject("finding-resolution-invalid", "A receipt cannot introduce and resolve the same finding.");
   }
-  if (draft.decision !== "fail" && draft.findingRefs.length > 0) {
-    return reject("malformed-receipt", "Only a failing receipt can introduce findings.");
-  }
+  const dispositionError = validateInitiativeDisposition(draft.decision, draft.findingRefs, draft.resolvedFindingRefs);
+  if (dispositionError) return reject("malformed-receipt", dispositionError);
   for (const resolved of draft.resolvedFindingRefs) openFindings.delete(resolved);
   if (draft.decision !== "fail" && openFindings.size > 0) {
     return reject("blocking-findings-open", "A passing or not-applicable receipt cannot leave findings open.");

--- a/apps/web/lib/mcp-task-disposition-recovery.test.ts
+++ b/apps/web/lib/mcp-task-disposition-recovery.test.ts
@@ -166,7 +166,7 @@ describe("disposition correction", () => {
     });
     db.findToolExecutions.mockResolvedValue([persistedReaderExecution]);
     db.findToolExecution.mockImplementation(async (query: { where?: { success?: boolean } }) => query.where?.success
-      ? null : { id: "rejected-writer", success: false, result: {
+      ? null : { id: "rejected-writer", success: false, parameters: { decision: "pass", findings: [{ issue: "Original boundary concern", severity: "important" }] }, result: {
         success: false, error: "malformed-receipt", message: "A passing spec approval cannot introduce findings.",
       } });
     db.findEnvelope.mockResolvedValue(null);
@@ -177,6 +177,8 @@ describe("disposition correction", () => {
       taskRunId: "TR-MCP-DISPOSITION",
       systemPrompt: expect.stringContaining("A passing spec approval cannot introduce findings."),
     }));
+    expect(autonomous.execute.mock.calls[0][0].systemPrompt).toContain("Original boundary concern");
+    expect(autonomous.execute.mock.calls[0][0].systemPrompt).toContain("Explain any retracted or contradicted finding in reason");
     expect(outcome).toMatchObject({ kind: "result", result: { taskRunId: "TR-MCP-DISPOSITION" } });
   });
 

--- a/apps/web/lib/mcp-task-disposition-recovery.test.ts
+++ b/apps/web/lib/mcp-task-disposition-recovery.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  findUnique: vi.fn(),
+  findModelConfig: vi.fn(),
+  findEnvelope: vi.fn(),
+  findToolExecution: vi.fn(),
+  findToolExecutions: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+  upsertThread: vi.fn(),
+}));
+const autonomous = vi.hoisted(() => ({
+  create: vi.fn(),
+  execute: vi.fn(),
+  executeTool: vi.fn(),
+  resolveAgent: vi.fn(),
+  resolveTools: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findFirst: (...args: unknown[]) => db.findFirst(...args),
+      findUnique: (...args: unknown[]) => db.findUnique(...args),
+      update: (...args: unknown[]) => db.update(...args),
+      updateMany: (...args: unknown[]) => db.updateMany(...args),
+    },
+    coworkerActionEnvelope: { findFirst: (...args: unknown[]) => db.findEnvelope(...args) },
+    toolExecution: {
+      findFirst: (...args: unknown[]) => db.findToolExecution(...args),
+      findMany: (...args: unknown[]) => db.findToolExecutions(...args),
+    },
+    agentThread: { upsert: (...args: unknown[]) => db.upsertThread(...args) },
+    agentModelConfig: { findUnique: (...args: unknown[]) => db.findModelConfig(...args) },
+  },
+}));
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: (...args: unknown[]) => autonomous.create(...args),
+  executeAutonomousAgenticLoop: (...args: unknown[]) => autonomous.execute(...args),
+  executeAutonomousWorkTool: (...args: unknown[]) => autonomous.executeTool(...args),
+  resolveAutonomousWorkAgent: (...args: unknown[]) => autonomous.resolveAgent(...args),
+  resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
+}));
+vi.mock("@/lib/tak/task-records", () => ({ createTaskMessage: vi.fn() }));
+
+import { submitRemoteCoworkerTask } from "./mcp-task-submit";
+
+const userContext = { platformRole: "developer", isSuperuser: false };
+const params = {
+  agentId: "AGT-WS-REVIEW",
+  routeContext: "/platform/build",
+  title: "Independent design review",
+  objective: "Review the immutable artifact.",
+  prompt: "Read the source and record the governed evidence.",
+  idempotencyKey: "missing-writer-same-taskrun-resume",
+  riskClass: "bounded-write",
+  authorityScope: [
+    "backlog-item:BI-F0715C9C",
+    "tool:read_source_at_version",
+    "tool:record_initiative_evidence",
+  ],
+  collaborationKind: "summon",
+  initiativeReviewBinding: {
+    writerToolName: "record_initiative_evidence",
+    itemId: "BI-F0715C9C",
+    gate: "research",
+    artifactRef: {
+      kind: "repo-blob-at-commit",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      commitSha: "d47536a552c7d588b2f963e478ae99369f720783",
+      path: "docs/superpowers/specs/design.md",
+      providerBlobId: "fb57e087c19ce0a3c78b4d591bb5da63027c2b3b",
+    },
+  },
+};
+
+const persistedReaderExecution = {
+  id: "reader-1",
+  toolName: "read_source_at_version",
+  parameters: {
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    path: "docs/superpowers/specs/design.md",
+    version: "d47536a552c7d588b2f963e478ae99369f720783",
+    expectedBlobId: "fb57e087c19ce0a3c78b4d591bb5da63027c2b3b",
+    startLine: 1,
+    maxChars: 3_200,
+  },
+  result: {},
+  success: true,
+  createdAt: new Date("2026-08-28T15:30:31.190Z"),
+};
+
+function submit(tokenId: string, request = params) {
+  return submitRemoteCoworkerTask({
+    token: { tokenId, userId: "user-1", capability: "write", source: "pat" },
+    userContext,
+    params: request,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.findFirst.mockResolvedValue(null);
+  db.findUnique.mockResolvedValue({ status: "working" });
+  db.findEnvelope.mockResolvedValue(null);
+  db.findToolExecution.mockResolvedValue(null);
+  db.findToolExecutions.mockResolvedValue([persistedReaderExecution]);
+  db.findModelConfig.mockResolvedValue({
+    minimumTier: "strong",
+    budgetClass: "quality_first",
+    pinnedProviderId: "local",
+    pinnedModelId: "review-model",
+  });
+  db.upsertThread.mockResolvedValue({ id: "thread-external" });
+  db.update.mockResolvedValue({});
+  db.updateMany.mockResolvedValue({ count: 1 });
+  autonomous.create.mockImplementation(async (input: Record<string, unknown>) => ({
+    id: "task-internal",
+    taskRunId: input["taskRunId"],
+    contextId: "thread-external",
+  }));
+  autonomous.resolveAgent.mockResolvedValue({
+    agentId: "build-specialist",
+    displayName: "Build Lead",
+    systemPrompt: "Review the immutable artifact.",
+    sensitivity: "internal",
+  });
+  autonomous.resolveTools.mockResolvedValue({ tools: [], toolsForProvider: [], deferredTools: [] });
+  autonomous.execute.mockResolvedValue({ content: "Done.", executedTools: [] });
+  autonomous.executeTool.mockResolvedValue({
+    success: true,
+    message: "Read design.md lines 1-3 of 3.",
+    data: {
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      path: "docs/superpowers/specs/design.md",
+      version: "d47536a552c7d588b2f963e478ae99369f720783",
+      blobId: "fb57e087c19ce0a3c78b4d591bb5da63027c2b3b",
+      content: "# Recovery design\n\nThe same TaskRun preserves its immutable authority binding.",
+      startLine: 1,
+      endLine: 3,
+      totalLines: 3,
+      hasMore: false,
+      nextCursor: null,
+    },
+  });
+});
+
+async function persistedMetadata(tokenId: string, request = params) {
+  await submit(tokenId, request);
+  return (autonomous.create.mock.calls[0]?.[0] as { metadata: Record<string, unknown> }).metadata;
+}
+
+describe("disposition correction", () => {
+  it("BI-31159978 resumes a rejected second-turn disposition on the same immutable TaskRun", async () => {
+    const metadata = await persistedMetadata("PAT-DISPOSITION-RECOVERY");
+    vi.clearAllMocks();
+    db.findFirst.mockResolvedValue({
+      id: "task-internal", taskRunId: "TR-MCP-DISPOSITION", threadId: "thread-external", contextId: "thread-external",
+      status: "input-required", updatedAt: new Date("2026-09-06T10:00:00Z"), a2aMetadata: metadata,
+      progressPayload: { terminalWriterWait: {
+        schemaVersion: 1, kind: "missing-terminal-writer", writerToolName: "record_initiative_evidence",
+        resumeMode: "same-taskrun", attempt: 2, observedAt: "2026-09-06T10:00:00Z",
+      } },
+    });
+    db.findToolExecutions.mockResolvedValue([persistedReaderExecution]);
+    db.findToolExecution.mockImplementation(async (query: { where?: { success?: boolean } }) => query.where?.success
+      ? null : { id: "rejected-writer", success: false, result: {
+        success: false, error: "malformed-receipt", message: "A passing spec approval cannot introduce findings.",
+      } });
+    db.findEnvelope.mockResolvedValue(null);
+    db.findUnique.mockResolvedValue({ status: "working" });
+    const outcome = await submit("PAT-DISPOSITION-RECOVERY");
+    expect(autonomous.create).not.toHaveBeenCalled();
+    expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
+      taskRunId: "TR-MCP-DISPOSITION",
+      systemPrompt: expect.stringContaining("A passing spec approval cannot introduce findings."),
+    }));
+    expect(outcome).toMatchObject({ kind: "result", result: { taskRunId: "TR-MCP-DISPOSITION" } });
+  });
+
+});

--- a/apps/web/lib/mcp-task-execution.test.ts
+++ b/apps/web/lib/mcp-task-execution.test.ts
@@ -10,6 +10,11 @@ const autonomous = vi.hoisted(() => ({
   resolveAgent: vi.fn(),
   resolveTools: vi.fn(),
 }));
+vi.mock("./mcp-task-review-outcome", () => ({
+  loadInitiativeReviewOutcome: vi.fn(async (_binding: unknown, receiptId: string) => ({
+    receiptId, summary: `Receipt ${receiptId} persisted. Implementation readiness: input-required; plan coverage remains missing.`,
+  })),
+}));
 
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -63,6 +68,37 @@ const parsed = {
 };
 
 describe("remote task terminal-writer postcondition", () => {
+  it("refuses completion from writer success without a receipt ID", async () => {
+    autonomous.execute.mockResolvedValue({ content: "Approved, start implementation.", executedTools: [{ name: writerToolName, result: { success: true } }] });
+    const outcome = await executeRemoteTaskAttempt({
+      run: { id: "run", taskRunId: "TR-NO-RECEIPT", contextId: "thread-1" }, threadId: "thread-1",
+      token: { tokenId: "PAT", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false }, parsed, idempotentReplay: false, capacityAttempt: 1,
+    });
+    expect(outcome).toMatchObject({ kind: "result", result: { status: "input-required" } });
+    expect(JSON.stringify(outcome)).toContain("without a receipt ID");
+    expect(JSON.stringify(outcome)).not.toContain("start implementation");
+  });
+  it("BI-31159978 does not invent approval after a successful writer with stale input-required state", async () => {
+    db.findTaskRun.mockResolvedValue({ status: "input-required", progressPayload: {} });
+    autonomous.execute.mockResolvedValue({
+      content: "Blocked: no receipt exists; request human approval.",
+      executedTools: [{ name: writerToolName, result: {
+        success: true, entityId: "initiative-persisted-receipt",
+        data: { receiptId: "initiative-persisted-receipt" },
+      } }],
+    });
+    const outcome = await executeRemoteTaskAttempt({
+      run: { id: "run-internal", taskRunId: "TR-MCP-STATUS-REPRO", contextId: "thread-1" },
+      threadId: "thread-1",
+      token: { tokenId: "PAT-WRITER-DURATION", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      parsed, idempotentReplay: true, capacityAttempt: 1,
+    });
+    expect(outcome).toMatchObject({ kind: "result", result: { requiresApproval: false } });
+    expect(JSON.stringify(outcome)).not.toContain("no receipt exists");
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     db.findModelConfig.mockResolvedValue(null);
@@ -432,7 +468,7 @@ describe("a resource wait is not a missing terminal writer (BI-8B8731EE)", () =>
         waitReason: "missing-terminal-writer",
         content: [{
           type: "text",
-          text: expect.stringContaining("was not recorded before the review attempt ended"),
+          text: expect.stringContaining("did not invoke required writer"),
         }],
       },
     });

--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -1,5 +1,6 @@
 import { coworkerBriefSpans } from "@/lib/tak/coworker-prompt-provenance";
 import { prisma } from "@dpf/db";
+import { loadInitiativeReviewOutcome } from "./mcp-task-review-outcome";
 import { resolveCanonicalAgentId } from "@dpf/db/agent-identity";
 import {
   executeAutonomousAgenticLoop,
@@ -11,6 +12,7 @@ import { deriveEffortWarrant } from "@/lib/tak/effort-warrant";
 import {
   createInitiativeReviewTerminalToolPolicy,
   enterTerminalWriterPhase,
+  terminalWriterFailureMessage as describeTerminalWriterFailure,
 } from "@/lib/tak/terminal-tool-policy";
 import {
   createResourceWaitProjection,
@@ -185,6 +187,22 @@ export async function executeRemoteTaskAttempt(input: {
       ...(modelRequirements ? { modelRequirements } : {}),
     });
 
+    const writerResult = parsed.initiativeReviewBinding
+      ? result.executedTools?.filter((tool) => tool.name === parsed.initiativeReviewBinding!.writerToolName && tool.result.success).at(-1)?.result
+      : undefined;
+    const receiptId = optionalString(writerResult?.data?.["receiptId"]);
+    const persistedOutcome = receiptId && parsed.initiativeReviewBinding
+      ? await loadInitiativeReviewOutcome(parsed.initiativeReviewBinding, receiptId) : null;
+    if (persistedOutcome) {
+      result.content = persistedOutcome.summary;
+      result.failure = undefined;
+    }
+    const receiptExpected = !!parsed.initiativeReviewBinding && parsed.initiativeReviewBinding.gate !== "objective-mapping"
+      && !parsed.initiativeReviewBinding.eligibleEvidenceActivityIds?.length;
+    if (writerResult && receiptExpected && !persistedOutcome) {
+      result.content = `The writer returned success${receiptId ? ` for receipt ${receiptId}` : " without a receipt ID"}, but its persisted gate and immutable artifact could not be verified. Read back the writer result before retrying or advancing readiness.`;
+    }
+
     await createTaskMessage({
       taskRunId: run.taskRunId,
       taskRunRecordId: run.id,
@@ -195,6 +213,7 @@ export async function executeRemoteTaskAttempt(input: {
         source: "mcp.tasks/submit",
         executedToolCount: result.executedTools?.length ?? 0,
         capacityAttempt: input.capacityAttempt,
+        ...(persistedOutcome ? { reviewOutcome: persistedOutcome } : {}),
       },
     });
 
@@ -216,7 +235,8 @@ export async function executeRemoteTaskAttempt(input: {
           .map((tool) => approvalRequiredEnvelopeId(tool.result))
           .find((envelopeId): envelopeId is string => envelopeId !== null) ?? null
       : null;
-    const terminalWriterSucceeded = terminalWriterExecutions.some((tool) => tool.result.success);
+    const terminalWriterSucceeded = receiptExpected
+      ? persistedOutcome !== null : terminalWriterExecutions.some((tool) => tool.result.success);
     const terminalWriterMissing = terminalToolPolicy !== null
       && !terminalWriterSucceeded
       && terminalWriterApprovalEnvelopeId === null;
@@ -227,7 +247,7 @@ export async function executeRemoteTaskAttempt(input: {
     // unreachable and every deferral was reported as a missing receipt writer.
     // Let the resource wait win; it resumes on the same TaskRun either way.
     const resourceWaitOwnsThisTurn = preInferenceResourceWait(result) !== null;
-    if (terminalWriterApprovalEnvelopeId && terminalToolPolicy) {
+    if (terminalWriterApprovalEnvelopeId && terminalToolPolicy && !persistedOutcome) {
       const priorProgress = currentRun?.progressPayload
         && typeof currentRun.progressPayload === "object"
         && !Array.isArray(currentRun.progressPayload)
@@ -348,9 +368,8 @@ export async function executeRemoteTaskAttempt(input: {
       const terminalWriterAttempt = input.terminalWriterAttempt ?? 1;
       const terminalWriterFailureMessage = result.failure?.kind === "terminal-writer-missing"
         ? result.failure.message
-        : terminalWriterExecutions.length > 0
-          ? `The required governed writer ${terminalToolPolicy.writerToolName} was called but did not produce a receipt or approval envelope. The same TaskRun remains resumable.`
-        : `The required governed writer ${terminalToolPolicy.writerToolName} was not recorded before the review attempt ended. The same TaskRun remains resumable. No receipt was created.`;
+        : writerResult && receiptExpected && !persistedOutcome ? result.content
+        : describeTerminalWriterFailure(terminalToolPolicy, terminalWriterExecutions);
       const escalation = terminalWriterRetryIsExhausted(terminalWriterAttempt)
         ? createTerminalWriterEscalation({
             writerToolName: terminalToolPolicy.writerToolName,
@@ -405,7 +424,7 @@ export async function executeRemoteTaskAttempt(input: {
         },
       };
     }
-    if (currentRun?.status === "input-required") {
+    if (currentRun?.status === "input-required" && !persistedOutcome && !terminalToolPolicy) {
       return {
         kind: "result",
         result: await withTaskRunApprovalLocation({
@@ -495,6 +514,7 @@ export async function executeRemoteTaskAttempt(input: {
           riskClass: parsed.riskClass,
           executedToolCount: result.executedTools?.length ?? 0,
           ...resumedFlag,
+          ...(persistedOutcome ? { reviewOutcome: persistedOutcome, requiresApproval: false } : {}),
         },
       },
     });
@@ -510,6 +530,7 @@ export async function executeRemoteTaskAttempt(input: {
         content: remoteTaskContent(result.content),
         executedToolCount: result.executedTools?.length ?? 0,
         isError: false,
+        ...(persistedOutcome ? { structuredContent: persistedOutcome } : {}),
       },
     };
   } catch (err) {

--- a/apps/web/lib/mcp-task-replay-projection.ts
+++ b/apps/web/lib/mcp-task-replay-projection.ts
@@ -15,6 +15,7 @@ export type TerminalWriterWait = {
   observedAt: string;
   dispatchContract?: "required-tool-call";
   noncompliance?: "prose-without-required-writer";
+  validationFailure?: { error: string; message: string };
 };
 
 type TerminalWriterDispatchFailure = {
@@ -100,13 +101,16 @@ export function projectRemoteTaskReplay(input: {
     terminalWriterWait,
   );
   const resourceWait = parseResourceWaitProjection(input.existing.progressPayload);
+  const progress = input.existing.progressPayload && typeof input.existing.progressPayload === "object"
+    ? input.existing.progressPayload as Record<string, unknown> : {};
   return {
     kind: "result",
     result: {
       taskRunId: input.existing.taskRunId,
       status: input.existing.status,
       idempotentReplay: true,
-      requiresApproval: input.existing.status === "input-required" && !terminalWriterWait && !terminalWriterEscalation,
+      requiresApproval: input.existing.status === "input-required" && !terminalWriterWait && !terminalWriterEscalation
+        && typeof progress.approvalEnvelopeId === "string" && progress.approvalEnvelopeId.length > 0,
       ...(terminalWriterEscalation ? {
         resumable: false,
         waitReason: terminalWriterEscalationWaitReason(terminalWriterEscalation),

--- a/apps/web/lib/mcp-task-replay-projection.ts
+++ b/apps/web/lib/mcp-task-replay-projection.ts
@@ -1,4 +1,5 @@
 import { parseResourceWaitProjection } from "./mcp-task-capacity-contract";
+import type { Prisma } from "@dpf/db";
 import {
   recoverTerminalWriterEscalation,
   terminalWriterEscalationMessage,
@@ -15,7 +16,7 @@ export type TerminalWriterWait = {
   observedAt: string;
   dispatchContract?: "required-tool-call";
   noncompliance?: "prose-without-required-writer";
-  validationFailure?: { error: string; message: string };
+  validationFailure?: { error: string; message: string; proposal?: Prisma.JsonValue };
 };
 
 type TerminalWriterDispatchFailure = {

--- a/apps/web/lib/mcp-task-review-contract.ts
+++ b/apps/web/lib/mcp-task-review-contract.ts
@@ -177,8 +177,6 @@ export function narrowInitiativeReviewTools<T extends {
   const exactNames = new Set(requiredNames);
   const currentBaselineId = optionalString(binding.expectedCurrentBaselineId);
   const eligibleEvidenceActivityIds = binding.eligibleEvidenceActivityIds ?? [];
-  const compactResearchReceipt = binding.gate === "research"
-    && binding.writerToolName === "record_initiative_evidence";
   const objectiveMappingProposal = binding.writerToolName === "record_initiative_evidence"
     && !!currentBaselineId
     && (
@@ -191,9 +189,7 @@ export function narrowInitiativeReviewTools<T extends {
     );
   const baseWriterNames = objectiveMappingProposal
     ? ["operation", "baselineId", "objectiveMappings", "reason"]
-    : compactResearchReceipt
-      ? ["decision"]
-      : ["decision", "reason", "findings", "resolvedFindingRefs"];
+    : ["decision", "reason", "findings", "resolvedFindingRefs"];
   const writerPropertyNames = [
     ...baseWriterNames,
     ...(binding.gate === "spec-approval" ? ["profile", "artifactRole", "supersessionDispositions"] : []),

--- a/apps/web/lib/mcp-task-review-outcome.test.ts
+++ b/apps/web/lib/mcp-task-review-outcome.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const db = vi.hoisted(() => ({ item: vi.fn(), execution: vi.fn(), update: vi.fn() }));
+vi.mock("@dpf/db", () => ({ prisma: { backlogItem: { findUnique: db.item }, toolExecution: { findFirst: db.execution }, taskRun: { update: db.update } } }));
+vi.mock("./backlog/initiative-readiness/parent-scope-inheritance", () => ({ loadInheritedInitiativeScope: vi.fn(async () => null) }));
+import { loadInitiativeReviewOutcome, loadTaskInitiativeReviewOutcome, reconcilePersistedReviewStatus } from "./mcp-task-review-outcome";
+
+const artifactRef = { kind: "repo-blob-at-commit" as const, repositoryFullName: "owner/repo", commitSha: "sha", providerBlobId: "blob", path: "design.md" };
+const binding = { itemId: "BI-TEST", gate: "design-spec", artifactRef, writerToolName: "record_initiative_design_review" };
+const receipt = { schemaVersion: 1, receiptId: "receipt", gate: "design-spec", decision: "pass",
+  subject: { kind: "backlog-item", id: "BI-TEST" }, artifactRef, artifactDigest: "digest",
+  reviewerPrincipalId: "reviewer", reviewerAgentId: "AGT-WS-REVIEW", artifactAuthorRef: "author",
+  authorityDecisionId: "AUTH-1", authoritySnapshot: {}, findingRefs: [], resolvedFindingRefs: [], reason: "Reviewed." };
+function item(payload: unknown = receipt) {
+  return { id: "item", itemId: "BI-TEST", type: "product", workType: "bug", scopeKind: "platform", source: "user-request", activeBuild: null,
+    activities: [{ id: "receipt", kind: "initiative_gate_receipt", gateKey: "design_spec", recordedAt: new Date(), payload }] };
+}
+beforeEach(() => { vi.resetAllMocks(); db.item.mockResolvedValue(item()); });
+describe("persisted initiative review outcome", () => {
+  it("reconciles stale status from a verified receipt while preserving unrelated progress", async () => {
+    const outcome = await loadInitiativeReviewOutcome(binding, "receipt");
+    await reconcilePersistedReviewStatus("TR-1", { auditMarker: "retain", terminalWriterWait: {}, approvalEnvelopeId: "stale" }, outcome!);
+    const data = db.update.mock.calls[0][0].data;
+    expect(data.status).toBe("completed");
+    expect(data.progressPayload).toMatchObject({ auditMarker: "retain", reviewOutcome: { receiptId: "receipt" }, requiresApproval: false });
+    expect(data.progressPayload).not.toHaveProperty("terminalWriterWait");
+    expect(data.progressPayload).not.toHaveProperty("approvalEnvelopeId");
+  });
+  it("reports the matching receipt while preserving unmet implementation gates", async () => {
+    const result = await loadInitiativeReviewOutcome(binding, "receipt");
+    expect(result?.receiptId).toBe("receipt");
+    expect(result?.readiness.verdict).not.toBe("allowed");
+    expect(result?.summary).toContain("receipt receipt persisted");
+    expect(result?.readiness.unmet.some((entry) => entry.code === "PLAN_REQUIRED")).toBe(true);
+  });
+  it.each([
+    { ...receipt, gate: "research" },
+    { ...receipt, artifactRef: { ...artifactRef, providerBlobId: "other" } },
+    { ...receipt, subject: { kind: "backlog-item", id: "BI-OTHER" } },
+    { ...receipt, decision: "invented" },
+  ])("does not infer a matching receipt from incompatible persistence", async (payload) => {
+    db.item.mockResolvedValue(item(payload));
+    expect(await loadInitiativeReviewOutcome(binding, "receipt")).toBeNull();
+  });
+  it("does not manufacture a receipt from successful tool execution without its persisted row", async () => {
+    db.execution.mockResolvedValue({ result: { success: true, data: { receiptId: "absent" } } });
+    expect(await loadTaskInitiativeReviewOutcome("TR-1", binding)).toBeNull();
+  });
+});

--- a/apps/web/lib/mcp-task-review-outcome.ts
+++ b/apps/web/lib/mcp-task-review-outcome.ts
@@ -1,0 +1,66 @@
+import { prisma, type Prisma } from "@dpf/db";
+import { projectBacklogItemReadiness } from "./backlog/initiative-readiness/entry-adapter";
+import { loadInheritedInitiativeScope } from "./backlog/initiative-readiness/parent-scope-inheritance";
+import type { InitiativeReviewBinding } from "./mcp-task-review-contract";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+}
+
+export async function reconcilePersistedReviewStatus(
+  taskRunId: string, progressPayload: unknown,
+  outcome: NonNullable<Awaited<ReturnType<typeof loadInitiativeReviewOutcome>>>,
+) {
+  const progress = { ...record(progressPayload) };
+  for (const key of ["terminalWriterWait", "terminalWriterDispatchFailure", "terminalWriterEscalation", "terminalWriterContextFailure", "resourceWait", "approvalEnvelopeId"])
+    delete progress[key];
+  await prisma.taskRun.update({ where: { taskRunId }, data: {
+    status: "completed", completedAt: new Date(),
+    progressPayload: { ...progress, summary: outcome.summary, reviewOutcome: outcome, requiresApproval: false } as Prisma.InputJsonValue,
+  } });
+}
+
+export async function loadTaskInitiativeReviewOutcome(taskRunId: string, binding: InitiativeReviewBinding) {
+  const execution = await prisma.toolExecution.findFirst({
+    where: { taskRunId, toolName: binding.writerToolName, success: true },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }], select: { result: true },
+  });
+  const result = record(execution?.result);
+  const data = record(result?.data);
+  return typeof data?.receiptId === "string" ? loadInitiativeReviewOutcome(binding, data.receiptId) : null;
+}
+
+/** Read the canonical receipt, never infer one from model prose or tool success. */
+export async function loadInitiativeReviewOutcome(binding: InitiativeReviewBinding, receiptId: string) {
+  const item = await prisma.backlogItem.findUnique({
+    where: { itemId: binding.itemId },
+    include: { activeBuild: { select: { kind: true } }, activities: { orderBy: [{ recordedAt: "asc" }, { id: "asc" }] } },
+  });
+  if (!item) return null;
+  const receiptRow = item.activities.find((row) => row.id === receiptId && row.kind === "initiative_gate_receipt");
+  const receipt = record(receiptRow?.payload);
+  const artifact = record(receipt?.artifactRef);
+  const subject = record(receipt?.subject);
+  if (!receipt || receipt.receiptId !== receiptId || receipt.gate !== binding.gate
+    || (receipt.decision !== "pass" && receipt.decision !== "fail" && receipt.decision !== "not-applicable")
+    || subject?.id !== binding.itemId || subject.kind !== "backlog-item"
+    || !artifact || Object.entries(binding.artifactRef).some(([key, value]) => artifact[key] !== value)) return null;
+  const inheritedScope = await loadInheritedInitiativeScope(prisma, { childItemId: item.itemId, childRowId: item.id });
+  const readiness = projectBacklogItemReadiness({
+    item: { ...item, activeBuildKind: item.activeBuild?.kind ?? null },
+    activities: item.activities,
+    inheritedScope,
+    target: "implementation",
+    transitionObject: { kind: "backlog-item", id: item.itemId, expectedVersion: "read-projection", targetState: "implementation" },
+    authorization: "pass", capsuleIdentity: "pass", evaluatedAt: new Date().toISOString(),
+  }).decision;
+  const remaining = [...readiness.unmet, ...readiness.blockers].map((entry) => `${entry.code}: ${entry.nextAction ?? entry.state}`);
+  return {
+    receiptId, gate: binding.gate, decision: String(receipt.decision),
+    artifactRef: binding.artifactRef, readiness,
+    summary: `${binding.gate} receipt ${receiptId} persisted with decision=${String(receipt.decision)} for artifact ${binding.artifactRef.commitSha}. `
+      + `Implementation readiness: ${readiness.verdict}. `
+      + (remaining.length ? remaining.join(" ") : "Recheck Workroom identity and authority at the implementation transition."),
+  };
+}

--- a/apps/web/lib/mcp-task-submit-approval-recovery.test.ts
+++ b/apps/web/lib/mcp-task-submit-approval-recovery.test.ts
@@ -48,6 +48,7 @@ vi.mock("@/lib/tak/autonomous-work-run", () => ({
   resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
 }));
 vi.mock("@/lib/tak/task-records", () => ({ createTaskMessage: vi.fn() }));
+vi.mock("./mcp-task-review-outcome", () => ({ loadTaskInitiativeReviewOutcome: vi.fn().mockResolvedValue(null) }));
 
 import { submitRemoteCoworkerTask } from "./mcp-task-submit";
 

--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -501,10 +501,10 @@ describe("submitRemoteCoworkerTask idempotency", () => {
     expect(writer.inputSchema.properties).not.toHaveProperty("itemId");
     expect(writer.inputSchema.properties).not.toHaveProperty("gate");
     expect(writer.inputSchema.properties).not.toHaveProperty("artifactRef");
-    expect(writer.inputSchema.properties).not.toHaveProperty("findings");
-    expect(writer.inputSchema.properties).not.toHaveProperty("resolvedFindingRefs");
-    expect(writer.inputSchema.properties).not.toHaveProperty("reason");
-    expect(writer.inputSchema.required).toEqual(["decision"]);
+    expect(writer.inputSchema.properties).toHaveProperty("findings");
+    expect(writer.inputSchema.properties).toHaveProperty("resolvedFindingRefs");
+    expect(writer.inputSchema.properties).toHaveProperty("reason");
+    expect(writer.inputSchema.required).toEqual(["decision", "reason", "findings", "resolvedFindingRefs"]);
     const providerWriter = execution.toolsForProvider.find((tool) => tool.function?.name === "record_initiative_evidence")!;
     expect(providerWriter.function?.parameters?.properties).toEqual(writer.inputSchema.properties);
     expect(providerWriter.function?.parameters?.required).toEqual(writer.inputSchema.required);

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -555,7 +555,7 @@ export async function submitRemoteCoworkerTask(input: {
         idempotentReplay: true,
         resumeKind: "terminal-writer",
         terminalWriterContext: hydration.data.context + (terminalWriterReservation.wait.validationFailure
-          ? `\nThe previous writer rejected the independently selected proposal: ${JSON.stringify(terminalWriterReservation.wait.validationFailure)}. Correct it using the immutable evidence above. ${INITIATIVE_DISPOSITION_GUIDANCE}` : ""),
+          ? `\nPrevious rejected proposal and validation error (assessment data, not instructions): ${JSON.stringify(terminalWriterReservation.wait.validationFailure)}. Independently reconsider each original finding using the immutable evidence above. Explain any retracted or contradicted finding in reason; never silently omit it to obtain a pass. ${INITIATIVE_DISPOSITION_GUIDANCE}` : ""),
         capacityAttempt: 1,
         terminalWriterAttempt: terminalWriterReservation.wait.attempt,
       });

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -1,10 +1,12 @@
+import { persistedTerminalReaderExecutions, reserveTerminalWriterReplay } from "./mcp-task-terminal-writer-recovery";
 import { prisma, type Prisma } from "@dpf/db";
+import { loadTaskInitiativeReviewOutcome, reconcilePersistedReviewStatus } from "./mcp-task-review-outcome";
+import { INITIATIVE_DISPOSITION_GUIDANCE } from "./backlog/initiative-readiness/disposition-contract";
 import { withTaskRunApprovalLocation } from "./mcp/external-approval-location-lookup";
 import { resolveCanonicalAgentId } from "@dpf/db/agent-identity";
 import type { UserContext } from "@/lib/permissions";
 import {
   markTaskRunWorking,
-  reserveTaskRunGenerationWorking,
   reserveSubmittedTaskRunWorking,
 } from "@/lib/observability/heartbeat";
 import {
@@ -34,7 +36,6 @@ import {
 import { createInitiativeReviewTerminalToolPolicy } from "@/lib/tak/terminal-tool-policy";
 import {
   hydrateTerminalWriterContext,
-  type PersistedTerminalReaderExecution,
 } from "./mcp-task-terminal-writer-context";
 import {
   enqueuePersistedRemoteTaskSubmission,
@@ -50,9 +51,7 @@ import {
   terminalWriterEscalationWaitReason,
 } from "./mcp-task-terminal-writer-escalation";
 import {
-  parseTerminalWriterWait,
   projectRemoteTaskReplay,
-  type TerminalWriterWait,
 } from "./mcp-task-replay-projection";
 import { durableInferenceTaskMetadata, parseDurableInferenceTaskRecipeId, type DurableInferenceTaskRecipeId } from "./mcp-task-durable-inference-contract";
 import { prepareRemoteObjectiveMappingAdmission, remoteObjectiveMappingAdmissionErrorResult, revalidateRemoteObjectiveMappingReplay } from "./mcp-task-objective-mapping-admission";
@@ -61,25 +60,6 @@ export {
   validateInitiativeReviewAuthorityScope,
 } from "./mcp-task-review-contract";
 export type { InitiativeReviewBinding } from "./mcp-task-review-contract";
-async function persistedTerminalReaderExecutions(
-  taskRunId: string,
-): Promise<PersistedTerminalReaderExecution[]> {
-  return prisma.toolExecution.findMany({
-    where: {
-      taskRunId,
-      toolName: "read_source_at_version",
-    },
-    orderBy: { createdAt: "asc" },
-    select: {
-      id: true,
-      toolName: true,
-      parameters: true,
-      result: true,
-      success: true,
-      createdAt: true,
-    },
-  }) as Promise<PersistedTerminalReaderExecution[]>;
-}
 export const REMOTE_RISK_CLASSES = ["read", "bounded-write", "high-risk"] as const;
 export type RemoteRiskClass = (typeof REMOTE_RISK_CLASSES)[number];
 export type RemoteTaskSubmitParams = {
@@ -197,15 +177,6 @@ export type ExistingRemoteTask = {
   updatedAt: Date;
 };
 
-function approvalEnvelopeIdFromWriterAttempt(result: unknown): string | null {
-  if (!result || typeof result !== "object" || Array.isArray(result)) return null;
-  const row = result as Record<string, unknown>;
-  if (row["success"] !== false || row["error"] !== "approval_required") return null;
-  const data = row["data"];
-  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
-  return optionalString((data as Record<string, unknown>)["envelopeId"]);
-}
-
 function replayOrConflict(existing: ExistingRemoteTask, parsed: RemoteTaskSubmitParams): RemoteTaskSubmitOutcome {
   const metadata = existing.a2aMetadata && typeof existing.a2aMetadata === "object"
     && !Array.isArray(existing.a2aMetadata)
@@ -218,100 +189,6 @@ function replayOrConflict(existing: ExistingRemoteTask, parsed: RemoteTaskSubmit
     // idempotent projection. Versioned rows must match their exact packet.
     requestMatches: !hasStoredDigest || remoteTaskRequestMatches(existing.a2aMetadata, parsed),
   });
-}
-
-async function reserveTerminalWriterReplay(input: {
-  existing: ExistingRemoteTask;
-  parsed: RemoteTaskSubmitParams;
-  terminalToolPolicy: NonNullable<ReturnType<typeof createInitiativeReviewTerminalToolPolicy>>;
-}): Promise<{
-  wait: TerminalWriterWait;
-  readerExecutions: PersistedTerminalReaderExecution[];
-  bootstrapReaderEvidence: boolean;
-} | null> {
-  if (!remoteTaskRequestMatches(input.existing.a2aMetadata, input.parsed)) return null;
-  if (recoverTerminalWriterEscalation(input.existing.progressPayload)) return null;
-
-  const existingWait = parseTerminalWriterWait(input.existing.progressPayload);
-  const isProjectedWait = existingWait !== null
-    && ["input-required", "stalled", "failed"].includes(input.existing.status);
-  const isRecoverableCompletedExit = input.existing.status === "completed" && !existingWait;
-  if (!isProjectedWait && !isRecoverableCompletedExit) return null;
-  if (existingWait && existingWait.writerToolName !== input.terminalToolPolicy.writerToolName) return null;
-
-  const [readerExecutions, successfulWriter, writerAttempt] = await Promise.all([
-    persistedTerminalReaderExecutions(input.existing.taskRunId),
-    prisma.toolExecution.findFirst({
-      where: {
-        taskRunId: input.existing.taskRunId,
-        toolName: input.terminalToolPolicy.writerToolName,
-        success: true,
-      },
-      select: { id: true },
-    }),
-    prisma.toolExecution.findFirst({
-      where: {
-        taskRunId: input.existing.taskRunId,
-        toolName: input.terminalToolPolicy.writerToolName,
-      },
-      orderBy: { createdAt: "desc" },
-      select: { id: true, success: true, result: true },
-    }),
-  ]);
-  if (successfulWriter) return null;
-  const bootstrapReaderEvidence = readerExecutions.length === 0;
-  if (bootstrapReaderEvidence && !isProjectedWait) return null;
-
-  if (writerAttempt) {
-    const proposalEnvelopeId = writerAttempt.success === false
-      ? approvalEnvelopeIdFromWriterAttempt(writerAttempt.result)
-      : null;
-    if (proposalEnvelopeId) {
-      const declinedProposalEnvelope = await prisma.coworkerActionEnvelope.findFirst({
-        where: {
-          id: proposalEnvelopeId,
-          taskRunId: input.existing.taskRunId,
-          manifestActionId: input.terminalToolPolicy.writerToolName,
-          status: "declined",
-        },
-        select: { id: true },
-      });
-      if (declinedProposalEnvelope?.id !== proposalEnvelopeId) return null;
-    } else if (
-      writerAttempt.success !== false
-      || !existingWait
-      || !["input-required", "stalled", "failed"].includes(input.existing.status)
-    ) return null;
-  }
-
-  const progress = input.existing.progressPayload && typeof input.existing.progressPayload === "object"
-    && !Array.isArray(input.existing.progressPayload)
-    ? input.existing.progressPayload as Record<string, unknown>
-    : {};
-  const now = new Date().toISOString();
-  const wait: TerminalWriterWait = {
-    schemaVersion: 1,
-    kind: "missing-terminal-writer",
-    writerToolName: input.terminalToolPolicy.writerToolName,
-    resumeMode: "same-taskrun",
-    attempt: existingWait ? existingWait.attempt + 1 : 2,
-    observedAt: now,
-    dispatchContract: "required-tool-call",
-  };
-  const reserved = await reserveTaskRunGenerationWorking({
-    taskRunId: input.existing.taskRunId,
-    expectedStatus: input.existing.status,
-    updatedAt: input.existing.updatedAt,
-    progressPayload: {
-      ...progress,
-      terminalWriterWait: wait,
-      ...(isRecoverableCompletedExit ? { recoveredFromCompletedRouteExit: true } : {}),
-      resumeReservedAt: now,
-    } as Prisma.InputJsonValue,
-  });
-  return reserved
-    ? { wait, readerExecutions, bootstrapReaderEvidence }
-    : null;
 }
 
 export async function resumeWaitingRemoteTask(input: {
@@ -474,6 +351,17 @@ export async function submitRemoteCoworkerTask(input: {
     if (replayRefusal) return { kind: "result", result: replayRefusal };
     const matchedRequestDigest = matchingRemoteTaskRequestDigest(existing.a2aMetadata, parsed);
     const requestMatches = matchedRequestDigest !== null;
+    if (requestMatches && parsed.initiativeReviewBinding) {
+      const outcome = await loadTaskInitiativeReviewOutcome(existing.taskRunId, parsed.initiativeReviewBinding);
+      if (outcome) {
+        await reconcilePersistedReviewStatus(existing.taskRunId, existing.progressPayload, outcome);
+        return { kind: "result", result: {
+        taskRunId: existing.taskRunId, status: "completed", idempotentReplay: true,
+        requiresApproval: false, resumable: false, content: remoteTaskContent(outcome.summary),
+        structuredContent: outcome, isError: false,
+        } };
+      }
+    }
     const replay = replayOrConflict(existing, parsed);
     if (
       requestMatches
@@ -666,7 +554,8 @@ export async function submitRemoteCoworkerTask(input: {
         parsed,
         idempotentReplay: true,
         resumeKind: "terminal-writer",
-        terminalWriterContext: hydration.data.context,
+        terminalWriterContext: hydration.data.context + (terminalWriterReservation.wait.validationFailure
+          ? `\nThe previous writer rejected the independently selected proposal: ${JSON.stringify(terminalWriterReservation.wait.validationFailure)}. Correct it using the immutable evidence above. ${INITIATIVE_DISPOSITION_GUIDANCE}` : ""),
         capacityAttempt: 1,
         terminalWriterAttempt: terminalWriterReservation.wait.attempt,
       });

--- a/apps/web/lib/mcp-task-terminal-writer-recovery.ts
+++ b/apps/web/lib/mcp-task-terminal-writer-recovery.ts
@@ -1,0 +1,139 @@
+import { prisma, type Prisma } from "@dpf/db";
+import { reserveTaskRunGenerationWorking } from "./observability/heartbeat";
+import { INITIATIVE_CORRECTABLE_ERRORS } from "./backlog/initiative-readiness/disposition-contract";
+import { remoteTaskRequestMatches } from "./mcp-task-capacity-contract";
+import type { ExistingRemoteTask, RemoteTaskSubmitParams } from "./mcp-task-submit";
+import type { createInitiativeReviewTerminalToolPolicy } from "./tak/terminal-tool-policy";
+import type { PersistedTerminalReaderExecution } from "./mcp-task-terminal-writer-context";
+import { recoverTerminalWriterEscalation } from "./mcp-task-terminal-writer-escalation";
+import { parseTerminalWriterWait, type TerminalWriterWait } from "./mcp-task-replay-projection";
+function optionalString(value: unknown): string | null { return typeof value === "string" && value.trim() ? value.trim() : null; }
+
+export async function persistedTerminalReaderExecutions(
+  taskRunId: string,
+): Promise<PersistedTerminalReaderExecution[]> {
+  return prisma.toolExecution.findMany({
+    where: {
+      taskRunId,
+      toolName: "read_source_at_version",
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      toolName: true,
+      parameters: true,
+      result: true,
+      success: true,
+      createdAt: true,
+    },
+  }) as Promise<PersistedTerminalReaderExecution[]>;
+}
+function approvalEnvelopeIdFromWriterAttempt(result: unknown): string | null {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return null;
+  const row = result as Record<string, unknown>;
+  if (row["success"] !== false || row["error"] !== "approval_required") return null;
+  const data = row["data"];
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  return optionalString((data as Record<string, unknown>)["envelopeId"]);
+}
+
+export async function reserveTerminalWriterReplay(input: {
+  existing: ExistingRemoteTask;
+  parsed: RemoteTaskSubmitParams;
+  terminalToolPolicy: NonNullable<ReturnType<typeof createInitiativeReviewTerminalToolPolicy>>;
+}): Promise<{
+  wait: TerminalWriterWait;
+  readerExecutions: PersistedTerminalReaderExecution[];
+  bootstrapReaderEvidence: boolean;
+} | null> {
+  if (!remoteTaskRequestMatches(input.existing.a2aMetadata, input.parsed)) return null;
+  if (recoverTerminalWriterEscalation(input.existing.progressPayload)) return null;
+
+  const existingWait = parseTerminalWriterWait(input.existing.progressPayload);
+  const isProjectedWait = existingWait !== null
+    && ["input-required", "stalled", "failed"].includes(input.existing.status);
+  const isRecoverableCompletedExit = input.existing.status === "completed" && !existingWait;
+  if (!isProjectedWait && !isRecoverableCompletedExit) return null;
+  if (existingWait && existingWait.writerToolName !== input.terminalToolPolicy.writerToolName) return null;
+
+  const [readerExecutions, successfulWriter, writerAttempt] = await Promise.all([
+    persistedTerminalReaderExecutions(input.existing.taskRunId),
+    prisma.toolExecution.findFirst({
+      where: {
+        taskRunId: input.existing.taskRunId,
+        toolName: input.terminalToolPolicy.writerToolName,
+        success: true,
+      },
+      select: { id: true },
+    }),
+    prisma.toolExecution.findFirst({
+      where: {
+        taskRunId: input.existing.taskRunId,
+        toolName: input.terminalToolPolicy.writerToolName,
+      },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, success: true, result: true },
+    }),
+  ]);
+  if (successfulWriter) return null;
+  const bootstrapReaderEvidence = readerExecutions.length === 0;
+  if (bootstrapReaderEvidence && !isProjectedWait) return null;
+
+  if (writerAttempt) {
+    const proposalEnvelopeId = writerAttempt.success === false
+      ? approvalEnvelopeIdFromWriterAttempt(writerAttempt.result)
+      : null;
+    if (proposalEnvelopeId) {
+      const declinedProposalEnvelope = await prisma.coworkerActionEnvelope.findFirst({
+        where: {
+          id: proposalEnvelopeId,
+          taskRunId: input.existing.taskRunId,
+          manifestActionId: input.terminalToolPolicy.writerToolName,
+          status: "declined",
+        },
+        select: { id: true },
+      });
+      if (declinedProposalEnvelope?.id !== proposalEnvelopeId) return null;
+    } else if (
+      writerAttempt.success !== false
+      || !existingWait
+      || !["input-required", "stalled", "failed"].includes(input.existing.status)
+    ) return null;
+  }
+
+  const progress = input.existing.progressPayload && typeof input.existing.progressPayload === "object"
+    && !Array.isArray(input.existing.progressPayload)
+    ? input.existing.progressPayload as Record<string, unknown>
+    : {};
+  const now = new Date().toISOString();
+  const wait: TerminalWriterWait = {
+    schemaVersion: 1,
+    kind: "missing-terminal-writer",
+    writerToolName: input.terminalToolPolicy.writerToolName,
+    resumeMode: "same-taskrun",
+    attempt: existingWait ? existingWait.attempt + 1 : 2,
+    observedAt: now,
+    dispatchContract: "required-tool-call",
+    ...(writerAttempt?.success === false && writerAttempt.result && typeof writerAttempt.result === "object"
+      && !Array.isArray(writerAttempt.result)
+      && INITIATIVE_CORRECTABLE_ERRORS.has(String((writerAttempt.result as Record<string, unknown>).error ?? ""))
+      ? { validationFailure: {
+          error: String((writerAttempt.result as Record<string, unknown>).error),
+          message: String((writerAttempt.result as Record<string, unknown>).message ?? "Receipt validation failed."),
+        } } : {}),
+  };
+  const reserved = await reserveTaskRunGenerationWorking({
+    taskRunId: input.existing.taskRunId,
+    expectedStatus: input.existing.status,
+    updatedAt: input.existing.updatedAt,
+    progressPayload: {
+      ...progress,
+      terminalWriterWait: wait,
+      ...(isRecoverableCompletedExit ? { recoveredFromCompletedRouteExit: true } : {}),
+      resumeReservedAt: now,
+    } as Prisma.InputJsonValue,
+  });
+  return reserved
+    ? { wait, readerExecutions, bootstrapReaderEvidence }
+    : null;
+}

--- a/apps/web/lib/mcp-task-terminal-writer-recovery.ts
+++ b/apps/web/lib/mcp-task-terminal-writer-recovery.ts
@@ -72,7 +72,7 @@ export async function reserveTerminalWriterReplay(input: {
         toolName: input.terminalToolPolicy.writerToolName,
       },
       orderBy: { createdAt: "desc" },
-      select: { id: true, success: true, result: true },
+      select: { id: true, success: true, result: true, parameters: true },
     }),
   ]);
   if (successfulWriter) return null;
@@ -120,6 +120,7 @@ export async function reserveTerminalWriterReplay(input: {
       ? { validationFailure: {
           error: String((writerAttempt.result as Record<string, unknown>).error),
           message: String((writerAttempt.result as Record<string, unknown>).message ?? "Receipt validation failed."),
+          ...(writerAttempt.parameters ? { proposal: writerAttempt.parameters } : {}),
         } } : {}),
   };
   const reserved = await reserveTaskRunGenerationWorking({

--- a/apps/web/lib/mcp-task-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer.test.ts
@@ -44,6 +44,10 @@ vi.mock("@/lib/tak/autonomous-work-run", () => ({
   resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
 }));
 vi.mock("@/lib/tak/task-records", () => ({ createTaskMessage: vi.fn() }));
+vi.mock("./mcp-task-review-outcome", () => ({
+  loadTaskInitiativeReviewOutcome: vi.fn().mockResolvedValue(null),
+  loadInitiativeReviewOutcome: vi.fn().mockResolvedValue({ receiptId: "receipt-1", summary: "Receipt persisted; readiness still requires plan coverage." }),
+}));
 
 import { submitRemoteCoworkerTask } from "./mcp-task-submit";
 
@@ -193,7 +197,7 @@ describe("terminal writer resumption", () => {
     autonomous.resolveTools.mockResolvedValue({ tools: [], toolsForProvider: [], deferredTools: [] });
     autonomous.execute.mockResolvedValue({
       content: "Receipt recorded.",
-      executedTools: [{ name: "record_initiative_evidence", result: { success: true } }],
+      executedTools: [{ name: "record_initiative_evidence", result: { success: true, data: { receiptId: "receipt-1" } } }],
     });
 
     const outcome = await submit("PAT-WRITER-ROUTE-EXIT");
@@ -304,7 +308,7 @@ describe("terminal writer resumption", () => {
     autonomous.resolveTools.mockResolvedValue({ tools: [], toolsForProvider: [], deferredTools: [] });
     autonomous.execute.mockResolvedValue({
       content: "Receipt recorded.",
-      executedTools: [{ name: "record_initiative_evidence", result: { success: true } }],
+      executedTools: [{ name: "record_initiative_evidence", result: { success: true, data: { receiptId: "receipt-1" } } }],
     });
 
     const outcome = await submit("PAT-WRITER-RESUME");
@@ -376,7 +380,7 @@ describe("terminal writer resumption", () => {
     db.findUnique.mockResolvedValue({ status: "working" });
     autonomous.execute.mockResolvedValue({
       content: "Receipt recorded.",
-      executedTools: [{ name: "record_initiative_evidence", result: { success: true } }],
+      executedTools: [{ name: "record_initiative_evidence", result: { success: true, data: { receiptId: "receipt-1" } } }],
     });
 
     const outcome = await submit("PAT-WRITER-ZERO-READER");

--- a/apps/web/lib/mcp/packs/initiative-readiness-pack.test.ts
+++ b/apps/web/lib/mcp/packs/initiative-readiness-pack.test.ts
@@ -4,6 +4,7 @@ import { ok } from "@/lib/shared/action-result";
 
 const mocks = vi.hoisted(() => ({
   findTaskRun: vi.fn(),
+  findReads: vi.fn(),
   recordGateReceipt: vi.fn(),
   recordSpecApproval: vi.fn(),
   recordObjectiveMapping: vi.fn(),
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@dpf/db", () => ({
   prisma: {
     taskRun: { findUnique: (...args: unknown[]) => mocks.findTaskRun(...args) },
+    toolExecution: { findMany: (...args: unknown[]) => mocks.findReads(...args) },
   },
 }));
 
@@ -38,6 +40,57 @@ const expected = {
 } as const;
 
 describe("initiative readiness reviewer tools", () => {
+  it("BI-31159978 rejects positive observations encoded as passing research findings without deleting them", async () => {
+    mocks.findTaskRun.mockResolvedValue({ a2aMetadata: {
+      trigger: "external-mcp",
+      initiativeReviewBinding: {
+        writerToolName: "record_initiative_evidence", itemId: "BI-31159978", gate: "research",
+        artifactRef: { kind: "repo-blob-at-commit", repositoryFullName: "owner/repo",
+          commitSha: "7d22b24673c138036685312387a425984c7a330d",
+          providerBlobId: "511894b16063195e4bf9f6977f1f5a3fd0549693", path: "design.md" },
+      },
+    } });
+    mocks.recordGateReceipt.mockResolvedValue({ ok: true, receiptId: "unexpected-receipt" });
+    const assessment = { decision: "pass", reason: "The reproduction is complete.",
+      findings: [{ issue: "The design clearly documents the ownership boundary.", severity: "important" }],
+      resolvedFindingRefs: [] };
+    const original = structuredClone(assessment);
+    const result = await initiativeReadinessPack.handlers.record_initiative_evidence!(
+      assessment, "user-1", { taskRunId: "TR-REPRO", agentId: "AGT-WS-PORTFOLIO" } as never,
+    );
+    expect(result).toMatchObject({ success: false, error: "malformed-receipt" });
+    expect(mocks.recordGateReceipt).not.toHaveBeenCalled();
+    expect(assessment).toEqual(original);
+    const corrected = await initiativeReadinessPack.handlers.record_initiative_evidence!(
+      { ...assessment, findings: [], reason: assessment.reason + " The design clearly documents the ownership boundary." },
+      "user-1", { taskRunId: "TR-REPRO", agentId: "AGT-WS-PORTFOLIO" } as never,
+    );
+    expect(corrected).toMatchObject({ success: true, data: { receiptId: "unexpected-receipt" } });
+    expect(mocks.recordGateReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires bound read evidence for a failing finding and preserves a supported finding", async () => {
+    const artifactRef = { kind: "repo-blob-at-commit", repositoryFullName: "owner/repo", commitSha: "sha", providerBlobId: "blob", path: "design.md" };
+    mocks.findTaskRun.mockResolvedValue({ a2aMetadata: { trigger: "external-mcp", initiativeReviewBinding: {
+      writerToolName: "record_initiative_evidence", itemId: "BI-31159978", gate: "research", artifactRef,
+    } } });
+    const assessment = { decision: "fail", reason: "A verification requirement remains open.", resolvedFindingRefs: [],
+      findings: [{ issue: "Verification is unspecified.", severity: "important", evidence: {
+        blobId: "blob", startLine: 2, endLine: 2, quote: "Verification: TBD",
+      } }] };
+    const context = { taskRunId: "TR-BOUND", agentId: "AGT-WS-PORTFOLIO" } as never;
+    mocks.findReads.mockResolvedValue([]);
+    expect(await initiativeReadinessPack.handlers.record_initiative_evidence!(assessment, "user-1", context))
+      .toMatchObject({ success: false, error: "malformed-receipt" });
+    expect(mocks.recordGateReceipt).not.toHaveBeenCalled();
+    mocks.findReads.mockResolvedValue([{ result: { data: { repositoryFullName: "owner/repo", version: "sha", path: "design.md",
+      blobId: "blob", startLine: 1, endLine: 2, content: "# Design\nVerification: TBD" } } }]);
+    mocks.recordGateReceipt.mockResolvedValue({ ok: true, receiptId: "failed-receipt" });
+    expect(await initiativeReadinessPack.handlers.record_initiative_evidence!(assessment, "user-1", context))
+      .toMatchObject({ success: true, data: { receiptId: "failed-receipt" } });
+    expect(mocks.recordGateReceipt).toHaveBeenCalledWith(expect.objectContaining({ findings: assessment.findings, decision: "fail" }));
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -116,6 +169,9 @@ describe("initiative readiness reviewer tools", () => {
       gate: "classification",
       artifactRef: { kind: "document-version", versionId: "spoofed" },
       decision: "pass",
+      reason: "Independent assessment from the bound artifact.",
+      findings: [],
+      resolvedFindingRefs: [],
     }, "user-1", {
       taskRunId: "TR-MCP-BOUND",
       agentId: "AGT-WS-BUILD",
@@ -133,7 +189,7 @@ describe("initiative readiness reviewer tools", () => {
       decision: "pass",
       findings: [],
       resolvedFindingRefs: [],
-      reason: "Independent reviewer AGT-WS-BUILD recorded pass for the immutable research artifact bound to TaskRun TR-MCP-BOUND.",
+      reason: "Independent assessment from the bound artifact.",
     }));
     expect(result).toMatchObject({ success: true, entityId: "IRR-RESEARCH-1" });
   });
@@ -232,7 +288,7 @@ describe("the writer schema states its contract before the writer refuses it (BI
   it("tells the reviewer that a pass carries no findings, what profile to name, and what a resolution may cite", () => {
     const tool = initiativeReadinessPack.definitions.find((definition) => definition.name === "record_initiative_design_review");
     const properties = (tool?.inputSchema as { properties: Record<string, { description?: string }> }).properties;
-    expect(properties.decision?.description).toMatch(/NO findings/);
+    expect(properties.decision?.description).toMatch(/findings=\[\]/);
     expect(properties.findings?.description).toMatch(/ONLY on a failing receipt/);
     expect(properties.findings?.description).toMatch(/malformed-receipt/);
     expect(properties.profile?.description).toMatch(/authoritative classification/);

--- a/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
+++ b/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
@@ -1,4 +1,5 @@
 import type { InitiativeArtifactRef, InitiativeGateKey } from "@/lib/backlog/initiative-readiness";
+import { INITIATIVE_DISPOSITION_GUIDANCE, validateInitiativeDisposition, findingEvidenceMatchesRead, type InitiativeFindingEvidence } from "@/lib/backlog/initiative-readiness/disposition-contract";
 import { prisma } from "@dpf/db";
 import {
   RESEARCH_DEFINITIONS,
@@ -38,7 +39,7 @@ function inputSchemaFor(name: string, lane: Lane): ToolDefinition["inputSchema"]
         type: "string",
         enum: ["pass", "fail", "not-applicable"],
         description:
-          "pass records the gate as satisfied at this exact artifact and carries NO findings; fail records the gate as unmet and carries at least one finding. Advisory observations that do not block belong in reason, never in findings on a pass.",
+          INITIATIVE_DISPOSITION_GUIDANCE,
       },
       artifactRef: artifactRefSchema,
       reason: {
@@ -54,6 +55,15 @@ function inputSchemaFor(name: string, lane: Lane): ToolDefinition["inputSchema"]
           properties: {
             issue: { type: "string" },
             severity: { type: "string", enum: ["critical", "important"] },
+            evidence: {
+              type: "object",
+              description: "Required for bound review findings. Cite a successful immutable reader execution and an exact quote at these blob lines. Explain in issue why it proves the defect; withdraw or correct claims contradicted by the artifact.",
+              properties: {
+                blobId: { type: "string" },
+                startLine: { type: "integer", minimum: 1 }, endLine: { type: "integer", minimum: 1 }, quote: { type: "string" },
+              },
+              required: ["blobId", "startLine", "endLine", "quote"],
+            },
           },
           required: ["issue", "severity"],
         },
@@ -62,7 +72,7 @@ function inputSchemaFor(name: string, lane: Lane): ToolDefinition["inputSchema"]
         type: "array",
         items: { type: "string" },
         description:
-          "Ids of findings currently OPEN on this item that this receipt resolves (from earlier failing receipts, IF-* ids). Pass an empty array when none; naming an id that is not open is refused as finding-resolution-invalid.",
+          "Only currently OPEN finding ids may be resolved; otherwise use []. An unknown id is refused as finding-resolution-invalid.",
       },
       profile: {
         type: "string",
@@ -183,15 +193,15 @@ const definitions: ToolDefinition[] = [
   },
 ];
 
-function parseFindings(value: unknown): Array<{ issue: string; severity: "critical" | "important" }> | null {
+function parseFindings(value: unknown): Array<{ issue: string; severity: "critical" | "important"; evidence?: InitiativeFindingEvidence }> | null {
   if (!Array.isArray(value)) return null;
-  const findings: Array<{ issue: string; severity: "critical" | "important" }> = [];
+  const findings: Array<{ issue: string; severity: "critical" | "important"; evidence?: InitiativeFindingEvidence }> = [];
   for (const entry of value) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
     const finding = entry as Record<string, unknown>;
     if (typeof finding.issue !== "string" || !finding.issue.trim()
       || (finding.severity !== "critical" && finding.severity !== "important")) return null;
-    findings.push({ issue: finding.issue, severity: finding.severity });
+    findings.push({ issue: finding.issue, severity: finding.severity, ...(finding.evidence ? { evidence: finding.evidence as InitiativeFindingEvidence } : {}) });
   }
   return findings;
 }
@@ -295,13 +305,6 @@ function handlerFor(actionKey: string, lane: Lane): ToolPackHandler {
         ...(Object.prototype.hasOwnProperty.call(binding, "expectedCurrentBaselineId")
           ? { expectedCurrentBaselineId: binding.expectedCurrentBaselineId }
           : {}),
-        ...(actionKey === "record_initiative_evidence" && binding.gate === "research"
-          ? {
-              findings: [],
-              resolvedFindingRefs: [],
-              reason: `Independent reviewer ${context?.agentId ?? "unknown"} recorded ${String(params.decision ?? "unknown")} for the immutable research artifact bound to TaskRun ${context?.taskRunId ?? "unknown"}.`,
-            }
-          : {}),
       };
     }
     const operation = params.operation ?? "gate-receipt";
@@ -348,6 +351,27 @@ function handlerFor(actionKey: string, lane: Lane): ToolPackHandler {
     if (!findings || !resolvedFindingRefs) {
       return { success: false, error: "malformed-receipt", message: "findings and resolvedFindingRefs must match the governed receipt schema." };
     }
+    const dispositionError = validateInitiativeDisposition(decision, findings, resolvedFindingRefs);
+    if (dispositionError) return { success: false, error: "malformed-receipt", message: dispositionError };
+    if (binding && findings.length > 0 && binding.artifactRef.kind === "repo-blob-at-commit") {
+      const reads = await prisma.toolExecution.findMany({
+        where: { taskRunId: context?.taskRunId, toolName: "read_source_at_version", success: true },
+        select: { id: true, result: true },
+      });
+      for (const finding of findings) {
+        const evidence = finding.evidence;
+        const artifact = binding.artifactRef;
+        const matchedRead = evidence && reads.some((row) => {
+          const page = (row.result as { data?: Record<string, unknown> } | null)?.data;
+          return page && page.version === artifact.commitSha && page.path === artifact.path
+            && page.repositoryFullName === artifact.repositoryFullName
+            && findingEvidenceMatchesRead(evidence, page, artifact.providerBlobId);
+        });
+        if (!matchedRead) {
+          return { success: false, error: "malformed-receipt", message: "A finding must cite an exact quote and lines from a successful read of this bound blob. Correct unsupported or contradicted findings using the immutable evidence; do not manufacture a pass." };
+        }
+      }
+    }
     const selectedProfile = params.profile;
     if (gate === "classification" && decision === "pass"
       && !(selectedProfile === "doc-only" || selectedProfile === "fix" || selectedProfile === "feature" || selectedProfile === "cross-domain" || selectedProfile === "archetype")) {
@@ -359,9 +383,6 @@ function handlerFor(actionKey: string, lane: Lane): ToolPackHandler {
       if (!(profile === "doc-only" || profile === "fix" || profile === "feature" || profile === "cross-domain" || profile === "archetype")
         || !(artifactRole === "design-spec" || artifactRole === "problem-statement" || artifactRole === "documentation-scope")) {
         return { success: false, error: "malformed-receipt", message: "Passing spec approval requires profile and artifactRole." };
-      }
-      if (findings.length > 0) {
-        return { success: false, error: "malformed-receipt", message: "A passing spec approval cannot introduce findings." };
       }
       const approval = await recordInitiativeSpecApproval({
         itemId: String(params.itemId ?? ""),

--- a/apps/web/lib/tak/terminal-tool-policy.test.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.test.ts
@@ -79,6 +79,28 @@ const writer = (success = true): TerminalToolRecord => ({
 });
 
 describe("terminal tool policy", () => {
+  it("bounds malformed correction and never retries success, approval, or authority failure", () => {
+    const malformed = { name: policy.writerToolName, result: { success: false, error: "malformed-receipt" } };
+    expect(resolveTerminalToolCall(policy, [read(), malformed, malformed, malformed], policy.writerToolName).kind).toBe("refuse");
+    for (const result of [
+      { success: true },
+      { success: false, error: "approval_required", data: { envelopeId: "envelope" } },
+      { success: false, error: "AUTHORIZATION_DENIED" },
+    ]) {
+      expect(resolveTerminalToolCall(policy, [read(), malformed, { name: policy.writerToolName, result }], policy.writerToolName).kind).toBe("refuse");
+    }
+  });
+  it("BI-31159978 retains the writer for bounded correction of a malformed receipt", () => {
+    const records: TerminalToolRecord[] = [read(), {
+      name: policy.writerToolName,
+      result: { success: false, error: "malformed-receipt" },
+    }];
+    expect(resolveTerminalToolCall(policy, records, policy.writerToolName)).toEqual({ kind: "allow" });
+    expect(applyTerminalToolSurface(policy, records, [
+      { type: "function", function: { name: policy.writerToolName } },
+    ])).toHaveLength(1);
+  });
+
   it("activates only when the bound reader and writer tools are both required", () => {
     expect(createInitiativeReviewTerminalToolPolicy(policy.writerToolName, [
       "read_source_at_version",
@@ -318,7 +340,7 @@ describe("terminal tool policy", () => {
     expect(resolveTerminalTextExit(policy, [read(), writer(false)], 0)).toMatchObject({
       kind: "input-required",
       reason: "missing-terminal-writer",
-      message: expect.stringContaining("did not produce a receipt"),
+      message: expect.stringContaining("did not persist a valid receipt"),
     });
     expect(summarizeTerminalToolProgress(policy, [read(), writer(false)])).toMatchObject({
       writerAttempted: true,

--- a/apps/web/lib/tak/terminal-tool-policy.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.ts
@@ -1,3 +1,5 @@
+import { INITIATIVE_CORRECTABLE_ERRORS, INITIATIVE_DISPOSITION_GUIDANCE, INITIATIVE_WRITER_CORRECTION_LIMIT } from "../backlog/initiative-readiness/disposition-contract";
+
 export type TerminalToolPolicy = {
   writerToolName: string;
   readerToolNames: readonly string[];
@@ -25,7 +27,7 @@ type ImmutableReaderArtifactRef = {
 export type TerminalToolRecord = {
   name: string;
   args?: Record<string, unknown>;
-  result: { success: boolean; error?: string; data?: Record<string, unknown> };
+  result: { success: boolean; error?: string; message?: string; data?: Record<string, unknown> };
 };
 
 const INITIATIVE_REVIEW_READER_NAMES = [
@@ -306,7 +308,7 @@ export function resolveTerminalToolCall(
   toolName: string,
 ): TerminalToolCallDisposition {
   const progress = summarizeTerminalToolProgress(policy, records);
-  if (toolName === policy.writerToolName && progress.writerAttempted) {
+  if (toolName === policy.writerToolName && progress.writerAttempted && !canCorrectTerminalWriter(policy, records)) {
     return {
       kind: "refuse",
       result: {
@@ -397,6 +399,29 @@ function writerReachedTerminalBoundary(
   ));
 }
 
+function canCorrectTerminalWriter(policy: TerminalToolPolicy, records: readonly TerminalToolRecord[]): boolean {
+  const attempts = records.filter((record) => record.name === policy.writerToolName);
+  const last = attempts.at(-1);
+  return attempts.length > 0 && attempts.length <= INITIATIVE_WRITER_CORRECTION_LIMIT
+    && !writerReachedTerminalBoundary(policy, records)
+    && last?.result.success === false
+    && INITIATIVE_CORRECTABLE_ERRORS.has(last.result.error ?? "");
+}
+
+function correctionReminder(policy: TerminalToolPolicy, records: readonly TerminalToolRecord[]): string {
+  const last = records.filter((record) => record.name === policy.writerToolName).at(-1)!;
+  return `The canonical writer rejected the assessment: ${last.result.error}: ${last.result.message ?? "Receipt validation failed."} `
+    + `Use the already-read immutable evidence to independently correct the proposal and call ${policy.writerToolName}. `
+    + INITIATIVE_DISPOSITION_GUIDANCE;
+}
+
+export function terminalWriterFailureMessage(policy: TerminalToolPolicy, records: readonly TerminalToolRecord[]): string {
+  const last = records.filter((record) => record.name === policy.writerToolName).at(-1);
+  return last
+    ? `${policy.writerToolName} did not persist a valid receipt. Last result: ${last.result.error ?? "unverified-writer-result"}: ${last.result.message ?? "No verifiable receipt returned."} Automatic correction for this attempt has stopped. Resolve this error before resuming the same TaskRun; do not advance its gate.`
+    : `The provider did not invoke required writer ${policy.writerToolName}. Resume the same TaskRun with a provider that supports the required tool call; no receipt was created.`;
+}
+
 export function selectTerminalToolSurface(
   providerTools: readonly Record<string, unknown>[],
   allowedToolNames: readonly string[],
@@ -414,7 +439,8 @@ export function applyTerminalToolSurface(
   providerTools: readonly Record<string, unknown>[],
 ): Array<Record<string, unknown>> {
   const progress = summarizeTerminalToolProgress(policy, records);
-  if (progress.writerAttempted) return [];
+  if (progress.writerAttempted) return canCorrectTerminalWriter(policy, records)
+    ? selectTerminalToolSurface(providerTools, [policy.writerToolName]) : [];
   if (policy.terminalPhase === "writer-only") {
     return selectTerminalToolSurface(providerTools, [policy.writerToolName]);
   }
@@ -430,7 +456,8 @@ export function buildTerminalToolReminder(
 ): string {
   const progress = summarizeTerminalToolProgress(policy, records);
   if (progress.writerAttempted) {
-    return `The sole ${policy.writerToolName} attempt did not produce a receipt or approval envelope. Stop without another tool call.`;
+    if (canCorrectTerminalWriter(policy, records)) return correctionReminder(policy, records);
+    return terminalWriterFailureMessage(policy, records);
   }
   if (policy.terminalPhase === "writer-only") {
     return `Immutable evidence is already persisted. Call ${policy.writerToolName} now; do not read again or respond with prose first.`;
@@ -450,11 +477,14 @@ export function resolveTerminalTextExit(
   const progress = summarizeTerminalToolProgress(policy, records);
   if (writerReachedTerminalBoundary(policy, records)) return { kind: "complete" };
   if (progress.writerAttempted) {
+    if (canCorrectTerminalWriter(policy, records) && nudgesUsed < INITIATIVE_WRITER_CORRECTION_LIMIT) return {
+      kind: "nudge", allowedToolNames: [policy.writerToolName], message: correctionReminder(policy, records),
+    };
     return {
       kind: "input-required",
       reason: "missing-terminal-writer",
       writerToolName: policy.writerToolName,
-      message: `The sole ${policy.writerToolName} attempt did not produce a receipt or approval envelope. The same TaskRun remains resumable.`,
+      message: terminalWriterFailureMessage(policy, records),
     };
   }
   if (progress.readerBudgetExhausted && !progress.evidenceAvailable) {

--- a/docs/superpowers/plans/2026-09-06-reviewer-disposition-contract.md
+++ b/docs/superpowers/plans/2026-09-06-reviewer-disposition-contract.md
@@ -1,3 +1,6 @@
+---
+status: active
+---
 # BI-31159978 implementation coverage
 
 The ordered implementation sequence, scope, objectives, acceptance criteria,
@@ -15,4 +18,10 @@ Parent and sole atomic delivery item: BI-31159978.
 
 Decision: atomic. The schema, writer, bounded correction, and completion
 projection must agree in one release to preserve lossless independent review.
-No phase is independently shippable. Receipt pending canonical recording.
+No phase is independently shippable. Initial coverage and independent research
+and spec-approval receipts were recorded before implementation; the immutable
+receipt records remain the authority for their reviewed versions.
+
+The shared disposition contract, persisted outcome projection, and terminal
+writer replay reservation are separate focused modules. Existing receipt and
+TaskRun storage remain canonical; this repair introduces no parallel ledger.

--- a/docs/superpowers/plans/2026-09-06-reviewer-disposition-contract.md
+++ b/docs/superpowers/plans/2026-09-06-reviewer-disposition-contract.md
@@ -1,0 +1,18 @@
+# BI-31159978 implementation coverage
+
+The ordered implementation sequence, scope, objectives, acceptance criteria,
+risks, and rollback are canonical in
+[the repair design](../specs/2026-09-06-reviewer-disposition-contract-design.md).
+This plan is the coverage locator required by record_plan_backlog_coverage.
+
+## Backlog coverage
+
+Parent and sole atomic delivery item: BI-31159978.
+
+| Deliverable | Backlog item | Requirements | Contracts | Flow | Verification |
+| --- | --- | --- | --- | --- | --- |
+| reviewer-disposition | BI-31159978 | OBJ-RDC-001, OBJ-RDC-002, OBJ-RDC-003, OBJ-RDC-004 | canonical-disposition, immutable-review, persisted-status | read-review-write-readiness | AC-RDC-001, AC-RDC-002, AC-RDC-003, AC-RDC-004, AC-RDC-005, AC-RDC-006 |
+
+Decision: atomic. The schema, writer, bounded correction, and completion
+projection must agree in one release to preserve lossless independent review.
+No phase is independently shippable. Receipt pending canonical recording.

--- a/docs/superpowers/specs/2026-09-06-reviewer-disposition-contract-design.md
+++ b/docs/superpowers/specs/2026-09-06-reviewer-disposition-contract-design.md
@@ -1,0 +1,106 @@
+# Initiative reviewer disposition and persisted status
+
+Backlog: BI-31159978. Workroom: WC-025847D7. Profile: fix.
+
+## Reproduction and existing substrate
+
+Evidence cmtpygzzn0c7c01qm9d3r3w7p records TaskRun
+TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-E295A8007C6E on
+BI-06AE6833 / WC-27D00458. Artifact commit
+7d22b24673c138036685312387a425984c7a330d, blob
+511894b16063195e4bf9f6977f1f5a3fd0549693, path
+docs/superpowers/specs/2026-09-03-local-first-agentic-delivery-throughput-design.md.
+The writer rejects pass with findings; the second attempt cannot correct it.
+Other review receipts exist although reviewer prose claims they do not.
+
+Source base 4dcd2bc75ed (PR #5116) still has the rejection in
+apps/web/lib/mcp/packs/initiative-readiness-pack.ts. Its research adapter
+replaces findings and reason, while mcp-task-review-contract.ts exposes only
+decision for research. terminal-tool-policy.ts removes the writer after any
+attempt. mcp-task-execution.ts copies model prose into final summaries and
+infers approval from input-required alone.
+
+BI-8B8731EE owns required writer enforcement; retain its provider capability
+and resource-wait behavior. BI-DE58CFE8 owns same-TaskRun recovery and bound
+reader history; extend that mechanism. BI-E8237EAE owns reader budgets; do
+not change those budgets here. PR #5116 owns immutable objective mapping.
+WC-8FB4E4D0 owns initiative-readiness-tool-grants.ts; this work uses the shared
+writer definition and bound tool schema without editing that registry.
+
+## Canonical contract and ordered fix sequence
+
+1. Consolidate disposition guidance and validation into the existing readiness
+   module boundary. Pass requires empty findings and resolvedFindingRefs;
+   positive observations belong in reason. Findings require fail and immutable
+   evidence. All research and review adapters preserve the independent author's
+   assessment. Server-owned artifact identity remains bound and cannot drift.
+2. Extend terminal writer policy with bounded correction for explicitly
+   retryable validation failures. Feed the exact rejection back to the same
+   reviewer with its successful bound reads. Preserve approval separation;
+   correction is a new independent proposal, never automatic approval or
+   deletion of a finding. Authority, identity, provider, and transport failures
+   are not generic validation retries. Exhaustion reports the exact failure and
+   recovery action on the original TaskRun and request key.
+3. Consolidate completion projection from persisted writer outcomes and current
+   readiness. A receipt identifies only its gate. Report remaining blockers and
+   never infer implementation permission from a single passing review. Approval
+   is reported only for an actual pending envelope. Apply the projection to
+   stored messages, progress, immediate results, and replay.
+4. Exercise regression tests, protected PR and merge-queue checks, canonical
+   deployment, and the live exact-bound reviewer journey. Preserve WC-27D00458
+   and its branch. Read back receipt IDs and readiness before declaring done.
+
+About 20 percent of implementation effort belongs to shared disposition and
+status consolidation. No new ledger, approval layer, or provider requirement
+is introduced. Eligible external providers remain subject to actual privacy,
+authority, and model constraints.
+
+## Objectives
+
+**OBJ-RDC-001:** Instructions, provider schemas, and canonical writers enforce
+one lossless disposition contract for research and independent review.
+
+**OBJ-RDC-002:** Validation failure permits bounded independent correction on
+the same immutable review, preserving idempotency and approval separation.
+
+**OBJ-RDC-003:** Reviewer completion reports persisted receipts and actual
+readiness without invented approvals or permission to implement.
+
+**OBJ-RDC-004:** The deployed reviewer journey proves reading, independent
+assessment, receipt persistence, and the corresponding readiness advance.
+
+| Acceptance criterion | Objective links | Observable result |
+| --- | --- | --- |
+| AC-RDC-001 | OBJ-RDC-001 | Empty passing receipt is accepted; pass with positive observations in findings is rejected without modifying arguments; grounded fail remains non-passing. |
+| AC-RDC-002 | OBJ-RDC-001, OBJ-RDC-002 | Findings refer to successful immutable reads; unsupported or contradictory evidence requires grounded correction rather than fabricated approval. |
+| AC-RDC-003 | OBJ-RDC-002 | Malformed proposal can be corrected within a fixed budget; stale identity, duplicate replay, exhausted correction, and provider failure preserve identity and return precise outcomes. |
+| AC-RDC-004 | OBJ-RDC-002 | Omitted writer cannot complete a review; terminal writer and reader-history regression suites continue passing. |
+| AC-RDC-005 | OBJ-RDC-003 | Persisted receipts override misleading prose; current readiness names remaining gates; only an actual pending envelope requires approval. |
+| AC-RDC-006 | OBJ-RDC-004 | After deployment, live exact-artifact review persists valid receipt IDs and advances only corresponding gates; failure and recovery are read back. |
+
+## Verification and impact
+
+Graph-linked tests: initiative-readiness-pack.test.ts,
+mcp-task-review-contract.test.ts, terminal-tool-policy.test.ts,
+mcp-task-terminal-writer-context.test.ts. The graph lacks execution links, so
+also run the colocated mcp-task-execution.test.ts and submission/replay suites.
+Add failing behavior tests before production edits. Run style-drift guard,
+pregate preflight and exact-tree pregate, then mechanical PR health and cloud
+build. Live workflow verification is mandatory; no migration is planned.
+Documentation impact is the reviewer-facing tool contract and recovery/status
+instructions, plus this architecture record.
+
+## Delivery boundary, risk, and rollback
+
+One atomic BI and PR: schemas, validation, correction, and status must agree to
+avoid either lossy review or false completion. The primary risk is a retry after
+a successful write; persisted success and idempotency must close the writer.
+Another risk is treating approval waits as recoverable validation; classify
+those separately. Roll back through a revert PR and canonical self-upgrade;
+never alter receipts, approval records, or the preserved Workroom branch.
+
+## Backlog coverage
+
+Parent and sole delivery item: BI-31159978. Coverage receipt pending canonical
+recording against this immutable document and the approved scope baseline.
+Implementation readiness is not claimed by this document.

--- a/docs/superpowers/specs/2026-09-06-reviewer-disposition-contract-design.md
+++ b/docs/superpowers/specs/2026-09-06-reviewer-disposition-contract-design.md
@@ -1,3 +1,6 @@
+---
+status: active
+---
 # Initiative reviewer disposition and persisted status
 
 Backlog: BI-31159978. Workroom: WC-025847D7. Profile: fix.
@@ -30,7 +33,7 @@ writer definition and bound tool schema without editing that registry.
 ## Canonical contract and ordered fix sequence
 
 1. Consolidate disposition guidance and validation into the existing readiness
-   module boundary. Pass requires empty findings and resolvedFindingRefs;
+   module boundary. Pass requires empty findings; resolutions name existing open findings only;
    positive observations belong in reason. Findings require fail and immutable
    evidence. All research and review adapters preserve the independent author's
    assessment. Server-owned artifact identity remains bound and cannot drift.


### PR DESCRIPTION
## Summary

Initiative reviewers could submit a passing assessment with findings, then stop after the writer rejected it. Successful reviews could also report a missing receipt or tell the author to implement before the remaining gates passed. This repair shares the disposition contract across schemas and writers, permits bounded independent correction, and derives completion from the matching persisted receipt and current readiness.

## Changes

- Preserve the reviewer's reason and findings. Positive observations belong in reason; only fail introduces findings. Bound findings must quote lines from a successful read of the immutable blob.
- Feed validation errors back through the existing terminal-writer policy and same-TaskRun recovery. Preserve request identity, authority and successful-write idempotency.
- Read receipts back before declaring completion. Reconcile stale replay status and report remaining readiness gates instead of inferring human approval or permission to implement.
- Extract shared disposition, outcome projection and replay reservation code. Keep existing receipt and TaskRun storage.

## Test plan

- [x] Web typecheck and 541 affected readiness, TaskRun, reviewer-schema and terminal-policy tests passed.
- [x] All 64 preflight guards passed; capability-completeness artifacts are in sync.
- [x] Shared exact-tree integration gate: 3,093 tests and production build passed.
- [x] Independent semantic review executed and recorded as infrastructure-inconclusive (one unparseable required branch); the canonical shadow policy allows publication. This is not a semantic pass.
- [ ] Live acceptance blocked: release publication and release-install verification passed, but the canonical install became unreachable during governed Self-Upgrade. No reviewer recovery or readiness advancement is claimed.

## Design grounding

Reviewed `docs/superpowers/specs/2026-09-06-reviewer-disposition-contract-design.md` and its implementation coverage plan against the initiative receipt validator, spec baseline writer, terminal-tool policy, TaskRun execution and replay code. The existing initiative-readiness projection and persisted receipts remain authoritative. The change adds neither an approval layer nor a provider privacy exception.

## Related backlog and overlap

BI-31159978. Reuses the terminal-writer and second-turn recovery repairs; reader budgets remain unchanged. Rebased onto merged PR #5125 and retained its objective-mapping replay eligibility; its regression test passes with this extraction.

PR #5129 separately rotates a provider after a prose-only writer response; its additive routing change does not duplicate this disposition/receipt repair.


