### PR TITLE
fix(ops): make the scheduled-job kill switch load-bearing (BI-7E49FA15)

### DIFF
--- a/apps/web/lib/asset-intelligence/catalog-sweep-runner.ts
+++ b/apps/web/lib/asset-intelligence/catalog-sweep-runner.ts
@@ -9,6 +9,7 @@ import { gunzipSync } from "node:zlib";
 import type { CatalogSweepResult } from "@dpf/db";
 import type { InventoryLifecycleProjectionResult } from "@/lib/lifecycle/inventory-projector";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { isJobEnabled } from "@/lib/operate/scheduled-jobs/core";
 import {
   CATALOG_SWEEP_JOB_ID,
   CATALOG_SWEEP_JOB_NAME,
@@ -64,10 +65,13 @@ export async function runCatalogEnrichmentSweepJob(
       nextRunAt: computeNextRunAt("weekly", new Date()),
     },
     update: {},
-    select: { enabled: true, schedule: true },
+    select: { schedule: true },
   });
 
-  if (job.enabled === false) {
+  // Operator kill switch — the one shared implementation (BI-7E49FA15). Kept
+  // here as well as in gateAtEntry because the run-now event path reaches this
+  // runner without passing through the cron entry gate.
+  if (!(await isJobEnabled(CATALOG_SWEEP_JOB_ID))) {
     return { skipped: true, reason: "disabled" };
   }
 

--- a/apps/web/lib/asset-intelligence/identity-inference-runner.ts
+++ b/apps/web/lib/asset-intelligence/identity-inference-runner.ts
@@ -16,6 +16,7 @@ import type {
   UnresolvedEntityRow,
 } from "@dpf/db";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { isJobEnabled } from "@/lib/operate/scheduled-jobs/core";
 import {
   IDENTITY_INFERENCE_JOB_ID,
   IDENTITY_INFERENCE_JOB_NAME,
@@ -142,10 +143,13 @@ export async function runIdentityInferenceFallbackJob(
       nextRunAt: computeNextRunAt("weekly", new Date()),
     },
     update: {},
-    select: { enabled: true, schedule: true },
+    select: { schedule: true },
   });
 
-  if (job.enabled === false) {
+  // Operator kill switch — the one shared implementation (BI-7E49FA15). Kept
+  // here as well as in gateAtEntry because the run-now event path reaches this
+  // runner without passing through the cron entry gate.
+  if (!(await isJobEnabled(IDENTITY_INFERENCE_JOB_ID))) {
     return { skipped: true, reason: "disabled" };
   }
 

--- a/apps/web/lib/operate/inngest-retention/run.ts
+++ b/apps/web/lib/operate/inngest-retention/run.ts
@@ -9,6 +9,8 @@
 
 import { type Prisma } from "@dpf/db";
 
+import { isJobEnabled } from "@/lib/operate/scheduled-jobs/core";
+
 import {
   runInngestRetentionSweep,
   type InngestRetentionSweepReport,
@@ -92,14 +94,9 @@ export async function executeScheduledInngestRetentionSweep(opts: {
   const { prisma } = await import("@dpf/db");
 
   // Operator kill switch. A maintenance sweep MUST be disableable without code.
-  const job = await prisma.scheduledJob
-    .findUnique({
-      where: { jobId: INNGEST_RETENTION_JOB_ID },
-      select: { enabled: true, metadata: true },
-    })
-    .catch(() => null);
-
-  if (job && job.enabled === false) {
+  // Shared implementation (BI-7E49FA15); kept here as well as in gateAtEntry
+  // because the run-now event path reaches this runner without the entry gate.
+  if (!(await isJobEnabled(INNGEST_RETENTION_JOB_ID))) {
     return emptyReport(now, dryRun, "disabled-by-operator");
   }
 
@@ -131,6 +128,12 @@ export async function executeScheduledInngestRetentionSweep(opts: {
   }
 
   if (!dryRun) {
+    const job = await prisma.scheduledJob
+      .findUnique({
+        where: { jobId: INNGEST_RETENTION_JOB_ID },
+        select: { metadata: true },
+      })
+      .catch(() => null);
     const prior = (job?.metadata ?? {}) as { recentRuns?: unknown[] };
     const recentRuns = Array.isArray(prior.recentRuns) ? prior.recentRuns : [];
     const nextRecent = [summarizeForMetadata(report), ...recentRuns].slice(

--- a/apps/web/lib/operate/retention/run.ts
+++ b/apps/web/lib/operate/retention/run.ts
@@ -10,6 +10,7 @@
 
 import { type Prisma } from "@dpf/db";
 
+import { isJobEnabled } from "@/lib/operate/scheduled-jobs/core";
 import { runRetentionSweep, type RetentionSweepReport } from "./execute";
 import type { RetentionPrismaClient } from "./policies";
 import { resolveOrgIndustryKey } from "./industry-floors";
@@ -65,14 +66,9 @@ export async function executeScheduledRetentionSweep(opts: {
   const retentionPrisma = prisma as unknown as RetentionPrismaClient;
 
   // Operator kill switch. A destructive purge MUST be disableable without code.
-  const job = await prisma.scheduledJob
-    .findUnique({
-      where: { jobId: DATA_RETENTION_JOB_ID },
-      select: { enabled: true, metadata: true },
-    })
-    .catch(() => null);
-
-  if (job && job.enabled === false) {
+  // Shared implementation (BI-7E49FA15); kept here as well as in gateAtEntry
+  // because the run-now event path reaches this runner without the entry gate.
+  if (!(await isJobEnabled(DATA_RETENTION_JOB_ID))) {
     return {
       dryRun,
       industryKey: null,
@@ -98,6 +94,12 @@ export async function executeScheduledRetentionSweep(opts: {
   });
 
   if (!dryRun) {
+    const job = await prisma.scheduledJob
+      .findUnique({
+        where: { jobId: DATA_RETENTION_JOB_ID },
+        select: { metadata: true },
+      })
+      .catch(() => null);
     const prior = (job?.metadata ?? {}) as { recentRuns?: unknown[] };
     const recentRuns = Array.isArray(prior.recentRuns) ? prior.recentRuns : [];
     const nextRecent = [summarizeForMetadata(report), ...recentRuns].slice(

--- a/apps/web/lib/operate/scheduled-jobs/catalog-flow.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog-flow.ts
@@ -14,6 +14,7 @@ export const FLOW_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "async-inference-operation-reconciliation",
     inngestId: ASYNC_INFERENCE_OPERATION_RECOVERY_INNGEST_ID,
+    honorsEnabledGate: true,
     name: "Async inference operation reconciliation",
     purpose:
       "Recovers advisory wake loss for due durable provider operations without repeating a provider-start request.",
@@ -26,6 +27,7 @@ export const FLOW_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "async-inference-operation-outbox",
     inngestId: ASYNC_INFERENCE_OPERATION_OUTBOX_INNGEST_ID,
+    honorsEnabledGate: true,
     name: "Async inference transition outbox",
     purpose:
       "Publishes undelivered durable operation transitions with deterministic identities so consumers can reconcile after event loss.",
@@ -38,6 +40,7 @@ export const FLOW_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "mcp-task-run-dispatch-reconciliation",
     inngestId: "mcp/task-run-dispatch-reconciliation",
+    honorsEnabledGate: true,
     name: "External MCP task dispatch reconciliation",
     purpose:
       "Re-enqueues persisted external MCP TaskRuns whose deterministic background handoff was lost or never claimed.",
@@ -50,6 +53,7 @@ export const FLOW_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "nonprod-lease-wait-reconciliation",
     inngestId: "nonprod/lease-wait-reconciliation",
+    honorsEnabledGate: true,
     name: "Nonproduction lease wait reconciliation",
     purpose:
       "Re-publishes capacity for the FIFO head of each queued nonproduction environment so durable waiters recover after missed events or worker restarts.",

--- a/apps/web/lib/operate/scheduled-jobs/catalog-hygiene.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog-hygiene.ts
@@ -1,0 +1,110 @@
+// apps/web/lib/operate/scheduled-jobs/catalog-hygiene.ts
+//
+// Catalog entries for the platform LIVENESS and HOST-HYGIENE crons: the
+// watchdog that keeps stuck work from wedging the runtime, token-expiry
+// monitoring, and the janitors that reclaim runtime targets, Docker
+// artifacts, worktrees, sandbox builds and infra leftovers. They share a
+// shape — core-locked, maintenance effect on the host itself — and most of
+// them are deliberately outside the ScheduledJob.enabled kill switch
+// (see each entry's ungatedReason, BI-7E49FA15).
+//
+// Split out of catalog.ts, which crossed the 800-LOC module ceiling when
+// every entry gained its kill-switch posture. Same precedent as
+// ./catalog-watches and ./catalog-flow.
+
+import type { ScheduledJobCatalogEntry } from "./catalog-types";
+
+export const HYGIENE_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
+  {
+    jobId: "taskrun-watchdog",
+    inngestId: "ops/taskrun-watchdog",
+    ungatedReason:
+      "Liveness guard: must keep running through every drain to detect stuck coordinators, so it is exempt from gateAtEntry entirely.",
+    name: "Task-run watchdog",
+    purpose: "Detects and resolves stuck task runs. Liveness guard for the task system.",
+    cron: "* * * * *",
+    cadence: "Every minute",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "token-expiry-monitor",
+    inngestId: "ops/token-expiry-monitor",
+    honorsEnabledGate: true,
+    name: "Token expiry monitor",
+    purpose: "Warns before provider/integration credentials expire. Auth continuity.",
+    cron: "0 9 * * *",
+    cadence: "Daily at 09:00",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "runtime-target-janitor",
+    inngestId: "ops/runtime-target-janitor",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
+    name: "Runtime-target janitor",
+    purpose: "Sweeps stale runtime targets + expires leases. Resource hygiene.",
+    cron: "0 * * * *",
+    cadence: "Hourly",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "runtime-artifact-janitor",
+    inngestId: "ops/runtime-artifact-janitor",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
+    name: "Runtime-artifact janitor",
+    purpose:
+      "Reaps orphaned CI build images + stray compose projects (and their named volumes). Default OFF; ENABLED alone = observe-only (logs would-reap); ENABLED + DPF_RUNTIME_ARTIFACT_JANITOR_AUTO_REAP=1 = live reap. CLI guards keep root dpf, running, and live-worktree stacks safe.",
+    cron: "20 5 * * *",
+    cadence: "Daily at 05:20",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "worktree-janitor",
+    inngestId: "ops/worktree-janitor",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
+    name: "Worktree janitor fleet backstop (Tier-A)",
+    purpose:
+      "OPTIONAL fleet sweeper for leftover worktrees. Primary reaping is session-lifecycle (worktree-session-hygiene on SessionEnd). This portal Inngest job dry-runs when DPF_WORKTREE_JANITOR_ENABLED=1; live Tier-A only with DPF_WORKTREE_JANITOR_AUTO_REAP=1. Not a per-client CLI cron.",
+    cron: "40 5 * * *",
+    cadence: "Daily at 05:40",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "sandbox-build-gc",
+    inngestId: "ops/sandbox-build-gc",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
+    name: "Build Studio sandbox build GC",
+    purpose:
+      "Backstop: removes leftover /workspace/.builds/<FB-*> for terminal or missing FeatureBuilds; optional aged build/* branch delete when DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES=1. Primary cleanup is transactional on promote/abandon/complete. Enable with DPF_SANDBOX_BUILD_GC_ENABLED=1.",
+    cron: "50 5 * * *",
+    cadence: "Daily at 05:50",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
+    jobId: "infra-prune",
+    inngestId: "ops/infra-prune",
+    honorsEnabledGate: true,
+    name: "Infrastructure prune",
+    purpose: "Weekly reclamation of stale infra. Destructive — kept core-locked.",
+    cron: "0 3 * * 0",
+    cadence: "Weekly, Sun 03:00",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+] as const;

--- a/apps/web/lib/operate/scheduled-jobs/catalog-types.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog-types.ts
@@ -30,6 +30,11 @@ export interface ScheduledJobCatalogEntry {
    *  read the column, and a switch that silently does nothing is worse than an
    *  absent one (BI-7E49FA15). */
   honorsEnabledGate?: boolean;
+  /** Declared reason a job is deliberately NOT gated on ScheduledJob.enabled.
+   *  Every entry carries exactly one of `honorsEnabledGate: true` or a
+   *  non-empty `ungatedReason` (catalog.test.ts enforces it), so "no kill
+   *  switch" is always a recorded decision rather than an omission. */
+  ungatedReason?: string;
   /** Inngest event name that triggers a one-shot manual run, or null when no
    *  manual-trigger event function exists for this job. */
   runNowEvent: string | null;

--- a/apps/web/lib/operate/scheduled-jobs/catalog-watches.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog-watches.ts
@@ -41,6 +41,7 @@ export const WATCH_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: BUSINESS_JOURNEY_WATCHDOG_JOB_ID,
     inngestId: BUSINESS_JOURNEY_WATCHDOG_INNGEST_ID,
+    honorsEnabledGate: true,
     name: BUSINESS_JOURNEY_WATCHDOG_JOB_NAME,
     purpose:
       "BI-E105303D / EP-PROACTIVE-OPS: exercises the install's critical business journeys (front door, enquiry, booking, sign-in, checkout) against the running system, records evidence, and raises a journey_failure issue the Needs-you inbox surfaces. If it stops, a broken signup or booking path goes unnoticed until a customer complains.",
@@ -53,6 +54,7 @@ export const WATCH_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: OBLIGATION_WATCH_JOB_ID,
     inngestId: OBLIGATION_WATCH_INNGEST_ID,
+    honorsEnabledGate: true,
     name: OBLIGATION_WATCH_JOB_NAME,
     purpose:
       "TAK §8.11 obligation-assurance-watch: sweeps recorded obligations, control reviews, and licence expiries against a 30-day look-ahead and raises an assurance finding for each one falling due, plus for any recurrence that has no next date. The accountable owner decides the response; this job never decides it. If it stops, six recorded cadence columns go back to reading as controls in force while behaving as controls that are not.",
@@ -65,6 +67,7 @@ export const WATCH_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: WORKROOM_DRIVE_JOB_ID,
     inngestId: WORKROOM_DRIVE_INNGEST_ID,
+    honorsEnabledGate: true,
     name: WORKROOM_DRIVE_JOB_NAME,
     purpose:
       "BI-FCD639D9: wakes standing Workrooms on their declared trigger, dispatches agent stages through ScheduledAgentTask, converts human/governed stages into attention, and stops on budget, review, or a declared stop. If it stops, standing rooms wait for a person to notice.",

--- a/apps/web/lib/operate/scheduled-jobs/catalog.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.test.ts
@@ -1,0 +1,38 @@
+// BI-7E49FA15 — every catalogued cron records its kill-switch posture.
+//
+// The Scheduled Jobs surface renders killSwitchEnforced from honorsEnabledGate,
+// and gateAtEntry enforces ScheduledJob.enabled only for entries that declare
+// it. An entry with neither flag is a job whose Disable button silently does
+// nothing — the defect this item fixed — so the catalog must say, for every
+// row, either "gated" or exactly why not.
+
+import { describe, expect, it } from "vitest";
+
+import { SCHEDULED_JOB_CATALOG, getCatalogEntryByInngestId } from "./catalog";
+
+describe("scheduled-job catalog kill-switch posture (BI-7E49FA15)", () => {
+  it("every entry declares exactly one of honorsEnabledGate: true or a non-empty ungatedReason", () => {
+    const offenders = SCHEDULED_JOB_CATALOG.filter((e) => {
+      const gated = e.honorsEnabledGate === true;
+      const reasoned =
+        typeof e.ungatedReason === "string" && e.ungatedReason.trim().length > 0;
+      return gated === reasoned;
+    }).map((e) => e.inngestId);
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the quiescence callers deliberately ungated", () => {
+    for (const inngestId of ["ops/self-upgrade-scheduled", "ops/all-backups-daily-scheduled"]) {
+      const entry = getCatalogEntryByInngestId(inngestId);
+      expect(entry?.honorsEnabledGate).not.toBe(true);
+      expect(entry?.ungatedReason).toMatch(/quiescence/i);
+    }
+  });
+
+  it("resolves an entry by Inngest function id and nothing for an unknown id", () => {
+    expect(getCatalogEntryByInngestId("ops/code-graph-reconcile-scheduled")?.jobId).toBe(
+      "code-graph-reconcile",
+    );
+    expect(getCatalogEntryByInngestId("ops/no-such-function")).toBeUndefined();
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -55,6 +55,7 @@ import {
 import type { JobCategory, ScheduledJobCatalogEntry } from "./catalog-types";
 import { FLOW_JOB_CATALOG_ENTRIES } from "./catalog-flow";
 import { WATCH_JOB_CATALOG_ENTRIES } from "./catalog-watches";
+import { HYGIENE_JOB_CATALOG_ENTRIES } from "./catalog-hygiene";
 
 // Re-exported so existing importers of the catalog keep working; the types are
 // owned by ./catalog-types (BI-ED117C82).
@@ -223,98 +224,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     tracksRunData: false,
     runNowEvent: null,
   },
-  {
-    jobId: "taskrun-watchdog",
-    inngestId: "ops/taskrun-watchdog",
-    ungatedReason:
-      "Liveness guard: must keep running through every drain to detect stuck coordinators, so it is exempt from gateAtEntry entirely.",
-    name: "Task-run watchdog",
-    purpose: "Detects and resolves stuck task runs. Liveness guard for the task system.",
-    cron: "* * * * *",
-    cadence: "Every minute",
-    category: "core",
-    tracksRunData: false,
-    runNowEvent: null,
-  },
-  {
-    jobId: "token-expiry-monitor",
-    inngestId: "ops/token-expiry-monitor",
-    honorsEnabledGate: true,
-    name: "Token expiry monitor",
-    purpose: "Warns before provider/integration credentials expire. Auth continuity.",
-    cron: "0 9 * * *",
-    cadence: "Daily at 09:00",
-    category: "core",
-    tracksRunData: false,
-    runNowEvent: null,
-  },
-  {
-    jobId: "runtime-target-janitor",
-    inngestId: "ops/runtime-target-janitor",
-    ungatedReason:
-      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
-    name: "Runtime-target janitor",
-    purpose: "Sweeps stale runtime targets + expires leases. Resource hygiene.",
-    cron: "0 * * * *",
-    cadence: "Hourly",
-    category: "core",
-    tracksRunData: false,
-    runNowEvent: null,
-  },
-  {
-    jobId: "runtime-artifact-janitor",
-    inngestId: "ops/runtime-artifact-janitor",
-    ungatedReason:
-      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
-    name: "Runtime-artifact janitor",
-    purpose:
-      "Reaps orphaned CI build images + stray compose projects (and their named volumes). Default OFF; ENABLED alone = observe-only (logs would-reap); ENABLED + DPF_RUNTIME_ARTIFACT_JANITOR_AUTO_REAP=1 = live reap. CLI guards keep root dpf, running, and live-worktree stacks safe.",
-    cron: "20 5 * * *",
-    cadence: "Daily at 05:20",
-    category: "core",
-    tracksRunData: false,
-    runNowEvent: null,
-  },
-  {
-    jobId: "worktree-janitor",
-    inngestId: "ops/worktree-janitor",
-    ungatedReason:
-      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
-    name: "Worktree janitor fleet backstop (Tier-A)",
-    purpose:
-      "OPTIONAL fleet sweeper for leftover worktrees. Primary reaping is session-lifecycle (worktree-session-hygiene on SessionEnd). This portal Inngest job dry-runs when DPF_WORKTREE_JANITOR_ENABLED=1; live Tier-A only with DPF_WORKTREE_JANITOR_AUTO_REAP=1. Not a per-client CLI cron.",
-    cron: "40 5 * * *",
-    cadence: "Daily at 05:40",
-    category: "core",
-    tracksRunData: false,
-    runNowEvent: null,
-  },
-  {
-    jobId: "sandbox-build-gc",
-    inngestId: "ops/sandbox-build-gc",
-    ungatedReason:
-      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
-    name: "Build Studio sandbox build GC",
-    purpose:
-      "Backstop: removes leftover /workspace/.builds/<FB-*> for terminal or missing FeatureBuilds; optional aged build/* branch delete when DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES=1. Primary cleanup is transactional on promote/abandon/complete. Enable with DPF_SANDBOX_BUILD_GC_ENABLED=1.",
-    cron: "50 5 * * *",
-    cadence: "Daily at 05:50",
-    category: "core",
-    tracksRunData: false,
-    runNowEvent: null,
-  },
-  {
-    jobId: "infra-prune",
-    inngestId: "ops/infra-prune",
-    honorsEnabledGate: true,
-    name: "Infrastructure prune",
-    purpose: "Weekly reclamation of stale infra. Destructive — kept core-locked.",
-    cron: "0 3 * * 0",
-    cadence: "Weekly, Sun 03:00",
-    category: "core",
-    tracksRunData: false,
-    runNowEvent: null,
-  },
+  ...HYGIENE_JOB_CATALOG_ENTRIES,
   {
     jobId: "alert-delivery-bridge",
     inngestId: "ops/alert-delivery-bridge",

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -66,6 +66,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "index-integrity-sweep",
     inngestId: "ops/index-integrity-sweep",
+    honorsEnabledGate: true,
     name: "Live database index integrity sweep",
     purpose:
       "Checks the persistent install database for btree-to-heap disagreement and blocking collation drift, then raises one deduplicated platform issue before ghost records reach users.",
@@ -78,6 +79,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "build-pr-delivery-reconcile",
     inngestId: "build/pr-delivery-reconcile",
+    honorsEnabledGate: true,
     name: "Build Studio PR delivery reconcile",
     purpose:
       "Recovers Build Studio pull requests through exact-head readiness, stale-branch updates, and the protected merge queue without bypassing governed release.",
@@ -90,6 +92,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "data-control-operation-recovery",
     inngestId: "govern/data-control-operation-recovery-scheduled",
+    honorsEnabledGate: true,
     name: "Data control operation recovery",
     purpose:
       "Resumes durable data-control operations after worker crashes and escalates partial outcomes.",
@@ -115,6 +118,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "self-upgrade",
     inngestId: "ops/self-upgrade-scheduled",
+    ungatedReason:
+      "Quiescence caller: self-upgrade drives the drain itself, so gating it on ScheduledJob.enabled would deadlock the upgrade path and strand an install with no route to a fix.",
     name: "Self-upgrade reconcile",
     purpose:
       "Autonomous deployment of merged main PRs to this install. Core to keeping the platform current.",
@@ -132,6 +137,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "postgres-daily-backup",
     inngestId: "ops/postgres-daily-backup-scheduled",
+    honorsEnabledGate: true,
     name: "Postgres daily backup",
     purpose:
       "Durable Postgres backup. Disaster-recovery floor — never disable on a real install.",
@@ -144,6 +150,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "all-backups-daily",
     inngestId: "ops/all-backups-daily-scheduled",
+    ungatedReason:
+      "Quiescence caller: the daily backup fan-out is the disaster-recovery floor the upgrade path depends on; gating it would deadlock self-upgrade.",
     name: "All backups (fan-out)",
     purpose: "Fans out daily backups across Postgres / Neo4j / Qdrant sub-runners.",
     cron: "daily",
@@ -155,6 +163,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "model-discovery-refresh",
     inngestId: "inference/model-discovery-refresh",
+    honorsEnabledGate: true,
     name: "Model discovery refresh",
     purpose:
       "Refreshes the provider model catalog routing depends on. Stale data degrades model selection.",
@@ -167,6 +176,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "routing-reachability-preflight",
     inngestId: "inference/routing-reachability-preflight",
+    honorsEnabledGate: true,
     name: "Coworker routing reachability preflight",
     purpose: "Dry-runs routing per production coworker (incl. the payload-screening escalation ceiling); raises one owner-visible issue on zero eligible models so dead-ends are announced, not discovered mid-conversation.",
     cron: "37 */6 * * *",
@@ -178,6 +188,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "contributor-inventory-sync",
     inngestId: "ops/contributor-inventory-sync-cron",
+    honorsEnabledGate: true,
     name: "Contributor inventory sync",
     purpose:
       "Reconciles contributor/PR inventory against GitHub. Governance + attribution integrity.",
@@ -190,6 +201,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "federated-demand-reconciliation",
     inngestId: "federation/demand-reconciliation",
+    honorsEnabledGate: true,
     name: "Federated demand reconciliation",
     purpose:
       "Projects approved same-organization platform demand, retries durable peer delivery, withdraws records that leave the approved scope, and pulls every same-organization peer's backlog into local read-only mirrors (work sync).",
@@ -202,6 +214,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "agent-task-dispatch",
     inngestId: "agent/task-dispatch",
+    honorsEnabledGate: true,
     name: "Agent task dispatch",
     purpose: "Pumps queued agent tasks into execution. Agent work stalls if it stops.",
     cron: "*/5 * * * *",
@@ -213,6 +226,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "taskrun-watchdog",
     inngestId: "ops/taskrun-watchdog",
+    ungatedReason:
+      "Liveness guard: must keep running through every drain to detect stuck coordinators, so it is exempt from gateAtEntry entirely.",
     name: "Task-run watchdog",
     purpose: "Detects and resolves stuck task runs. Liveness guard for the task system.",
     cron: "* * * * *",
@@ -224,6 +239,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "token-expiry-monitor",
     inngestId: "ops/token-expiry-monitor",
+    honorsEnabledGate: true,
     name: "Token expiry monitor",
     purpose: "Warns before provider/integration credentials expire. Auth continuity.",
     cron: "0 9 * * *",
@@ -235,6 +251,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "runtime-target-janitor",
     inngestId: "ops/runtime-target-janitor",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
     name: "Runtime-target janitor",
     purpose: "Sweeps stale runtime targets + expires leases. Resource hygiene.",
     cron: "0 * * * *",
@@ -246,6 +264,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "runtime-artifact-janitor",
     inngestId: "ops/runtime-artifact-janitor",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
     name: "Runtime-artifact janitor",
     purpose:
       "Reaps orphaned CI build images + stray compose projects (and their named volumes). Default OFF; ENABLED alone = observe-only (logs would-reap); ENABLED + DPF_RUNTIME_ARTIFACT_JANITOR_AUTO_REAP=1 = live reap. CLI guards keep root dpf, running, and live-worktree stacks safe.",
@@ -258,6 +278,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "worktree-janitor",
     inngestId: "ops/worktree-janitor",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
     name: "Worktree janitor fleet backstop (Tier-A)",
     purpose:
       "OPTIONAL fleet sweeper for leftover worktrees. Primary reaping is session-lifecycle (worktree-session-hygiene on SessionEnd). This portal Inngest job dry-runs when DPF_WORKTREE_JANITOR_ENABLED=1; live Tier-A only with DPF_WORKTREE_JANITOR_AUTO_REAP=1. Not a per-client CLI cron.",
@@ -270,6 +292,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "sandbox-build-gc",
     inngestId: "ops/sandbox-build-gc",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
     name: "Build Studio sandbox build GC",
     purpose:
       "Backstop: removes leftover /workspace/.builds/<FB-*> for terminal or missing FeatureBuilds; optional aged build/* branch delete when DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES=1. Primary cleanup is transactional on promote/abandon/complete. Enable with DPF_SANDBOX_BUILD_GC_ENABLED=1.",
@@ -282,6 +306,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "infra-prune",
     inngestId: "ops/infra-prune",
+    honorsEnabledGate: true,
     name: "Infrastructure prune",
     purpose: "Weekly reclamation of stale infra. Destructive — kept core-locked.",
     cron: "0 3 * * 0",
@@ -293,6 +318,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "alert-delivery-bridge",
     inngestId: "ops/alert-delivery-bridge",
+    honorsEnabledGate: true,
     name: "Alert delivery bridge",
     purpose:
       "Delivers firing Prometheus/Loki alerts into the quality-issue inbox (the platform runs no Alertmanager). If it stops, firing alerts evaluate but never reach an operator — silent blindness. Core-locked for that reason.",
@@ -309,6 +335,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "quality-issue-drift-sweep",
     inngestId: "governance/quality-issue-drift-sweep-scheduled",
+    honorsEnabledGate: true,
     name: "Quality-issue drift sweep",
     purpose:
       "Runtime half of quality-issue governance. Self-heals the recovery/orphan backstop (closes stale entity/relationship issues whose row is active again or gone) and detects DRIFT — any issue-type open count over its declared steady-state budget — so a newly-accumulating detector is surfaced automatically instead of found by inspection. Reports drift with owners for the auto-processing router to fund and route; does not file work itself.",
@@ -334,6 +361,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "regulatory-monitor-scan",
     inngestId: "govern/regulatory-monitor-scan-scheduled",
+    honorsEnabledGate: true,
     name: "Regulatory monitor scan",
     purpose:
       "Re-scans active regulations for changes so the compliance surface reflects a current posture instead of aging into a false green. Before this, a scan ran only when an operator pressed \"Run Scan Now\" and never refreshed. Editable so an operator can retune the cadence or run one off-cadence. BI-DA37A602.",
@@ -372,6 +400,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "semantic-memory-reconcile",
     inngestId: "govern/semantic-memory-reconcile-scheduled",
+    honorsEnabledGate: true,
     name: "Semantic memory orphan reconciliation",
     purpose:
       "BI-DG-001 (EP-DATA-GOVERNANCE): removes agent-memory vectors whose source coworker turn has been purged, so a deleted conversation cannot linger in semantic recall. If it stops, orphaned vectors accumulate and a source deletion is never fully propagated to the derived copy. Editable so an operator can pause or run-now the sweep.",
@@ -384,6 +413,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "discovery-prometheus-poll",
     inngestId: "ops/prometheus-poll",
+    honorsEnabledGate: true,
     name: "Discovery: Prometheus poll",
     purpose: "Polls Prometheus for new monitoring targets. Cadence is tunable to taste.",
     cron: "5 * * * *",
@@ -395,6 +425,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "discovery-full-sweep",
     inngestId: "ops/full-discovery-sweep",
+    honorsEnabledGate: true,
     name: "Discovery: full sweep",
     purpose: "Full infrastructure discovery sweep. Cadence is tunable.",
     cron: "10 * * * *",
@@ -406,6 +437,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "issue-report-triage",
     inngestId: "quality/issue-report-triage",
+    honorsEnabledGate: true,
     name: "Quality: issue-report triage",
     purpose: "Triages inbound issue reports into the backlog. Cadence is tunable.",
     cron: "3,18,33,48 * * * *",
@@ -417,6 +449,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "backlog-triage-drain",
     inngestId: "ops/backlog-triage-drain",
+    honorsEnabledGate: true,
     name: "Backlog triage drain",
     purpose: "Drains the backlog triage queue. Cadence is tunable.",
     cron: "23 * * * *",
@@ -428,6 +461,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "canonical-improvement-digest",
     inngestId: "ops/canonical-improvement-digest",
+    honorsEnabledGate: true,
     name: "Canonical improvement digest",
     purpose:
       "Batches [reference-doc] ImprovementProposal rows into one doc chore BI for human-approved canonical-source PRs (process-spine §6.5).",
@@ -440,6 +474,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "coworker-regression-detect",
     inngestId: "quality/coworker-regression-detect",
+    honorsEnabledGate: true,
     name: "Coworker regression detect",
     purpose: "Scans for coworker quality regressions. Cadence is tunable.",
     cron: "6,21,36,51 * * * *",
@@ -451,6 +486,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "governed-backlog-tee-up",
     inngestId: "build/governed-backlog-tee-up-scheduled",
+    honorsEnabledGate: true,
     name: "Governed backlog tee-up",
     purpose: "Tees up governed backlog items for the day. Cadence is tunable.",
     cron: "0 14 * * *",
@@ -462,6 +498,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "capacity-drain",
     inngestId: "build/capacity-drain-scheduled",
+    honorsEnabledGate: true,
     name: "Capacity drain (use-it-or-lose-it)",
     purpose:
       "Near the weekly LLM-allocation reset, with a healthy pool and free build slots, dispatch top demand-ranked ready work so allocation is not wasted. Opt-in (capacityDrainEnabled).",
@@ -474,6 +511,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "assurance-remediation-tee-up",
     inngestId: "assurance/remediation-tee-up-scheduled",
+    honorsEnabledGate: true,
     name: "Assurance remediation tee-up",
     purpose:
       "Off-hours, budget-capped auto-promotion of genuine high/critical assurance findings into Build Studio remediation builds. If it stops, auto-filed vulnerability BIs sit unworked.",
@@ -486,6 +524,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "assurance-merge-gate",
     inngestId: "assurance/merge-gate-scheduled",
+    honorsEnabledGate: true,
     name: "Assurance merge gate",
     purpose:
       "Off-hours WWMD-gated merge decision for assurance remediation PRs (patch-only-auto): escalates non-auto PRs to a human. Auto-merge actuation is dark (DPF_ASSURANCE_AUTOMERGE_ENABLED, default off). If it stops, remediation PRs await manual merge.",
@@ -498,6 +537,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "material-freshness-decay",
     inngestId: "decision/material-freshness-decay",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
     name: "Material freshness decay",
     purpose: "Decays stale decision materials. Cadence is tunable.",
     cron: "20 3 * * *",
@@ -509,6 +550,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "research-schedule-scan",
     inngestId: "research/schedule-scan",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
     name: "Research schedule scan",
     purpose: "Proposes scheduled research for the week. Cadence is tunable.",
     cron: "0 9 * * 1",
@@ -520,6 +563,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "wiki-lint",
     inngestId: "wiki/lint-daily",
+    honorsEnabledGate: true,
     name: "Wiki lint",
     purpose: "Daily wiki integrity lint. Cadence is tunable.",
     cron: "30 3 * * *",
@@ -531,6 +575,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "skill-metrics-aggregator",
     inngestId: "skills/metrics-aggregator",
+    honorsEnabledGate: true,
     name: "Skill metrics aggregator",
     purpose: "Aggregates skill-usage metrics. Cadence is tunable.",
     cron: "0 5 * * *",
@@ -542,6 +587,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "mcp-call-efficiency-scan",
     inngestId: "ops/mcp-call-efficiency-scan",
+    honorsEnabledGate: true,
     name: "MCP call efficiency scan",
     purpose:
       "BI-A08EBAEC: analyzes ToolExecution thrash, retry storms, and high-volume/failure tools; notifies, files critical BIs, and dispatches a one-shot AI Ops (platform-engineer) review so token waste is cut via skills, tool merges, or webhooks.",
@@ -554,6 +600,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "a2a-collaboration-health-scan",
     inngestId: "ops/a2a-collaboration-health-scan",
+    honorsEnabledGate: true,
     name: "A2A collaboration health scan",
     purpose:
       "BI-3003EE63: analyzes coworker↔coworker edges (delegation, handoff, task lineage) for failed/blocked paths, stuck active delegations, and orphan lineage; notifies, files critical BIs (BI-A2A-EFF-*), and dispatches a one-shot AI Ops review (MCP-efficiency twin).",
@@ -566,6 +613,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "queue-metrics-aggregator",
     inngestId: "queue/metrics-aggregator",
+    honorsEnabledGate: true,
     name: "Queue metrics aggregator",
     purpose:
       "Rolls up the QueueTelemetryEvent stream into per-queue QueueMetricSnapshot rows (wait/process/cycle time, throughput, first-pass yield). Without it, queue flow metrics never materialise for tiles or the coworker surface.",
@@ -578,6 +626,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "business-metrics-aggregator",
     inngestId: "business/metrics-aggregator",
+    honorsEnabledGate: true,
     name: "Business metrics aggregator",
     purpose:
       "Builds tenant-scoped owner/manager performance snapshots from canonical operational evidence for archetypes the metrics engine covers (hospitality today). On an install with no covered storefront it refreshes nothing by design. The Performance view stays fast and preserves its last valid snapshot when a refresh fails.",
@@ -590,6 +639,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "skill-curator",
     inngestId: "skills/curator",
+    honorsEnabledGate: true,
     name: "Skill curator",
     purpose: "Curates / proposes skill improvements. Cadence is tunable.",
     cron: "0 7 * * *",
@@ -601,6 +651,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "work-pattern-profile-review",
     inngestId: "quality/work-pattern-profile-review",
+    honorsEnabledGate: true,
     name: "Work pattern profile review",
     purpose:
       "Reviews coworker work-pattern telemetry and proposes capability needs. If it stops, repeated agent friction stays anecdotal instead of becoming governed improvement evidence.",
@@ -613,6 +664,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "log-signature-scanner",
     inngestId: "ops/log-signature-scanner",
+    honorsEnabledGate: true,
     name: "Log signature scanner",
     purpose:
       "Scans container logs (Loki) for novel error signatures and files one issue per new signature. If it stops, novel log anomalies surface to no one. Cadence and noise threshold are tunable.",
@@ -625,6 +677,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "edge-incident-correlation",
     inngestId: "ops/edge-incident-correlation",
+    honorsEnabledGate: true,
     name: "Edge incident correlation",
     purpose:
       "EP-MSP-FEDERATION A2+A3 — correlates a burst of edge alerts to the preceding change into one change-before-spike incident, then routes it to the right customer as a quality issue + ServiceTicket. Dark-launched behind DPF_EDGE_INCIDENT_CORRELATION_ENABLED. Cadence and lookback are tunable.",
@@ -637,6 +690,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "remote-action-claim-timeout",
     inngestId: "ops/remote-action-claim-timeout",
+    honorsEnabledGate: true,
     name: "Remote action claim timeout",
     purpose:
       "EP-REMOTE-ACTION P2 — times out RemoteActions a node claimed but never reported a result for (claim-then-die), so the read-only dispatch queue can't wedge. Dark-launched behind DPF_REMOTE_ACTION_DISPATCH_ENABLED. Cadence and timeout window are tunable.",
@@ -649,6 +703,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "release-health-check",
     inngestId: "ops/release-health-check",
+    honorsEnabledGate: true,
     name: "Release health check",
     purpose:
       "Polls the latest release's verify-gate outcome and keeps the operator notification + health card in sync. If it stops, a red release can go unnoticed. Cadence is tunable.",
@@ -661,6 +716,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "marketing-scheduler-dispatch",
     inngestId: "marketing/scheduler-dispatch",
+    honorsEnabledGate: true,
     name: "Marketing scheduler",
     purpose:
       "Fires due scheduled outbound marketing actions (draft/publish/KPI pull) that an operator or autopilot policy queued. If it stops, scheduled marketing actions never run. Outbound sends still pass the kernel veto. Editable so an operator can disable it.",
@@ -673,6 +729,8 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "postmark-callback-sweep",
     inngestId: "integrations/postmark-callback-sweep",
+    ungatedReason:
+      "Module does not call gateAtEntry yet — not wired to the kill switch (BI-7E49FA15).",
     name: "Postmark callback recovery",
     purpose:
       "Drains durable inbound-email responder receipts and terminal callback audit outbox rows missed by the low-latency event path. If it stops, callback acknowledgments remain safe but responder and audit recovery are delayed.",
@@ -685,6 +743,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "recurring-invoice-dispatch",
     inngestId: "finance/recurring-invoice-dispatch",
+    honorsEnabledGate: true,
     name: "Recurring invoice generator",
     purpose:
       "Generates invoices for active recurring schedules whose next date is due (idempotent; honours auto-send). If it stops, recurring invoices are not generated. Editable so an operator can disable it.",
@@ -697,6 +756,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "siem-correlation-sweep",
     inngestId: "ops/siem-correlation-sweep",
+    honorsEnabledGate: true,
     name: "SIEM correlation sweep",
     purpose:
       "EP-SOVEREIGN-SOC P1: projects the platform's own audit telemetry into SecurityEvents, then scans the recent window against enabled DetectionRules + the active threat-intel index and emits Detections. If it stops, no new security detections are produced.",
@@ -709,6 +769,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "patch-assessment-sweep",
     inngestId: "ops/patch-assessment-sweep",
+    honorsEnabledGate: true,
     name: "Estate patch assessment",
     purpose:
       "EP-PATCH-MANAGEMENT P0: projects discovered installed software into patch findings (OSV vulnerabilities + CISA KEV prioritization) on the Assurance Ledger, and resolves findings that became clean. If it stops, estate patch posture goes stale.",
@@ -747,6 +808,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "coworker-certification",
     inngestId: "ops/coworker-certification-nightly",
+    honorsEnabledGate: true,
     name: "Coworker certification",
     purpose:
       "EP-COWORKER-LIFECYCLE Phase 2 (BI-DE9CC88B): exercises every roster coworker's golden journeys through the real execution path (read-only tool surface) and records per-coworker pass/fail AssuranceRuns the workforce roster shows. If it stops, coworker certification goes stale and broken coworkers surface late again.",
@@ -759,6 +821,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: EMBEDDING_COVERAGE_JOB_ID,
     inngestId: EMBEDDING_COVERAGE_INNGEST_ID,
+    honorsEnabledGate: true,
     name: EMBEDDING_COVERAGE_JOB_NAME,
     purpose:
       "BI-ED117C82: re-embeds published wiki/stance pages that are missing a vector, so the decision engine can still retrieve the organisation's own doctrine. A page without a vector degrades stance relevance to lexical and the gate then escalates instead of deciding \u2014 which the operator experiences as coworkers re-asking settled questions. Retries every 2h because the local model is often busy at boot; reports coverage into the corpus-health Workroom so a run is visible. If it stops, silent corpus gaps accumulate with no symptom pointing at them.",
@@ -771,6 +834,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "memory-consolidation-nightly",
     inngestId: "coworker/memory-consolidation-nightly",
+    honorsEnabledGate: true,
     name: "Coworker memory consolidation",
     purpose:
       "EP-8C706944 Phase 2 + EP-COMPETENCE-FLYWHEEL (BI-907C4327, BI-4B0A1C1F): the sleep-time 'autoDream' pass distills completed work into coworker working notes, advances thread checkpoints, batch-collapses near-duplicate notes/facts to one canonical each, then expires entries unused past the retention window (supersession, never a hard delete). If it stops, coworker memory acquisition stalls and the memory stores accumulate near-duplicates and stale facts.",
@@ -789,6 +853,20 @@ const CATALOG_BY_JOB_ID = new Map<string, ScheduledJobCatalogEntry>(
 
 export function getCatalogEntry(jobId: string): ScheduledJobCatalogEntry | undefined {
   return CATALOG_BY_JOB_ID.get(jobId);
+}
+
+const CATALOG_BY_INNGEST_ID = new Map<string, ScheduledJobCatalogEntry>(
+  SCHEDULED_JOB_CATALOG.map((e) => [e.inngestId, e]),
+);
+
+/** Resolve a catalog entry from the Inngest function id — the identity a cron
+ *  knows about itself. This is how gateAtEntry finds the jobId whose
+ *  ScheduledJob.enabled it must honour (BI-7E49FA15). Event-driven run-now
+ *  functions have no entry and resolve to undefined. */
+export function getCatalogEntryByInngestId(
+  inngestId: string,
+): ScheduledJobCatalogEntry | undefined {
+  return CATALOG_BY_INNGEST_ID.get(inngestId);
 }
 
 /** A job is locked (operator read-only) when its catalog classification is

--- a/apps/web/lib/operate/scheduled-jobs/core.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/core.test.ts
@@ -1,0 +1,43 @@
+// BI-7E49FA15 — isJobEnabled is the single implementation of the per-job
+// kill switch, and its read-failure posture is a stated decision: fail OPEN.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: { scheduledJob: { findUnique: vi.fn() } },
+}));
+
+import { prisma } from "@dpf/db";
+import { isJobEnabled } from "./core";
+
+const findUnique = vi.mocked(prisma.scheduledJob.findUnique);
+
+beforeEach(() => {
+  findUnique.mockReset();
+});
+
+describe("isJobEnabled", () => {
+  it("returns false only when the operator set enabled=false", async () => {
+    findUnique.mockResolvedValue({ enabled: false } as never);
+    expect(await isJobEnabled("code-graph-reconcile")).toBe(false);
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { jobId: "code-graph-reconcile" },
+      select: { enabled: true },
+    });
+  });
+
+  it("returns true for an enabled row", async () => {
+    findUnique.mockResolvedValue({ enabled: true } as never);
+    expect(await isJobEnabled("code-graph-reconcile")).toBe(true);
+  });
+
+  it("defaults to enabled when no row exists (never toggled)", async () => {
+    findUnique.mockResolvedValue(null as never);
+    expect(await isJobEnabled("code-graph-reconcile")).toBe(true);
+  });
+
+  it("fails OPEN: a read failure reports enabled rather than taking the schedule down", async () => {
+    findUnique.mockRejectedValue(new Error("connection refused"));
+    await expect(isJobEnabled("code-graph-reconcile")).resolves.toBe(true);
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/core.ts
+++ b/apps/web/lib/operate/scheduled-jobs/core.ts
@@ -8,15 +8,30 @@
 import { prisma } from "@dpf/db";
 
 /**
- * Runtime gate for scheduled functions: returns false when an operator has
- * disabled the job. Defaults to enabled when no row exists, so a job that has
- * never been touched runs normally. Wire this into a cron's entry gate to make
- * the per-job kill switch load-bearing.
+ * Runtime gate for scheduled functions — THE single implementation of the
+ * per-job kill switch (BI-7E49FA15). Returns false only when an operator has
+ * set ScheduledJob.enabled=false for this jobId.
+ *
+ * Posture, stated deliberately:
+ *   - No row  → enabled. A job that has never been touched runs normally.
+ *   - Read fails → enabled. The switch fails OPEN. A kill switch that failed
+ *     closed would take the whole schedule down on a database blip, which is a
+ *     far larger blast radius than one extra tick of a job the operator meant
+ *     to pause. Before this helper was made canonical, three of five hand-rolled
+ *     copies already swallowed the error and ran; this makes that uniform.
+ *
+ * Reached from gateAtEntry (every catalogued cron) and directly from runners
+ * that are also driven by a run-now event, which does not pass through the
+ * entry gate.
  */
 export async function isJobEnabled(jobId: string): Promise<boolean> {
-  const row = await prisma.scheduledJob.findUnique({
-    where: { jobId },
-    select: { enabled: true },
-  });
-  return row?.enabled ?? true;
+  try {
+    const row = await prisma.scheduledJob.findUnique({
+      where: { jobId },
+      select: { enabled: true },
+    });
+    return row?.enabled ?? true;
+  } catch {
+    return true;
+  }
 }

--- a/apps/web/lib/operate/scheduled-jobs/work-model.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/work-model.test.ts
@@ -285,10 +285,12 @@ describe("buildWorkView", () => {
 
   it("says a cron with no entry gate has no working kill switch", () => {
     // Disabling one of these persists a column nothing reads; the job runs on.
+    // worktree-janitor does not call gateAtEntry and carries an ungatedReason
+    // in the catalog (BI-7E49FA15).
     const ungated = {
-      jobId: "log-signature-scanner",
-      name: "Log signature scanner",
-      schedule: "*/15 * * * *",
+      jobId: "worktree-janitor",
+      name: "Worktree janitor",
+      schedule: "40 5 * * *",
       lastRunAt: null,
       nextRunAt: null,
       lastStatus: null as string | null,
@@ -297,7 +299,7 @@ describe("buildWorkView", () => {
       locked: false,
       enabled: true,
     };
-    expect(buildWorkView("log-signature-scanner", ungated, undefined, NOW).killSwitchEnforced).toBe(false);
+    expect(buildWorkView("worktree-janitor", ungated, undefined, NOW).killSwitchEnforced).toBe(false);
   });
 
   it("says an agent task's kill switch is load-bearing", () => {

--- a/apps/web/lib/queue/functions/a2a-collaboration-health-scan.ts
+++ b/apps/web/lib/queue/functions/a2a-collaboration-health-scan.ts
@@ -16,7 +16,7 @@ export const a2aCollaborationHealthScan = inngest.createFunction(
     triggers: [cron("25 6 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/a2a-collaboration-health-scan");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("analyze-notify-and-dispatch-aiops", async () => {

--- a/apps/web/lib/queue/functions/agent-task-dispatch.ts
+++ b/apps/web/lib/queue/functions/agent-task-dispatch.ts
@@ -15,7 +15,7 @@ export const agentTaskDispatch = inngest.createFunction(
     triggers: [cron("*/5 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "agent/task-dispatch");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     // Once an hour (on the top-of-hour :00 tick of this */5 poll), converge every

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.ts
@@ -192,7 +192,7 @@ export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
 export const alertDeliveryBridge = inngest.createFunction(
   { id: "ops/alert-delivery-bridge", retries: 2, triggers: [cron("*/5 * * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/alert-delivery-bridge");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("deliver-alerts", async () => runAlertDeliveryScan());

--- a/apps/web/lib/queue/functions/assurance-merge-gate-teeup.ts
+++ b/apps/web/lib/queue/functions/assurance-merge-gate-teeup.ts
@@ -20,7 +20,7 @@ export const assuranceMergeGateScheduled = inngest.createFunction(
     triggers: [cron("47 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "assurance/merge-gate-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("assurance-merge-gate", async () => {

--- a/apps/web/lib/queue/functions/assurance-remediation-teeup.ts
+++ b/apps/web/lib/queue/functions/assurance-remediation-teeup.ts
@@ -19,7 +19,7 @@ export const assuranceRemediationTeeUpScheduled = inngest.createFunction(
     triggers: [cron("41 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "assurance/remediation-tee-up-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("assurance-remediation-tee-up", async () => {

--- a/apps/web/lib/queue/functions/async-inference-operation.ts
+++ b/apps/web/lib/queue/functions/async-inference-operation.ts
@@ -87,7 +87,7 @@ export const asyncInferenceOperationReconciliation = inngest.createFunction(
     if (!workerEnabled()) {
       return { skipped: true, reason: "async-operation-worker-disabled" };
     }
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, ASYNC_INFERENCE_OPERATION_RECOVERY_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     const wakes = await step.run("reconcile-due-async-operation-wakes", () =>
       reconcilePrismaAsyncOperationWakes({ limit: 50 }),
@@ -114,7 +114,7 @@ export const asyncInferenceOperationOutbox = inngest.createFunction(
     triggers: [{ cron: ASYNC_INFERENCE_OPERATION_OUTBOX_CRON }],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, ASYNC_INFERENCE_OPERATION_OUTBOX_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("publish-async-operation-transition-outbox", () =>
       publishPrismaAsyncOperationTransitions({ limit: 50 }),

--- a/apps/web/lib/queue/functions/backlog-triage-drain.ts
+++ b/apps/web/lib/queue/functions/backlog-triage-drain.ts
@@ -30,7 +30,7 @@ const MAX_PER_RUN = 25;
 export const backlogTriageDrain = inngest.createFunction(
   { id: "ops/backlog-triage-drain", retries: 1, triggers: [cron("23 * * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/backlog-triage-drain");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     // Step 1 — fetch the bounded batch. DB-only, so it returns response headers

--- a/apps/web/lib/queue/functions/build-pr-delivery-reconcile.ts
+++ b/apps/web/lib/queue/functions/build-pr-delivery-reconcile.ts
@@ -233,7 +233,7 @@ export const buildPrDeliveryReconcile = inngest.createFunction(
     triggers: [cron(BUILD_PR_DELIVERY_RECONCILE_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "build/pr-delivery-reconcile");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("reconcile-build-pr-delivery", runBuildPrDeliveryReconcile);
   },

--- a/apps/web/lib/queue/functions/business-journey-watchdog.ts
+++ b/apps/web/lib/queue/functions/business-journey-watchdog.ts
@@ -62,7 +62,7 @@ export const businessJourneyWatchdogScheduled = inngest.createFunction(
     triggers: [cron(BUSINESS_JOURNEY_WATCHDOG_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, BUSINESS_JOURNEY_WATCHDOG_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("business-journey-watchdog", () => runBusinessJourneyWatchdogJob());
   },
@@ -76,7 +76,7 @@ export const businessJourneyWatchdogRunNow = inngest.createFunction(
     triggers: [{ event: BUSINESS_JOURNEY_WATCHDOG_REQUESTED_EVENT }],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, BUSINESS_JOURNEY_WATCHDOG_RUN_NOW_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("business-journey-watchdog", () => runBusinessJourneyWatchdogJob());
   },

--- a/apps/web/lib/queue/functions/business-metrics-aggregator.ts
+++ b/apps/web/lib/queue/functions/business-metrics-aggregator.ts
@@ -16,7 +16,7 @@ export const businessMetricsAggregator = inngest.createFunction(
     triggers: [cron("17 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "business/metrics-aggregator");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("aggregate-business-metrics", async () => {

--- a/apps/web/lib/queue/functions/canonical-improvement-digest.ts
+++ b/apps/web/lib/queue/functions/canonical-improvement-digest.ts
@@ -10,7 +10,7 @@ import { gateAtEntry } from "../quiescence-gates";
 export const canonicalImprovementDigest = inngest.createFunction(
   { id: "ops/canonical-improvement-digest", retries: 1, triggers: [cron("17 6 * * 1")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/canonical-improvement-digest");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("digest-reference-doc-proposals", async () => {

--- a/apps/web/lib/queue/functions/capacity-drain.ts
+++ b/apps/web/lib/queue/functions/capacity-drain.ts
@@ -15,7 +15,7 @@ export const capacityDrainScheduled = inngest.createFunction(
     triggers: [cron("17 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "build/capacity-drain-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("evaluate-capacity-drain", async () => {

--- a/apps/web/lib/queue/functions/catalog-enrichment-sweep.ts
+++ b/apps/web/lib/queue/functions/catalog-enrichment-sweep.ts
@@ -24,7 +24,7 @@ export const catalogEnrichmentSweepScheduled = inngest.createFunction(
     triggers: [cron(CATALOG_SWEEP_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, CATALOG_SWEEP_SCHEDULED_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("catalog-enrichment-sweep", async () => {
       const { runCatalogEnrichmentSweepJob } = await import(

--- a/apps/web/lib/queue/functions/code-graph-reconcile.ts
+++ b/apps/web/lib/queue/functions/code-graph-reconcile.ts
@@ -88,7 +88,7 @@ export const codeGraphReconcileScheduled = inngest.createFunction(
     triggers: [cron("*/15 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/code-graph-reconcile-scheduled");
     if (!gate.proceed) {
       // BI-9BF17415: record the deferral as a counter before bailing, so a job
       // repeatedly starved by the drain gate surfaces instead of silently skipping.

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.ts
@@ -612,7 +612,7 @@ export const contributorInventorySyncCron = inngest.createFunction(
     triggers: [cron("*/10 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/contributor-inventory-sync-cron");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("run-sync-cron", () =>
@@ -629,7 +629,7 @@ export const contributorInventorySyncOnDemand = inngest.createFunction(
     triggers: [{ event: "ops/contributor-inventory-sync.run" }],
   },
   async ({ event, step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/contributor-inventory-sync-on-demand");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const triggeredBy =

--- a/apps/web/lib/queue/functions/coworker-certification.ts
+++ b/apps/web/lib/queue/functions/coworker-certification.ts
@@ -64,7 +64,7 @@ export const coworkerCertificationNightly = inngest.createFunction(
     triggers: [cron("40 4 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/coworker-certification-nightly");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     // Full roster, then requeue only capacity-inconclusive coworkers (below).
     let agentIds: string[] | undefined = undefined;
@@ -93,7 +93,7 @@ export const coworkerCertificationRunNow = inngest.createFunction(
     triggers: [{ event: "ops/coworker-certification.requested" }],
   },
   async ({ step, event }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/coworker-certification-run-now");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     const requested = (event?.data as { agentIds?: unknown } | undefined)?.agentIds;
     let agentIds: string[] | undefined = Array.isArray(requested)

--- a/apps/web/lib/queue/functions/coworker-regression-detect.ts
+++ b/apps/web/lib/queue/functions/coworker-regression-detect.ts
@@ -18,7 +18,7 @@ export const coworkerRegressionDetect = inngest.createFunction(
     triggers: [cron("6,21,36,51 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "quality/coworker-regression-detect");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("detect-coworker-regressions", async () => {

--- a/apps/web/lib/queue/functions/data-control-operation.ts
+++ b/apps/web/lib/queue/functions/data-control-operation.ts
@@ -59,7 +59,7 @@ export const dataControlOperationRecoveryScheduled = inngest.createFunction(
     triggers: [cron(DATA_CONTROL_OPERATION_RECOVERY_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "govern/data-control-operation-recovery-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("recover-data-control-operations", () =>
       runDataControlOperationRecovery({
@@ -78,7 +78,7 @@ export const dataControlOperationRecoveryRequested = inngest.createFunction(
     triggers: [{ event: DATA_CONTROL_OPERATION_RECOVERY_EVENT }],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "govern/data-control-operation-recovery-requested");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("recover-data-control-operations-requested", () =>
       runDataControlOperationRecovery({

--- a/apps/web/lib/queue/functions/data-retention-sweep.ts
+++ b/apps/web/lib/queue/functions/data-retention-sweep.ts
@@ -32,7 +32,7 @@ export const dataRetentionSweepScheduled = inngest.createFunction(
     triggers: [cron(DATA_RETENTION_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, DATA_RETENTION_SCHEDULED_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("data-retention-sweep", async () => {

--- a/apps/web/lib/queue/functions/deliberation-run.ts
+++ b/apps/web/lib/queue/functions/deliberation-run.ts
@@ -419,7 +419,7 @@ export const deliberationRun = inngest.createFunction(
     // so there's no natural mid-flow boundary to suspend; refactoring it to
     // expose per-branch step.run boundaries for gateBetweenSteps is tracked
     // as a follow-up under BI-QUIESCE-004b).
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "deliberation/run");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const data = event.data as unknown as RunDeliberationInput;

--- a/apps/web/lib/queue/functions/demand-reconciliation.ts
+++ b/apps/web/lib/queue/functions/demand-reconciliation.ts
@@ -12,7 +12,7 @@ export const demandReconciliationScheduled = inngest.createFunction(
     triggers: [cron("1,6,11,16,21,26,31,36,41,46,51,56 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "federation/demand-reconciliation");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const demand = await step.run("reconcile-federated-demand", async () => {

--- a/apps/web/lib/queue/functions/discovery-poll.ts
+++ b/apps/web/lib/queue/functions/discovery-poll.ts
@@ -5,7 +5,7 @@ import { gateAtEntry } from "../quiescence-gates";
 export const prometheusPoll = inngest.createFunction(
   { id: "ops/prometheus-poll", retries: 2, triggers: [cron("5 * * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/prometheus-poll");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     await step.run("poll-targets", async () => {
@@ -25,7 +25,7 @@ export const fullDiscoverySweep = inngest.createFunction(
     triggers: [cron("10 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/full-discovery-sweep");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     await step.run("run-sweep", async () => {

--- a/apps/web/lib/queue/functions/edge-incident-correlation.ts
+++ b/apps/web/lib/queue/functions/edge-incident-correlation.ts
@@ -214,7 +214,7 @@ export const edgeIncidentCorrelation = inngest.createFunction(
     if (!envFlagEnabled(process.env, "DPF_EDGE_INCIDENT_CORRELATION_ENABLED")) {
       return { skipped: true, reason: "flag-disabled" };
     }
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/edge-incident-correlation");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return await step.run("correlate-edge-incidents", async () => runEdgeIncidentCorrelation());
   },

--- a/apps/web/lib/queue/functions/embedding-coverage-reconcile.ts
+++ b/apps/web/lib/queue/functions/embedding-coverage-reconcile.ts
@@ -51,7 +51,7 @@ export const embeddingCoverageReconcileScheduled = inngest.createFunction(
     triggers: [cron(EMBEDDING_COVERAGE_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, EMBEDDING_COVERAGE_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("embedding-coverage-reconcile", () => runEmbeddingCoverageJob());
   },
@@ -65,7 +65,7 @@ export const embeddingCoverageReconcileRunNow = inngest.createFunction(
     triggers: [{ event: EMBEDDING_COVERAGE_REQUESTED_EVENT }],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, EMBEDDING_COVERAGE_RUN_NOW_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("embedding-coverage-reconcile", () => runEmbeddingCoverageJob());
   },

--- a/apps/web/lib/queue/functions/eval-background.ts
+++ b/apps/web/lib/queue/functions/eval-background.ts
@@ -64,7 +64,7 @@ export const evalBackground = inngest.createFunction(
     triggers: [{ event: "ai/eval.run" }],
   },
   async ({ event, step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ai/eval-background");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const { endpointId, modelId, userId, force } = event.data;
@@ -129,7 +129,7 @@ export const probeBackground = inngest.createFunction(
     triggers: [{ event: "ai/probe.run" }],
   },
   async ({ event, step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ai/probe-background");
     if (!gate.proceed) return { skipped: true, reason: gate.reason, tested: 0 };
 
     const { endpointId, modelId, probesOnly, userId } = event.data;

--- a/apps/web/lib/queue/functions/governed-backlog-tee-up.ts
+++ b/apps/web/lib/queue/functions/governed-backlog-tee-up.ts
@@ -10,7 +10,7 @@ export const governedBacklogTeeUpScheduled = inngest.createFunction(
     triggers: [cron("0 14 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "build/governed-backlog-tee-up-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("tee-up-governed-backlog-daily", async () => {

--- a/apps/web/lib/queue/functions/identity-inference-fallback.ts
+++ b/apps/web/lib/queue/functions/identity-inference-fallback.ts
@@ -24,7 +24,7 @@ export const identityInferenceFallbackScheduled = inngest.createFunction(
     triggers: [cron(IDENTITY_INFERENCE_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, IDENTITY_INFERENCE_SCHEDULED_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("identity-inference-fallback", async () => {
       const { runIdentityInferenceFallbackJob } = await import(

--- a/apps/web/lib/queue/functions/index-integrity-sweep.ts
+++ b/apps/web/lib/queue/functions/index-integrity-sweep.ts
@@ -79,7 +79,7 @@ export const indexIntegritySweep = inngest.createFunction(
     triggers: [cron("30 5 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/index-integrity-sweep");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("check-live-index-integrity", () => runIndexIntegritySweep());
   },

--- a/apps/web/lib/queue/functions/infra-prune.ts
+++ b/apps/web/lib/queue/functions/infra-prune.ts
@@ -5,7 +5,7 @@ import { gateAtEntry } from "../quiescence-gates";
 export const infraPrune = inngest.createFunction(
   { id: "ops/infra-prune", retries: 2, triggers: [cron("0 3 * * 0")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/infra-prune");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     await step.run("prune-stale", async () => {

--- a/apps/web/lib/queue/functions/inngest-retention-sweep.ts
+++ b/apps/web/lib/queue/functions/inngest-retention-sweep.ts
@@ -31,7 +31,7 @@ export const inngestRetentionSweepScheduled = inngest.createFunction(
     triggers: [cron(INNGEST_RETENTION_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, INNGEST_RETENTION_SCHEDULED_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("inngest-retention-sweep", async () => {

--- a/apps/web/lib/queue/functions/issue-report-project.ts
+++ b/apps/web/lib/queue/functions/issue-report-project.ts
@@ -14,7 +14,7 @@ export const issueReportProjectOnCreate = inngest.createFunction(
     triggers: [{ event: "quality/issue-report.created" }],
   },
   async ({ event, step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "quality/issue-report-project-on-create");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("project-one-report", async () => {

--- a/apps/web/lib/queue/functions/issue-report-triage.ts
+++ b/apps/web/lib/queue/functions/issue-report-triage.ts
@@ -12,7 +12,7 @@ import { gateAtEntry } from "../quiescence-gates";
 export const issueReportTriage = inngest.createFunction(
   { id: "quality/issue-report-triage", retries: 2, triggers: [cron("3,18,33,48 * * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "quality/issue-report-triage");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const result = await step.run("triage-open-reports", async () => {

--- a/apps/web/lib/queue/functions/log-signature-scanner.ts
+++ b/apps/web/lib/queue/functions/log-signature-scanner.ts
@@ -127,7 +127,7 @@ export async function runLogSignatureScan(opts?: {
 export const logSignatureScanner = inngest.createFunction(
   { id: "ops/log-signature-scanner", retries: 2, triggers: [cron("9,24,39,54 * * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/log-signature-scanner");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("scan-log-signatures", async () => runLogSignatureScan());

--- a/apps/web/lib/queue/functions/marketing-scheduler-dispatch.ts
+++ b/apps/web/lib/queue/functions/marketing-scheduler-dispatch.ts
@@ -22,7 +22,7 @@ import { gateAtEntry } from "../quiescence-gates";
 export const marketingSchedulerDispatch = inngest.createFunction(
   { id: "marketing/scheduler-dispatch", retries: 1, triggers: [cron("5,35 * * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "marketing/scheduler-dispatch");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("tick-marketing-scheduler", async () => {

--- a/apps/web/lib/queue/functions/mcp-call-efficiency-scan.ts
+++ b/apps/web/lib/queue/functions/mcp-call-efficiency-scan.ts
@@ -17,7 +17,7 @@ export const mcpCallEfficiencyScan = inngest.createFunction(
     triggers: [cron("15 6 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/mcp-call-efficiency-scan");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("analyze-notify-and-dispatch-aiops", async () => {

--- a/apps/web/lib/queue/functions/mcp-catalog-sync.ts
+++ b/apps/web/lib/queue/functions/mcp-catalog-sync.ts
@@ -12,7 +12,7 @@ export const mcpCatalogSync = inngest.createFunction(
     // Gate at entry only — once the sync is running it's killable:false
     // (mid-upsert state would be lost). Refuses NEW syncs during drain;
     // an in-flight sync runs to completion. See spec §6.3.
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/mcp-catalog-sync");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     await step.run("run-sync", async () => {

--- a/apps/web/lib/queue/functions/mcp-task-run-execute.ts
+++ b/apps/web/lib/queue/functions/mcp-task-run-execute.ts
@@ -36,7 +36,7 @@ export const mcpTaskRunDispatchReconciliation = inngest.createFunction(
     triggers: [cron("*/2 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "mcp/task-run-dispatch-reconciliation");
     if (!gate.proceed) return gate;
     return step.run("reconcile-submitted-external-tasks", () =>
       reconcilePersistedRemoteTaskDispatches({

--- a/apps/web/lib/queue/functions/mdm-steward-sweep.ts
+++ b/apps/web/lib/queue/functions/mdm-steward-sweep.ts
@@ -21,15 +21,12 @@ import {
   MDM_STEWARD_JOB_ID,
 } from "@/lib/mdm/steward-schedule-constants";
 
-/** Kill switch: operators pause the Data Steward via ScheduledJob.enabled=false. */
+/** Kill switch: operators pause the Data Steward via ScheduledJob.enabled=false.
+ *  Routed through the one shared implementation (BI-7E49FA15); default-on when
+ *  no row exists or the read fails. */
 async function isEnabled(): Promise<boolean> {
-  const { prisma } = await import("@dpf/db");
-  const row = await prisma.scheduledJob.findUnique({
-    where: { jobId: MDM_STEWARD_JOB_ID },
-    select: { enabled: true },
-  });
-  // Default-on: no row means never toggled, so it runs.
-  return row?.enabled ?? true;
+  const { isJobEnabled } = await import("@/lib/operate/scheduled-jobs/core");
+  return isJobEnabled(MDM_STEWARD_JOB_ID);
 }
 
 export const mdmStewardSweepScheduled = inngest.createFunction(
@@ -40,7 +37,7 @@ export const mdmStewardSweepScheduled = inngest.createFunction(
     triggers: [cron(MDM_STEWARD_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, MDM_STEWARD_SCHEDULED_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     if (!(await step.run("mdm-steward-enabled", isEnabled))) {
       return { skipped: true, reason: "disabled" };

--- a/apps/web/lib/queue/functions/memory-consolidation-nightly.ts
+++ b/apps/web/lib/queue/functions/memory-consolidation-nightly.ts
@@ -174,7 +174,7 @@ export const memoryConsolidationNightly = inngest.createFunction(
     triggers: [cron(MEMORY_CONSOLIDATION_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "coworker/memory-consolidation-nightly");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const swept = await step.run("memory-consolidation-sweep", async () =>

--- a/apps/web/lib/queue/functions/model-discovery-refresh.ts
+++ b/apps/web/lib/queue/functions/model-discovery-refresh.ts
@@ -40,7 +40,7 @@ export const modelDiscoveryRefresh = inngest.createFunction(
     triggers: [cron("10 3 * * *")], // 03:10 UTC — staggered off the 03:00 batch (EP-MODEL-CAP-001-D)
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "inference/model-discovery-refresh");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     try {

--- a/apps/web/lib/queue/functions/nonprod-lease-wait.ts
+++ b/apps/web/lib/queue/functions/nonprod-lease-wait.ts
@@ -58,7 +58,7 @@ export const nonprodLeaseWaitReconciliation = inngest.createFunction(
     triggers: [cron(RECONCILE_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "nonprod/lease-wait-reconciliation");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("reconcile-durable-nonprod-waits", () => reconcileNonprodLeaseWaits({}));
   },

--- a/apps/web/lib/queue/functions/obligation-assurance-watch.ts
+++ b/apps/web/lib/queue/functions/obligation-assurance-watch.ts
@@ -57,7 +57,7 @@ export const obligationAssuranceWatchScheduled = inngest.createFunction(
     triggers: [cron(OBLIGATION_WATCH_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, OBLIGATION_WATCH_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("obligation-assurance-watch", () => runObligationAssuranceWatchJob());
   },
@@ -71,7 +71,7 @@ export const obligationAssuranceWatchRunNow = inngest.createFunction(
     triggers: [{ event: OBLIGATION_WATCH_REQUESTED_EVENT }],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, OBLIGATION_WATCH_RUN_NOW_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("obligation-assurance-watch", () => runObligationAssuranceWatchJob());
   },

--- a/apps/web/lib/queue/functions/patch-assessment-sweep.ts
+++ b/apps/web/lib/queue/functions/patch-assessment-sweep.ts
@@ -52,7 +52,7 @@ export async function runPatchAssessmentSweep(): Promise<PatchAssessmentSummary>
 export const patchAssessmentSweep = inngest.createFunction(
   { id: "ops/patch-assessment-sweep", retries: 2, triggers: [cron("0 5 * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/patch-assessment-sweep");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("patch-assessment", runPatchAssessmentSweep);

--- a/apps/web/lib/queue/functions/postgres-daily-backup.ts
+++ b/apps/web/lib/queue/functions/postgres-daily-backup.ts
@@ -97,7 +97,7 @@ export const allBackupsDailyScheduled = inngest.createFunction(
     triggers: [cron(ALL_BACKUPS_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/all-backups-daily-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const planned = await runScheduledCoreAndCapabilityBackups({ step, runPostgres: async () => {
@@ -157,7 +157,7 @@ export const postgresDailyBackupScheduled = inngest.createFunction(
     triggers: [cron(POSTGRES_BACKUP_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/postgres-daily-backup-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("run-postgres-backup-scheduled", async () => {

--- a/apps/web/lib/queue/functions/quality-issue-drift-sweep.ts
+++ b/apps/web/lib/queue/functions/quality-issue-drift-sweep.ts
@@ -30,7 +30,7 @@ export const qualityIssueDriftSweepScheduled = inngest.createFunction(
     triggers: [cron("23 5 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "governance/quality-issue-drift-sweep-scheduled");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("quality-issue-drift-sweep", async () => {

--- a/apps/web/lib/queue/functions/queue-metrics-aggregator.ts
+++ b/apps/web/lib/queue/functions/queue-metrics-aggregator.ts
@@ -19,7 +19,7 @@ export const queueMetricsAggregator = inngest.createFunction(
     triggers: [cron("7 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "queue/metrics-aggregator");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("aggregate-current-day", async () => {

--- a/apps/web/lib/queue/functions/recurring-invoice-dispatch.ts
+++ b/apps/web/lib/queue/functions/recurring-invoice-dispatch.ts
@@ -17,7 +17,7 @@ import { gateAtEntry } from "../quiescence-gates";
 export const recurringInvoiceDispatch = inngest.createFunction(
   { id: "finance/recurring-invoice-dispatch", retries: 1, triggers: [cron("30 6 * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "finance/recurring-invoice-dispatch");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("generate-due-invoices", async () => {

--- a/apps/web/lib/queue/functions/regulatory-monitor-scan.ts
+++ b/apps/web/lib/queue/functions/regulatory-monitor-scan.ts
@@ -46,7 +46,7 @@ export const regulatoryMonitorScanScheduled = inngest.createFunction(
     triggers: [cron(REGULATORY_MONITOR_SCAN_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, REGULATORY_MONITOR_SCAN_SCHEDULED_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("regulatory-monitor-scan", runScheduledRegulatoryScan);

--- a/apps/web/lib/queue/functions/release-health-check.ts
+++ b/apps/web/lib/queue/functions/release-health-check.ts
@@ -19,7 +19,7 @@ export const releaseHealthCheck = inngest.createFunction(
     triggers: [cron("12,27,42,57 * * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/release-health-check");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("check-release-health", () => runReleaseHealthCheck());

--- a/apps/web/lib/queue/functions/remote-action-claim-timeout.ts
+++ b/apps/web/lib/queue/functions/remote-action-claim-timeout.ts
@@ -40,7 +40,7 @@ export const remoteActionClaimTimeout = inngest.createFunction(
     if (!envFlagEnabled(process.env, "DPF_REMOTE_ACTION_DISPATCH_ENABLED")) {
       return { skipped: true, reason: "flag-disabled" };
     }
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/remote-action-claim-timeout");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return await step.run("timeout-stale-remote-action-claims", async () => runRemoteActionClaimTimeout());
   },

--- a/apps/web/lib/queue/functions/routing-reachability-preflight.ts
+++ b/apps/web/lib/queue/functions/routing-reachability-preflight.ts
@@ -44,7 +44,7 @@ export const routingReachabilityPreflight = inngest.createFunction(
     triggers: [cron("37 */6 * * *")], // every 6h, offset to avoid the :00/:10 batches
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "inference/routing-reachability-preflight");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     try {

--- a/apps/web/lib/queue/functions/semantic-memory-reconcile.ts
+++ b/apps/web/lib/queue/functions/semantic-memory-reconcile.ts
@@ -69,7 +69,7 @@ export const semanticMemoryReconcileScheduled = inngest.createFunction(
     triggers: [cron(SEMANTIC_MEMORY_RECONCILE_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, SEMANTIC_MEMORY_RECONCILE_SCHEDULED_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("semantic-memory-reconcile", async () => runSemanticMemoryReconcile());
   },

--- a/apps/web/lib/queue/functions/siem-correlation-sweep.ts
+++ b/apps/web/lib/queue/functions/siem-correlation-sweep.ts
@@ -371,7 +371,7 @@ async function groupOpenDetectionsIntoCases(
 export const siemCorrelationSweep = inngest.createFunction(
   { id: "ops/siem-correlation-sweep", retries: 2, triggers: [cron("3,18,33,48 * * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/siem-correlation-sweep");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     // 1. Flow the platform's own audit telemetry into SecurityEvents first, so

--- a/apps/web/lib/queue/functions/skill-curator.ts
+++ b/apps/web/lib/queue/functions/skill-curator.ts
@@ -26,7 +26,7 @@ export const skillCurator = inngest.createFunction(
     triggers: [cron("0 7 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "skills/curator");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("run-skill-curator", async () => {

--- a/apps/web/lib/queue/functions/skill-metrics-aggregator.ts
+++ b/apps/web/lib/queue/functions/skill-metrics-aggregator.ts
@@ -19,7 +19,7 @@ export const skillMetricsAggregator = inngest.createFunction(
     triggers: [cron("0 5 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "skills/metrics-aggregator");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("aggregate-current-period", async () => {

--- a/apps/web/lib/queue/functions/token-expiry-monitor.ts
+++ b/apps/web/lib/queue/functions/token-expiry-monitor.ts
@@ -157,7 +157,7 @@ export async function runTokenExpiryScan(): Promise<{
 export const tokenExpiryMonitor = inngest.createFunction(
   { id: "ops/token-expiry-monitor", retries: 2, triggers: [cron("0 9 * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "ops/token-expiry-monitor");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return await step.run("scan-token-expiry", async () => runTokenExpiryScan());

--- a/apps/web/lib/queue/functions/wiki-lint.ts
+++ b/apps/web/lib/queue/functions/wiki-lint.ts
@@ -17,7 +17,7 @@ import { gateAtEntry } from "../quiescence-gates";
 export const wikiLint = inngest.createFunction(
   { id: "wiki/lint-daily", retries: 2, triggers: [cron("30 3 * * *")] },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "wiki/lint-daily");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const orgIds = await step.run("collect-active-orgs", async () => {

--- a/apps/web/lib/queue/functions/work-pattern-profile-review.ts
+++ b/apps/web/lib/queue/functions/work-pattern-profile-review.ts
@@ -10,7 +10,7 @@ export const workPatternProfileReview = inngest.createFunction(
     triggers: [cron("17 7 * * *")],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, "quality/work-pattern-profile-review");
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     return step.run("review-agent-work-patterns", async () => {

--- a/apps/web/lib/queue/functions/workroom-drive.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.ts
@@ -548,7 +548,7 @@ export const workroomDriveScheduled = inngest.createFunction(
     triggers: [cron(WORKROOM_DRIVE_CRON)],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, WORKROOM_DRIVE_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("workroom-drive", () => runWorkroomDriveJob());
   },
@@ -562,7 +562,7 @@ export const workroomDriveRunNow = inngest.createFunction(
     triggers: [{ event: WORKROOM_DRIVE_REQUESTED_EVENT }],
   },
   async ({ step }) => {
-    const gate = await gateAtEntry(step);
+    const gate = await gateAtEntry(step, WORKROOM_DRIVE_RUN_NOW_INNGEST_ID);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
     return step.run("workroom-drive", () => runWorkroomDriveJob());
   },

--- a/apps/web/lib/queue/quiescence-gates.test.ts
+++ b/apps/web/lib/queue/quiescence-gates.test.ts
@@ -5,12 +5,20 @@
  * Confirms the gate returns the documented shape for each level and that
  * step.waitForEvent is invoked for the between-steps variant.
  */
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import {
+  DISABLED_BY_OPERATOR_REASON,
   gateAtEntry,
   gateBetweenSteps,
   type GateBetweenStepsRunner,
 } from "./quiescence-gates";
+import { allFunctions, scheduledFunctions } from "./functions/index";
+import {
+  SCHEDULED_JOB_CATALOG,
+  getCatalogEntryByInngestId,
+} from "@/lib/operate/scheduled-jobs/catalog";
 
 // Mock the dynamic import of @/lib/self-upgrade/quiescence so each test can
 // pin the returned level deterministically.
@@ -20,10 +28,25 @@ vi.mock("@/lib/self-upgrade/quiescence", () => {
   };
 });
 
+// The kill switch reads ScheduledJob.enabled through the one shared helper;
+// mock it so each test pins the answer. The helper's own posture (default-on,
+// fail-open) is covered in lib/operate/scheduled-jobs/core.test.ts.
+vi.mock("@/lib/operate/scheduled-jobs/core", () => ({ isJobEnabled: vi.fn() }));
+
 import { getQuiescenceLevel } from "@/lib/self-upgrade/quiescence";
+import { isJobEnabled } from "@/lib/operate/scheduled-jobs/core";
+
+const isJobEnabledMock = vi.mocked(isJobEnabled);
+
+// A catalogued cron that declares honorsEnabledGate: true.
+const GATED_ID = "ops/code-graph-reconcile-scheduled";
+const GATED_JOB_ID = "code-graph-reconcile";
 
 beforeEach(() => {
   vi.mocked(getQuiescenceLevel).mockReset();
+  isJobEnabledMock.mockReset();
+  // Default: enabled.
+  isJobEnabledMock.mockResolvedValue(true);
 });
 
 type FakeStep = GateBetweenStepsRunner & {
@@ -40,19 +63,21 @@ function makeFakeStep(): FakeStep {
 }
 
 describe("gateAtEntry", () => {
-  it("returns { proceed: true } when level is normal", async () => {
+  it("returns { proceed: true } when level is normal and the job is enabled", async () => {
     vi.mocked(getQuiescenceLevel).mockResolvedValue("normal");
     const step = makeFakeStep();
-    const result = await gateAtEntry(step);
+    const result = await gateAtEntry(step, GATED_ID);
     expect(result).toEqual({ proceed: true });
-    expect(step.run).toHaveBeenCalledTimes(1);
+    expect(step.run).toHaveBeenCalledTimes(2);
     expect(step.run.mock.calls[0][0]).toBe("quiescence-gate-at-entry");
+    expect(step.run.mock.calls[1][0]).toBe("kill-switch-gate-at-entry");
+    expect(isJobEnabledMock).toHaveBeenCalledWith(GATED_JOB_ID);
   });
 
   it("returns { proceed: false, skipped: true, reason } when draining", async () => {
     vi.mocked(getQuiescenceLevel).mockResolvedValue("draining");
     const step = makeFakeStep();
-    const result = await gateAtEntry(step);
+    const result = await gateAtEntry(step, GATED_ID);
     expect(result.proceed).toBe(false);
     if (!result.proceed) {
       expect(result.skipped).toBe(true);
@@ -63,7 +88,7 @@ describe("gateAtEntry", () => {
   it("returns the same shape for swapping (callable contract)", async () => {
     vi.mocked(getQuiescenceLevel).mockResolvedValue("swapping");
     const step = makeFakeStep();
-    const result = await gateAtEntry(step);
+    const result = await gateAtEntry(step, GATED_ID);
     expect(result.proceed).toBe(false);
     if (!result.proceed) {
       expect(result.reason).toBe("quiescing(swapping)");
@@ -73,11 +98,186 @@ describe("gateAtEntry", () => {
   it("wraps the level check in step.run for Inngest checkpointing", async () => {
     vi.mocked(getQuiescenceLevel).mockResolvedValue("normal");
     const step = makeFakeStep();
-    await gateAtEntry(step);
-    // Sole step.run call uses the documented step name; the fn it received
+    await gateAtEntry(step, GATED_ID);
+    // First step.run call uses the documented step name; the fn it received
     // is what reads the level (test simply ensures the wrapping happens).
-    expect(step.run).toHaveBeenCalledTimes(1);
     expect(step.run.mock.calls[0][0]).toBe("quiescence-gate-at-entry");
+  });
+});
+
+describe("gateAtEntry kill switch (BI-7E49FA15)", () => {
+  beforeEach(() => {
+    vi.mocked(getQuiescenceLevel).mockResolvedValue("normal");
+  });
+
+  it("skips a job the operator disabled with reason disabled-by-operator", async () => {
+    isJobEnabledMock.mockResolvedValue(false);
+    const step = makeFakeStep();
+    const result = await gateAtEntry(step, GATED_ID);
+    expect(result).toEqual({
+      proceed: false,
+      skipped: true,
+      reason: DISABLED_BY_OPERATOR_REASON,
+    });
+    expect(DISABLED_BY_OPERATOR_REASON).toBe("disabled-by-operator");
+  });
+
+  it("checkpoints the kill-switch read in its own step.run", async () => {
+    isJobEnabledMock.mockResolvedValue(false);
+    const step = makeFakeStep();
+    await gateAtEntry(step, GATED_ID);
+    expect(step.run.mock.calls.map((c) => c[0])).toEqual([
+      "quiescence-gate-at-entry",
+      "kill-switch-gate-at-entry",
+    ]);
+  });
+
+  it("proceeds when the job is enabled", async () => {
+    isJobEnabledMock.mockResolvedValue(true);
+    expect(await gateAtEntry(makeFakeStep(), GATED_ID)).toEqual({ proceed: true });
+  });
+
+  it("lets quiescence take precedence over the kill switch", async () => {
+    vi.mocked(getQuiescenceLevel).mockResolvedValue("draining");
+    isJobEnabledMock.mockResolvedValue(false);
+    const step = makeFakeStep();
+    const result = await gateAtEntry(step, GATED_ID);
+    expect(result).toEqual({ proceed: false, skipped: true, reason: "quiescing(draining)" });
+    // Never reached the kill-switch read.
+    expect(step.run).toHaveBeenCalledTimes(1);
+    expect(isJobEnabledMock).not.toHaveBeenCalled();
+  });
+
+  it("proceeds for an Inngest id with no catalog entry (event-driven run-now functions)", async () => {
+    isJobEnabledMock.mockResolvedValue(false);
+    expect(await gateAtEntry(makeFakeStep(), "ops/no-such-function")).toEqual({ proceed: true });
+    expect(isJobEnabledMock).not.toHaveBeenCalled();
+  });
+
+  it("proceeds for a catalogued entry that carries an ungatedReason (quiescence callers)", async () => {
+    isJobEnabledMock.mockResolvedValue(false);
+    expect(await gateAtEntry(makeFakeStep(), "ops/self-upgrade-scheduled")).toEqual({
+      proceed: true,
+    });
+    expect(isJobEnabledMock).not.toHaveBeenCalled();
+  });
+
+  it("fails OPEN: a read failure proceeds rather than taking the schedule down", async () => {
+    // isJobEnabled itself swallows the read error (core.test.ts); the gate
+    // must not add a throwing path of its own around it.
+    isJobEnabledMock.mockResolvedValue(true);
+    expect(await gateAtEntry(makeFakeStep(), GATED_ID)).toEqual({ proceed: true });
+  });
+});
+
+describe("gateAtEntry call-site identity guard (BI-7E49FA15)", () => {
+  // Source scan over every cron module: each gateAtEntry(step, X) must pass
+  // the same expression its enclosing createFunction declares as `id`, and
+  // that id must be a registered Inngest function. A copy-pasted wrong
+  // constant would gate the wrong job silently; this fails the build instead.
+  const FUNCTIONS_DIR = path.join(__dirname, "functions");
+  const registeredIds = new Set(
+    allFunctions.map((fn) => (fn as { id: () => string }).id()),
+  );
+
+  type Site = { file: string; declaredId: string; passed: string; isCron: boolean };
+
+  function scanSites(): Site[] {
+    const sites: Site[] = [];
+    for (const file of fs.readdirSync(FUNCTIONS_DIR)) {
+      if (!file.endsWith(".ts") || file.endsWith(".test.ts")) continue;
+      const src = fs.readFileSync(path.join(FUNCTIONS_DIR, file), "utf8");
+      if (!src.includes("gateAtEntry(")) continue;
+      const starts: number[] = [];
+      const re = /createFunction\(/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) starts.push(m.index);
+      starts.push(src.length);
+      for (let i = 0; i < starts.length - 1; i++) {
+        const block = src.slice(starts[i], starts[i + 1]);
+        const idMatch = block.match(/\bid:\s*([^,\n]+)/);
+        for (const call of block.matchAll(/gateAtEntry\(([^)]*)\)/g)) {
+          const args = call[1].split(",").map((a) => a.trim());
+          sites.push({
+            file,
+            declaredId: idMatch ? idMatch[1].trim() : "",
+            passed: args[1] ?? "",
+            isCron: /\bcron\(|\bcron:/.test(block),
+          });
+        }
+      }
+    }
+    return sites;
+  }
+
+  /** Resolve a literal or an imported constant to its runtime string. */
+  async function resolveId(file: string, expr: string): Promise<string | undefined> {
+    const literal = expr.match(/^"([^"]+)"$/);
+    if (literal) return literal[1];
+    const src = fs.readFileSync(path.join(FUNCTIONS_DIR, file), "utf8");
+    // Declared in this module?
+    const local = src.match(new RegExp(`const ${expr}\\s*=\\s*"([^"]+)"`));
+    if (local) return local[1];
+    // Find the import statement that brings `expr` in.
+    const importRe = /import\s*\{([^}]*)\}\s*from\s*"([^"]+)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = importRe.exec(src))) {
+      const names = m[1].split(",").map((n) => n.trim().split(/\s+as\s+/).pop());
+      if (!names.includes(expr)) continue;
+      const spec = m[2].startsWith(".") ? path.join(FUNCTIONS_DIR, m[2]) : m[2];
+      const mod = (await import(/* @vite-ignore */ spec)) as Record<string, unknown>;
+      const value = mod[expr];
+      return typeof value === "string" ? value : undefined;
+    }
+    return undefined;
+  }
+
+  it("covers every cron module (the scan itself is not vacuous)", () => {
+    const sites = scanSites();
+    expect(sites.length).toBeGreaterThanOrEqual(60);
+  });
+
+  it("passes the enclosing function's own id at every call site", () => {
+    const wrong = scanSites()
+      .filter((s) => !s.passed || s.passed !== s.declaredId)
+      .map((s) => `${s.file}: id ${s.declaredId} but gateAtEntry got ${s.passed || "<nothing>"}`);
+    expect(wrong).toEqual([]);
+  });
+
+  it("resolves every passed id to a registered Inngest function, and every cron's to a catalog entry", async () => {
+    const problems: string[] = [];
+    for (const site of scanSites()) {
+      const id = await resolveId(site.file, site.passed);
+      if (!id) {
+        problems.push(`${site.file}: could not resolve ${site.passed}`);
+        continue;
+      }
+      if (!registeredIds.has(id)) problems.push(`${site.file}: ${id} is not a registered function`);
+      if (site.isCron && !getCatalogEntryByInngestId(id)) {
+        problems.push(`${site.file}: cron ${id} has no catalog entry`);
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  it("marks every catalogued cron that reaches gateAtEntry as honorsEnabledGate: true", async () => {
+    const gatedIds = new Set<string>();
+    for (const site of scanSites()) {
+      if (!site.isCron) continue;
+      const id = await resolveId(site.file, site.passed);
+      if (id) gatedIds.add(id);
+    }
+    const scheduledIds = new Set(
+      scheduledFunctions.map((fn) => (fn as { id: () => string }).id()),
+    );
+    const mislabelled = SCHEDULED_JOB_CATALOG.filter((e) => {
+      if (!scheduledIds.has(e.inngestId)) return false;
+      const reaches = gatedIds.has(e.inngestId);
+      // Reaches the gate but says it is not enforced (and is not a declared
+      // exemption), or claims enforcement without reaching the gate.
+      return reaches ? e.honorsEnabledGate !== true && !e.ungatedReason : e.honorsEnabledGate === true;
+    }).map((e) => e.inngestId);
+    expect(mislabelled).toEqual([]);
   });
 });
 

--- a/apps/web/lib/queue/quiescence-gates.ts
+++ b/apps/web/lib/queue/quiescence-gates.ts
@@ -39,18 +39,39 @@ export type GateStepRunner = {
   run(name: string, fn: () => Promise<unknown>): Promise<unknown>;
 };
 
+/** Skip reason returned when an operator has set ScheduledJob.enabled=false. */
+export const DISABLED_BY_OPERATOR_REASON = "disabled-by-operator";
+
 /**
  * Call at the top of every cron function (except self-upgrade callers).
  *
- * Returns { proceed: false, skipped: true, reason } when level ≥ draining;
- * caller should return early with the same shape so Inngest run history
- * records the skip with a recognizable label.
+ * Two checks, in order, each its own checkpointed `step.run` (Inngest
+ * re-running the function after a worker restart replays the gate result
+ * deterministically rather than re-querying state):
  *
- * Wrapped in `step.run` so the level check is itself a checkpointed step
- * (Inngest re-running the function after a worker restart will replay
- * the gate result deterministically rather than re-querying state).
+ *   1. Quiescence — returns `quiescing(<level>)` when level ≥ draining.
+ *   2. Per-job kill switch (BI-7E49FA15) — resolves `inngestId` through the
+ *      scheduled-job catalog and returns `disabled-by-operator` when the
+ *      catalogued job's ScheduledJob.enabled is false. Only entries that
+ *      declare `honorsEnabledGate: true` are enforced; an entry carrying an
+ *      `ungatedReason` (the quiescence callers) and an id with no catalog
+ *      entry (event-driven run-now functions) proceed. A failed read also
+ *      proceeds — see isJobEnabled().
+ *
+ * `inngestId` is REQUIRED so the compiler, not review attention, enforces
+ * that every gated cron declares which job it is. Pass the same value as the
+ * enclosing createFunction's `id`; the source-scan test in
+ * quiescence-gates.test.ts fails the build on a mismatch.
+ *
+ * Callers return early with the same shape so Inngest run history records
+ * the skip with a recognizable label — a skip, never a failure, which is why
+ * this lives in the entry gate rather than client middleware (design doc
+ * 2026-08-28-scheduled-job-kill-switch-design.md).
  */
-export async function gateAtEntry(step: GateStepRunner): Promise<GateAtEntryResult> {
+export async function gateAtEntry(
+  step: GateStepRunner,
+  inngestId: string,
+): Promise<GateAtEntryResult> {
   const level = (await step.run("quiescence-gate-at-entry", async () => {
     // Dynamic import to avoid loading prisma into every Inngest function's
     // module graph at definition time.
@@ -59,6 +80,18 @@ export async function gateAtEntry(step: GateStepRunner): Promise<GateAtEntryResu
   })) as string;
   if (level !== "normal") {
     return { proceed: false, skipped: true, reason: `quiescing(${level})` };
+  }
+  const enabled = (await step.run("kill-switch-gate-at-entry", async () => {
+    const { getCatalogEntryByInngestId } = await import(
+      "@/lib/operate/scheduled-jobs/catalog"
+    );
+    const entry = getCatalogEntryByInngestId(inngestId);
+    if (!entry || entry.honorsEnabledGate !== true) return true;
+    const { isJobEnabled } = await import("@/lib/operate/scheduled-jobs/core");
+    return isJobEnabled(entry.jobId);
+  })) as boolean;
+  if (!enabled) {
+    return { proceed: false, skipped: true, reason: DISABLED_BY_OPERATOR_REASON };
   }
   return { proceed: true };
 }

--- a/docs/data-impact/2026-09-06-scheduled-job-kill-switch.data-impact.json
+++ b/docs/data-impact/2026-09-06-scheduled-job-kill-switch.data-impact.json
@@ -1,0 +1,33 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-operations",
+  "affectedCopies": [
+    "ScheduledJob rows (jobId, enabled) read by the cron entry gate and by the retention / inngest-retention / catalog-sweep / identity-inference / mdm-steward runners"
+  ],
+  "migration": {
+    "name": "none",
+    "backfill": "no schema change \u2014 ScheduledJob.enabled already exists and every row defaults to enabled=true. This change only makes existing rows load-bearing: crons now READ the column through the one shared isJobEnabled() helper (fail-open on read error) and skip with reason disabled-by-operator when an operator has set it false. No row is created, deleted, or modified by the change itself; the retention runners still write their existing heartbeat/metadata exactly as before"
+  },
+  "tests": [
+    "apps/web/lib/queue/quiescence-gates.test.ts",
+    "apps/web/lib/operate/scheduled-jobs/core.test.ts",
+    "apps/web/lib/operate/scheduled-jobs/catalog.test.ts",
+    "apps/web/lib/queue/functions/index.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:ScheduledJob#enabled-kill-switch",
+      "prismaModel": "ScheduledJob",
+      "lifecycleDisposition": "no-schema-change: the retention lifecycle executors (lib/operate/retention/run.ts, lib/operate/inngest-retention/run.ts) change only HOW they read the operator kill switch \u2014 through the shared isJobEnabled() helper instead of a hand-rolled findUnique \u2014 and what they purge, when, and how they record disposition is untouched. Legal-hold handling and disposition evidence are unchanged (BI-7E49FA15)",
+      "fields": [
+        {
+          "fieldId": "data:ScheduledJob#enabled",
+          "resolution": "governed",
+          "reason": "the column is documented as the per-job kill switch; this change makes every catalogued cron honour it via gateAtEntry(step, inngestId) so the Scheduled Jobs surface's Disable action is true rather than merely labelled. Read failures default to enabled so a database blip cannot take the schedule down",
+          "provenance": "BI-7E49FA15; design docs/superpowers/specs/2026-08-28-scheduled-job-kill-switch-design.md; surface honesty landed in #4667 (honorsEnabledGate)"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-08-28-scheduled-job-kill-switch.md
+++ b/docs/superpowers/plans/2026-08-28-scheduled-job-kill-switch.md
@@ -1,3 +1,6 @@
+---
+status: active
+---
 # Make the scheduled-job kill switch load-bearing (BI-7E49FA15)
 
 Status: implemented (branch fix/scheduled-job-kill-switch-v2) · Umbrella backlog item: BI-7E49FA15 · Workroom: WC-5586F794

--- a/docs/superpowers/plans/2026-08-28-scheduled-job-kill-switch.md
+++ b/docs/superpowers/plans/2026-08-28-scheduled-job-kill-switch.md
@@ -1,0 +1,97 @@
+# Make the scheduled-job kill switch load-bearing (BI-7E49FA15)
+
+Status: implemented (branch fix/scheduled-job-kill-switch-v2) · Umbrella backlog item: BI-7E49FA15 · Workroom: WC-5586F794
+
+## Problem
+
+`ScheduledJob.enabled` is documented as a per-job kill switch. In practice six of
+the 55 catalogued crons consult it, and five of those six hand-roll the query
+instead of calling the shared `isJobEnabled()` helper. For every other recurring
+job, pressing **Disable** on the Scheduled Jobs surface writes a column nobody
+reads and the job runs on its next tick. The operator is told the job is off and
+it is not.
+
+`#4667` already made the surface honest — the catalog carries `honorsEnabledGate`
+and a row without it renders "no kill switch". This plan makes the switch true
+rather than merely honestly labelled.
+
+## Research & benchmarking
+
+Three shapes were considered for where the gate belongs.
+
+1. **Per-cron hand-rolled check** — the status quo for five jobs. Rejected: it is
+   the single-source-of-truth violation underneath the coverage gap, and its
+   default-on-missing-row semantics have already drifted between call sites
+   (three sites swallow read failures with `.catch(() => null)`, one does not).
+2. **Inngest middleware on the client** (`onFunctionRun`, which does see `fn.id`).
+   This is how Temporal interceptors and Sidekiq middleware express cross-cutting
+   run gates, and it needs zero per-function edits. Rejected: Inngest middleware
+   cannot short-circuit a run. The only abort is throwing `NonRetriableError`,
+   which records a *failure* in run history rather than a skip — the opposite of
+   what an operator pressing Disable should see, and it would corrupt the
+   `lastStatus` the register reads.
+3. **Extend the existing shared entry gate** — `gateAtEntry(step)` in
+   `apps/web/lib/queue/quiescence-gates.ts`, already called by 55 of the cron
+   modules for the Activity Quiescence Protocol. It returns
+   `{ proceed: false, skipped: true, reason }`, which is exactly the skip shape a
+   kill switch wants, and every caller already handles it. **Adopted.**
+
+Option 3 is also what the platform already does for the other operator-facing
+run gate (quiescence), so the kill switch does not become a second mechanism for
+"reasons this tick did not run" — consistent with §1 single source of truth.
+
+The gate needs to know *which* job it is gating. `gateAtEntry` takes a **required**
+second parameter, the Inngest function id, and resolves the `jobId` through the
+catalog. Required rather than optional so the compiler — not a lint rule and not
+review attention — enforces that every gated cron declares its identity.
+
+## Design
+
+1. `catalog-types.ts` gains `ungatedReason?: string`: the declared reason a job is
+   deliberately not gated. Every catalog entry must carry exactly one of
+   `honorsEnabledGate: true` or a non-empty `ungatedReason`.
+2. `catalog.ts` gains `getCatalogEntryByInngestId(inngestId)`.
+3. `core.ts` `isJobEnabled()` becomes the one implementation of the gate,
+   including its read-failure posture: a failed read defaults to **enabled**. A
+   kill switch that fails closed would take the platform down on a database blip;
+   three of the five existing call sites already fail open and this makes that
+   uniform and stated.
+4. `quiescence-gates.ts` `gateAtEntry(step, inngestId)` checks quiescence first,
+   then the kill switch, returning `reason: "disabled-by-operator"`. The check is
+   its own `step.run` so it is checkpointed like the quiescence check.
+5. The five hand-rolled sites (`catalog-sweep-runner.ts`,
+   `identity-inference-runner.ts`, `operate/retention/run.ts`,
+   `operate/inngest-retention/run.ts`, `queue/functions/mdm-steward-sweep.ts`)
+   call `isJobEnabled()`. They keep their own check because they are also reached
+   by the run-now event path, which does not pass through `gateAtEntry`.
+6. All 64 `gateAtEntry(step)` call sites pass their function id.
+7. Catalog entries flip to `honorsEnabledGate: true` as each is wired.
+
+### Deliberate exemptions
+
+`self-upgrade` and `all-backups-daily` are the quiescence *callers*; the existing
+protocol already forbids gating them, and a kill switch on the upgrade path would
+strand an install with no route to a fix. Catalogued crons whose modules do not
+call `gateAtEntry` keep `ungatedReason` until they are wired.
+
+## Verification
+
+- Unit: `quiescence-gates.test.ts` — disabled job skips with
+  `disabled-by-operator`; enabled job proceeds; quiescence still takes precedence;
+  unknown inngest id proceeds; read failure proceeds.
+- Unit: `catalog.test.ts` — every entry declares exactly one of
+  `honorsEnabledGate: true` or a non-empty `ungatedReason`.
+- Unit: source-scan guard — every `gateAtEntry(step, X)` passes an id that appears
+  as this module's own `id:` and resolves to a catalogued entry, so a copy-paste
+  of the wrong constant fails the build rather than silently gating the wrong job.
+- Production build: `pnpm --filter web build`.
+- Migration: none — no schema change; `ScheduledJob.enabled` already exists.
+- UX: no route markup changes. The Scheduled Jobs surface already renders
+  `killSwitchEnforced` from `honorsEnabledGate`; the rows stop saying "no kill
+  switch" as a consequence of the catalog data, not of a component change.
+
+## Rollout
+
+One PR, no schema change, one clean revert. It changes the runtime behaviour of
+live jobs only when an operator has actually set `enabled = false` — every job
+defaults to enabled, so a green install sees no behaviour change at all.

--- a/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
@@ -525,7 +525,7 @@ Each subsection covers a surface category from §2.1 with its four answers (Dete
 
 **Stop-accept** — Two helpers in `apps/web/lib/queue/inngest-client.ts`:
 
-- `gateAtEntry(step)` — for cron functions. Returns early with `{ skipped: true, reason: "quiescing" }` if level ≥ `draining`. Function will re-fire on next cron tick after `cleared`.
+- `gateAtEntry(step, inngestId)` — for cron functions. Returns early with `{ skipped: true, reason: "quiescing" }` if level ≥ `draining`. Function will re-fire on next cron tick after `cleared`. Since BI-7E49FA15 the same gate also enforces the per-job kill switch (`ScheduledJob.enabled`, reason `disabled-by-operator`) for catalog entries declaring `honorsEnabledGate: true`; the required `inngestId` is how it resolves the job — see `docs/superpowers/specs/2026-08-28-scheduled-job-kill-switch-design.md`.
 - `gateBetweenSteps(step)` — for long-running event-driven functions. Calls `step.waitForEvent("platform.quiescence-cleared", { timeout: "30m" })` between major steps to suspend cleanly. Resumes when the durable Inngest `platform.quiescence-cleared` event fires for any terminal outcome. The UI `system:quiescence` event is emitted from the same transition but is not the durable wake signal.
 
 Every existing Inngest function in `apps/web/lib/queue/functions/` is wrapped with the appropriate gate as a Phase 1 deliverable. Cron functions get `gateAtEntry`; event-driven and long-running functions get `gateBetweenSteps` between their natural steps.

--- a/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
@@ -1,3 +1,6 @@
+---
+status: active
+---
 # Activity Quiescence Protocol
 
 > **Observation architecture note:** this spec owns the durable quiescence lifecycle. Browser

--- a/docs/superpowers/specs/2026-08-28-scheduled-job-kill-switch-design.md
+++ b/docs/superpowers/specs/2026-08-28-scheduled-job-kill-switch-design.md
@@ -1,3 +1,6 @@
+---
+status: active
+---
 # Scheduled-job kill switch — design
 
 Backlog item: BI-7E49FA15 · Workroom: WC-5586F794 · Profile: fix

--- a/docs/superpowers/specs/2026-08-28-scheduled-job-kill-switch-design.md
+++ b/docs/superpowers/specs/2026-08-28-scheduled-job-kill-switch-design.md
@@ -1,0 +1,112 @@
+# Scheduled-job kill switch — design
+
+Backlog item: BI-7E49FA15 · Workroom: WC-5586F794 · Profile: fix
+Implementation plan: `docs/superpowers/plans/2026-08-28-scheduled-job-kill-switch.md`
+
+## Problem
+
+`ScheduledJob.enabled` is documented as a per-job kill switch. Six of the 55
+catalogued crons consult it, and five of those six hand-roll the query instead of
+calling the shared `isJobEnabled()` helper. For every other recurring job,
+pressing **Disable** on the Scheduled Jobs surface writes a column nobody reads
+and the job runs on its next tick. The operator is told the job is off and it is
+not.
+
+`#4667` already made the surface honest — the catalog carries `honorsEnabledGate`
+and a row without it renders "no kill switch". This design makes the switch true
+rather than merely honestly labelled.
+
+Two defects sit under one symptom, and this design addresses both:
+
+- **Coverage.** 49 catalogued crons never read the column.
+- **Single source of truth.** The gate is implemented six times. The copies have
+  already drifted: three swallow read failures with `.catch(() => null)` and
+  default to running, one lets the read throw, and two fold the read into an
+  upsert that also materialises the row.
+
+## Research & benchmarking
+
+Three shapes were considered for where the gate belongs.
+
+### 1. Per-cron hand-rolled check — the status quo
+
+How five of the six enforcing jobs do it today: a local
+`select: { enabled: true }` followed by `if (job.enabled === false) return`.
+
+**Rejected.** It is the single-source-of-truth violation underneath the coverage
+gap, it has already drifted across call sites, and extending it to 49 more crons
+would multiply the drift by eight.
+
+### 2. Inngest middleware on the client
+
+Inngest's `InngestMiddleware` exposes `onFunctionRun({ ctx, fn })`, so a single
+client-level middleware could see every function's id and gate every run with no
+per-function edits. This is how the comparable open-source schedulers express
+cross-cutting run gates:
+
+- **Temporal** — worker *interceptors* wrap every workflow/activity execution and
+  are the documented place for cross-cutting concerns.
+- **Sidekiq** — server-side *middleware* wraps every job; the ecosystem's standard
+  pause/kill plugins (`sidekiq-limit_fetch`, Sidekiq Pro's queue pause) hook there.
+- **Celery** — the `task_prerun` signal plus `Task.throws`, again a single
+  cross-cutting hook rather than per-task code.
+
+DPF adopts the *principle* these three share — one cross-cutting gate, not N
+copies — and **rejects the middleware mechanism specifically**, because Inngest's
+middleware cannot short-circuit a run. The only abort available is throwing
+`NonRetriableError`, which records a **failure** in run history rather than a
+skip. That is the opposite of what an operator pressing Disable should see, and
+it would poison the `lastStatus` the scheduled-work register reads to derive job
+health — a disabled job would render as failing.
+
+### 3. Extend the existing shared entry gate — adopted
+
+`gateAtEntry(step)` in `apps/web/lib/queue/quiescence-gates.ts` is already called
+by 55 cron modules for the Activity Quiescence Protocol. It returns
+`{ proceed: false, skipped: true, reason }` — exactly the skip shape a kill switch
+wants, already handled by every caller, and already recorded as a skip rather
+than a failure.
+
+This is the same cross-cutting-hook principle as Temporal/Sidekiq/Celery,
+expressed through the hook this platform already has. It also keeps the kill
+switch from becoming a *second* mechanism for "reasons this tick did not run":
+quiescence and the kill switch answer that question in one place, in one shape.
+
+## Design
+
+The gate needs to know which job it is gating. `gateAtEntry` takes a **required**
+second parameter, the Inngest function id, and resolves the `jobId` through the
+catalog. Required rather than optional so the compiler — not a lint rule, not
+review attention — enforces that every gated cron declares its identity.
+
+1. `catalog-types.ts` gains `ungatedReason?: string`: the declared reason a job is
+   deliberately not gated. Every catalog entry must carry exactly one of
+   `honorsEnabledGate: true` or a non-empty `ungatedReason`.
+2. `catalog.ts` gains `getCatalogEntryByInngestId(inngestId)`.
+3. `core.ts` `isJobEnabled()` becomes the one implementation of the gate,
+   including its read-failure posture: **a failed read defaults to enabled.** A
+   kill switch that failed closed would take the whole schedule down on a database
+   blip. Three of the five existing call sites already fail open; this makes that
+   uniform and stated rather than accidental.
+4. `gateAtEntry(step, inngestId)` checks quiescence first, then the kill switch,
+   returning `reason: "disabled-by-operator"`. The check is its own `step.run` so
+   it is checkpointed like the quiescence check.
+5. The five hand-rolled sites call `isJobEnabled()`. They keep a check of their
+   own because they are also reached by the run-now event path, which does not
+   pass through `gateAtEntry`.
+6. All `gateAtEntry(step)` call sites pass their function id.
+7. Catalog entries flip to `honorsEnabledGate: true` as each is wired.
+
+### Deliberate exemptions
+
+`self-upgrade` and `all-backups-daily` are the quiescence *callers*; the protocol
+already forbids gating them, and a kill switch on the upgrade path would strand
+an install with no route to a fix. Catalogued crons whose modules do not call
+`gateAtEntry` keep an `ungatedReason` until they are wired.
+
+## Consequences
+
+No schema change — `ScheduledJob.enabled` already exists, and every job defaults
+to enabled, so a green install sees no behaviour change at all. The change is
+observable only where an operator has actually set `enabled = false`, which is
+the entire point.


### PR DESCRIPTION
## Problem

`ScheduledJob.enabled` is documented as a per-job kill switch. Only 6 of the catalogued crons consulted it, and 5 of those hand-rolled the query. For every other job, pressing Disable wrote a column nobody read and the job ran on its next tick. #4667 made the surface honest (`honorsEnabledGate`); this makes the switch true.

Design (settled, alternatives on record): `docs/superpowers/specs/2026-08-28-scheduled-job-kill-switch-design.md`.

## Change

- `gateAtEntry(step, inngestId)` — required second param. Quiescence first, then a second checkpointed `step.run` that resolves the catalog entry by Inngest id and skips with `disabled-by-operator`. Only entries declaring `honorsEnabledGate: true` are enforced; an entry with an `ungatedReason` or an uncatalogued (event-driven run-now) id proceeds.
- `isJobEnabled()` in `scheduled-jobs/core.ts` is the single implementation and **fails open** on a read error (three of the five copies already did; now uniform and stated).
- Catalog: `getCatalogEntryByInngestId()`, `ungatedReason?: string`. Every entry carries exactly one of the two. Deliberate exemptions: `self-upgrade` and `all-backups-daily` (quiescence callers), `taskrun-watchdog` (liveness guard); 7 crons that never call `gateAtEntry` record that as their reason.
- The five hand-rolled sites route through `isJobEnabled()` and keep a check for the run-now event path (upsert sites keep the upsert, drop `enabled` from the select).
- All 70 `gateAtEntry` call sites across 59 modules pass their function id.
- `catalog.ts` crossed the 800-LOC ceiling → hygiene/janitor entries moved to `catalog-hygiene.ts`, spread in place (display order unchanged).

Rejected, not revisited: Inngest client middleware — it cannot short-circuit a run; `NonRetriableError` records a FAILURE, which would poison `lastStatus`.

## Tests

- `quiescence-gates.test.ts`: disabled skips with `disabled-by-operator`; enabled proceeds; quiescence precedence; unknown id proceeds; `ungatedReason` entry proceeds; fail-open. Plus a source-scan guard: every `gateAtEntry(step, X)` passes its enclosing function's own `id:`, resolves to a registered function, and every cron's id resolves to a catalog entry whose `honorsEnabledGate` matches whether it reaches the gate.
- `core.test.ts`: default-on, fail-open.
- `catalog.test.ts`: exactly-one-of invariant; quiescence callers stay ungated.
- `queue/functions/index.test.ts` parity kept green.

## Verification (AGENTS.md §4)

- Unit: `pnpm --filter web exec vitest run` → 66 files / 597 tests green.
- Build: `pnpm --filter web build` exit 0 (45 pre-existing "Ecmascript file had an error" lines in untouched files, same count as on main).
- Migration: **none** — `ScheduledJob.enabled` already exists.
- UX: no component change. The Scheduled Jobs surface derives `killSwitchEnforced` from `honorsEnabledGate`; rows stop saying "no kill switch" as a consequence of catalog data (`work-model.test.ts`).
- `pregate:preflight`: 64 guards clean. Data-Impact manifest: `docs/data-impact/2026-09-06-scheduled-job-kill-switch.data-impact.json` (lifecycle trigger, disposition no-schema-change).
- Local sandbox gate: **skipped/unrun**, not passed. Run 1 fenced by portal quiescence (self-upgrade); run 2 queued as durable task `TR-NONPROD-816A6CB840957A57A06D7D24` with the shared lease not admitting. Pushed under a recorded `operator-emergency` override at operator direction; the cloud merge queue is the safety net.

## Scope

Runtime behaviour changes only where an operator has actually set `enabled=false`; every job defaults to enabled. One clean revert. Does not bundle the WorkCapsule→Workroom rename.

Docs-Impact-Decision: no user-facing documentation changes; operator-visible effect is described by the design doc and the Scheduled Jobs surface itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
