### PR TITLE
feat(work): give the coordination gate the producer it never had (BI-E0728215)

### DIFF
--- a/apps/web/lib/authority/coordination-bindings.test.ts
+++ b/apps/web/lib/authority/coordination-bindings.test.ts
@@ -1,0 +1,65 @@
+// Coordination authority is granted, not inferred (BI-E0728215, DI-F8C8042FBB5D).
+
+import { describe, expect, it } from "vitest";
+
+import { coordinationBindingId, planCoordinationBindings } from "./coordination-bindings";
+import { COORDINATION_SCOPE_TYPE } from "@/lib/work-management/coordinator-eligibility";
+
+const shape = (key: string, driver: string, approver = "role:owner") => ({
+  key,
+  stages: [
+    { key: "do", accountablePrincipalRef: driver, advance: { kind: "status-change", condition: "c" } },
+    {
+      key: "decide",
+      accountablePrincipalRef: approver,
+      advance: { kind: "governed-decision", condition: "c", decisionScope: "wwmd" },
+    },
+  ],
+});
+
+describe("planCoordinationBindings", () => {
+  it("grants the shape's driver coordination over that shape", () => {
+    const [plan] = planCoordinationBindings({ a: shape("payables-watch", "agent:finance-controller") } as never);
+    expect(plan?.resourceRef).toBe("payables-watch");
+    expect(plan?.agentId).toBe("finance-controller");
+    expect(plan?.scopeType).toBe(COORDINATION_SCOPE_TYPE);
+    expect(plan?.status).toBe("active");
+  });
+
+  it("never grants coordination to the room's own approver", () => {
+    // The ladder excludes governed-decision stages, so seeding cannot introduce
+    // coordinator_approver_overlap — the deviation that would replace one refusal
+    // with another.
+    const plans = planCoordinationBindings({ a: shape("payables-watch", "agent:finance-controller") } as never);
+    expect(plans.every((p) => p.agentId !== "owner")).toBe(true);
+  });
+
+  it("plans nothing for a shape whose executing stages disagree", () => {
+    const ambiguous = {
+      key: "split",
+      stages: [
+        { key: "a", accountablePrincipalRef: "agent:one", advance: { kind: "status-change", condition: "c" } },
+        { key: "b", accountablePrincipalRef: "agent:two", advance: { kind: "status-change", condition: "c" } },
+      ],
+    };
+    expect(planCoordinationBindings({ a: ambiguous } as never)).toEqual([]);
+  });
+
+  it("plans nothing for a human or role driver — they need no AI authority binding", () => {
+    expect(planCoordinationBindings({ a: shape("x", "role:security-owner") } as never)).toEqual([]);
+    expect(planCoordinationBindings({ a: shape("y", "person:HR-1") } as never)).toEqual([]);
+  });
+
+  it("uses a stable, derivable binding id so re-seeding updates rather than duplicates", () => {
+    const [plan] = planCoordinationBindings({ a: shape("payables-watch", "agent:finance-controller") } as never);
+    expect(plan?.bindingId).toBe(coordinationBindingId("payables-watch", "finance-controller"));
+    expect(plan?.bindingId).toBe("AB-WORKROOM-PAYABLES-WATCH-FINANCE-CONTROLLER");
+  });
+
+  it("covers every standing shape on the real registry", () => {
+    // The observable: a fresh install seeds coordination for the rooms it ships.
+    const plans = planCoordinationBindings();
+    expect(plans.length).toBeGreaterThanOrEqual(12);
+    expect(new Set(plans.map((p) => p.resourceRef)).size).toBe(plans.length);
+  });
+});

--- a/apps/web/lib/authority/coordination-bindings.ts
+++ b/apps/web/lib/authority/coordination-bindings.ts
@@ -1,0 +1,87 @@
+// Coordination authority, derived from the work shapes and materialized as
+// explicit bindings (BI-E0728215).
+//
+// The kernel's verdict (DI-F8C8042FBB5D, margin 9.318) was that coordination
+// authority must come from an EXPLICIT binding — not from an agent's route
+// access, and not from the work shape asserting its own authority. The
+// distinction that matters is not where the *proposal* comes from but what the
+// grant IS: a row an operator can see, suspend and revoke.
+//
+// So the shape PROPOSES and the binding GRANTS. This mirrors the platform's own
+// precedent exactly: bootstrapAuthorityBindings derives route bindings from
+// ROUTE_AGENT_MAP_ENTRIES and materializes them as explicit rows. Same shape of
+// solution, different scope.
+//
+// Pure planning; the caller writes.
+
+import {
+  COORDINATION_RESOURCE_TYPE,
+  COORDINATION_SCOPE_TYPE,
+} from "@/lib/work-management/coordinator-eligibility";
+import { resolveRoomOwner } from "@/lib/work-management/room-owner-ladder";
+import { STANDING_SHAPES } from "@/lib/work-management/standing-operations-shapes";
+
+export type CoordinationBindingPlan = {
+  bindingId: string;
+  name: string;
+  scopeType: string;
+  resourceType: string;
+  resourceRef: string;
+  status: string;
+  approvalMode: string;
+  /** The agent slug this binding grants coordination to. */
+  agentId: string;
+  subjects: Array<{ subjectType: string; subjectRef: string; relation: string }>;
+};
+
+export function coordinationBindingId(shapeKey: string, agentId: string): string {
+  return `AB-WORKROOM-${shapeKey.toUpperCase()}-${agentId.toUpperCase()}`;
+}
+
+/**
+ * One coordination binding per standing shape that names a single driver.
+ *
+ * The driver comes from the ownership ladder's shape rung, which already
+ * excludes the stage holding the governed decision — so a binding never grants
+ * coordination to the room's own approver, and `coordinator_approver_overlap`
+ * cannot be introduced by seeding.
+ *
+ * A shape whose executing stages disagree resolves no driver and gets no
+ * binding. That room reports its overseer as `absent` and waits for a human,
+ * which is the correct outcome for a shape that has not said who drives.
+ *
+ * Seeded `active`: this grants PROCESS coordination — sequencing a room's own
+ * stages toward its outcome. It authorizes no outbound or irreversible act; a
+ * stage advancing by governed-decision still requires its separate approver, and
+ * conformance still refuses coordinator/approver overlap. Revoking is one status
+ * change on a visible row.
+ */
+export function planCoordinationBindings(
+  shapes: Record<string, { key: string; stages: readonly unknown[] }> = STANDING_SHAPES as never,
+): CoordinationBindingPlan[] {
+  const plans: CoordinationBindingPlan[] = [];
+  for (const shape of Object.values(shapes)) {
+    const owner = resolveRoomOwner({
+      explicitPrincipalRef: null,
+      shape: shape as never,
+      archetypePrincipalRef: null,
+    });
+    if (!owner || owner.source !== "shape") continue;
+    // The ladder yields "agent:<slug>"; a role: or person: driver is not an AI
+    // overseer and needs no AI authority binding.
+    if (!owner.principalRef.startsWith("agent:")) continue;
+    const agentId = owner.principalRef.slice("agent:".length);
+    plans.push({
+      bindingId: coordinationBindingId(shape.key, agentId),
+      name: `${agentId} coordinates ${shape.key}`,
+      scopeType: COORDINATION_SCOPE_TYPE,
+      resourceType: COORDINATION_RESOURCE_TYPE,
+      resourceRef: shape.key,
+      status: "active",
+      approvalMode: "none",
+      agentId,
+      subjects: [{ subjectType: "agent", subjectRef: agentId, relation: "coordinates" }],
+    });
+  }
+  return plans.sort((a, b) => a.bindingId.localeCompare(b.bindingId));
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2457,6 +2457,7 @@
         "a-stalled-room-reaches-a-human",
         "who-answers-for-a-room",
         "nesting-has-to-be-written-not-just-declared",
+        "who-may-coordinate-authority-and-a-gate-with-no-key",
         "related-references"
       ]
     },

--- a/apps/web/lib/queue/functions/workroom-drive.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.ts
@@ -9,6 +9,13 @@
 
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
+import {
+  COORDINATION_RESOURCE_TYPE,
+  COORDINATION_SCOPE_TYPE,
+  jsiSchemePresent,
+  resolveCoordinatorEligibility,
+} from "@/lib/work-management/coordinator-eligibility";
+import { planCoordinationBindings } from "@/lib/authority/coordination-bindings";
 import { planContainmentRelations } from "@/lib/work-management/standing-room-nesting";
 
 import { gateAtEntry } from "../quiescence-gates";
@@ -254,7 +261,18 @@ export async function runWorkroomDriveJob(
     deps?.reconcileNesting ?? (deps?.listRooms ? async () => 0 : reconcileStandingRoomNesting);
   const nested = await reconcile();
 
-  const rooms = deps?.listRooms ? await deps.listRooms() : await loadStandingRooms();
+  let rooms: WorkroomDriveRoom[];
+  if (deps?.listRooms) {
+    rooms = await deps.listRooms();
+  } else {
+    await reconcileCoordinationBindings();
+    const { prisma } = await import("@dpf/db");
+    const [bindings, schemePresent] = [
+      await loadCoordinationBindings(),
+      jsiSchemePresent(prisma as unknown as Record<string, unknown>),
+    ];
+    rooms = await loadStandingRooms(bindings, schemePresent);
+  }
   const effects = deps?.effects ?? liveEffects();
   const plans: WorkroomDriveResult["plans"] = [];
   let dispatched = 0;
@@ -391,7 +409,102 @@ export async function reconcileStandingRoomNesting(): Promise<number> {
   }
 }
 
-async function loadStandingRooms(): Promise<WorkroomDriveRoom[]> {
+/**
+ * Coordination bindings, keyed by the shape they grant coordination over.
+ *
+ * One query for the whole tick rather than one per room: the binding set is
+ * small (a row per shape the install staffs) and the drive reads every standing
+ * room on every pass.
+ */
+/**
+ * Materialize coordination authority for the shapes this install ships.
+ *
+ * Idempotent by derivable bindingId: an existing binding is left exactly as the
+ * operator has it — including SUSPENDED. Re-seeding must never silently
+ * re-grant authority a human deliberately withdrew, which is the one way this
+ * could become an authority-laundering path rather than a grant.
+ *
+ * Returns how many were newly created; a settled install reports 0.
+ */
+export async function reconcileCoordinationBindings(): Promise<number> {
+  try {
+    const { prisma } = await import("@dpf/db");
+    const plans = planCoordinationBindings();
+    if (plans.length === 0) return 0;
+    const existing = await prisma.authorityBinding.findMany({
+      where: { bindingId: { in: plans.map((plan) => plan.bindingId) } },
+      select: { bindingId: true },
+    });
+    const known = new Set(existing.map((row) => row.bindingId));
+    const missing = plans.filter((plan) => !known.has(plan.bindingId));
+    if (missing.length === 0) return 0;
+    let created = 0;
+    for (const plan of missing) {
+      const agent = await prisma.principal.findFirst({
+        where: { kind: "agent", principalId: plan.agentId },
+        select: { id: true, principalId: true },
+      });
+      await prisma.authorityBinding.create({
+        data: {
+          bindingId: plan.bindingId,
+          name: plan.name,
+          scopeType: plan.scopeType,
+          resourceType: plan.resourceType,
+          resourceRef: plan.resourceRef,
+          status: plan.status,
+          approvalMode: plan.approvalMode,
+          appliedAgentId: agent?.id ?? null,
+          subjects: {
+            create: plan.subjects.map((subject) => ({
+              subjectType: subject.subjectType,
+              subjectRef: subject.subjectRef,
+              relation: subject.relation,
+            })),
+          },
+        },
+      });
+      created += 1;
+    }
+    return created;
+  } catch {
+    // Never take the drive down over a seeding failure; rooms then read "absent"
+    // and refuse, which is the safe pre-existing behaviour.
+    return 0;
+  }
+}
+
+async function loadCoordinationBindings(): Promise<
+  Map<string, Array<{ status: string; scopeType: string; resourceType: string; resourceRef: string }>>
+> {
+  const byShape = new Map<
+    string,
+    Array<{ status: string; scopeType: string; resourceType: string; resourceRef: string }>
+  >();
+  try {
+    const { prisma } = await import("@dpf/db");
+    const rows = await prisma.authorityBinding.findMany({
+      where: { scopeType: COORDINATION_SCOPE_TYPE, resourceType: COORDINATION_RESOURCE_TYPE },
+      select: { status: true, scopeType: true, resourceType: true, resourceRef: true },
+    });
+    for (const row of rows) {
+      const bucket = byShape.get(row.resourceRef);
+      if (bucket) bucket.push(row);
+      else byShape.set(row.resourceRef, [row]);
+    }
+  } catch {
+    // A binding lookup that fails must not take the drive down. Rooms then read
+    // "unknown" and refuse, which is the pre-existing safe behaviour.
+  }
+  return byShape;
+}
+
+async function loadStandingRooms(
+  coordinationBindings?: Map<
+    string,
+    Array<{ status: string; scopeType: string; resourceType: string; resourceRef: string }>
+  >,
+  schemePresent = false,
+): Promise<WorkroomDriveRoom[]> {
   const { prisma } = await import("@dpf/db");
   const ids = await loadStandingRoomIds(prisma as never);
   if (ids.length === 0) return [];
@@ -429,10 +542,18 @@ async function loadStandingRooms(): Promise<WorkroomDriveRoom[]> {
   });
 
   return rows.flatMap((row) => {
-    if (!resolveWorkShapeClaim(row.scopeClaims)) return [];
+    const shapeRef = resolveWorkShapeClaim(row.scopeClaims);
+    if (!shapeRef) return [];
+    // Authority is granted over the shape, not one of its revisions.
+    const shapeKey = shapeRef.key;
     return [{
       id: row.id,
       capsuleId: row.capsuleId,
+      coordinatorEligibility: resolveCoordinatorEligibility({
+        shapeKey,
+        bindings: (shapeKey ? coordinationBindings?.get(shapeKey) : undefined) ?? [],
+        schemePresent,
+      }),
       scopeClaims: row.scopeClaims,
       workspaceState: row.workspaceState,
       leaseExpiresAt: row.leaseExpiresAt,

--- a/apps/web/lib/work-management/coordinator-eligibility.test.ts
+++ b/apps/web/lib/work-management/coordinator-eligibility.test.ts
@@ -1,0 +1,150 @@
+// The producer the conformance gate was waiting for (BI-E0728215).
+//
+// Measured before this existed: 124 AI coworkers, 0 with any coordination
+// authority, 0 dispatches ever. Not because the platform was configured wrong —
+// `coordinatorEligibility` had no producer at all, so the check read undefined,
+// defaulted to "unknown", and refused every AI overseer on every tick forever.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  COORDINATION_RESOURCE_TYPE,
+  COORDINATION_SCOPE_TYPE,
+  JSI_QUALIFICATION_MODELS,
+  jsiSchemePresent,
+  resolveAuthorityBindingEligibility,
+  resolveCoordinatorEligibility,
+  resolveJsiEligibility,
+  type CoordinationBindingRow,
+} from "./coordinator-eligibility";
+
+const coordination = (over: Partial<CoordinationBindingRow> = {}): CoordinationBindingRow => ({
+  status: "active",
+  scopeType: COORDINATION_SCOPE_TYPE,
+  resourceType: COORDINATION_RESOURCE_TYPE,
+  resourceRef: "dependency-advisory-watch",
+  ...over,
+});
+
+describe("resolveAuthorityBindingEligibility", () => {
+  it("is eligible with an active coordination binding for the shape", () => {
+    expect(resolveAuthorityBindingEligibility("dependency-advisory-watch", [coordination()])).toBe(
+      "eligible",
+    );
+  });
+
+  it("reports ABSENT, not unknown, when it looked and found none", () => {
+    // The whole point. "unknown" told the operator nothing and named no remedy;
+    // "absent" says a binding is missing and creating one resolves it.
+    expect(resolveAuthorityBindingEligibility("dependency-advisory-watch", [])).toBe("absent");
+  });
+
+  it("does NOT accept a route binding as coordination authority", () => {
+    // The option the kernel rejected (DI-F8C8042FBB5D): an agent bound to
+    // /platform has page access, not authority to drive a room to verdict.
+    const routeBinding = coordination({ scopeType: "route", resourceType: "route", resourceRef: "/platform" });
+    expect(resolveAuthorityBindingEligibility("dependency-advisory-watch", [routeBinding])).toBe(
+      "absent",
+    );
+  });
+
+  it("does not accept a binding for a different shape", () => {
+    const other = coordination({ resourceRef: "payables-watch" });
+    expect(resolveAuthorityBindingEligibility("dependency-advisory-watch", [other])).toBe("absent");
+  });
+
+  it("distinguishes suspended from absent, because the remedy differs", () => {
+    // Reinstate vs grant. Collapsing them would send the operator to the wrong fix.
+    expect(
+      resolveAuthorityBindingEligibility("dependency-advisory-watch", [
+        coordination({ status: "suspended" }),
+      ]),
+    ).toBe("suspended");
+  });
+
+  it("treats a draft binding as absent — authority is not granted until it is active", () => {
+    expect(
+      resolveAuthorityBindingEligibility("dependency-advisory-watch", [
+        coordination({ status: "draft" }),
+      ]),
+    ).toBe("absent");
+  });
+
+  it("prefers an active binding when several exist for the shape", () => {
+    expect(
+      resolveAuthorityBindingEligibility("dependency-advisory-watch", [
+        coordination({ status: "suspended" }),
+        coordination({ status: "active" }),
+      ]),
+    ).toBe("eligible");
+  });
+
+  it("is unknown — not absent — when the room claims no shape", () => {
+    // Nothing was looked up, so nothing was found to be missing. Saying "absent"
+    // here would name a remedy that does not apply.
+    expect(resolveAuthorityBindingEligibility(null, [])).toBe("unknown");
+  });
+});
+
+describe("resolveJsiEligibility", () => {
+  it("is not-applicable when the platform has no qualification scheme", () => {
+    // DI-FF4A015CF917. No JSI qualification model exists in the schema, so
+    // requiring one denies every coworker on every install permanently. A gate
+    // that can never pass is not a safeguard.
+    expect(resolveJsiEligibility({ schemePresent: false })).toBe("not-applicable");
+  });
+
+  it("still blocks a coworker who fails a scheme that DOES exist", () => {
+    // The control stays real. This is the difference between the recommended
+    // option and simply deleting the check (which scored 0.713).
+    expect(resolveJsiEligibility({ schemePresent: true, qualified: false })).toBe("absent");
+  });
+
+  it("is eligible for a coworker qualified under a present scheme", () => {
+    expect(resolveJsiEligibility({ schemePresent: true, qualified: true })).toBe("eligible");
+  });
+
+  it("reports stale qualification distinctly from absent", () => {
+    expect(resolveJsiEligibility({ schemePresent: true, qualified: true, stale: true })).toBe("stale");
+  });
+
+  it("is unknown when a scheme exists but the lookup returned nothing", () => {
+    expect(resolveJsiEligibility({ schemePresent: true })).toBe("unknown");
+  });
+});
+
+describe("jsiSchemePresent", () => {
+  it("is false against a client with no qualification model — today's platform", () => {
+    expect(jsiSchemePresent({ workroom: {}, principal: {}, authorityBinding: {} })).toBe(false);
+  });
+
+  it("becomes true the moment a qualification model exists, with no code change", () => {
+    // The tripwire: detection is from the substrate, not a constant, so the gate
+    // turns real on its own rather than waiting for someone to remember.
+    for (const model of JSI_QUALIFICATION_MODELS) {
+      expect(jsiSchemePresent({ [model]: {} })).toBe(true);
+    }
+  });
+});
+
+describe("resolveCoordinatorEligibility", () => {
+  it("produces the state today's platform actually has: absent authority, N/A qualification", () => {
+    expect(
+      resolveCoordinatorEligibility({
+        shapeKey: "dependency-advisory-watch",
+        bindings: [],
+        schemePresent: false,
+      }),
+    ).toEqual({ authorityBinding: "absent", jsi: "not-applicable" });
+  });
+
+  it("produces a fully eligible overseer once the binding exists", () => {
+    expect(
+      resolveCoordinatorEligibility({
+        shapeKey: "dependency-advisory-watch",
+        bindings: [coordination()],
+        schemePresent: false,
+      }),
+    ).toEqual({ authorityBinding: "eligible", jsi: "not-applicable" });
+  });
+});

--- a/apps/web/lib/work-management/coordinator-eligibility.ts
+++ b/apps/web/lib/work-management/coordinator-eligibility.ts
@@ -1,0 +1,133 @@
+// Who may coordinate a Workroom — the producer the conformance gate was waiting
+// for (BI-E0728215).
+//
+// `workroom-shape-conformance` reads `coordinatorEligibility` and falls back to
+// `{ jsi: "unknown", authorityBinding: "unknown" }` when it is absent. NOTHING
+// populated it. The field was undefined on every tick of every room, so every AI
+// Process Overseer was refused permanently — not for want of configuration, but
+// because the check had no producer. This is that producer.
+//
+// Two governed decisions shape it, both scored by the kernel rather than assumed:
+//
+//   DI-F8C8042FBB5D — authority comes from an EXPLICIT binding (margin 9.318,
+//   high confidence). Reusing an agent's route binding, or treating the work
+//   shape's own declaration as authority, both scored ~2.3-2.9; `Least privilege,
+//   deny by default` contributed NEGATIVELY to each. A binding is a row an
+//   operator can see, suspend and revoke — not an inference.
+//
+//   DI-FF4A015CF917 — an ABSENT qualification scheme is not a failed one (margin
+//   5.420, high confidence). Removing the JSI check outright scored 0.713.
+//
+// Pure resolution over supplied state; the caller owns the queries.
+
+/** Mirrors WORKROOM_COORDINATOR_ELIGIBILITY_STATES, plus `not-applicable`. */
+export type CoordinatorEligibilityState =
+  | "eligible"
+  | "absent"
+  | "stale"
+  | "narrowed"
+  | "suspended"
+  | "incompatible"
+  | "not-applicable"
+  | "unknown";
+
+export type CoordinatorEligibility = {
+  jsi: CoordinatorEligibilityState;
+  authorityBinding: CoordinatorEligibilityState;
+};
+
+/** The scope an AuthorityBinding must carry to grant room coordination. A route
+ *  binding (`platform-engineer on /platform`) is page access and deliberately
+ *  does NOT qualify — that conflation is the option the kernel rejected. */
+export const COORDINATION_SCOPE_TYPE = "workroom";
+export const COORDINATION_RESOURCE_TYPE = "work-shape";
+
+/** Just the binding facts this resolution needs. */
+export type CoordinationBindingRow = {
+  status: string;
+  scopeType: string;
+  resourceType: string;
+  /** The work shape this binding grants coordination over. */
+  resourceRef: string;
+};
+
+/**
+ * Authority-binding eligibility for one agent coordinating one shape.
+ *
+ * `absent` — we looked and there is no binding. Honest and actionable: the room
+ * names what is missing, and creating the binding resolves it. This is the state
+ * that replaces the permanent, uninformative `unknown`.
+ *
+ * `suspended` — a binding exists but is not active. Distinguished from absent
+ * because the remedy differs: reinstate rather than grant.
+ */
+export function resolveAuthorityBindingEligibility(
+  shapeKey: string | null,
+  bindings: readonly CoordinationBindingRow[],
+): CoordinatorEligibilityState {
+  if (!shapeKey) return "unknown";
+  const forShape = bindings.filter(
+    (binding) =>
+      binding.scopeType === COORDINATION_SCOPE_TYPE &&
+      binding.resourceType === COORDINATION_RESOURCE_TYPE &&
+      binding.resourceRef === shapeKey,
+  );
+  if (forShape.length === 0) return "absent";
+  if (forShape.some((binding) => binding.status === "active")) return "eligible";
+  if (forShape.some((binding) => binding.status === "suspended")) return "suspended";
+  return "absent";
+}
+
+/**
+ * JSI qualification eligibility.
+ *
+ * There is no TAK-JSI qualification substrate in the schema — no qualification
+ * model exists, so no coworker on any install can be qualified. A precondition
+ * that can never be met is not a safeguard; it is a permanent denial wearing a
+ * safeguard's clothes, and it offers no graduated control at all.
+ *
+ * So an absent SCHEME resolves `not-applicable` (recorded on the room, does not
+ * block), while a scheme that exists and is not satisfied blocks exactly as
+ * before. `schemePresent` is detected from the substrate rather than hardcoded,
+ * so the control becomes real the day the qualification model lands — nobody has
+ * to remember to switch it on.
+ */
+export function resolveJsiEligibility(input: {
+  schemePresent: boolean;
+  qualified?: boolean;
+  stale?: boolean;
+}): CoordinatorEligibilityState {
+  if (!input.schemePresent) return "not-applicable";
+  if (input.stale) return "stale";
+  if (input.qualified === true) return "eligible";
+  if (input.qualified === false) return "absent";
+  return "unknown";
+}
+
+/** Candidate names for the qualification substrate, checked against the live
+ *  Prisma client. Presence of the model IS the scheme's presence — see
+ *  resolveJsiEligibility. Extend this list if the model lands under another name;
+ *  the accompanying test fails loudly if none is found AND the doc claims one. */
+export const JSI_QUALIFICATION_MODELS = [
+  "jsiQualification",
+  "jobQualification",
+  "agentQualification",
+] as const;
+
+/** True when the platform has a qualification substrate to evaluate against. */
+export function jsiSchemePresent(client: Record<string, unknown>): boolean {
+  return JSI_QUALIFICATION_MODELS.some((model) => model in client);
+}
+
+export function resolveCoordinatorEligibility(input: {
+  shapeKey: string | null;
+  bindings: readonly CoordinationBindingRow[];
+  schemePresent: boolean;
+  qualified?: boolean;
+  stale?: boolean;
+}): CoordinatorEligibility {
+  return {
+    authorityBinding: resolveAuthorityBindingEligibility(input.shapeKey, input.bindings),
+    jsi: resolveJsiEligibility(input),
+  };
+}

--- a/apps/web/lib/work-management/workroom-shape-conformance.ts
+++ b/apps/web/lib/work-management/workroom-shape-conformance.ts
@@ -85,11 +85,22 @@ export const WORKROOM_COORDINATOR_ELIGIBILITY_STATES = [
   "narrowed",
   "suspended",
   "incompatible",
+  // An absent qualification SCHEME is not a failed qualification (DI-FF4A015CF917,
+  // margin 5.420). A precondition nothing on the platform can satisfy is a
+  // permanent denial, not a safeguard; this state records that honestly and does
+  // not block, while a scheme that exists and is unmet blocks exactly as before.
+  "not-applicable",
   "unknown",
 ] as const;
 
 export type WorkroomCoordinatorEligibilityState =
   (typeof WORKROOM_COORDINATOR_ELIGIBILITY_STATES)[number];
+
+/** States that do NOT raise a deviation. `eligible` is a positive verdict;
+ *  `not-applicable` means the platform has no scheme to verdict against, so
+ *  there is nothing for this coworker to fail. Every other state — including
+ *  `unknown` — still blocks. */
+const SATISFIED_ELIGIBILITY: ReadonlySet<string> = new Set(["eligible", "not-applicable"]);
 
 export type WorkroomCoordinatorEligibility = {
   jsi: WorkroomCoordinatorEligibilityState;
@@ -250,13 +261,13 @@ export function evaluateWorkroomShapeConformance(
       jsi: "unknown" as const,
       authorityBinding: "unknown" as const,
     };
-    if (eligibility.authorityBinding !== "eligible") {
+    if (!SATISFIED_ELIGIBILITY.has(eligibility.authorityBinding)) {
       deviations.push({
         code: "coordinator_authority_binding_ineligible",
         summary: `The AI Process Overseer's TAK authority binding is ${eligibility.authorityBinding}.`,
       });
     }
-    if (eligibility.jsi !== "eligible") {
+    if (!SATISFIED_ELIGIBILITY.has(eligibility.jsi)) {
       deviations.push({
         code: "coordinator_jsi_ineligible",
         summary: `The AI Process Overseer's JSI qualification is ${eligibility.jsi}.`,

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -569,6 +569,53 @@ The drive tick now reconciles the declared tree before driving:
 `nestedRelations` on the drive result is how an operator tells "nesting is done"
 from "nesting was never written" — the distinction that hid this defect.
 
+## Who may coordinate: authority, and a gate with no key
+
+Conformance refuses an AI Process Overseer unless its authority binding and its
+TAK-JSI qualification are both eligible. It reads `coordinatorEligibility` and
+defaults to `unknown` when absent — and until `BI-E0728215` **nothing populated
+that field**. It was undefined on every tick of every room, so every AI overseer
+was refused permanently: not for want of configuration, but because the check had
+no producer. Measured at the time: 124 AI coworkers, 0 with coordination
+authority, 0 dispatches ever.
+
+Two governed decisions, both scored rather than assumed:
+
+**Authority comes from an explicit binding** (`DI-F8C8042FBB5D`, margin 9.318,
+high confidence). Reusing an agent's route binding, or letting the work shape's
+own declaration stand as authority, both scored ~2.3-2.9 — `Least privilege, deny
+by default` contributed *negatively* to each. A route binding
+(`platform-engineer on /platform`) is page access; it is not authority to drive a
+room to verdict.
+
+The shape *proposes* and the binding *grants*. Coordination bindings are derived
+from the standing shapes and materialized as explicit `AuthorityBinding` rows
+(`scopeType: workroom`, `resourceType: work-shape`), exactly as
+`bootstrapAuthorityBindings` derives route bindings from `ROUTE_AGENT_MAP_ENTRIES`.
+The distinction the kernel drew is not where the proposal comes from but what the
+grant *is*: a row an operator can see, suspend and revoke. Re-seeding never
+re-grants a binding a human suspended.
+
+The driver comes from the ownership ladder's shape rung, which already excludes
+the governed-decision stage — so seeding can never introduce
+`coordinator_approver_overlap`.
+
+**An absent scheme is not a failed one** (`DI-FF4A015CF917`, margin 5.420, high
+confidence). There is no TAK-JSI qualification substrate in the schema: no
+qualification model exists, so no coworker on any install could ever be
+qualified. A precondition nothing can satisfy is not a safeguard; it is a
+permanent denial wearing a safeguard's clothes, and it offers no graduated
+control at all.
+
+So `jsi` resolves `not-applicable` when the platform has no scheme — recorded on
+the room, not blocking — while a scheme that exists and is unmet blocks exactly
+as before. Deleting the check outright scored 0.713 and was rejected. Scheme
+presence is detected from the live Prisma client rather than a constant, so the
+control becomes real the day a qualification model lands, with no code change and
+nobody needing to remember.
+
+`unknown` still blocks. Only `eligible` and `not-applicable` satisfy the gate.
+
 ## Related references
 
 - [Workroom vocabulary boundary](workroom-vocabulary-boundary.md) — what the word means at each layer

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -308,6 +308,14 @@ lines, then `wsl --shutdown` and restart Docker Desktop. This is the
 **Build fails with an out-of-memory / killed error (Customizable mode).**
 The Docker VM is under-provisioned — see [Docker memory](#docker-memory).
 
+**Builds fail later with `host-capacity-lost:host-memory-low`.**
+The opposite problem: the Docker VM is over-provisioned and starving the host.
+Preflight warns when the VM exceeds half of host RAM. On Windows this is usually
+benign — WSL2 sizes dynamically and `autoMemoryReclaim` returns freed pages — but
+an explicit `memory=` in `%USERPROFILE%\.wslconfig` pins it. Remove or lower it,
+then `wsl --shutdown`. (On macOS the VM is fixed-size and never returns memory to
+the host, so over-allocation there ratchets until builds fail.)
+
 **`/api/health` returns 500.**
 The database migrations may not have completed. Tail the portal-init
 container: `docker compose logs portal-init`.

--- a/scripts/installer/lib/preflight.sh
+++ b/scripts/installer/lib/preflight.sh
@@ -137,6 +137,41 @@ dpf_preflight_unsupported_host() {
 DPF_DOCKER_MIN_MEM_MB="${DPF_DOCKER_MIN_MEM_MB:-6144}"   # 6 GB hard floor
 DPF_DOCKER_WARN_MEM_MB="${DPF_DOCKER_WARN_MEM_MB:-8192}" # 8 GB soft target
 
+# ── ...and a ceiling. ─────────────────────────────────────────────────────
+# The floor check above is one-sided: the more memory the VM is given, the
+# happier it is. That is wrong on macOS, and it cost nine fenced builds on a
+# 128 GB host configured with a 68.5 GiB Docker VM running 3.5 GB of
+# containers.
+#
+# The platform difference is architectural, not capacity:
+#
+#   Windows (WSL2)  the VM sizes dynamically and, since WSL 2.0,
+#                   autoMemoryReclaim returns freed pages to Windows. A
+#                   generous ceiling costs little because it is given back.
+#   macOS (VZ)      a FIXED-size Apple Virtualization VM. Its resident size
+#                   grows toward the ceiling as pages are touched and is
+#                   NEVER returned to the host. Over-allocation ratchets
+#                   until the host starves.
+#
+# Starving the host does not break the install — it breaks the local-CI
+# capacity watchdog later, with `host-capacity-lost:host-memory-low` and no
+# hint as to why. So this warns loudly with the actual remedy rather than
+# refusing: the install itself is fine.
+DPF_DOCKER_MAX_MEM_FRACTION="${DPF_DOCKER_MAX_MEM_FRACTION:-50}"  # percent of host RAM
+
+# Host physical memory in MB, or 0 when it cannot be determined.
+_dpf_host_mem_mb() {
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    local bytes
+    bytes="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
+    echo $(( bytes / 1048576 ))
+  elif [ -r /proc/meminfo ]; then
+    awk '/^MemTotal:/ { print int($2 / 1024); exit }' /proc/meminfo 2>/dev/null || echo 0
+  else
+    echo 0
+  fi
+}
+
 dpf_preflight_docker_memory() {
   if ! command -v docker >/dev/null 2>&1; then
     return 0  # docker.sh will handle a missing daemon later
@@ -168,6 +203,26 @@ dpf_preflight_docker_memory() {
     info "  To increase: Docker Desktop → Settings → Resources → Memory."
   else
     ok "Docker VM memory: ${mem_mb} MB"
+  fi
+
+  # Ceiling: an over-allocated VM starves the host it runs on.
+  local host_mb ceiling_mb
+  host_mb="$(_dpf_host_mem_mb)"
+  if [ "${host_mb:-0}" -gt 0 ] 2>/dev/null; then
+    ceiling_mb=$(( host_mb * DPF_DOCKER_MAX_MEM_FRACTION / 100 ))
+    if [ "$mem_mb" -gt "$ceiling_mb" ] 2>/dev/null; then
+      warn "Docker VM memory is ${mem_mb} MB of ${host_mb} MB host RAM (over ${DPF_DOCKER_MAX_MEM_FRACTION}%)."
+      if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+        info "  On macOS the Docker VM never returns memory to the host, so this ratchets"
+        info "  upward until builds fail with host-capacity-lost:host-memory-low."
+        info "  Fix: Docker Desktop -> Settings -> Resources -> Memory. 16-24 GB is ample;"
+        info "  DPF containers use around 4 GB and the rest is build headroom."
+      else
+        info "  WSL2 reclaims freed memory, so this is usually benign — but an explicit"
+        info "  memory= in %USERPROFILE%\\.wslconfig pins it. Remove it, or lower it, and"
+        info "  run: wsl --shutdown"
+      fi
+    fi
   fi
   return 0
 }


### PR DESCRIPTION
## The gate had no producer

Conformance refuses an AI Process Overseer unless its authority binding and TAK-JSI qualification are eligible. It reads `coordinatorEligibility` and defaults to `unknown` when absent — and **nothing populated that field**. Undefined on every tick of every room, so every AI overseer was refused permanently: not for want of configuration, but because the check had no producer.

Measured before this: **124 AI coworkers, 0 with coordination authority, 0 dispatches ever.**

## Two contract choices, routed through the kernel rather than assumed

**`DI-F8C8042FBB5D`** — authority comes from an **explicit binding** (composite 12.27, margin 9.32, high confidence, autonomy-eligible). Reusing an agent's route binding, or letting the work shape's own declaration stand as authority, both scored ~2.3–2.9; *Least privilege, deny by default* contributed **negatively** to each. A route binding (`platform-engineer on /platform`) is page access, not authority to drive a room to verdict.

So the shape **proposes** and the binding **grants**. Coordination bindings are derived from the standing shapes and materialized as explicit `AuthorityBinding` rows (`scopeType: workroom`, `resourceType: work-shape`) — exactly as `bootstrapAuthorityBindings` derives route bindings from `ROUTE_AGENT_MAP_ENTRIES`. The distinction the kernel drew is not where the proposal comes from but what the grant *is*: a row an operator can see, suspend and revoke.

Safeguards that follow from it:
- Re-seeding **never re-grants a binding a human suspended** — that would make this an authority-laundering path rather than a grant.
- The driver comes from the ownership ladder's shape rung, which excludes the governed-decision stage, so seeding **cannot introduce `coordinator_approver_overlap`**.
- The grant is *process* coordination only. It authorizes no outbound or irreversible act; a governed-decision stage still requires its separate approver.

**`DI-FF4A015CF917`** — an **absent scheme is not a failed one** (composite 9.74, margin 5.42, high confidence). There is no TAK-JSI qualification substrate in the schema — no qualification model exists, so no coworker on any install could ever be qualified. A precondition nothing can satisfy is not a safeguard; it is a permanent denial wearing a safeguard's clothes, offering no graduated control at all.

`jsi` now resolves `not-applicable` when the platform has no scheme (recorded on the room, not blocking), while a scheme that exists and is unmet blocks exactly as before. **Deleting the check outright scored 0.713 and was rejected.** Scheme presence is detected from the live Prisma client rather than a constant, so the control becomes real the day a qualification model lands — no code change, nobody has to remember.

`unknown` still blocks. Only `eligible` and `not-applicable` satisfy the gate.

Authority binding also now reports **`absent`** rather than `unknown` when it looks and finds nothing, so the room names a remedy instead of shrugging; `suspended` is distinguished from `absent` because reinstating differs from granting.

## Also: the installer's Docker memory check was one-sided

It enforced a 6 GB floor and got *happier* the more memory the VM was given — it would print `ok: 68698 MB` for the configuration that fenced nine builds on this host (a **68.5 GiB VM on 128 GB RAM running 3.5 GB of containers**).

It now warns above half of host RAM, with platform-correct remediation:

- **macOS** — a fixed-size Apple Virtualization VM whose resident size grows toward the ceiling and is *never returned to the host*, so over-allocation ratchets until builds fail with `host-capacity-lost:host-memory-low`.
- **Windows** — WSL2 sizes dynamically and `autoMemoryReclaim` returns freed pages, so a generous ceiling is usually benign; the culprit is an explicit `memory=` in `.wslconfig`.

Verified the ceiling trips on this machine (68698 MB VM vs a 65536 MB ceiling on 131072 MB host). Windows troubleshooting doc updated to cover the over-provisioned case alongside the under-provisioned one.

## Verification

- 64 pregate preflight guards clean
- 851 tests pass (100 files) — 21 new across eligibility and coordination bindings
- `tsc --noEmit`: exit 0
- `bash -n` on the preflight, plus the ceiling logic exercised against this host's real values

**The heavy local-CI build was NOT run and is NOT passed** — fenced on `host-capacity-lost:host-memory-low`, which is precisely the defect this PR's ceiling now warns about. Recorded `operator-emergency` override; cloud merge queue is the adjudicating build per AGENTS.md §4.

`BI-E0728215`

Local-CI-Override: operator-emergency: heavy build unrun (NOT passed) — local-CI fenced on host-capacity-lost:host-memory-low. Fast tier clean (64 preflight guards, 851 tests, tsc --noEmit exit 0). Cloud merge queue is the adjudicating build per AGENTS.md 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
