### PR TITLE
docs(spec): acceptance table header must not match the AC-/OBJ- id pattern (BI-B19BE117)

### DIFF
--- a/docs/superpowers/plans/2026-09-06-convergence-impact-gate-plan.md
+++ b/docs/superpowers/plans/2026-09-06-convergence-impact-gate-plan.md
@@ -12,6 +12,23 @@ design: docs/superpowers/specs/2026-09-06-convergence-impact-gate-design.md
 - **Design:** [`2026-09-06-convergence-impact-gate-design.md`](../specs/2026-09-06-convergence-impact-gate-design.md)
 - **Status:** delivered in PR #5133 (f0f8fcd), spec corrections in #5140 and #5142
 
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-B19BE117`
+- Receipt: `cmtq7ir8408zk01lclpl9xy6t`
+- Rationale: The guard, its surface registry, the trailer-contract entry, the
+  gate-context advertisement, the pull-request profile wiring, the Dockerfile
+  COPY and the docs row are one unit. A guard without the profile entry never
+  runs, a trailer name without the guard is dead vocabulary, and the Dockerfile
+  COPY exists only because gate-context imports the classifier. Any subset
+  ships an inert gate, which is the failure the work exists to prevent.
+- Dependencies: none
+
+| Key | Requirement refs | Contract refs | Flow refs | Verification refs |
+| --- | --- | --- | --- | --- |
+| convergence-impact-gate | OBJ-CONVERGENCE-GATE-1 | scripts/lib/pr-trailer-contract.mjs, scripts/convergence-surfaces.json, convergence-impact-gate | runs check-convergence-impact.mjs over BASE_SHA...HEAD; advertises the trailer before generation | AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7 |
+
 ## Decision: atomic
 
 One deliverable. The guard, its registry, the trailer contract entry, the gate-context advertisement, the profile wiring and the docs row are not independently shippable: a guard without the profile entry never runs, a trailer name without the guard is dead vocabulary, and the Dockerfile COPY exists only because gate-context imports the classifier. Shipping any subset would be the inert-guard failure the plan exists to avoid.

--- a/docs/superpowers/plans/2026-09-06-convergence-impact-gate-plan.md
+++ b/docs/superpowers/plans/2026-09-06-convergence-impact-gate-plan.md
@@ -1,0 +1,40 @@
+---
+status: active
+title: Convergence-Impact Gate — implementation plan
+backlog_item: BI-B19BE117
+design: docs/superpowers/specs/2026-09-06-convergence-impact-gate-design.md
+---
+
+# Convergence-Impact Gate — implementation plan
+
+- **Date:** 2026-09-06
+- **Backlog item:** `BI-B19BE117` (umbrella, atomic)
+- **Design:** [`2026-09-06-convergence-impact-gate-design.md`](../specs/2026-09-06-convergence-impact-gate-design.md)
+- **Status:** delivered in PR #5133 (f0f8fcd), spec corrections in #5140 and #5142
+
+## Decision: atomic
+
+One deliverable. The guard, its registry, the trailer contract entry, the gate-context advertisement, the profile wiring and the docs row are not independently shippable: a guard without the profile entry never runs, a trailer name without the guard is dead vocabulary, and the Dockerfile COPY exists only because gate-context imports the classifier. Shipping any subset would be the inert-guard failure the plan exists to avoid.
+
+## Phases (all complete)
+
+| Phase | Deliverable | Verified by |
+| --- | --- | --- |
+| 1 | Kernel decisions: blocking vs shadow, sibling vs extension | DI-9DF1A83ECACD, DI-91594F6EF8FA |
+| 2 | `scripts/convergence-surfaces.json` registry with a cited `why` per surface | test "registry lists only surfaces with a documented reason" |
+| 3 | `scripts/check-convergence-impact.mjs` classifier, trailer parser, gate | 17 red/green fixtures in `scripts/check-convergence-impact.test.mjs` |
+| 4 | Wiring: `pr-trailer-contract.mjs`, `gate-context.mjs`, `ci-policy-guards.mjs`, `pregate-preflight.mjs`, `package.json` | `pr-readiness.test.mjs`, `ci-policy-guards.test.mjs`, `pregate-preflight.test.mjs` |
+| 5 | Dockerfile COPY of classifier and registry so the packaged gate-context names the same surfaces | `check-dockerfile-copied-script-imports.mjs` |
+| 6 | Docs: `enforced-ci-gates.md`, `backlog-and-planning-runbook.md`, `pre-pr-gate.md`, `pr-health.md` | Docs Impact Gate |
+| 7 | Non-inert proof: the gate fails this PR's own diff without a trailer, and failed its own first CI run on a quoted template | PR #5133 CI history, commit 3af4c61 |
+
+## Traceability
+
+- **Requirements:** spec §1 (problem), §4.1 (registry), §4.2 (attestation), §4.3 (where it runs); OBJ-CONVERGENCE-GATE-1.
+- **Contracts:** `Convergence-Impact-Decision` trailer in `scripts/lib/pr-trailer-contract.mjs`; `scripts/convergence-surfaces.json` schemaVersion 1; guard id `convergence-impact-gate` in the `pull-request` profile.
+- **Flows:** PR opened → Policy Guards (PR) → `check-convergence-impact.mjs` classifies `BASE_SHA...HEAD` → trailer read from commits and `PR_BODY` → pass or fail with the mode table; `gate-context` advertises the trailer before generation.
+- **Verification:** AC-1..AC-7 in the design; `pnpm check:convergence-impact:test`; local-CI gate PASS on 943922b and 3af4c61.
+
+## Follow-ups filed
+
+- `BI-A57B6185` — reviewer TaskRun reports "writer omitted" when the writer was called and rejected; surface the rejection.

--- a/docs/superpowers/plans/2026-09-06-convergence-impact-gate-plan.md
+++ b/docs/superpowers/plans/2026-09-06-convergence-impact-gate-plan.md
@@ -31,9 +31,9 @@ One deliverable. The guard, its registry, the trailer contract entry, the gate-c
 ## Traceability
 
 - **Requirements:** spec §1 (problem), §4.1 (registry), §4.2 (attestation), §4.3 (where it runs); OBJ-CONVERGENCE-GATE-1.
-- **Contracts:** `Convergence-Impact-Decision` trailer in `scripts/lib/pr-trailer-contract.mjs`; `scripts/convergence-surfaces.json` schemaVersion 1; guard id `convergence-impact-gate` in the `pull-request` profile.
-- **Flows:** PR opened → Policy Guards (PR) → `check-convergence-impact.mjs` classifies `BASE_SHA...HEAD` → trailer read from commits and `PR_BODY` → pass or fail with the mode table; `gate-context` advertises the trailer before generation.
-- **Verification:** AC-1..AC-7 in the design; `pnpm check:convergence-impact:test`; local-CI gate PASS on 943922b and 3af4c61.
+- **Contracts:** Convergence-Impact-Decision trailer in scripts/lib/pr-trailer-contract.mjs; scripts/convergence-surfaces.json schemaVersion 1; guard id convergence-impact-gate in the pull-request profile.
+- **Flows:** PR opened, Policy Guards (PR) runs check-convergence-impact.mjs over BASE_SHA...HEAD, trailer read from commits and PR_BODY, pass or fail with the mode table; gate-context advertises the trailer before generation.
+- **Verification:** AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7 in the design (OBJ-CONVERGENCE-GATE-1); `pnpm check:convergence-impact:test`; local-CI gate PASS on 943922b and 3af4c61.
 
 ## Follow-ups filed
 

--- a/docs/superpowers/specs/2026-09-06-convergence-impact-gate-design.md
+++ b/docs/superpowers/specs/2026-09-06-convergence-impact-gate-design.md
@@ -84,7 +84,7 @@ The trailer is the durable record. `gate-context.mjs` advertises it before gener
 
 ## 5. Acceptance criteria
 
-| AC-ID | OBJ-ID | Statement |
+| Criterion | Objective | Statement |
 | --- | --- | --- |
 | AC-1 | OBJ-CONVERGENCE-GATE-1 | A compose change with no trailer fails the gate (test "gate FAILS a compose change") |
 | AC-2 | OBJ-CONVERGENCE-GATE-1 | A trailer with a mode and no reason fails (test "attestation is theater") |


### PR DESCRIPTION
## Summary

Follow-up to #5140. The baseline-manifest parser treats any table row starting with `AC-…` as a criterion, so the header row `| AC-ID | OBJ-ID | … |` was read as a criterion linking to an objective named OBJ-ID and spec-approval rejected it as an unknown objective link. Header renamed to `| Criterion | Objective | Statement |`. Docs-only.

Process-Spine-Decision: docs-only correction to an existing spec, no code change
Docs-Impact-Decision: spec under docs/superpowers, not a published user-guide page

Backlog: BI-B19BE117 · Workroom: WC-FCDDB197 · Parser trap noted on BI-A57B6185

🤖 Generated with [Claude Code](https://claude.com/claude-code)