### PR TITLE
fix(proactivity): resolve the coworker alias at the required-tool lookup too (BI-B05E5D30)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
@@ -167,6 +167,29 @@ describe("rollout registry (BI-E962B9CD)", () => {
 });
 
 describe("coworkerSelfTaskRequiredTool (anti-fabrication floor)", () => {
+
+  it("resolves the CANONICAL agent id the scheduler actually passes (BI-B05E5D30 third site)", async () => {
+    // ScheduledAgentTask.agentId holds AGT-WS-MARKETING, because the proactivity
+    // roster collapses the slug row and can only write the canonical form. Before
+    // this resolution the lookup returned null, the required-tool guarantee never
+    // fired, and a stuck run produced no artifact while reporting ok.
+    // Inventory IS dual-seeded and DOES have a guarantee: before this resolution
+    // the canonical form returned null and its fallback silently never fired.
+    expect(coworkerSelfTaskRequiredTool("AGT-WS-INVENTORY")?.name).toBe("create_knowledge_article");
+    // Marketing stays null in BOTH id forms — the placeholder brief was removed
+    // deliberately (an honest empty state beats a fabricated brief); resolving
+    // the alias must not resurrect it.
+    expect(coworkerSelfTaskRequiredTool("AGT-WS-MARKETING")).toBeNull();
+    expect(coworkerSelfTaskRequiredTool("marketing-specialist")).toBeNull();
+  });
+
+  it("still returns null for a coworker with no procedural guarantee", () => {
+    // The resolution must not invent a fallback for a coworker that has none.
+    expect(coworkerSelfTaskRequiredTool("coo")).toBeNull();
+    expect(coworkerSelfTaskRequiredTool("AGT-WS-EA")).toBeNull();
+  });
+
+
   it("forces a knowledge article for the Estate Specialist, recency-guarded on KnowledgeArticle", async () => {
     const { prisma } = await import("@dpf/db");
     const tool = coworkerSelfTaskRequiredTool(INV);

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
@@ -453,8 +453,21 @@ async function hasRecentKnowledgeArticle(titlePrefix: string): Promise<boolean> 
  * zeros, never better than the truth.
  */
 export function coworkerSelfTaskRequiredTool(
-  agentId: string,
+  rawAgentId: string,
 ): CoworkerSelfTaskProceduralTool | null {
+  // The caller passes ScheduledAgentTask.agentId, which for a dual-seeded
+  // coworker is the CANONICAL id (AGT-WS-MARKETING) — the roster can only write
+  // that form. The branches below are keyed by registry SLUG, so without this
+  // resolution the lookup returns null and the required-tool guarantee never
+  // fires. That is the same alias gap BI-B05E5D30 closed in the sweep and in
+  // reconcileCoworkerSelfTask; this was the third lookup site and it was missed.
+  //
+  // Observed cost: the marketing self-task ran on 2026-08-31, made four READ
+  // calls, produced no artifact, ended with "I got stuck retrying the same step",
+  // and was still recorded lastStatus=ok. The fallback that exists precisely to
+  // catch that could not match the agent id it was handed.
+  const agentId = selfTaskRegistryKey(rawAgentId) ?? rawAgentId;
+
   if (agentId === "inventory-specialist") {
     return {
       name: "create_knowledge_article",


### PR DESCRIPTION
Third lookup site for the alias gap BI-B05E5D30 closed in two others.

## The gap

`coworkerSelfTaskRequiredTool(agentId)` compares raw registry **slugs**:

```ts
if (agentId === "inventory-specialist") { … }
if (agentId === "platform-engineer")   { … }
if (agentId === "doc-specialist")      { … }
```

Its caller passes `ScheduledAgentTask.agentId`, which for a dual-seeded coworker is the **canonical** id (`AGT-WS-INVENTORY`, `AGT-WS-MARKETING`) — the proactivity roster collapses the slug row and can only write the canonical form.

So the lookup returned `null`, and the **required-tool guarantee never fired for any dual-seeded coworker**. That guarantee is the anti-fabrication floor: it force-calls the artifact tool when a coworker's own loop produces nothing. `inventory-specialist` and `platform-engineer` both have one, and both have been silently unprotected since the roster started writing canonical ids — a run that produced nothing still recorded `ok`.

## Observed cost

The marketing self-task, 2026-08-31 14:10 on the reference install:

```
get_marketing_summary   ok
get_marketing_summary   ok
suggest_campaign_ideas  ok
get_marketing_summary   ok
```

Four reads, no artifact, and the coworker's own closing message:

> "I got stuck retrying the same step and stopped before going in circles."

Recorded as `lastStatus: ok`, `lastError: (none)`, `attempts: 0`.

## The fix

Resolve the alias once at the top of the function via `selfTaskRegistryKey`, the same helper already applied in the sweep and in `reconcileCoworkerSelfTask`.

## What is deliberately NOT changed

**Marketing still returns `null` in both id forms.** The marketing placeholder brief was removed on purpose: `/customer/marketing` renders an honest, actionable empty state — an "establish-campaign" next step plus a no-campaign blocker carrying a recovery action — so a fabricated brief is strictly worse than the truth, and one was observed creating real placeholder rows on 2026-07-31 while model dispatch was failing.

An earlier revision of this branch re-added that fallback to make the task always produce *something*. The existing test pinning its absence caught it, and it is reverted. Resolving an alias must not resurrect a deliberately removed guarantee, so a test now pins marketing `null` in **both** forms.

## Verification

- **local-CI gate: PASS** at `944c34761a84`
- 11 test files / 147 tests pass across `lib/operate/scheduled-jobs`

New cases cover the canonical-id resolution, the marketing-stays-null invariant in both id forms, and that resolution does not invent a guarantee for a coworker that has none (`coo`, `AGT-WS-EA` still `null`).

## Known follow-on, not fixed here

`lastStatus` is hardcoded `"ok"` for any scheduled run that does not throw (`agent-task-scheduler.ts`, the coworker-run completion path). A run whose own output says it got stuck still records `ok` with `lastError: null`. Every scheduled coworker shares that path, so any of them can report success indefinitely while producing nothing. The signal for a real fix is `coworkerArtifact` on the tool definitions — a self-task run that executed no artifact-producing tool did not do its work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
