### PR TITLE
fix: allow fresh upgrades after completed dispatched failures

### DIFF
--- a/apps/web/lib/actions/promotions.self-upgrade.test-fixtures.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test-fixtures.ts
@@ -50,3 +50,43 @@ export const mockRun = {
   createdAt: new Date("2026-05-20T02:00:00Z"),
   updatedAt: new Date("2026-05-20T02:05:00Z"),
 };
+
+export const mockRunRow1 = {
+  runId: "SUR-AAAA0001",
+  status: "succeeded",
+  trigger: "scheduled",
+  currentSha: "abc1234",
+  targetSha: "def5678",
+  deployedSha: "def5678",
+  startedAt: new Date("2026-05-20T02:00:00Z"),
+  completedAt: new Date("2026-05-20T02:05:00Z"),
+  completionEvidence: { recoveryPoint: { status: "ok" } },
+  failureLog: null,
+  createdAt: new Date("2026-05-20T02:00:00Z"),
+};
+
+export const mockRunRow2 = {
+  runId: "SUR-BBBB0002",
+  status: "failed",
+  trigger: "manual",
+  currentSha: "abc1234",
+  targetSha: "def5678",
+  deployedSha: null,
+  startedAt: new Date("2026-05-19T02:00:00Z"),
+  completedAt: new Date("2026-05-19T02:01:00Z"),
+  completionEvidence: null,
+  failureLog: "promoter exited with code 1",
+  createdAt: new Date("2026-05-19T02:00:00Z"),
+};
+
+export const recoverableRun = {
+  ...mockRun,
+  runId: "SUR-6B312E24",
+  status: "failed",
+  admissionFingerprint: "admission-fingerprint",
+  dispatchStatus: "failed",
+  targetTag: "v2026.08.29-source-free-upgrade-reconciliation.1",
+  dispatchAttemptCount: 0,
+  dispatchAcknowledgedAt: null,
+  dispatchEventIds: [],
+};

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -200,7 +200,7 @@ import {
   rollbackSelfUpgrade,
   triggerSelfUpgrade,
 } from "./promotions";
-import { consumerReleaseContext, consumerReleaseSupport, mockConfig, mockRun, mockSession } from "./promotions.self-upgrade.test-fixtures";
+import { consumerReleaseContext, consumerReleaseSupport, mockConfig, mockRun, mockSession, mockRunRow1, mockRunRow2, recoverableRun } from "./promotions.self-upgrade.test-fixtures";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -598,34 +598,6 @@ describe("getSelfUpgradeStatus", () => {
 
 // ─── listSelfUpgradeRuns ──────────────────────────────────────────────────────
 
-const mockRunRow1 = {
-  runId: "SUR-AAAA0001",
-  status: "succeeded",
-  trigger: "scheduled",
-  currentSha: "abc1234",
-  targetSha: "def5678",
-  deployedSha: "def5678",
-  startedAt: new Date("2026-05-20T02:00:00Z"),
-  completedAt: new Date("2026-05-20T02:05:00Z"),
-  completionEvidence: { recoveryPoint: { status: "ok" } },
-  failureLog: null,
-  createdAt: new Date("2026-05-20T02:00:00Z"),
-};
-
-const mockRunRow2 = {
-  runId: "SUR-BBBB0002",
-  status: "failed",
-  trigger: "manual",
-  currentSha: "abc1234",
-  targetSha: "def5678",
-  deployedSha: null,
-  startedAt: new Date("2026-05-19T02:00:00Z"),
-  completedAt: new Date("2026-05-19T02:01:00Z"),
-  completionEvidence: null,
-  failureLog: "promoter exited with code 1",
-  createdAt: new Date("2026-05-19T02:00:00Z"),
-};
-
 describe("listSelfUpgradeRuns – access control", () => {
   it("rejects unauthenticated users", async () => {
     vi.mocked(auth).mockResolvedValue(null as never);
@@ -921,10 +893,22 @@ describe("triggerSelfUpgrade – access control", () => {
 
 describe("triggerSelfUpgrade – dispatch", () => {
   it("does not grant recovery authority to a plain failed-run retry", async () => {
-    vi.mocked(getLatestRun).mockResolvedValue({ ...mockRun, runId: "SUR-6B312E24", status: "failed" } as never);
+    vi.mocked(getLatestRun).mockResolvedValue(recoverableRun as never);
     const result = await triggerSelfUpgrade();
     expect(admitSelfUpgrade).not.toHaveBeenCalled();
     expect(result).toMatchObject({ queued: false, reason: "recovery-binding-required", runId: "SUR-6B312E24" });
+  });
+  it.each([
+    { dispatchAttemptCount: 1 },
+    { dispatchAcknowledgedAt: new Date("2026-09-06T18:28:00Z") },
+    { dispatchEventIds: ["dispatch-event"] },
+  ])("admits a fresh run after a dispatched failure: %j", async (dispatch) => {
+    vi.mocked(getLatestRun).mockResolvedValue({ ...recoverableRun, ...dispatch } as never);
+    const result = await triggerSelfUpgrade();
+    expect(result).toMatchObject({ queued: true, admitted: true });
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
+      recoveryOfRunId: null, requestedForce: false,
+    }));
   });
   it("uses the authenticated operator action as the sole typed recovery boundary", async () => {
     const releaseTarget = { targetKind: "release-artifact" as const, targetSha: "c137e6cdb1fe82d00565841ec683cec5c80710ab",
@@ -932,12 +916,26 @@ describe("triggerSelfUpgrade – dispatch", () => {
     vi.stubEnv("DPF_SELF_UPGRADE_TARGET_BINDING_SECRET", "test-target-binding-secret");
     vi.mocked(readSelfUpgradeSupport).mockResolvedValue(consumerReleaseSupport);
     vi.mocked(resolveCurrentSelfUpgradeTarget).mockResolvedValue(null);
-    vi.mocked(getLatestRun).mockResolvedValue({ ...mockRun, runId: "SUR-6B312E24", status: "failed" } as never);
+    vi.mocked(getLatestRun).mockResolvedValue(recoverableRun as never);
     const result = await triggerSelfUpgrade({ targetBinding: createSelfUpgradeTargetBinding(releaseTarget) });
     expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
       triggeredBy: "manual:user-ops-1", target: releaseTarget, recoveryOfRunId: "SUR-6B312E24",
     }));
     expect(result).toMatchObject({ queued: true, admitted: true, runId: "SUR-QUEUED1" });
+  });
+  it("preserves the rendered target on a fresh dispatched-failure retry", async () => {
+    const target = { targetKind: "release-artifact" as const, targetSha: "c137e6cdb1fe82d00565841ec683cec5c80710ab", targetTag: "v2026.08.29-source-free-upgrade-reconciliation.1" };
+    vi.stubEnv("DPF_SELF_UPGRADE_TARGET_BINDING_SECRET", "test-target-binding-secret");
+    vi.mocked(readSelfUpgradeSupport).mockResolvedValue(consumerReleaseSupport);
+    vi.mocked(getLatestRun).mockResolvedValue({ ...recoverableRun, dispatchAttemptCount: 1 } as never);
+    vi.mocked(resolveCurrentSelfUpgradeTarget).mockResolvedValue(target);
+    expect(await triggerSelfUpgrade({ targetBinding: createSelfUpgradeTargetBinding(target) })).toMatchObject({ queued: true });
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({ target, recoveryOfRunId: null, requestedForce: false }));
+  });
+  it("refuses an incomplete failed run without fresh admission", async () => {
+    vi.mocked(getLatestRun).mockResolvedValue({ ...recoverableRun, completedAt: null, dispatchAttemptCount: 1 } as never);
+    expect(await triggerSelfUpgrade()).toMatchObject({ queued: false, reason: "recovery-predecessor-not-terminal" });
+    expect(admitSelfUpgrade).not.toHaveBeenCalled();
   });
   it("attaches the reviewed impact summary to the run when one exists", async () => {
     vi.mocked(getCurrentImpactSummaryId).mockResolvedValueOnce("UIS-77");

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -18,6 +18,7 @@ import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
 import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
 import { getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
+import { isEligibleRecoveryPredecessor } from "@/lib/self-upgrade/recovery-eligibility";
 import { admitSelfUpgrade, resolveCurrentSelfUpgradeTarget } from "@/lib/self-upgrade/admission";
 import { selectSelfUpgradeAdmissionTarget } from "@/lib/self-upgrade/target-admission";
 import {
@@ -793,10 +794,7 @@ export async function triggerSelfUpgrade(opts?: {
     if (!support.enabled) {
       return { queued: false, reason: "disabled" } as const;
     }
-    // A manual trigger is NOT window-gated: the operator clicking "Upgrade now"
-    // has chosen this moment. The store-closed window only governs the unattended
-    // scheduled poll (runSelfUpgrade skips the window for non-scheduled runs).
-    // `force` is reserved for bypassing the quiescence drain in an emergency.
+    // Manual triggers skip the routine window; force is only for an emergency drain override.
   }
   const latestRun = await getLatestRun();
   if (latestRun?.status === "running") {
@@ -805,7 +803,9 @@ export async function triggerSelfUpgrade(opts?: {
   if (latestRun?.status === "queued" || latestRun?.status === "pending") {
     return { queued: false, reason: "already-queued", runId: latestRun.runId } as const;
   }
-  if (latestRun?.status === "failed" && !opts?.targetBinding) return { queued: false, reason: "recovery-binding-required", runId: latestRun.runId } as const;
+  if (latestRun?.status === "failed" && latestRun.completedAt == null) return { queued: false, reason: "recovery-predecessor-not-terminal", runId: latestRun.runId } as const;
+  const recoveryRun = isEligibleRecoveryPredecessor(latestRun) ? latestRun : null;
+  if (recoveryRun && !opts?.targetBinding) return { queued: false, reason: "recovery-binding-required", runId: recoveryRun.runId } as const;
   const resolvedTarget = await resolveCurrentSelfUpgradeTarget();
   const selection = selectSelfUpgradeAdmissionTarget({
     targetBinding: opts?.targetBinding,
@@ -818,7 +818,7 @@ export async function triggerSelfUpgrade(opts?: {
   // any) so the run records the changes it carried. Best effort — the upgrade
   // proceeds whether or not a summary was generated.
   const impactSummaryId = await getCurrentImpactSummaryId();
-  const admission = await admitSelfUpgrade({ triggeredBy, target, recoveryOfRunId: latestRun?.status === "failed" ? latestRun.runId : null,
+  const admission = await admitSelfUpgrade({ triggeredBy, target, recoveryOfRunId: recoveryRun?.runId ?? null,
     requestedForce: opts?.force === true,
     dryRun: opts?.dryRun === true,
     routine: false,

--- a/apps/web/lib/self-upgrade/recovery-eligibility.ts
+++ b/apps/web/lib/self-upgrade/recovery-eligibility.ts
@@ -1,0 +1,22 @@
+type RecoveryCandidate = {
+  status: string;
+  completedAt: Date | null;
+  admissionFingerprint: string | null;
+  dispatchStatus: string | null;
+  targetSha: string | null;
+  targetTag: string | null;
+  dispatchAttemptCount: number;
+  dispatchAcknowledgedAt: Date | null;
+  dispatchEventIds: string[];
+};
+
+/** Only a proven never-dispatched terminal failure can be a typed predecessor. */
+export function isEligibleRecoveryPredecessor<T extends RecoveryCandidate>(
+  run: T | null,
+): run is T & { targetSha: string; targetTag: string } {
+  return !!run && run.status === "failed" && run.completedAt != null
+    && !!run.admissionFingerprint && !!run.dispatchStatus
+    && !!run.targetSha && !!run.targetTag
+    && run.dispatchAttemptCount === 0
+    && run.dispatchAcknowledgedAt === null && run.dispatchEventIds.length === 0;
+}

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isEligibleRecoveryPredecessor } from "@/lib/self-upgrade/recovery-eligibility";
 import { prisma, Prisma } from "@dpf/db";
 import { safeSyncSelfUpgradeChangeRecord } from "@/lib/self-upgrade/change-record";
 import { agentEventBus } from "@/lib/agent-event-bus";
@@ -118,15 +119,7 @@ export const selfUpgradeAdmissionRepository: SelfUpgradeAdmissionRepository = {
             run: null,
           };
         }
-        if (
-          !predecessor.admissionFingerprint ||
-          !predecessor.dispatchStatus ||
-          !predecessor.targetSha ||
-          !predecessor.targetTag ||
-          predecessor.dispatchAttemptCount !== 0 ||
-          predecessor.dispatchAcknowledgedAt !== null ||
-          predecessor.dispatchEventIds.length !== 0
-        ) {
+        if (!isEligibleRecoveryPredecessor(predecessor)) {
           return { disposition: "recovery_refused" as const, reason: "recovery-predecessor-ambiguous" as const, run: null };
         }
         const targetRelationship = classifyRecoveryTargetRelationship(

--- a/docs/superpowers/plans/2026-09-06-self-upgrade-dispatched-retry.md
+++ b/docs/superpowers/plans/2026-09-06-self-upgrade-dispatched-retry.md
@@ -1,0 +1,22 @@
+---
+status: active
+---
+
+# Dispatched self-upgrade retry — BI-54284E21
+
+The canonical ordered fix sequence is in
+[Completed dispatched failures](../specs/2026-08-30-self-upgrade-exact-target-recovery-design.md#completed-dispatched-failures--bi-54284e21).
+This coverage locator maps its one atomic deliverable to BI-54284E21.
+
+| Deliverable | Requirements | Contract | Flow | Verification |
+| --- | --- | --- | --- | --- |
+| Shared recovery eligibility and manual retry | AC-SUA-015, AC-SUA-016 | SelfUpgradeAdmissionRepository.admit; triggerSelfUpgrade | /ops/self-upgrade | promotions.self-upgrade.test.ts; run-store.test.ts; typecheck; live fresh admission |
+
+No phase is independently shippable: the caller and store must use the same
+eligibility rule. Normal authority, target selection, active-run exclusion and
+the safety drain remain in force. The design owns scope, sequence and rollback.
+
+## Backlog coverage
+
+Atomic mapping: retry-contract → BI-54284E21. No internal dependencies.
+The immutable coverage receipt is recorded in the live backlog.

--- a/docs/superpowers/plans/2026-09-06-self-upgrade-dispatched-retry.md
+++ b/docs/superpowers/plans/2026-09-06-self-upgrade-dispatched-retry.md
@@ -10,7 +10,12 @@ This coverage locator maps its one atomic deliverable to BI-54284E21.
 
 | Deliverable | Requirements | Contract | Flow | Verification |
 | --- | --- | --- | --- | --- |
-| Shared recovery eligibility and manual retry | AC-SUA-015, AC-SUA-016 | SelfUpgradeAdmissionRepository.admit; triggerSelfUpgrade | /ops/self-upgrade | promotions.self-upgrade.test.ts; run-store.test.ts; typecheck; live fresh admission |
+| Shared recovery eligibility and manual retry | OBJ-SUA-002, OBJ-SUA-003, OBJ-SUA-004, OBJ-SUA-006, OBJ-SUA-007 | SelfUpgradeAdmissionRepository.admit; triggerSelfUpgrade | /ops/self-upgrade | AC-SUA-010, AC-SUA-011, AC-SUA-012, AC-SUA-013, AC-SUA-014, AC-SUA-015, AC-SUA-016 |
+
+Retain the baseline's existing exact-target, duplicate-worker, live-observation
+and registration recovery tests (AC-SUA-010 through AC-SUA-014). Add the manual
+dispatch-evidence regressions and preserve typed recovery (AC-SUA-015 and
+AC-SUA-016). Run action and run-store tests, typecheck and live fresh admission.
 
 No phase is independently shippable: the caller and store must use the same
 eligibility rule. Normal authority, target selection, active-run exclusion and

--- a/docs/superpowers/specs/2026-08-30-self-upgrade-exact-target-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-30-self-upgrade-exact-target-recovery-design.md
@@ -59,3 +59,41 @@ or AI action. `SelfUpgradeRun`, quiescence, and job-engine health remain truth.
 
 The classifier, successor, worker CAS, and projection are one revert boundary;
 a subset could duplicate execution or leave failure without safe recovery.
+
+## Completed dispatched failures — BI-54284E21
+
+At source ref `d603f6dcbd6`, the manual trigger binds every failed run as a
+recovery predecessor. The store correctly rejects a predecessor with dispatch
+evidence. Together these rules strand Upgrade now after a watchdog-completed
+failure such as SUR-E18E0141. Three action tests reproduce this with an attempt,
+an acknowledgement, or a dispatch event; the other 56 action tests pass.
+The live refusal is `recovery-predecessor-ambiguous`, so the failure occurs
+before dispatch, rather than in release selection or the safety drain.
+
+**OBJ-SUA-007:** A completed failed upgrade must leave an executable next action
+without reusing a dispatched run's recovery identity.
+
+| Acceptance | Objectives | Statement |
+| --- | --- | --- |
+| AC-SUA-015 | OBJ-SUA-007, OBJ-SUA-004 | A completed dispatched failure admits a fresh run with no recoveryOfRunId and normal target, authority, single-flight and drain checks. |
+| AC-SUA-016 | OBJ-SUA-006, OBJ-SUA-004 | A fully evidenced never-dispatched failure still requires the rendered target binding and typed recovery; explicit ambiguous recovery remains refused. |
+
+### Ordered fix sequence
+
+1. Reproduce each dispatch-evidence case in the existing action test suite.
+2. Share recovery eligibility between the manual action and transactional store;
+   keep completed-state, dispatch, target and admission metadata checks explicit.
+3. Bind only eligible recovery predecessors. A failed row missing completion
+   remains refused; completed failures outside typed recovery use fresh admission.
+4. Run action, admission, run-store, target-binding and trigger UI regressions,
+   then typecheck and the repository's publication checks.
+5. Merge and publish the repair, deploy through the supported self-upgrade path,
+   verify CAN-TEST, then finish BI-31159978's original immutable reviewer journey.
+
+This is one atomic repair under BI-54284E21: changing either caller eligibility
+or store validation alone would leave their contract inconsistent. Existing
+SelfUpgradeRun storage and the Upgrade now control remain authoritative. No
+migration, new control, authority grant, drain override or status rewrite is
+introduced. Revert the single repair commit if regression occurs. Live acceptance
+must show fresh admission after a dispatched terminal failure and retain safe
+typed recovery for never-dispatched failures.


### PR DESCRIPTION
After a dispatched Self-Upgrade run reaches failed/completed, Upgrade now incorrectly binds that run as a recovery predecessor. The store correctly refuses it, leaving manual upgrades stranded with recovery-predecessor-ambiguous.

Share the store's recovery eligibility with the manual action. Completed failures outside typed recovery now request fresh admission; fully evidenced never-dispatched failures retain the rendered target binding and typed successor. Incomplete failed records remain refused. Existing authority, target validation, active-run exclusion, worker idempotency and safety drain remain in force.

BI-54284E21 · Workroom WC-4661E82B. Extends the existing exact-target recovery design and plan coverage cmtq7gm25081k01lc7cjffzq6.

Verification: three dispatch-evidence regressions failed before the fix. Final affected suites: 187 distinct tests passed; web typecheck and pre-commit typecheck passed. Semantic evidence cmtq7nstd09jh01lcqqzhfpbw is a policy auto-pass, not an independent code review. Live acceptance will be performed by the coordinating task after canonical release publication; this PR alone does not close BI-31159978.

Docs-Impact-Decision: Operations behavior and the shared admission contract are recorded in the existing recovery design and linked plan. No new UI control or schema is introduced.

Local-CI-Override: operator-emergency: BI-54284E21 at f0aa59d8df80010cec17dae21910c13312650060; local CI INCONCLUSIVE because NPEL-E37C36BB12 occupied the shared slot. Own queued NPEL-6C4F99B20E cancelled. Coordinating task authorized this exact publication through protected cloud checks. Evidence cmtq8bdtk01bx01ncshci4ky3; deterministic preflight 65 guards passed. No local build pass claimed.
