### PR TITLE
fix(readiness): plan-review binds the plan artifact the coverage record names (BI-B5C8FEFC)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/entry-adapter.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/entry-adapter.test.ts
@@ -442,3 +442,49 @@ describe("parent scope inheritance", () => {
     expect(projection.decision.unmet.map((entry) => entry.code)).toContain("OBJECTIVE_BASELINE_REQUIRED");
   });
 });
+
+describe("plan-review binds the plan artifact, not the design (BI-B5C8FEFC)", () => {
+  const planReviewAgainstPlan = { ...receipt("r-plan-review-plan", "plan-review"), payload: { ...receipt("r-plan-review-plan", "plan-review").payload, artifactDigest: "sha256:plan" } };
+  const withoutPlanReview = () => readyActivities().filter((entry) => entry.gateKey !== "plan-review");
+
+  it("accepts a plan-review receipt recorded against the coverage record's plan digest", () => {
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities: [...withoutPlanReview(), planReviewAgainstPlan],
+      target: "implementation",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    expect(projection.decision.verdict).toBe("allowed");
+  });
+
+  it("still marks a plan-review receipt stale when it matches neither the plan nor the design", () => {
+    const foreign = { ...planReviewAgainstPlan, payload: { ...planReviewAgainstPlan.payload, artifactDigest: "sha256:elsewhere" } };
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities: [...withoutPlanReview(), foreign],
+      target: "implementation",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    expect(projection.decision.unmet.find((entry) => entry.code === "PLAN_REVIEW_REQUIRED")?.state).toBe("stale");
+  });
+
+  it("keeps the design digest for every other gate", () => {
+    const specAgainstPlan = { ...receipt("r-approval-plan", "spec-approval"), payload: { ...receipt("r-approval-plan", "spec-approval").payload, artifactDigest: "sha256:plan" } };
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities: [...readyActivities().filter((entry) => entry.gateKey !== "spec-approval"), specAgainstPlan],
+      target: "implementation",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+    expect(projection.decision.unmet.find((entry) => entry.code === "SPEC_APPROVAL_REQUIRED")?.state).toBe("stale");
+  });
+});

--- a/apps/web/lib/backlog/initiative-readiness/entry-adapter.ts
+++ b/apps/web/lib/backlog/initiative-readiness/entry-adapter.ts
@@ -215,9 +215,27 @@ function persistedTerminalCompletionDecision(
   return null;
 }
 
+/**
+ * Which artifact a gate receipt is bound to. Every design gate binds the
+ * canonical design; plan-review binds the PLAN the coverage record names (and
+ * still accepts the design digest, which earlier receipts were bound to)
+ * (BI-B5C8FEFC, 2026-09-06: a reviewer routed to the design honestly failed
+ * plan-review because "this document is a design specification", and a
+ * receipt recorded against the plan read as stale against the design digest).
+ */
+type AcceptedDigests = { canonical: string | null; plan: string | null };
+
+function isStaleFor(gate: string, artifactDigest: unknown, digests: AcceptedDigests): boolean {
+  if (gate === "plan-review") {
+    const accepted = [digests.plan, digests.canonical].filter((value): value is string => Boolean(value));
+    return accepted.length > 0 && !accepted.includes(String(artifactDigest));
+  }
+  return Boolean(digests.canonical) && artifactDigest !== digests.canonical;
+}
+
 function projectGateReceipt(
   activity: InitiativeReadinessActivity,
-  canonicalDigest: string | null,
+  digests: AcceptedDigests,
   itemId: string,
 ): { state: ReadinessEvidenceState; malformed: boolean; gate: string | null } {
   const payload = object(activity.payload);
@@ -250,7 +268,7 @@ function projectGateReceipt(
     && (gate === "classification" || payload.selectedProfile === undefined)
     && (decision === "fail" || payload.findingRefs.length === 0);
   if (!valid) return { state: "malformed", malformed: true, gate };
-  if (canonicalDigest && payload.artifactDigest !== canonicalDigest) {
+  if (isStaleFor(gate, payload.artifactDigest, digests)) {
     return { state: "stale", malformed: false, gate };
   }
   return { state: decision as ReadinessEvidenceState, malformed: false, gate };
@@ -258,7 +276,7 @@ function projectGateReceipt(
 
 function latestGateStates(
   activities: readonly InitiativeReadinessActivity[],
-  canonicalDigest: string | null,
+  digests: AcceptedDigests,
   itemId: string,
 ): { states: Map<string, ReadinessEvidenceState>; malformed: boolean } {
   const latest = [...activities]
@@ -269,7 +287,7 @@ function latestGateStates(
   for (const activity of latest) {
     const gate = normalizeGate(activity.gateKey);
     if (gate && states.has(gate)) continue;
-    const projected = projectGateReceipt(activity, canonicalDigest, itemId);
+    const projected = projectGateReceipt(activity, digests, itemId);
     malformed ||= projected.malformed;
     if (projected.gate) states.set(projected.gate, projected.state);
   }
@@ -317,11 +335,11 @@ function unreadEvidenceByCode(
 function projectPlanCoverage(
   activities: readonly InitiativeReadinessActivity[],
   baseline: Baseline | null,
-): ReadinessEvidenceState {
+): { state: ReadinessEvidenceState; planDigest: string | null } {
   const latest = [...activities]
     .filter((activity) => activity.kind === "plan_backlog_coverage")
     .sort((left, right) => right.recordedAt.getTime() - left.recordedAt.getTime() || right.id.localeCompare(left.id))[0];
-  if (!latest) return "missing";
+  if (!latest) return { state: "missing", planDigest: null };
   const payload = object(latest.payload);
   const artifact = object(payload?.planArtifactRef);
   if (!payload
@@ -335,9 +353,9 @@ function projectPlanCoverage(
     || !baseline
     || payload.scopeBaselineId !== baseline.baselineId
     || payload.scopeBaselineArtifactDigest !== baseline.artifactDigest) {
-    return "malformed";
+    return { state: "malformed", planDigest: null };
   }
-  return "pass";
+  return { state: "pass", planDigest: String(payload.planArtifactDigest) };
 }
 
 export function projectBacklogItemReadiness(args: {
@@ -392,8 +410,10 @@ export function projectBacklogItemReadiness(args: {
   const inherited = parent?.current ? args.inheritedScope! : null;
   const baseline = inherited ? parent! : own;
   const digest = baseline.current?.artifactDigest ?? null;
-  const ownReceipts = latestGateStates(args.activities, digest, args.item.itemId);
-  const parentReceipts = inherited ? latestGateStates(inherited.activities, digest, inherited.parentItemId) : null;
+  const projectedCoverage = projectPlanCoverage(inherited ? inherited.activities : args.activities, baseline.current);
+  const digests: AcceptedDigests = { canonical: digest, plan: projectedCoverage.planDigest };
+  const ownReceipts = latestGateStates(args.activities, digests, args.item.itemId);
+  const parentReceipts = inherited ? latestGateStates(inherited.activities, digests, inherited.parentItemId) : null;
   const receipts = parentReceipts
     ? {
       states: new Map([...parentReceipts.states, ...[...ownReceipts.states].filter(([, state]) => state !== "missing")]),
@@ -409,8 +429,7 @@ export function projectBacklogItemReadiness(args: {
   const governed = profile !== null;
   const evidence = receipts.states;
   const baselineState: ReadinessEvidenceState = baseline.current ? "pass" : "missing";
-  const coverage = args.planCoverage
-    ?? projectPlanCoverage(inherited ? inherited.activities : args.activities, baseline.current);
+  const coverage = args.planCoverage ?? projectedCoverage.state;
   const dependency = state(evidence, "dependency-disposition");
   const archetypeProvisioning = state(evidence, "archetype-provisioning");
   // merge-through-gates recognition (EP-4614F35E): coerce the design/plan lanes to


### PR DESCRIPTION
## Why

`initiative-readiness.v2` compared every gate receipt to the canonical design digest. The plan-review recovery route therefore bound the reviewer to the design, and today AGT-WS-REVIEW honestly failed it ("this document is a design specification ... it does not contain the implementation plan"). A plan-review receipt then recorded against the plan itself (receipt initiative-92cefe98) projected as stale, so no child of the plan could enter implementation although every other gate passed.

## What

The projector reads the latest valid `plan_backlog_coverage` record's `planArtifactDigest` and accepts a plan-review receipt bound to it; the design digest is still accepted for plan-review so earlier receipts keep their standing. Every other gate binds the design exactly as before.

## Verification

- `entry-adapter.test.ts`: plan-review accepted against the plan digest; a foreign digest stays stale; spec-approval still binds the design.
- Readiness, claim and read-tools suites 244/244; web typecheck clean; local-CI gate PASS at 987fff4c1e18 (evidence cmtq3dsio09lw01lcc0i8urhe).

Backlog: BI-B5C8FEFC under EP-129D11FD (kernel DI-C0989B8514AF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)