### PR TITLE
feat(federation): paired-estate posture surface and peer runtime targets (BI-27B578C7)

### DIFF
--- a/apps/web/app/(shell)/ops/installation/page.tsx
+++ b/apps/web/app/(shell)/ops/installation/page.tsx
@@ -17,6 +17,7 @@ import { redirect } from "next/navigation";
 
 import { prisma } from "@dpf/db";
 
+import { PairedEstatePosturePanel } from "@/components/ops/PairedEstatePosturePanel";
 import { EstateNameField } from "@/components/workspace/EstateNameField";
 import { InstallationIdentityPanel } from "@/components/workspace/InstallationIdentityPanel";
 import { auth } from "@/lib/auth";
@@ -24,6 +25,8 @@ import {
   ENVIRONMENT_ROLE_WORD,
   loadEstateNameResolution,
 } from "@/lib/install/estate-identity";
+import { resolveFederationIdentity, type FederationIdentityDb } from "@/lib/federation/demand-identity";
+import { getPairedEstatePosture } from "@/lib/federation/operational-posture-read-model";
 import { prismaInstanceStanceStore } from "@/lib/install/instance-stance";
 import { loadInstallationIdentityView } from "@/lib/installation-journey/installation-identity-view";
 import { can } from "@/lib/permissions";
@@ -43,10 +46,17 @@ export default async function InstallationIdentityPage() {
   if (!canManageInstallation) redirect("/workspace");
 
   const store = prismaInstanceStanceStore(prisma);
-  const [view, estate] = await Promise.all([
+  const [view, estate, identity] = await Promise.all([
     loadInstallationIdentityView(prisma, store),
     loadEstateNameResolution(store),
+    resolveFederationIdentity(prisma as unknown as FederationIdentityDb),
   ]);
+  // The paired estate: this installation's posture captured now, beside what
+  // each same-organization peer last reported (BI-648F01A0 Slice 3).
+  const posture = await getPairedEstatePosture({
+    installationId: identity.installationId,
+    label: `${estate.estateName} ${ENVIRONMENT_ROLE_WORD[view.environment.environmentClass]}`.trim(),
+  });
 
   // The badge pairs the estate name with the role word, and renders at all only
   // when the installation is not production. Passing null for production keeps
@@ -65,6 +75,9 @@ export default async function InstallationIdentityPage() {
           badgePreview={badgePreview}
           organizationFallback={estate.tier === "organization-name" ? estate.estateName : null}
         />
+      </div>
+      <div className="px-4 pb-6 sm:px-6">
+        <PairedEstatePosturePanel view={JSON.parse(JSON.stringify(posture))} />
       </div>
     </div>
   );

--- a/apps/web/components/ops/PairedEstatePosturePanel.tsx
+++ b/apps/web/components/ops/PairedEstatePosturePanel.tsx
@@ -1,0 +1,95 @@
+import type {
+  PairedEstatePostureView,
+  PostureInstallView,
+} from "@/lib/federation/operational-posture-read-model";
+import { Surface } from "@/components/ui/Surface";
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
+
+const HEALTH_BADGE: Record<PostureInstallView["health"]["status"], { intent: Intent; label: string }> = {
+  healthy: { intent: "success", label: "Healthy" },
+  degraded: { intent: "warning", label: "Degraded" },
+  offline: { intent: "danger", label: "Offline" },
+};
+
+const FRESHNESS_BADGE: Record<PostureInstallView["freshness"], { intent: Intent; label: string }> = {
+  fresh: { intent: "info", label: "Current" },
+  stale: { intent: "warning", label: "Stale" },
+  silent: { intent: "danger", label: "Silent" },
+};
+
+function Figure({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-dpf-caption uppercase tracking-wide text-[var(--dpf-muted)]">{label}</p>
+      <p className="mt-0.5 truncate text-sm font-medium text-[var(--dpf-text)]">{value}</p>
+    </div>
+  );
+}
+
+function InstallCard({ install }: { install: PostureInstallView }) {
+  const health = HEALTH_BADGE[install.health.status];
+  const freshness = FRESHNESS_BADGE[install.freshness];
+  const patch = install.patchPosture;
+  return (
+    <Surface as="li" padding="sm" data-posture-basis={install.basis} className="space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[var(--dpf-text)]">{install.label}</p>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">{install.basisLine}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {install.basis === "mirrored-report" ? (
+            <StatusBadge intent={freshness.intent} label={freshness.label} variant="soft" />
+          ) : null}
+          <StatusBadge intent={health.intent} label={health.label} variant="soft" />
+        </div>
+      </div>
+      <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Figure label="Version" value={install.servedVersion} />
+        <Figure label="Build" value={install.servedSha.slice(0, 12)} />
+        <Figure label="Runtimes serving" value={`${install.runtime.healthyCount} of ${install.runtime.targetCount}`} />
+        <Figure label="Estate items" value={install.health.estateItemCount} />
+      </dl>
+      <p className="text-xs text-[var(--dpf-muted)]">
+        Open patch findings:{" "}
+        <span className="text-[var(--dpf-text)]">{patch.critical} critical</span>
+        {" · "}{patch.high} high{" · "}{patch.medium} medium{" · "}{patch.low} low
+        {install.resourceFootprint?.cpuCores !== undefined ? ` · ${install.resourceFootprint.cpuCores} cores` : ""}
+        {install.resourceFootprint?.memoryMb !== undefined ? ` · ${Math.round(install.resourceFootprint.memoryMb / 1024)} GB memory` : ""}
+      </p>
+    </Surface>
+  );
+}
+
+/**
+ * BI-648F01A0 Slice 3 — the paired estate in one picture: this installation's
+ * posture captured live, beside what each same-organization peer last reported.
+ * Every card says where its numbers came from and how old they are; a peer that
+ * has gone quiet is shown as silent rather than as its last self-assessment.
+ */
+export function PairedEstatePosturePanel({ view }: { view: PairedEstatePostureView }) {
+  return (
+    <Surface as="section" level={2} rounded="xl" aria-labelledby="paired-estate-heading">
+      <h2 id="paired-estate-heading" className="text-base font-semibold text-[var(--dpf-text)]">
+        Operational posture across your installations
+      </h2>
+      <p className="mt-1 max-w-3xl text-xs text-[var(--dpf-muted)]">
+        What each connected installation last reported about itself. Only counts travel; the detail stays where it was found.
+      </p>
+      <ul className="mt-3 space-y-2">
+        <InstallCard install={view.local} />
+        {view.peers.map((peer) => <InstallCard key={peer.key} install={peer} />)}
+      </ul>
+      {view.awaiting.length > 0 ? (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          Waiting for a first report from {view.awaiting.map((entry) => entry.label).join(", ")}.
+        </p>
+      ) : null}
+      {view.peers.length === 0 && view.awaiting.length === 0 ? (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          No other installation in your organization is connected yet.
+        </p>
+      ) : null}
+    </Surface>
+  );
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -11912,6 +11912,7 @@
         "what-this-installation-is",
         "who-runs-this-installation",
         "what-your-ai-coworkers-may-do-here",
+        "operational-posture-across-your-installations",
         "correcting-the-identity"
       ]
     },

--- a/apps/web/lib/federation/operational-posture-peer-targets.test.ts
+++ b/apps/web/lib/federation/operational-posture-peer-targets.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  peerRuntimeTargetId,
+  peerRuntimeTargetStatus,
+  reflectPeerRuntimeTargets,
+} from "./operational-posture-peer-targets";
+import type { PostureInstallView } from "./operational-posture-read-model";
+
+const now = new Date("2026-09-06T12:00:00.000Z");
+
+function peer(overrides: Partial<PostureInstallView> = {}): PostureInstallView {
+  return {
+    key: "peer:link_dev",
+    label: "Example DEV",
+    basis: "mirrored-report",
+    installationId: `inst_${"d".repeat(32)}`,
+    linkId: "link_dev",
+    servedVersion: "5.11.0",
+    servedSha: "def456",
+    patchPosture: { critical: 0, high: 0, medium: 0, low: 0 },
+    health: { status: "healthy", estateItemCount: 3 },
+    runtime: { targetCount: 2, healthyCount: 2 },
+    resourceFootprint: null,
+    capturedAt: now.toISOString(),
+    receivedAt: now.toISOString(),
+    ageMs: 0,
+    freshness: "fresh",
+    basisLine: "Reported by Example DEV · captured just now",
+    ...overrides,
+  };
+}
+
+describe("peerRuntimeTargetId / peerRuntimeTargetStatus", () => {
+  it("derives a stable id from the link and a status from the report's freshness", () => {
+    expect(peerRuntimeTargetId("link_0123456789abcdef")).toBe("RT-PEER-0123456789ABCDEF");
+    expect(peerRuntimeTargetStatus("fresh")).toBe("running");
+    expect(peerRuntimeTargetStatus("stale")).toBe("blocked");
+    expect(peerRuntimeTargetStatus("silent")).toBe("expired");
+  });
+});
+
+describe("reflectPeerRuntimeTargets", () => {
+  it("registers one external-preview target per reported peer, never a root-portal", async () => {
+    const register = vi.fn().mockResolvedValue({});
+    const db = {} as never;
+
+    const result = await reflectPeerRuntimeTargets(db, {
+      peers: [peer(), peer({ key: "peer:link_other", linkId: "link_other", label: "Other", freshness: "silent" })],
+      links: [
+        { linkId: "link_dev", peerAuthorityUrl: "http://10.0.0.5:3000" },
+        { linkId: "link_other", peerAuthorityUrl: "http://10.0.0.9:3000" },
+      ],
+      now,
+    }, { register });
+
+    expect(result).toEqual({ reflected: 2 });
+    expect(register).toHaveBeenCalledTimes(2);
+    expect(register.mock.calls[0][0].input).toMatchObject({
+      targetId: "RT-PEER-DEV",
+      kind: "external-preview",
+      status: "running",
+      hostUrl: "http://10.0.0.5:3000",
+      serviceVersion: "5.11.0+def456",
+      metadata: expect.objectContaining({
+        federated: true,
+        federationLinkId: "link_dev",
+        originInstallationId: `inst_${"d".repeat(32)}`,
+        freshness: "fresh",
+      }),
+    });
+    expect(register.mock.calls[1][0].input).toMatchObject({ targetId: "RT-PEER-OTHER", status: "expired" });
+    for (const call of register.mock.calls) expect(call[0].input.kind).not.toBe("root-portal");
+  });
+
+  it("skips a view without a link (the local capture)", async () => {
+    const register = vi.fn();
+    const result = await reflectPeerRuntimeTargets({} as never, {
+      peers: [peer({ key: "local", basis: "local-capture", linkId: null })],
+      links: [],
+    }, { register });
+    expect(result).toEqual({ reflected: 0 });
+    expect(register).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/federation/operational-posture-peer-targets.ts
+++ b/apps/web/lib/federation/operational-posture-peer-targets.ts
@@ -1,0 +1,121 @@
+// Cross-install operational control plane · Slice 3 (BI-648F01A0).
+//
+// Reflect each same-organization peer's portal into THIS install's runtime-target
+// registry, so `get_runtime_coordination_map` shows both installs instead of only
+// localhost. The target is a summary of the peer's mirrored posture report — never
+// a second source of truth: its status follows the report's freshness, its
+// version string the report's served version, and its host URL the link's own
+// peer authority (local knowledge, nothing that crossed the wire).
+//
+// Kind is `external-preview` on purpose: a peer install is never this install's
+// final-acceptance surface, so it must not inherit the root-portal role.
+
+import { prisma } from "@dpf/db";
+
+import {
+  registerRuntimeTarget,
+  type RuntimeCoordinationDb,
+} from "@/lib/runtime-coordination/runtime-targets";
+import type { RuntimeTargetStatus } from "@/lib/runtime-coordination/types";
+
+import { decodeOperationalPostureMirrorPayload } from "./operational-posture-exchange";
+import {
+  mapPeerPosture,
+  type PostureFreshness,
+  type PostureInstallView,
+  type PostureLinkRow,
+  type PostureMirrorRow,
+} from "./operational-posture-read-model";
+
+export function peerRuntimeTargetId(linkId: string): string {
+  return `RT-PEER-${linkId.replace(/^link_/, "").toUpperCase()}`;
+}
+
+/** A fresh report means the peer is serving; a stale one is blocked pending news;
+ *  a silent one has expired from the live footprint. */
+export function peerRuntimeTargetStatus(freshness: PostureFreshness): RuntimeTargetStatus {
+  if (freshness === "fresh") return "running";
+  if (freshness === "stale") return "blocked";
+  return "expired";
+}
+
+export async function reflectPeerRuntimeTargets(
+  db: RuntimeCoordinationDb,
+  input: {
+    peers: readonly PostureInstallView[];
+    links: ReadonlyArray<{ linkId: string; peerAuthorityUrl: string }>;
+    now?: Date;
+  },
+  deps: { register?: typeof registerRuntimeTarget } = {},
+): Promise<{ reflected: number }> {
+  const now = input.now ?? new Date();
+  const urlByLink = new Map(input.links.map((link) => [link.linkId, link.peerAuthorityUrl]));
+  let reflected = 0;
+  for (const peer of input.peers) {
+    if (!peer.linkId) continue;
+    const hostUrl = urlByLink.get(peer.linkId) ?? null;
+    await (deps.register ?? registerRuntimeTarget)({
+      db,
+      now,
+      input: {
+        targetId: peerRuntimeTargetId(peer.linkId),
+        kind: "external-preview",
+        status: peerRuntimeTargetStatus(peer.freshness),
+        hostUrl,
+        serviceName: "portal",
+        serviceVersion: `${peer.servedVersion}+${peer.servedSha}`,
+        metadata: {
+          federated: true,
+          basis: "operational-posture mirror",
+          federationLinkId: peer.linkId,
+          originInstallationId: peer.installationId,
+          peerLabel: peer.label,
+          capturedAt: peer.capturedAt,
+          receivedAt: peer.receivedAt,
+          freshness: peer.freshness,
+          health: peer.health.status,
+          runtime: peer.runtime,
+        },
+      },
+    });
+    reflected++;
+  }
+  return { reflected };
+}
+
+export interface PeerRuntimeTargetSyncDb extends RuntimeCoordinationDb {
+  federationLink: { findMany(args: unknown): Promise<PostureLinkRow[]> };
+  federatedRecordMirror: { findMany(args: unknown): Promise<PostureMirrorRow[]> };
+}
+
+/** Cron entry point: read every trusted same-organization peer's mirrored posture
+ *  and reflect it into the runtime-target registry. Runs on the receiving side
+ *  on the federation cadence; nothing is dialled. */
+export async function syncPeerRuntimeTargets(
+  db: PeerRuntimeTargetSyncDb = prisma as unknown as PeerRuntimeTargetSyncDb,
+  deps: { register?: typeof registerRuntimeTarget; now?: Date } = {},
+): Promise<{ links: number; reflected: number }> {
+  const now = deps.now ?? new Date();
+  const links = await db.federationLink.findMany({
+    where: { role: "same-org-peer", linkState: "trusted", revokedAt: null, quarantinedAt: null },
+    select: { linkId: true, peerAuthorityUrl: true, principal: { select: { displayName: true } } },
+  });
+  if (links.length === 0) return { links: 0, reflected: 0 };
+  const mirrors = await db.federatedRecordMirror.findMany({
+    where: {
+      federationLinkId: { in: links.map((link) => link.linkId) },
+      recordType: "operational-posture",
+      canonicalSide: "peer",
+      syncStatus: "synced",
+    },
+    select: { federationLinkId: true, syncStatus: true, lastSyncedAt: true, payload: true },
+  });
+  const peers: PostureInstallView[] = [];
+  for (const link of links) {
+    const row = mirrors.find((mirror) => mirror.federationLinkId === link.linkId);
+    const payload = row ? decodeOperationalPostureMirrorPayload(row.payload) : null;
+    if (row && payload) peers.push(mapPeerPosture(link, payload.record, row.lastSyncedAt, now));
+  }
+  const result = await reflectPeerRuntimeTargets(db, { peers, links, now }, deps);
+  return { links: links.length, reflected: result.reflected };
+}

--- a/apps/web/lib/federation/operational-posture-read-model.test.ts
+++ b/apps/web/lib/federation/operational-posture-read-model.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { OPERATIONAL_POSTURE_HEARTBEAT_MS } from "./operational-posture-delivery";
+import { buildOperationalPostureRecord } from "./operational-posture-projection";
+import {
+  POSTURE_FRESH_WINDOW_MS,
+  POSTURE_SILENT_AFTER_MS,
+  classifyPostureFreshness,
+  formatPostureAge,
+  loadPairedEstatePosture,
+  mapPairedEstatePosture,
+  type PairedEstatePostureDb,
+} from "./operational-posture-read-model";
+
+const now = new Date("2026-09-06T12:00:00.000Z");
+const peerIdentity = { installationId: `inst_${"d".repeat(32)}`, projectionSecret: "e".repeat(64) };
+const localIdentity = { installationId: `inst_${"a".repeat(32)}`, label: "Example PROD" };
+const localSource = {
+  servedVersion: "5.12.0",
+  servedSha: "abc123",
+  patchPosture: { critical: 0, high: 1, medium: 2, low: 3 },
+  health: { status: "degraded" as const, estateItemCount: 40 },
+  runtime: { targetCount: 2, healthyCount: 1 },
+  capturedAt: now,
+  updatedAt: now,
+};
+const link = { linkId: "link_dev", peerAuthorityUrl: "http://10.0.0.5:3000", principal: { displayName: "Example DEV" } };
+
+function peerRecord(capturedAt: Date, overrides: Partial<typeof localSource> = {}) {
+  return buildOperationalPostureRecord({
+    source: { ...localSource, servedVersion: "5.11.0", servedSha: "def456", ...overrides, capturedAt, updatedAt: capturedAt },
+    identity: peerIdentity,
+  }).record;
+}
+
+function mirrorRow(capturedAt: Date, receivedAt = capturedAt, syncStatus = "synced") {
+  return {
+    federationLinkId: "link_dev",
+    syncStatus,
+    lastSyncedAt: receivedAt,
+    payload: { record: peerRecord(capturedAt), activity: "dpf.operational-posture.reported", receivedAt: receivedAt.toISOString() },
+  };
+}
+
+describe("classifyPostureFreshness", () => {
+  it("bands age against the heartbeat: fresh, stale, then silent", () => {
+    expect(classifyPostureFreshness(0)).toBe("fresh");
+    expect(classifyPostureFreshness(OPERATIONAL_POSTURE_HEARTBEAT_MS)).toBe("fresh");
+    expect(classifyPostureFreshness(POSTURE_FRESH_WINDOW_MS)).toBe("stale");
+    expect(classifyPostureFreshness(POSTURE_SILENT_AFTER_MS - 1)).toBe("stale");
+    expect(classifyPostureFreshness(POSTURE_SILENT_AFTER_MS)).toBe("silent");
+  });
+});
+
+describe("formatPostureAge", () => {
+  it("renders minutes, hours and days", () => {
+    expect(formatPostureAge(10_000)).toBe("just now");
+    expect(formatPostureAge(4 * 60_000)).toBe("4m ago");
+    expect(formatPostureAge(3 * 3_600_000)).toBe("3h ago");
+    expect(formatPostureAge(72 * 3_600_000)).toBe("3d ago");
+  });
+});
+
+describe("mapPairedEstatePosture", () => {
+  it("places the local capture beside the peer's mirrored report, each stating basis and age", () => {
+    const captured = new Date(now.getTime() - 4 * 60_000);
+    const view = mapPairedEstatePosture({
+      local: localSource, identity: localIdentity, links: [link], mirrors: [mirrorRow(captured)], now,
+    });
+
+    expect(view.local).toMatchObject({
+      key: "local", basis: "local-capture", label: "Example PROD",
+      installationId: localIdentity.installationId, servedVersion: "5.12.0", freshness: "fresh",
+    });
+    expect(view.local.basisLine).toBe("Captured on this installation · just now");
+    expect(view.peers).toHaveLength(1);
+    expect(view.peers[0]).toMatchObject({
+      key: "peer:link_dev", basis: "mirrored-report", label: "Example DEV", linkId: "link_dev",
+      installationId: peerIdentity.installationId, servedVersion: "5.11.0", servedSha: "def456",
+      health: { status: "degraded", estateItemCount: 40 }, freshness: "fresh",
+      capturedAt: captured.toISOString(),
+    });
+    expect(view.peers[0].basisLine).toBe("Reported by Example DEV · captured 4m ago");
+    expect(view.awaiting).toEqual([]);
+  });
+
+  it("measures a peer's age from capture, not delivery, and marks missed heartbeats", () => {
+    const captured = new Date(now.getTime() - 2 * OPERATIONAL_POSTURE_HEARTBEAT_MS);
+    const landed = new Date(now.getTime() - 60_000);
+    const view = mapPairedEstatePosture({
+      local: localSource, identity: localIdentity, links: [link], mirrors: [mirrorRow(captured, landed)], now,
+    });
+    expect(view.peers[0].freshness).toBe("stale");
+    expect(view.peers[0].receivedAt).toBe(landed.toISOString());
+    expect(view.peers[0].basisLine).toContain("missed heartbeats");
+    // The peer's own health band still stands while merely stale.
+    expect(view.peers[0].health.status).toBe("degraded");
+  });
+
+  it("reports a silent peer as offline rather than repeating its last self-assessment", () => {
+    const captured = new Date(now.getTime() - POSTURE_SILENT_AFTER_MS);
+    const view = mapPairedEstatePosture({
+      local: localSource, identity: localIdentity, links: [link], mirrors: [mirrorRow(captured)], now,
+    });
+    expect(view.peers[0].freshness).toBe("silent");
+    expect(view.peers[0].health).toEqual({ status: "offline", estateItemCount: 40 });
+    expect(view.peers[0].basisLine).toContain("no report since");
+  });
+
+  it("lists a trusted link with no synced report under awaiting instead of inventing a row", () => {
+    const view = mapPairedEstatePosture({
+      local: localSource, identity: localIdentity, links: [link],
+      mirrors: [mirrorRow(now, now, "conflict")], now,
+    });
+    expect(view.peers).toEqual([]);
+    expect(view.awaiting).toEqual([{ linkId: "link_dev", label: "Example DEV" }]);
+  });
+});
+
+describe("loadPairedEstatePosture", () => {
+  it("reads only trusted same-organization links and their peer-canonical posture mirrors", async () => {
+    const db = {
+      federationLink: { findMany: vi.fn().mockResolvedValue([link]) },
+      federatedRecordMirror: { findMany: vi.fn().mockResolvedValue([mirrorRow(now)]) },
+    } as unknown as PairedEstatePostureDb;
+
+    const view = await loadPairedEstatePosture(db, localIdentity, { capture: vi.fn().mockResolvedValue(localSource), now });
+
+    expect(view.peers).toHaveLength(1);
+    expect(db.federationLink.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { role: "same-org-peer", linkState: "trusted", revokedAt: null, quarantinedAt: null },
+    }));
+    expect(db.federatedRecordMirror.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ recordType: "operational-posture", canonicalSide: "peer" }),
+    }));
+  });
+});

--- a/apps/web/lib/federation/operational-posture-read-model.ts
+++ b/apps/web/lib/federation/operational-posture-read-model.ts
@@ -1,0 +1,223 @@
+// Cross-install operational control plane · Slice 3 (BI-648F01A0).
+//
+// Operator-facing view of the PAIRED ESTATE: this install's posture, captured
+// live, beside every same-organization peer's posture, read from the
+// peer-canonical `operational-posture` mirror it reported. Each side states its
+// BASIS (captured here vs. reported by the peer) and its AGE, because a fleet
+// picture that hides where a number came from is the assurance-honesty defect
+// tracked in BI-DD93808A. Mappers are pure; only the loader touches the database.
+
+import { cache } from "react";
+
+import { prisma } from "@dpf/db";
+import type {
+  OperationalPostureV1,
+  PostureHealthRollupV1,
+  PosturePatchSummaryV1,
+  PostureResourceFootprintV1,
+  PostureRuntimeSummaryV1,
+} from "@dpf/db/federated-operational-posture-contract";
+
+import { OPERATIONAL_POSTURE_HEARTBEAT_MS } from "./operational-posture-delivery";
+import { captureLocalOperationalPosture, type OperationalPostureCaptureDb } from "./operational-posture-capture";
+import { decodeOperationalPostureMirrorPayload } from "./operational-posture-exchange";
+import type { ProjectableOperationalPostureSource } from "./operational-posture-projection";
+
+/** How a posture row came to be on this install. */
+export type PostureBasis = "local-capture" | "mirrored-report";
+
+/**
+ * How much the age of a mirrored report should worry the operator. `fresh`
+ * means a report landed within one heartbeat plus delivery slack; `stale`
+ * means the peer has missed heartbeats; `silent` means it has been quiet for
+ * long enough that its numbers describe a past, not a present.
+ */
+export type PostureFreshness = "fresh" | "stale" | "silent";
+
+/** One heartbeat plus the outbox retry slack: a healthy peer always lands inside this. */
+export const POSTURE_FRESH_WINDOW_MS = OPERATIONAL_POSTURE_HEARTBEAT_MS + 15 * 60_000;
+/** Three missed heartbeats and the peer is treated as silent. */
+export const POSTURE_SILENT_AFTER_MS = 3 * OPERATIONAL_POSTURE_HEARTBEAT_MS;
+
+export interface PostureInstallView {
+  key: string;
+  label: string;
+  basis: PostureBasis;
+  installationId: string;
+  /** Present only for a mirrored report. */
+  linkId: string | null;
+  servedVersion: string;
+  servedSha: string;
+  patchPosture: PosturePatchSummaryV1;
+  health: PostureHealthRollupV1;
+  runtime: PostureRuntimeSummaryV1;
+  resourceFootprint: PostureResourceFootprintV1 | null;
+  /** When the reporting install captured these numbers (ISO). */
+  capturedAt: string;
+  /** When the report landed here (ISO); equals capturedAt for the local capture. */
+  receivedAt: string;
+  ageMs: number;
+  freshness: PostureFreshness;
+  /** The honest one-liner: basis and age, e.g. "Reported by Example DEV · captured 4m ago". */
+  basisLine: string;
+}
+
+export interface PairedEstatePostureView {
+  local: PostureInstallView;
+  peers: PostureInstallView[];
+  /** Trusted same-organization links that have not reported a posture yet. */
+  awaiting: Array<{ linkId: string; label: string }>;
+}
+
+export interface PostureLinkRow {
+  linkId: string;
+  peerAuthorityUrl: string;
+  principal: { displayName: string } | null;
+}
+
+export interface PostureMirrorRow {
+  federationLinkId: string;
+  syncStatus: string;
+  lastSyncedAt: Date | null;
+  payload: unknown;
+}
+
+export function classifyPostureFreshness(ageMs: number): PostureFreshness {
+  if (ageMs < POSTURE_FRESH_WINDOW_MS) return "fresh";
+  if (ageMs < POSTURE_SILENT_AFTER_MS) return "stale";
+  return "silent";
+}
+
+export function formatPostureAge(ageMs: number): string {
+  const minutes = Math.max(0, Math.floor(ageMs / 60_000));
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function mapLocalPosture(
+  source: ProjectableOperationalPostureSource,
+  identity: { installationId: string; label: string },
+  now: Date,
+): PostureInstallView {
+  const capturedAt = source.capturedAt.toISOString();
+  const ageMs = Math.max(0, now.getTime() - source.capturedAt.getTime());
+  return {
+    key: "local",
+    label: identity.label,
+    basis: "local-capture",
+    installationId: identity.installationId,
+    linkId: null,
+    servedVersion: source.servedVersion,
+    servedSha: source.servedSha,
+    patchPosture: source.patchPosture,
+    health: source.health,
+    runtime: source.runtime,
+    resourceFootprint: source.resourceFootprint ?? null,
+    capturedAt,
+    receivedAt: capturedAt,
+    ageMs,
+    freshness: "fresh",
+    basisLine: `Captured on this installation · ${formatPostureAge(ageMs)}`,
+  };
+}
+
+export function mapPeerPosture(
+  link: PostureLinkRow,
+  record: OperationalPostureV1,
+  receivedAt: Date | null,
+  now: Date,
+): PostureInstallView {
+  const capturedAtMs = Date.parse(record.capturedAt);
+  const capturedAt = Number.isFinite(capturedAtMs) ? new Date(capturedAtMs) : receivedAt ?? now;
+  const landed = receivedAt ?? capturedAt;
+  // Age is measured from the CAPTURE, not the delivery: a report that sat in a
+  // retrying outbox for an hour is an hour old when it lands.
+  const ageMs = Math.max(0, now.getTime() - capturedAt.getTime());
+  const label = link.principal?.displayName ?? link.linkId;
+  const freshness = classifyPostureFreshness(ageMs);
+  // A silent peer's own health band is overtaken by the silence: the contract's
+  // `offline` status is exactly this receiver-side judgement.
+  const health: PostureHealthRollupV1 = freshness === "silent"
+    ? { status: "offline", estateItemCount: record.health.estateItemCount }
+    : record.health;
+  return {
+    key: `peer:${link.linkId}`,
+    label,
+    basis: "mirrored-report",
+    installationId: record.originInstallationId,
+    linkId: link.linkId,
+    servedVersion: record.servedVersion,
+    servedSha: record.servedSha,
+    patchPosture: record.patchPosture,
+    health,
+    runtime: record.runtime,
+    resourceFootprint: record.resourceFootprint ?? null,
+    capturedAt: capturedAt.toISOString(),
+    receivedAt: landed.toISOString(),
+    ageMs,
+    freshness,
+    basisLine: `Reported by ${label} · captured ${formatPostureAge(ageMs)}`
+      + (freshness === "silent" ? " · no report since" : freshness === "stale" ? " · missed heartbeats" : ""),
+  };
+}
+
+export function mapPairedEstatePosture(input: {
+  local: ProjectableOperationalPostureSource;
+  identity: { installationId: string; label: string };
+  links: readonly PostureLinkRow[];
+  mirrors: readonly PostureMirrorRow[];
+  now?: Date;
+}): PairedEstatePostureView {
+  const now = input.now ?? new Date();
+  const peers: PostureInstallView[] = [];
+  const awaiting: PairedEstatePostureView["awaiting"] = [];
+  for (const link of input.links) {
+    const row = input.mirrors.find((mirror) => mirror.federationLinkId === link.linkId && mirror.syncStatus === "synced");
+    const payload = row ? decodeOperationalPostureMirrorPayload(row.payload) : null;
+    if (!row || !payload) {
+      awaiting.push({ linkId: link.linkId, label: link.principal?.displayName ?? link.linkId });
+      continue;
+    }
+    peers.push(mapPeerPosture(link, payload.record, row.lastSyncedAt, now));
+  }
+  return { local: mapLocalPosture(input.local, input.identity, now), peers, awaiting };
+}
+
+export interface PairedEstatePostureDb extends OperationalPostureCaptureDb {
+  federationLink: { findMany(args: unknown): Promise<PostureLinkRow[]> };
+  federatedRecordMirror: { findMany(args: unknown): Promise<PostureMirrorRow[]> };
+}
+
+export async function loadPairedEstatePosture(
+  db: PairedEstatePostureDb,
+  identity: { installationId: string; label: string },
+  deps: { capture?: typeof captureLocalOperationalPosture; now?: Date } = {},
+): Promise<PairedEstatePostureView> {
+  const now = deps.now ?? new Date();
+  const [local, links] = await Promise.all([
+    (deps.capture ?? captureLocalOperationalPosture)(db, { now }),
+    db.federationLink.findMany({
+      where: { role: "same-org-peer", linkState: "trusted", revokedAt: null, quarantinedAt: null },
+      orderBy: { createdAt: "asc" },
+      select: { linkId: true, peerAuthorityUrl: true, principal: { select: { displayName: true } } },
+    }),
+  ]);
+  const mirrors = links.length === 0 ? [] : await db.federatedRecordMirror.findMany({
+    where: {
+      federationLinkId: { in: links.map((link) => link.linkId) },
+      recordType: "operational-posture",
+      canonicalSide: "peer",
+    },
+    select: { federationLinkId: true, syncStatus: true, lastSyncedAt: true, payload: true },
+  });
+  return mapPairedEstatePosture({ local, identity, links, mirrors, now });
+}
+
+/** Request-scoped loader for server components. */
+export const getPairedEstatePosture = cache(
+  async (identity: { installationId: string; label: string }): Promise<PairedEstatePostureView> =>
+    loadPairedEstatePosture(prisma as unknown as PairedEstatePostureDb, identity),
+);

--- a/apps/web/lib/queue/functions/demand-reconciliation.ts
+++ b/apps/web/lib/queue/functions/demand-reconciliation.ts
@@ -22,6 +22,13 @@ export const demandReconciliationScheduled = inngest.createFunction(
       const { runOperationalPostureReconciliation } = await import("@/lib/federation/operational-posture-reconciliation");
       return runOperationalPostureReconciliation();
     });
+    // Receiving side of the same exchange: every peer's mirrored posture is
+    // reflected into this install's runtime-target registry, so the coordination
+    // map shows both installs (BI-648F01A0 Slice 3).
+    const peerTargets = await step.run("reflect-peer-runtime-targets", async () => {
+      const { syncPeerRuntimeTargets } = await import("@/lib/federation/operational-posture-peer-targets");
+      return syncPeerRuntimeTargets();
+    });
     const demand = await step.run("reconcile-federated-demand", async () => {
       const { runDemandReconciliation } = await import("@/lib/federation/demand-reconciliation");
       return runDemandReconciliation();
@@ -45,6 +52,6 @@ export const demandReconciliationScheduled = inngest.createFunction(
       const { reconcileOrganizationMembership } = await import("@/lib/federation/organization-membership");
       return reconcileOrganizationMembership();
     });
-    return { posture, demand, work, links, membership };
+    return { posture, peerTargets, demand, work, links, membership };
   },
 );

--- a/docs/superpowers/plans/2026-09-06-cross-install-operational-posture-flow-plan.md
+++ b/docs/superpowers/plans/2026-09-06-cross-install-operational-posture-flow-plan.md
@@ -28,7 +28,14 @@ merge-queue safety net. `DPF_FEDERATION_EXCHANGE_ENABLED` is referenced in a tes
 cleanup only — no live code path reads it today, so posture is gated the same way
 demand is: the cron plus a trusted same-organization link.
 
-## Phase B — Slice 3: paired-estate surface
+## Phase B — Slice 3: paired-estate surface (BI-27B578C7 follow-on)
+
+| Step | Module | What it does |
+|---|---|---|
+| B1 | `apps/web/lib/federation/operational-posture-read-model.ts` | Pure mapper + cached loader: the local capture beside every peer-canonical `operational-posture` mirror. Age is measured from the peer's capture, not the delivery; freshness bands are one heartbeat + slack (fresh), then stale, then silent at three missed heartbeats, at which point the peer's own health band is overtaken by `offline`. |
+| B2 | `apps/web/components/ops/PairedEstatePosturePanel.tsx`, `/ops/installation` | One card per installation, each stating its basis line ("Captured on this installation" / "Reported by <peer> · captured 4m ago") and freshness chip; shared `Surface` + `StatusBadge`, `--dpf-*` tokens only. |
+| B3 | `apps/web/lib/federation/operational-posture-peer-targets.ts` + cron step `reflect-peer-runtime-targets` | Each reported peer becomes an `external-preview` runtime target (`RT-PEER-<link>`), status from freshness, version from the report, host URL from the link's own peer authority — so the coordination map shows both installs without granting a peer the root-portal acceptance role. |
+
 
 - Read model: local posture (captured live) + every peer-canonical
   `operational-posture` mirror, each stamped with **basis** (local capture vs

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -227,6 +227,22 @@ Five stances, each shown with the reason it resolved that way:
 An installation that has not said what it is counts as production, so every
 brake stays on until someone declares otherwise.
 
+### Operational posture across your installations
+
+Below the identity, one card per installation shows its version and build, how
+many of its runtimes are serving, how many estate items it tracks, and its open
+patch findings by severity. Your own card is captured the moment the page loads.
+A connected installation's card is what it last reported over the approved
+link, and the card says so — **Reported by** the installation, with how old the
+report is. Only counts travel between installations; the findings themselves
+stay where they were found.
+
+A connected installation reports every five minutes when something changes and
+at least hourly otherwise. A card marked **Stale** has missed heartbeats; one
+marked **Silent** has been quiet for three hours and shows as **Offline** rather
+than repeating its last self-assessment. A connection that has not reported yet
+is listed as waiting.
+
 ### Correcting the identity
 
 Open **Change what this installation is** to set its main job, its environment,

--- a/docs/ux-fit/2026-09-06-paired-estate-posture-cards.ux-fit.json
+++ b/docs/ux-fit/2026-09-06-paired-estate-posture-cards.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "cards-on-installation-page",
+  "decisionInteractionId": "DI-4548A2BBF2BC",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/ops/installation/page.tsx",
+      "apps/web/components/ops/PairedEstatePosturePanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "cards-on-installation-page",
+      "dedicated-paired-estate-route"
+    ],
+    "note": "BI-648F01A0 Slice 3 (spec docs/superpowers/specs/2026-09-01-cross-install-operational-control-plane-design.md, plan docs/superpowers/plans/2026-09-06-cross-install-operational-posture-flow-plan.md Phase B). The paired estate's operational posture is rendered as one summary card per installation appended to Operations → Installation, composed from the shared Surface + StatusBadge primitives with no new route and no new controls; every card states its basis (captured here vs. reported by the peer) and age, and a silent peer renders as offline. The kernel scored the appended-cards shape highest (composite 9.22, margin 3.64, confidence high) against a dedicated /ops/paired-estate route with a DataTable, filters and drill-down."
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -6783,6 +6783,14 @@
     "longSentences": 0,
     "textMass": 22
   },
+  "apps/web/components/ops/PairedEstatePosturePanel.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
   "apps/web/components/ops/PromotionsClient.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,
@@ -7813,7 +7821,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 156
+    "textMass": 113
   },
   "apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary

Slice 3 of the cross-install operational control plane (BI-648F01A0). Stacked on #5146 (Slice 2.2); GitHub retargets to `main` when that merges. With posture flowing, render BOTH installs in one picture and reflect the peer into the runtime-target registry:

- **Read model** (`lib/federation/operational-posture-read-model.ts`): this install's posture captured live beside every same-org peer's mirrored report, each stating its **basis** ("Captured on this installation" vs "Reported by <peer>") and **age**. Age runs from the peer's capture, not the delivery. Freshness bands: one heartbeat plus slack → current; then stale; three missed heartbeats → silent, at which point the peer's own health band is overtaken by `offline` rather than repeating its last self-assessment (the honesty defect tracked in BI-DD93808A).
- **Surface**: `PairedEstatePosturePanel` on Operations → Installation, one card per installation; shared `Surface` + `StatusBadge`, `--dpf-*` tokens only. UX-fit manifest `docs/ux-fit/2026-09-06-paired-estate-posture-cards.ux-fit.json` backed by kernel decision DI-4548A2BBF2BC (cards on the existing page vs a dedicated route).
- **Peer runtime targets** (`operational-posture-peer-targets.ts` + cron step `reflect-peer-runtime-targets`): `RT-PEER-<link>` registered as `external-preview`, status from freshness, version from the report, host URL from the link's own peer authority — so `get_runtime_coordination_map` shows both installs without granting a peer the root-portal acceptance role.
- User guide: new "Operational posture across your installations" section under Operations → Installation.

Plan: `docs/superpowers/plans/2026-09-06-cross-install-operational-posture-flow-plan.md` (Phase B).

## Design grounding
Extends the design spec's Slice 3; substrate is `FederatedRecordMirror` + the runtime-target registry, no new table/transport/registry (AC-OCP-006).

## Verification
- Affected vitest: 7 files / 37 tests green; web typecheck clean; prose-lint, style-drift, UX-fit, docs-impact and convergence guards green.
- Local-CI sandbox gate: **PASS** on the pushed head.
- Full build: cloud merge queue. UX verification on the running install is not possible from this source-only worktree; the panel is exercised by the read-model tests and will be verified on the live install after self-upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)