### PR TITLE
fix(local-ci): measure available memory, not the free page pool (BI-EB6DBAF0)

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -391,6 +391,20 @@ displayed model size is ordinary RAM, conflate GPU VRAM with physical memory,
 or infer the Docker/WSL/shared-memory mechanism. It also does not terminate a
 model that was already resident before admission.
 
+**The fence measures available memory, not free memory (BI-EB6DBAF0).** The
+execution-pressure fence revokes an admitted lease when the host observation
+reports less than 4 GiB. That observation is reclaimable-inclusive: `vm_stat`
+free + inactive + speculative + purgeable on Darwin, `/proc/meminfo`
+`MemAvailable` on Linux, with `os.freemem()` kept only as a last resort so a
+wedged probe cannot wedge the gate. `os.freemem()` alone reports the free page
+pool, which excludes memory the kernel returns on demand — on a 128 GiB macOS
+host it read 17.5 GiB against 47.5 GiB genuinely available. Measuring the free
+pool made the gate fence its own work: `next build`, running under the 16 GiB
+heap the gate had just granted, drove the free pool under the floor while tens
+of GiB stayed reclaimable, and the run was killed as `host-memory-low` after
+its tests had already passed. A reading that matched only the free bucket is
+refused rather than reported as available.
+
 **Fail-fast command order (BI-7BCCDE3D).** Inside an admitted runtime-code
 gate, freshness, Prisma generation, migrations, and the cheap doc/repository
 guards run first. Web typecheck then runs before exhaustive Vitest, followed by

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -229,6 +229,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/documentation-evidence-lane.test.mjs",
         "scripts/ci-policy-guards.test.mjs",
         "scripts/lib/host-command-invocation.test.mjs",
+        "scripts/lib/host-available-memory.test.mjs",
         "packages/dpf-skill-pack/hooks/claim-work-guidance.test.mjs",
         "packages/dpf-skill-pack/hooks/plan-coverage-guidance.test.mjs",
         // BI-812C676D: every covered-root *.test.mjs must appear here or on the

--- a/scripts/lib/host-available-memory.mjs
+++ b/scripts/lib/host-available-memory.mjs
@@ -1,0 +1,122 @@
+// What "available memory" means to the local-CI gate.
+//
+// THE FAILURE THIS FIXES (BI-EB6DBAF0)
+//
+// The gate fenced its own run. `local-ci-pool-policy` revokes an admitted lease
+// when `availableMemoryBytes` falls under a 4 GiB floor, and that number came
+// from `os.freemem()`. On Darwin `freemem()` reports only the FREE page pool —
+// it excludes inactive, speculative and purgeable pages, all of which the
+// kernel hands back on demand. macOS deliberately keeps the free pool small and
+// parks everything else in those reclaimable buckets.
+//
+// So `next build`, running under a 16 GiB heap the gate itself granted, drove
+// the free pool under 4 GiB while tens of GiB stayed reclaimable. The watchdog
+// read "host-memory-low" and killed the build it had just admitted. Measured on
+// a 128 GiB host: freemem() 24.4 GiB against 49.6 GiB genuinely available.
+//
+// Linux has the same blind spot in smaller form — `os.freemem()` is MemFree,
+// which excludes the page cache; MemAvailable is the kernel's own estimate of
+// what a new allocation can actually get.
+//
+// Every probe is injectable so tests never touch host state (the rule from
+// BI-95A83B47's ambient-host-state guard, and BI-EFA383AA before it).
+
+import { freemem } from "node:os";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/** Page-bucket names on Darwin that are reclaimable under memory pressure. */
+const DARWIN_RECLAIMABLE = [
+  "Pages free",
+  "Pages inactive",
+  "Pages speculative",
+  "Pages purgeable",
+];
+
+/**
+ * Parse `vm_stat` output into available bytes.
+ *
+ * Exported for tests: the parser is pure, so the Darwin path is covered without
+ * a Darwin host.
+ */
+export function parseVmStatAvailableBytes(vmStat) {
+  if (typeof vmStat !== "string" || vmStat.length === 0) return undefined;
+  const pageSize = /page size of (\d+) bytes/.exec(vmStat);
+  if (!pageSize) return undefined;
+  const bytesPerPage = Number(pageSize[1]);
+  if (!Number.isFinite(bytesPerPage) || bytesPerPage <= 0) return undefined;
+
+  let pages = 0;
+  let matched = 0;
+  for (const bucket of DARWIN_RECLAIMABLE) {
+    // `vm_stat` prints "Pages free:   123456." — trailing period, no separators.
+    const found = new RegExp(`^${bucket}:\\s+(\\d+)\\.`, "m").exec(vmStat);
+    if (!found) continue;
+    pages += Number(found[1]);
+    matched += 1;
+  }
+  // "Pages free" alone is what we are trying to get away from; require at least
+  // one reclaimable bucket beyond it before trusting the reading.
+  if (matched < 2) return undefined;
+  return pages * bytesPerPage;
+}
+
+/** Parse `MemAvailable` (kB) out of /proc/meminfo contents into bytes. */
+export function parseMemAvailableBytes(meminfo) {
+  if (typeof meminfo !== "string") return undefined;
+  const match = /^MemAvailable:\s+(\d+)\s*kB/im.exec(meminfo);
+  if (!match) return undefined;
+  const kb = Number(match[1]);
+  return Number.isFinite(kb) ? kb * 1024 : undefined;
+}
+
+function attempt(fn) {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The host's genuinely-available memory in bytes, with the source that produced
+ * it. Never throws: a wedged probe must not wedge the gate, so the last resort
+ * is `os.freemem()` — the value this module exists to stop trusting alone, but
+ * still better than refusing to measure.
+ */
+export function readAvailableMemory(deps = {}) {
+  const platform = deps.platform ?? process.platform;
+
+  if (platform === "darwin") {
+    const vmStat = attempt(
+      deps.readVmStat
+        ?? (() => execFileSync("vm_stat", { encoding: "utf8", timeout: 5_000 })),
+    );
+    const bytes = parseVmStatAvailableBytes(vmStat);
+    if (Number.isFinite(bytes) && bytes > 0) {
+      return { availableBytes: bytes, source: "vm_stat" };
+    }
+  }
+
+  if (platform === "linux") {
+    const meminfo = attempt(
+      deps.readMeminfo
+        ?? (() => readFileSync("/proc/meminfo", "utf8")),
+    );
+    const bytes = parseMemAvailableBytes(meminfo);
+    if (Number.isFinite(bytes) && bytes > 0) {
+      return { availableBytes: bytes, source: "meminfo" };
+    }
+  }
+
+  const free = attempt(deps.osFreeMemoryBytes ?? freemem);
+  if (Number.isFinite(free)) {
+    return { availableBytes: free, source: "os-freemem" };
+  }
+  return { availableBytes: undefined, source: "unmeasurable" };
+}
+
+/** Bytes only, for call sites that already have their own failure handling. */
+export function availableMemoryBytes(deps = {}) {
+  return readAvailableMemory(deps).availableBytes;
+}

--- a/scripts/lib/host-available-memory.test.mjs
+++ b/scripts/lib/host-available-memory.test.mjs
@@ -1,0 +1,139 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import {
+  availableMemoryBytes,
+  parseMemAvailableBytes,
+  parseVmStatAvailableBytes,
+  readAvailableMemory,
+} from "./host-available-memory.mjs";
+
+// A trimmed real `vm_stat` header plus the buckets we read. Page size 16384 is
+// Apple silicon; the parser must take it from the text, never assume 4096.
+const VM_STAT = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               90224.
+Pages active:                           1210544.
+Pages inactive:                         1100000.
+Pages speculative:                        50000.
+Pages throttled:                              0.
+Pages wired down:                        600000.
+Pages purgeable:                          40000.
+`;
+
+test("counts every reclaimable bucket, not just free pages", () => {
+  const bytes = parseVmStatAvailableBytes(VM_STAT);
+  assert.equal(bytes, (90224 + 1100000 + 50000 + 40000) * 16384);
+});
+
+test("the reclaimable reading dwarfs the free pool it replaces", () => {
+  // The whole point of BI-EB6DBAF0: free pages alone read ~1.4 GiB here while
+  // ~19 GiB is genuinely available, which is what tripped the 4 GiB fence.
+  const freeOnly = 90224 * 16384;
+  const available = parseVmStatAvailableBytes(VM_STAT);
+  assert.ok(freeOnly < 4 * 1024 ** 3, "fixture should trip the 4 GiB floor on free pages");
+  assert.ok(available > 4 * 1024 ** 3, "and clear it on reclaimable pages");
+});
+
+test("takes the page size from the text rather than assuming one", () => {
+  const fourK = VM_STAT.replace("page size of 16384 bytes", "page size of 4096 bytes");
+  assert.equal(
+    parseVmStatAvailableBytes(fourK),
+    (90224 + 1100000 + 50000 + 40000) * 4096,
+  );
+});
+
+test("refuses a reading with no page size", () => {
+  assert.equal(parseVmStatAvailableBytes("Pages free: 100.\n"), undefined);
+});
+
+test("refuses a reading that found only the free bucket", () => {
+  // Falling through to os.freemem() is honest; reporting free-pages-only under
+  // the name "available" is the bug this module exists to remove.
+  const onlyFree = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               90224.
+`;
+  assert.equal(parseVmStatAvailableBytes(onlyFree), undefined);
+});
+
+test("refuses non-string and empty input", () => {
+  assert.equal(parseVmStatAvailableBytes(undefined), undefined);
+  assert.equal(parseVmStatAvailableBytes(""), undefined);
+});
+
+test("prefers MemAvailable over MemFree on linux", () => {
+  const meminfo = "MemTotal:  65536000 kB\nMemFree:  1048576 kB\nMemAvailable: 41943040 kB\n";
+  assert.equal(parseMemAvailableBytes(meminfo), 41943040 * 1024);
+});
+
+test("refuses meminfo with no MemAvailable line", () => {
+  assert.equal(parseMemAvailableBytes("MemTotal: 100 kB\nMemFree: 50 kB\n"), undefined);
+});
+
+test("darwin reads vm_stat", () => {
+  const result = readAvailableMemory({
+    platform: "darwin",
+    readVmStat: () => VM_STAT,
+    osFreeMemoryBytes: () => 1,
+  });
+  assert.equal(result.source, "vm_stat");
+  assert.equal(result.availableBytes, (90224 + 1100000 + 50000 + 40000) * 16384);
+});
+
+test("linux reads meminfo", () => {
+  const result = readAvailableMemory({
+    platform: "linux",
+    readMeminfo: () => "MemAvailable: 2048 kB\n",
+    osFreeMemoryBytes: () => 1,
+  });
+  assert.equal(result.source, "meminfo");
+  assert.equal(result.availableBytes, 2048 * 1024);
+});
+
+test("a wedged probe falls back rather than throwing", () => {
+  const result = readAvailableMemory({
+    platform: "darwin",
+    readVmStat: () => {
+      throw new Error("vm_stat missing");
+    },
+    osFreeMemoryBytes: () => 7 * 1024 ** 3,
+  });
+  assert.equal(result.source, "os-freemem");
+  assert.equal(result.availableBytes, 7 * 1024 ** 3);
+});
+
+test("an unparseable probe falls back rather than reporting zero", () => {
+  const result = readAvailableMemory({
+    platform: "darwin",
+    readVmStat: () => "not vm_stat output",
+    osFreeMemoryBytes: () => 3 * 1024 ** 3,
+  });
+  assert.equal(result.source, "os-freemem");
+  assert.equal(result.availableBytes, 3 * 1024 ** 3);
+});
+
+test("reports unmeasurable when even the fallback fails", () => {
+  const result = readAvailableMemory({
+    platform: "sunos",
+    osFreeMemoryBytes: () => {
+      throw new Error("no");
+    },
+  });
+  assert.equal(result.source, "unmeasurable");
+  assert.equal(result.availableBytes, undefined);
+});
+
+test("an unknown platform goes straight to the fallback", () => {
+  const result = readAvailableMemory({
+    platform: "win32",
+    readVmStat: () => VM_STAT,
+    osFreeMemoryBytes: () => 5 * 1024 ** 3,
+  });
+  assert.equal(result.source, "os-freemem");
+});
+
+test("availableMemoryBytes returns bytes only", () => {
+  assert.equal(
+    availableMemoryBytes({ platform: "linux", readMeminfo: () => "MemAvailable: 1024 kB\n" }),
+    1024 * 1024,
+  );
+});

--- a/scripts/lib/local-ci-host-pressure.mjs
+++ b/scripts/lib/local-ci-host-pressure.mjs
@@ -1,7 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { statfs } from "node:fs/promises";
-import { cpus, freemem } from "node:os";
+import { cpus } from "node:os";
+
+import { availableMemoryBytes as readAvailableMemoryBytes } from "./host-available-memory.mjs";
 
 import { reconcileDeadLocalSandboxFence } from "./local-sandbox-fence.mjs";
 import { reconcileStaleLocalConvergenceLock } from "./local-convergence-lock.mjs";
@@ -109,7 +111,10 @@ export async function sampleLocalCiHostPressure({
   deps = {},
 }) {
   const now = deps.now ?? (() => new Date());
-  const freeMemoryBytes = deps.freeMemoryBytes ?? freemem;
+  // Reclaimable-inclusive, not the free page pool: on Darwin `os.freemem()`
+  // omits inactive/speculative/purgeable pages, so a sanctioned build drove
+  // this under the 4 GiB fence floor and killed itself (BI-EB6DBAF0).
+  const freeMemoryBytes = deps.freeMemoryBytes ?? readAvailableMemoryBytes;
   const cpuTimes = deps.cpuTimes ?? defaultCpuTimes;
   const delay = deps.delay ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   const diskFreeBytes = deps.diskFreeBytes ?? defaultDiskFreeBytes;

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -250,6 +250,7 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(join(repoRoot, "scripts", "lib", "pregate-console.mjs"), join(temp, "scripts", "lib", "pregate-console.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-convergence-lock.mjs"), join(temp, "scripts", "lib", "local-convergence-lock.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-host-pressure.mjs"), join(temp, "scripts", "lib", "local-ci-host-pressure.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "host-available-memory.mjs"), join(temp, "scripts", "lib", "host-available-memory.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "agent-identity.mjs"), join(temp, "scripts", "lib", "agent-identity.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-base-freshness.mjs"), join(temp, "scripts", "lib", "local-ci-base-freshness.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "git-fetch-shared-safe.mjs"), join(temp, "scripts", "lib", "git-fetch-shared-safe.mjs"));


### PR DESCRIPTION
## The gate was killing its own builds

`local-ci-pool-policy` revokes an admitted lease when the host observation reports less than 4 GiB available. That number came from `os.freemem()`, which on Darwin reports only the **free page pool** — it excludes inactive, speculative and purgeable pages, all of which the kernel returns on demand. macOS deliberately keeps the free pool small and parks everything else in those buckets.

So `next build`, running under the 16 GiB heap the gate itself granted, drove the free pool under 4 GiB while tens of GiB stayed reclaimable. The watchdog read `host-capacity-lost:host-memory-low` and terminated the build it had just admitted — **after 2958 tests had already passed**. The gate could not distinguish "the host is exhausted" from "the sanctioned build is using the memory we gave it."

Measured on a 128 GiB host:

| metric | value |
|---|---|
| `os.freemem()` — what the fence used | **17.5 GiB** |
| reclaimable-inclusive — what is actually available | **47.5 GiB** |
| fence floor | 4 GiB |

A ~3x under-report against the floor it gates on.

## Change

`scripts/lib/host-available-memory.mjs` measures *available*, not *free*:

- **Darwin** — `vm_stat` free + inactive + speculative + purgeable, taking the page size from the output rather than assuming 4096 (Apple silicon is 16384).
- **Linux** — `/proc/meminfo` `MemAvailable`. `os.freemem()` there is `MemFree`, which excludes the page cache and has the same blind spot in smaller form.
- **Fallback** — `os.freemem()`, kept only as a last resort so a wedged probe cannot wedge the gate.

A `vm_stat` reading that matched only the free bucket is refused rather than returned, because reporting free-pages-only under the name "available" is the defect being removed.

Wired into `scripts/lib/local-ci-host-pressure.mjs`, which produces the client observation the fence actually reads.

## Verification

- **Local-CI gate PASS** on this branch — `✓ Compiled successfully in 2.4min`. The two runs immediately before this fix were killed at that exact step.
- 15 new unit tests, 6 existing pressure tests, guard tests — all pass.
- Every probe is injected, so the parsers are covered on any host without touching host state (the ambient-host-state guard, BI-95A83B47).

## Prior art

BI-EFA383AA recorded this same measurement blind spot causing 49 false failures in the self-upgrade guard; it was resolved by mocking the probe in that test rather than fixing the metric. `apps/web/lib/self-upgrade/host-memory-preflight.ts` already prefers `MemAvailable` on Linux but has no Darwin path.

## Follow-up (tracked on BI-EB6DBAF0)

These still read `freemem()` directly and should converge on this reader: `local-ci-capacity-broker.ts`, `host-resource-runner.mjs`, and the Darwin gap in `host-memory-preflight.ts`. Left out here to keep this to one concern.

Docs-Impact-Decision: docs/testing/pre-pr-gate.md is updated in this diff for the changed fence metric. The remaining flags link to scripts/lib/ci-policy-guards.mjs, where the only change is registering one new test file in the CI run inventory; that alters no behaviour described by context-engineering-standards.md or staleness-report.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
