### PR TITLE
fix(federation): a member presents its declared estate name to the authority, not the normalised ref

### DIFF
--- a/apps/web/lib/federation/organization-membership.test.ts
+++ b/apps/web/lib/federation/organization-membership.test.ts
@@ -245,4 +245,17 @@ describe("enrolWithOrganizationAuthority + reconcile", () => {
     expect(deriveAuthorityPortalUrls("https://192.168.0.152:9000")).toEqual(["http://192.168.0.152:3000", "https://192.168.0.152"]);
     expect(deriveAuthorityPortalUrls("nope")).toEqual([]);
   });
+
+  it("reconcile: presents the declared estate name to the authority, not its normalised comparison form", async () => {
+    const member = installation("member");
+    const seen: string[] = [];
+    const post = vi.fn(async ({ cloudEvent }: { cloudEvent: { statement: { displayName: string; organizationRef: string } } }) => {
+      seen.push(`${cloudEvent.statement.displayName}|${cloudEvent.statement.organizationRef}`);
+      return { ok: false, status: 404 };
+    });
+    expect(await reconcileOrganizationMembership(member.db, { readText: readMember, caUrl: "https://192.168.0.152:9000", localAuthorityUrl: "http://192.168.0.200:3000", post: post as never }))
+      .toMatchObject({ outcome: "failed" });
+    // The live pair showed the same slug twice on the authority: display and ref had collapsed together.
+    expect(seen[0]).toBe("Northwind Test|northwind test");
+  });
 });

--- a/apps/web/lib/federation/organization-membership.ts
+++ b/apps/web/lib/federation/organization-membership.ts
@@ -78,7 +78,8 @@ export interface MembershipDb extends FederationIdentityDb {
   $transaction<T>(fn: (tx: Parameters<typeof createFederationLinkRow>[0]) => Promise<T>): Promise<T>;
 }
 
-async function localOrganizationRef(db: MembershipDb, env?: Record<string, string | undefined>): Promise<string | null> {
+/** The estate name as declared (display form), or null when the installation is unnamed. */
+async function localEstateName(db: MembershipDb, env?: Record<string, string | undefined>): Promise<string | null> {
   const resolution = await loadEstateNameResolution(
     {
       readConfig: async (key: string) => (await db.platformConfig.findUnique({ where: { key }, select: { value: true } }))?.value ?? null,
@@ -89,7 +90,11 @@ async function localOrganizationRef(db: MembershipDb, env?: Record<string, strin
     },
     env ? { env } : {},
   );
-  return normalizeOrganizationRef(resolution.estateName);
+  return resolution.estateName;
+}
+
+async function localOrganizationRef(db: MembershipDb, env?: Record<string, string | undefined>): Promise<string | null> {
+  return normalizeOrganizationRef(await localEstateName(db, env));
 }
 
 export interface MembershipProofEnvelope {
@@ -431,7 +436,9 @@ export async function reconcileOrganizationMembership(
     if (links.some((link) => { try { return hosts.has(new URL(link.peerAuthorityUrl).hostname.toLowerCase()); } catch { return false; } })) {
       return { outcome: "already-linked" };
     }
-    const displayName = (await localOrganizationRef(db, env)) ?? "Member installation";
+    // The name the authority shows for us is the declared estate name, not its
+    // normalised comparison form (the live pair listed the member as "<slug>(<slug>)").
+    const displayName = (await localEstateName(db, env)) ?? "Member installation";
     const result = await enrolWithOrganizationAuthority(db, {
       material, authorityUrls, localAuthorityUrl, displayName, now: deps.now, env, post: deps.post,
     });


### PR DESCRIPTION
## Summary

Follow-up to #5126 (EP-ZERO-CONFIG-FEDERATION, BI-105BB8B2). On the live pair the authority listed the newly enrolled member with the same slug as both display name and organization ref, because `reconcileOrganizationMembership` passed the normalised comparison form as the display name. It now passes the estate name as declared; the normalised ref stays what the proof compares.

## Tests

`organization-membership.test.ts`: the reconcile path presents the declared name and the normalised ref side by side (9 pass). `apps/web` typecheck clean.

Pushed with the recorded pre-push override because the local-CI pool is dead-parked (exit 75). CI enforces every gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)