### PR TITLE
fix(edge): retire an installer enrollment a live one has superseded so the conflict heals itself (BI-D4F79CE2)

### DIFF
--- a/apps/web/lib/actions/edge-nodes.ts
+++ b/apps/web/lib/actions/edge-nodes.ts
@@ -19,6 +19,7 @@ import { prisma } from "@dpf/db";
 import { resolveAppBaseUrl } from "@/lib/app-url";
 import { auth } from "@/lib/auth";
 import { issueBootstrapToken } from "@/lib/edge-node/enrollment";
+import { revokeEdgeNode, type RevokeEdgeNodeDb } from "@/lib/edge-node/revoke";
 import { resolveNativeReleaseAssets } from "@/lib/edge-node/native-release-assets";
 import {
   buildRemoteProvisioningPlan,
@@ -380,59 +381,15 @@ export async function revokeEdgeNodeAction(
 ): Promise<LifecycleActionResult> {
   const gate = await assertManagePlatform();
   if (!gate.ok) return gate;
-  if (!edgeNodeId || typeof edgeNodeId !== "string") {
-    return { ok: false, error: "invalid_input", message: "edgeNodeId required" };
-  }
-  if (!reason || typeof reason !== "string" || !reason.trim()) {
-    return {
-      ok: false,
-      error: "invalid_input",
-      message: "revocation reason required",
-    };
-  }
-
-  const node = await prisma.edgeNode.findUnique({
-    where: { id: edgeNodeId },
-    select: { id: true, trustState: true },
+  // Single revocation home (lib/edge-node/revoke.ts): the janitor and
+  // enrollment-time supersession retire nodes through the same transaction.
+  const result = await revokeEdgeNode(prisma as unknown as RevokeEdgeNodeDb, {
+    edgeNodeId,
+    reason: typeof reason === "string" ? reason : "",
   });
-  if (!node) {
-    return { ok: false, error: "not_found", message: "Edge Node not found" };
+  if (result.status !== "revoked") {
+    return { ok: false, error: result.status, message: result.message };
   }
-  // Revoking an already-revoked node is idempotent (no-op).
-  if (node.trustState === "revoked") {
-    return { ok: true, edgeNodeId, trustState: "revoked" };
-  }
-
-  // Revoke the node + null its tokenHash so any further request
-  // bearing the now-orphaned token fails at the auth-resolution
-  // step (resolveEdgeNodeAuth looks up by hash and finds nothing).
-  // The Phase 0 schema stores a single tokenHash per EdgeNode row —
-  // there's no separate EdgeNodeToken table to clear; the hash on
-  // the row IS the credential. Re-enrollment is operator-explicit
-  // per spec § Re-enrollment.
-  const revocationReason = reason.trim();
-  const revokedAt = new Date();
-  await prisma.$transaction([
-    prisma.edgeNode.update({
-      where: { id: edgeNodeId },
-      data: {
-        trustState: "revoked",
-        revokedAt,
-        revocationReason,
-        tokenHash: null,
-        tokenPrefix: null,
-        tokenRotatedAt: null,
-      },
-    }),
-    prisma.edgeNodeCertificate.updateMany({
-      where: { edgeNodeId, status: { not: "revoked" } },
-      data: {
-        status: "revoked",
-        revokedAt,
-        revocationReason: `node_revoked:${revocationReason}`,
-      },
-    }),
-  ]);
   revalidatePath(ADMIN_PATH);
   return { ok: true, edgeNodeId, trustState: "revoked" };
 }

--- a/apps/web/lib/edge-node/enrollment.ts
+++ b/apps/web/lib/edge-node/enrollment.ts
@@ -29,6 +29,10 @@
 import { randomUUID } from "crypto";
 
 import { prisma } from "@dpf/db";
+
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+import { supersedeStaleInstallerNodes, type StaleSupersessionDb } from "./stale-supersession";
 import {
   EDGE_NODE_ALIAS_KIND,
   EDGE_NODE_ENROLLMENT_CAPABILITIES,
@@ -412,6 +416,18 @@ export async function enrollEdgeNode(input: EnrollInput): Promise<EnrollResult> 
       });
     }
   });
+
+  // An installer-managed re-enrollment is the moment a previous, long-silent
+  // installer enrollment becomes provably obsolete. Retire it now rather than
+  // leaving "Enrollment conflict" for a human (BI-D4F79CE2). Best-effort: a
+  // failure here must not fail the enrollment that just succeeded.
+  if (effectiveAutoApprove) {
+    try {
+      await supersedeStaleInstallerNodes(prisma as unknown as StaleSupersessionDb, { now });
+    } catch (error) {
+      console.warn(`[edge-enrollment] stale-enrollment supersession skipped: ${getErrorMessage(error)}`);
+    }
+  }
 
   return {
     ok: true,

--- a/apps/web/lib/edge-node/readiness.test.ts
+++ b/apps/web/lib/edge-node/readiness.test.ts
@@ -201,7 +201,7 @@ describe("deriveNearbyDiscoveryHealth", () => {
       status: "unavailable",
       label: "Enrollment conflict",
       detail:
-        "Multiple installer-managed Edge Nodes claim this installation. Review Edge Nodes before relying on nearby discovery.",
+        "Multiple installer-managed Edge Nodes claim this installation. One that has been silent for a week beside a live one retires itself within the hour; two live ones need a person to review Edge Nodes.",
     });
   });
 });

--- a/apps/web/lib/edge-node/readiness.ts
+++ b/apps/web/lib/edge-node/readiness.ts
@@ -258,7 +258,7 @@ export function deriveNearbyDiscoveryHealth({
       status: "unavailable",
       label: "Enrollment conflict",
       detail:
-        "Multiple installer-managed Edge Nodes claim this installation. Review Edge Nodes before relying on nearby discovery.",
+        "Multiple installer-managed Edge Nodes claim this installation. One that has been silent for a week beside a live one retires itself within the hour; two live ones need a person to review Edge Nodes.",
     };
   }
   if (selection.status !== "found" || !readiness || !discoveryCapability) {

--- a/apps/web/lib/edge-node/revoke.test.ts
+++ b/apps/web/lib/edge-node/revoke.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { revokeEdgeNode, type RevokeEdgeNodeDb } from "./revoke";
+
+function db(node: { id: string; trustState: string } | null) {
+  const update = vi.fn().mockResolvedValue({});
+  const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+  const $transaction = vi.fn().mockImplementation(async (ops: Promise<unknown>[]) => Promise.all(ops));
+  return {
+    store: {
+      edgeNode: { findUnique: vi.fn().mockResolvedValue(node), update },
+      edgeNodeCertificate: { updateMany },
+      $transaction,
+    } as unknown as RevokeEdgeNodeDb,
+    update, updateMany, $transaction,
+  };
+}
+
+describe("revokeEdgeNode", () => {
+  it("rejects a missing id or an empty reason before touching the database", async () => {
+    const { store, update } = db({ id: "row_1", trustState: "trusted" });
+    expect(await revokeEdgeNode(store, { edgeNodeId: "", reason: "x" })).toMatchObject({ status: "invalid_input" });
+    expect(await revokeEdgeNode(store, { edgeNodeId: "row_1", reason: "   " })).toMatchObject({ status: "invalid_input" });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("reports not_found for an unknown node", async () => {
+    const { store } = db(null);
+    expect(await revokeEdgeNode(store, { edgeNodeId: "row_x", reason: "gone" })).toMatchObject({ status: "not_found" });
+  });
+
+  it("is idempotent on an already-revoked node", async () => {
+    const { store, $transaction } = db({ id: "row_1", trustState: "revoked" });
+    expect(await revokeEdgeNode(store, { edgeNodeId: "row_1", reason: "again" })).toEqual({ status: "revoked", edgeNodeId: "row_1", changed: false });
+    expect($transaction).not.toHaveBeenCalled();
+  });
+
+  it("revokes trust, clears the node token and revokes live certificates in one transaction", async () => {
+    const now = new Date("2026-09-06T12:00:00.000Z");
+    const { store, update, updateMany, $transaction } = db({ id: "row_1", trustState: "trusted" });
+    const result = await revokeEdgeNode(store, { edgeNodeId: "row_1", reason: " compromised ", now });
+    expect(result).toEqual({ status: "revoked", edgeNodeId: "row_1", changed: true });
+    expect($transaction).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "row_1" },
+      data: { trustState: "revoked", revokedAt: now, revocationReason: "compromised", tokenHash: null, tokenPrefix: null, tokenRotatedAt: null },
+    });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { edgeNodeId: "row_1", status: { not: "revoked" } },
+      data: { status: "revoked", revokedAt: now, revocationReason: "node_revoked:compromised" },
+    });
+  });
+});

--- a/apps/web/lib/edge-node/revoke.ts
+++ b/apps/web/lib/edge-node/revoke.ts
@@ -1,0 +1,69 @@
+// Single home for "retire this Edge Node" (AGENTS §8: compose from shared
+// primitives, never a second copy per caller). The admin server action, the
+// stale-enrollment janitor and enrollment-time supersession all revoke through
+// here, so the invariant — trust revoked, node token cleared, every live
+// certificate revoked, in one transaction — has exactly one implementation.
+
+export interface RevokeEdgeNodeDb {
+  edgeNode: {
+    findUnique(args: unknown): Promise<{ id: string; trustState: string } | null>;
+    update(args: unknown): Promise<unknown>;
+  };
+  edgeNodeCertificate: {
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  $transaction<T>(operations: Promise<T>[]): Promise<T[]>;
+}
+
+export type RevokeEdgeNodeResult =
+  | { status: "revoked"; edgeNodeId: string; changed: boolean }
+  | { status: "not_found" | "invalid_input"; message: string };
+
+export async function revokeEdgeNode(
+  db: RevokeEdgeNodeDb,
+  input: { edgeNodeId: string; reason: string; now?: Date },
+): Promise<RevokeEdgeNodeResult> {
+  const reason = input.reason?.trim();
+  if (!input.edgeNodeId || typeof input.edgeNodeId !== "string") {
+    return { status: "invalid_input", message: "edgeNodeId required" };
+  }
+  if (!reason) {
+    return { status: "invalid_input", message: "revocation reason required" };
+  }
+  const node = await db.edgeNode.findUnique({
+    where: { id: input.edgeNodeId },
+    select: { id: true, trustState: true },
+  });
+  if (!node) return { status: "not_found", message: "Edge Node not found" };
+  // Revoking an already-revoked node is idempotent (no-op).
+  if (node.trustState === "revoked") {
+    return { status: "revoked", edgeNodeId: node.id, changed: false };
+  }
+
+  // Revoke the node + null its tokenHash so any further request bearing the
+  // now-orphaned token fails at auth resolution (the hash on the row IS the
+  // credential). Re-enrollment is operator-explicit per spec § Re-enrollment.
+  const revokedAt = input.now ?? new Date();
+  await db.$transaction([
+    db.edgeNode.update({
+      where: { id: node.id },
+      data: {
+        trustState: "revoked",
+        revokedAt,
+        revocationReason: reason,
+        tokenHash: null,
+        tokenPrefix: null,
+        tokenRotatedAt: null,
+      },
+    }),
+    db.edgeNodeCertificate.updateMany({
+      where: { edgeNodeId: node.id, status: { not: "revoked" } },
+      data: {
+        status: "revoked",
+        revokedAt,
+        revocationReason: `node_revoked:${reason}`,
+      },
+    }),
+  ]);
+  return { status: "revoked", edgeNodeId: node.id, changed: true };
+}

--- a/apps/web/lib/edge-node/stale-supersession.test.ts
+++ b/apps/web/lib/edge-node/stale-supersession.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  EDGE_LIVE_ENROLLMENT_WITHIN_MS,
+  EDGE_STALE_ENROLLMENT_AFTER_MS,
+  selectSupersededInstallerNodes,
+  supersedeStaleInstallerNodes,
+  type StaleSupersessionDb,
+} from "./stale-supersession";
+
+const now = new Date("2026-09-06T12:00:00.000Z");
+const minutesAgo = (m: number) => new Date(now.getTime() - m * 60_000);
+const daysAgo = (d: number) => new Date(now.getTime() - d * 24 * 60 * 60_000);
+
+const live = { id: "row_native", nodeId: "edge_native", trustState: "trusted", lastSeenAt: minutesAgo(1), enrolledAt: daysAgo(40) };
+const stale = { id: "row_container", nodeId: "edge_container", trustState: "trusted", lastSeenAt: daysAgo(48), enrolledAt: daysAgo(90) };
+
+describe("selectSupersededInstallerNodes", () => {
+  it("retires an installer enrollment silent for a week beside a live one", () => {
+    const decision = selectSupersededInstallerNodes({ candidates: [live, stale], now });
+    expect(decision.liveNodeIds).toEqual(["edge_native"]);
+    expect(decision.retire.map((n) => n.nodeId)).toEqual(["edge_container"]);
+    expect(decision.retire[0].reason).toContain("superseded-stale-installer-enrollment");
+    expect(decision.retire[0].reason).toContain("edge_native");
+    expect(decision.retire[0].silentSinceIso).toBe(stale.lastSeenAt.toISOString());
+    expect(decision.skipped).toBeNull();
+  });
+
+  it("never guesses between two live enrollments", () => {
+    const other = { ...stale, id: "row_other", nodeId: "edge_other", lastSeenAt: minutesAgo(5) };
+    const decision = selectSupersededInstallerNodes({ candidates: [live, other], now });
+    expect(decision.retire).toEqual([]);
+    expect(decision.skipped).toBe("nothing-stale");
+  });
+
+  it("retires nothing when no candidate is provably live", () => {
+    const quiet = { ...live, lastSeenAt: new Date(now.getTime() - EDGE_LIVE_ENROLLMENT_WITHIN_MS - 1) };
+    const decision = selectSupersededInstallerNodes({ candidates: [quiet, stale], now });
+    expect(decision.retire).toEqual([]);
+    expect(decision.skipped).toBe("no-live-candidate");
+  });
+
+  it("leaves a recently silent enrollment alone until the week has passed", () => {
+    const recent = { ...stale, lastSeenAt: new Date(now.getTime() - EDGE_STALE_ENROLLMENT_AFTER_MS + 60_000) };
+    expect(selectSupersededInstallerNodes({ candidates: [live, recent], now }).retire).toEqual([]);
+    const overdue = { ...stale, lastSeenAt: new Date(now.getTime() - EDGE_STALE_ENROLLMENT_AFTER_MS) };
+    expect(selectSupersededInstallerNodes({ candidates: [live, overdue], now }).retire).toHaveLength(1);
+  });
+
+  it("does nothing with a single candidate or when the only other row is already revoked", () => {
+    expect(selectSupersededInstallerNodes({ candidates: [live], now }).skipped).toBe("single-candidate");
+    expect(selectSupersededInstallerNodes({ candidates: [live, { ...stale, trustState: "revoked" }], now }).skipped).toBe("single-candidate");
+  });
+
+  it("uses enrolledAt for a node that never heartbeated", () => {
+    const neverSeen = { ...stale, lastSeenAt: null, enrolledAt: daysAgo(30) };
+    const decision = selectSupersededInstallerNodes({ candidates: [live, neverSeen], now });
+    expect(decision.retire.map((n) => n.nodeId)).toEqual(["edge_container"]);
+    expect(decision.retire[0].silentSinceIso).toBe(neverSeen.enrolledAt.toISOString());
+  });
+});
+
+describe("supersedeStaleInstallerNodes", () => {
+  it("loads installer-managed, unrevoked, install-scoped nodes and revokes the superseded one through the shared helper", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const db = {
+      edgeNode: {
+        findMany: vi.fn().mockResolvedValue([live, stale]),
+        findUnique: vi.fn().mockImplementation(async ({ where }: { where: { id: string } }) =>
+          [live, stale].find((n) => n.id === where.id) ?? null),
+        update,
+      },
+      edgeNodeCertificate: { updateMany },
+      $transaction: vi.fn().mockImplementation(async (ops: Promise<unknown>[]) => Promise.all(ops)),
+    } as unknown as StaleSupersessionDb;
+
+    const result = await supersedeStaleInstallerNodes(db, { now });
+
+    expect(result.revoked).toEqual(["edge_container"]);
+    expect(db.edgeNode.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        trustState: { not: "revoked" },
+        customerAccountId: null,
+        customerSiteId: null,
+        consumedTokens: { some: { autoApprove: true } },
+      }),
+    }));
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: "row_container" },
+      data: expect.objectContaining({ trustState: "revoked", tokenHash: null, revokedAt: now }),
+    }));
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ edgeNodeId: "row_container" }) }));
+  });
+});

--- a/apps/web/lib/edge-node/stale-supersession.ts
+++ b/apps/web/lib/edge-node/stale-supersession.ts
@@ -1,0 +1,117 @@
+// Self-healing for the "Enrollment conflict" state.
+//
+// `selectMainInstallationNode` refuses to guess between installer-managed
+// enrollments that both claim this installation — correctly, when both are
+// alive. But the common way to reach that state is not two live nodes: it is
+// an old installer-managed enrollment (a container-host node from a previous
+// install) that stopped heartbeating weeks ago, plus the native node the
+// current install enrolled. Leaving that to a human to notice and click Revoke
+// made a non-technical operator the platform's garbage collector.
+//
+// The rule here is deliberately narrow so it never guesses:
+//   - only installer-managed, non-revoked nodes are considered;
+//   - nothing is retired unless at least one candidate is provably LIVE
+//     (heartbeat inside `liveWithinMs`);
+//   - a candidate is retired only when it has been silent for at least
+//     `staleAfterMs` (a week by default) — far past the offline window;
+//   - two live candidates remain a conflict for a human.
+// Everything else stays exactly as the readiness surface reports it.
+
+import { revokeEdgeNode, type RevokeEdgeNodeDb } from "./revoke";
+
+/** A week of silence before an installer-managed enrollment is treated as abandoned. */
+export const EDGE_STALE_ENROLLMENT_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+/** A candidate counts as live when it has heartbeated within the last hour. */
+export const EDGE_LIVE_ENROLLMENT_WITHIN_MS = 60 * 60 * 1000;
+
+export interface InstallerNodeCandidate {
+  id: string;
+  nodeId: string;
+  trustState: string;
+  lastSeenAt: Date | null;
+  enrolledAt: Date | null;
+}
+
+export interface StaleSupersessionDecision {
+  /** The live candidate(s) that make the others provably obsolete. */
+  liveNodeIds: string[];
+  /** Candidates to retire, with the machine-readable reason to record. */
+  retire: Array<{ id: string; nodeId: string; reason: string; silentSinceIso: string | null }>;
+  /** Why nothing was retired, when nothing was. */
+  skipped: "single-candidate" | "no-live-candidate" | "nothing-stale" | null;
+}
+
+function lastSignalAt(node: InstallerNodeCandidate): Date | null {
+  return node.lastSeenAt ?? node.enrolledAt ?? null;
+}
+
+export function selectSupersededInstallerNodes(input: {
+  candidates: readonly InstallerNodeCandidate[];
+  now?: Date;
+  staleAfterMs?: number;
+  liveWithinMs?: number;
+}): StaleSupersessionDecision {
+  const now = input.now ?? new Date();
+  const staleAfterMs = input.staleAfterMs ?? EDGE_STALE_ENROLLMENT_AFTER_MS;
+  const liveWithinMs = input.liveWithinMs ?? EDGE_LIVE_ENROLLMENT_WITHIN_MS;
+  const candidates = input.candidates.filter((node) => node.trustState !== "revoked");
+  if (candidates.length < 2) return { liveNodeIds: [], retire: [], skipped: "single-candidate" };
+
+  const live = candidates.filter((node) => {
+    const at = node.lastSeenAt;
+    return at !== null && now.getTime() - at.getTime() <= liveWithinMs;
+  });
+  if (live.length === 0) return { liveNodeIds: [], retire: [], skipped: "no-live-candidate" };
+
+  const liveIds = new Set(live.map((node) => node.id));
+  const liveNodeIds = live.map((node) => node.nodeId);
+  const retire = candidates
+    .filter((node) => !liveIds.has(node.id))
+    .filter((node) => {
+      const at = lastSignalAt(node);
+      return at !== null && now.getTime() - at.getTime() >= staleAfterMs;
+    })
+    .map((node) => ({
+      id: node.id,
+      nodeId: node.nodeId,
+      silentSinceIso: lastSignalAt(node)?.toISOString() ?? null,
+      reason: `superseded-stale-installer-enrollment: silent since ${lastSignalAt(node)?.toISOString() ?? "enrollment"}; `
+        + `live installer-managed node ${liveNodeIds.join(", ")} claims this installation`,
+    }));
+  return { liveNodeIds, retire, skipped: retire.length === 0 ? "nothing-stale" : null };
+}
+
+export interface StaleSupersessionDb extends RevokeEdgeNodeDb {
+  edgeNode: RevokeEdgeNodeDb["edgeNode"] & {
+    findMany(args: unknown): Promise<InstallerNodeCandidate[]>;
+  };
+}
+
+/**
+ * Load this installation's installer-managed enrollments (a consumed
+ * auto-approve bootstrap token is what makes a node installer-managed — the
+ * same basis `/platform/edge-nodes` uses) and retire the provably superseded
+ * ones. Safe to call from the hourly janitor and right after an enrollment.
+ */
+export async function supersedeStaleInstallerNodes(
+  db: StaleSupersessionDb,
+  options: { now?: Date; staleAfterMs?: number; liveWithinMs?: number } = {},
+): Promise<{ decision: StaleSupersessionDecision; revoked: string[] }> {
+  const now = options.now ?? new Date();
+  const candidates = await db.edgeNode.findMany({
+    where: {
+      trustState: { not: "revoked" },
+      customerAccountId: null,
+      customerSiteId: null,
+      consumedTokens: { some: { autoApprove: true } },
+    },
+    select: { id: true, nodeId: true, trustState: true, lastSeenAt: true, enrolledAt: true },
+  });
+  const decision = selectSupersededInstallerNodes({ candidates, now, ...options });
+  const revoked: string[] = [];
+  for (const target of decision.retire) {
+    const result = await revokeEdgeNode(db, { edgeNodeId: target.id, reason: target.reason, now });
+    if (result.status === "revoked" && result.changed) revoked.push(target.nodeId);
+  }
+  return { decision, revoked };
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog-hygiene.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog-hygiene.ts
@@ -54,6 +54,19 @@ export const HYGIENE_JOB_CATALOG_ENTRIES: readonly ScheduledJobCatalogEntry[] = 
     runNowEvent: null,
   },
   {
+    jobId: "edge-node-janitor",
+    inngestId: "ops/edge-node-janitor",
+    honorsEnabledGate: true,
+    name: "Edge-node janitor",
+    purpose:
+      "Retires an installer-managed Edge Node enrollment that a live one has superseded (silent a week beside a live node), so an Enrollment conflict heals itself.",
+    cron: "33 * * * *",
+    cadence: "Hourly",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "runtime-artifact-janitor",
     inngestId: "ops/runtime-artifact-janitor",
     ungatedReason:

--- a/apps/web/lib/queue/functions/edge-node-janitor.test.ts
+++ b/apps/web/lib/queue/functions/edge-node-janitor.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockSupersede } = vi.hoisted(() => ({ mockSupersede: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({ prisma: { edgeNode: {}, edgeNodeCertificate: {}, $transaction: vi.fn() } }));
+vi.mock("@/lib/edge-node/stale-supersession", () => ({ supersedeStaleInstallerNodes: mockSupersede }));
+vi.mock("../quiescence-gates", () => ({ gateAtEntry: vi.fn(async () => ({ proceed: true })) }));
+vi.mock("../inngest-client", () => ({
+  inngest: {
+    createFunction: vi.fn((config: unknown, handler: unknown) => ({ config, handler })),
+  },
+}));
+
+import { edgeNodeJanitor } from "./edge-node-janitor";
+
+describe("edgeNodeJanitor (BI-D4F79CE2)", () => {
+  it("is an hourly cron that runs the stale-enrollment supersession as one step", async () => {
+    const fn = edgeNodeJanitor as unknown as {
+      config: { id: string; triggers: Array<{ cron?: string }> };
+      handler: (ctx: { step: { run: (name: string, f: () => Promise<unknown>) => Promise<unknown> } }) => Promise<unknown>;
+    };
+    expect(fn.config.id).toBe("ops/edge-node-janitor");
+    expect(JSON.stringify(fn.config.triggers)).toContain("33 * * * *");
+
+    mockSupersede.mockResolvedValue({ decision: { liveNodeIds: ["edge_native"], retire: [], skipped: null }, revoked: ["edge_container"] });
+    const run = vi.fn(async (_name: string, f: () => Promise<unknown>) => f());
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const result = await fn.handler({ step: { run } });
+
+    expect(run).toHaveBeenCalledWith("supersede-stale-installer-nodes", expect.any(Function));
+    expect(mockSupersede).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ supersession: { revoked: ["edge_container"] } });
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("edge_container"));
+    info.mockRestore();
+  });
+});

--- a/apps/web/lib/queue/functions/edge-node-janitor.ts
+++ b/apps/web/lib/queue/functions/edge-node-janitor.ts
@@ -1,0 +1,35 @@
+// Edge-node janitor: retire an installer-managed enrollment that a later, live
+// enrollment has provably superseded, so the "Enrollment conflict" state heals
+// itself instead of waiting for a human to find the obsolete row and click
+// Revoke. Hourly, no quiescence gate (coordination records, not portal state).
+// The decision rule and its guard-rails live in lib/edge-node/stale-supersession.
+
+import { cron } from "inngest";
+
+import { prisma } from "@dpf/db";
+
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import { supersedeStaleInstallerNodes, type StaleSupersessionDb } from "@/lib/edge-node/stale-supersession";
+
+export const edgeNodeJanitor = inngest.createFunction(
+  {
+    id: "ops/edge-node-janitor",
+    retries: 1,
+    // Idempotent: a revoked node drops out of the candidate set, so an
+    // overlapping trigger finds nothing to do.
+    triggers: [cron("33 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step, "ops/edge-node-janitor");
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    const supersession = await step.run("supersede-stale-installer-nodes", async () => {
+      const result = await supersedeStaleInstallerNodes(prisma as unknown as StaleSupersessionDb);
+      if (result.revoked.length > 0) {
+        console.info(`[edge-node-janitor] retired superseded installer enrollment(s): ${result.revoked.join(", ")}`);
+      }
+      return result;
+    });
+    return { supersession };
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -54,6 +54,7 @@ import {
   postgresTrialRestoreRequested,
 } from "./postgres-daily-backup";
 import { runtimeTargetJanitor } from "./runtime-target-janitor";
+import { edgeNodeJanitor } from "./edge-node-janitor";
 import { runtimeArtifactJanitor } from "./runtime-artifact-janitor";
 import { worktreeJanitor } from "./worktree-janitor";
 import { sandboxBuildGc } from "./sandbox-build-gc";
@@ -172,6 +173,7 @@ export const scheduledFunctions = [
   postgresDailyBackupScheduled,
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
+  edgeNodeJanitor, // BI-D4F79CE2: retire an installer enrollment a live one has superseded, hourly
   runtimeArtifactJanitor, // BI-DBF3F426/BI-A55BE432: orphaned CI images + stray compose projects (+ their volumes), daily 05:20; DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED=observe, +DPF_RUNTIME_ARTIFACT_JANITOR_AUTO_REAP=live
   worktreeJanitor, // BI-42FA7DD8: host worktree Tier-A fleet backstop; daily 05:40
   sandboxBuildGc, // BI-8BD61C30: BS sandbox .builds worktree + aged build/* branch GC (flag DPF_SANDBOX_BUILD_GC_ENABLED), daily 05:50

--- a/docs/user-guide/platform/edge-nodes.md
+++ b/docs/user-guide/platform/edge-nodes.md
@@ -33,7 +33,7 @@ The card checks the supervised service, enrollment, trust, heartbeat freshness, 
 
 Health and trust are different axes. A node can be trusted yet offline, or alive yet quarantined. The fleet table therefore shows both columns, plus the first failed readiness check and its next action, and derives health from live evidence rather than `EdgeNode.status` alone.
 
-If **Connections** reports an **Enrollment conflict**, discovery may still be running, but the Authority cannot safely prove which installer-managed node belongs to this installation. DPF does not guess from the newest heartbeat or hostname; open **Edge Nodes**, identify the obsolete enrollment, and retire or repair it through the governed lifecycle.
+If **Connections** reports an **Enrollment conflict**, discovery may still be running, but the Authority cannot safely prove which installer-managed node belongs to this installation. DPF does not guess from the newest heartbeat or hostname. The common cause heals on its own: an installer-managed enrollment that has been silent for a week while another installer-managed node is live is retired automatically, both right after a new installer enrollment and by an hourly sweep, and its retirement reason names the live node that superseded it. Only two live installer-managed nodes remain a conflict; then open **Edge Nodes**, identify the obsolete enrollment, and retire or repair it through the governed lifecycle.
 
 Once Edge is enabled, each governed install or self-upgrade refreshes the checksum-bound native binary and its supervisor while preserving the enrolled machine identity. Replacement bytes are staged before the service stops, and a failed restart restores the prior binary. A platform version change does not issue a new bootstrap token.
 

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -38,7 +38,7 @@ Use the Platform area to supervise AI operations, Edge Nodes, integrations, iden
 
 Open **Platform > Connections** to find nearby DPF installations or connect by invitation. A nearby result is only a setup suggestion: it never creates trust or shares backlog data by itself. Both installations must approve a connection before any shared demand or disposition can cross it.
 
-The page reports whether the native Edge Node is listening for nearby installations. If discovery is not set up, paused, unhealthy, or blocked by an **Enrollment conflict**, use the Edge Nodes link to review its authority and network status. An enrollment conflict means that more than one installer-managed node claims this installation; DPF will not guess which node is authoritative. Invitation-based setup remains available when local-network discovery cannot be used.
+The page reports whether the native Edge Node is listening for nearby installations. If discovery is not set up, paused, unhealthy, or blocked by an **Enrollment conflict**, use the Edge Nodes link to review its authority and network status. An enrollment conflict means that more than one installer-managed node claims this installation; DPF will not guess which node is authoritative, but it does retire an enrollment that has been silent for a week once a live one has replaced it. Invitation-based setup remains available when local-network discovery cannot be used.
 
 For another installation owned by the same organization, choose **Set up this
 DPF**. Automatic setup is available only when both installations advertise a


### PR DESCRIPTION
## Summary

/platform/edge-nodes sat in **Enrollment conflict** for 48 days on the production install: an installer-managed container-host enrollment that stopped heartbeating on 2026-07-20 beside the live native node. `selectMainInstallationNode` correctly refuses to guess between two candidates, but nothing ever retired the one that was provably dead, so a non-technical operator was the platform's garbage collector. Operator direction: this must be self-maintaining.

- **One revocation home** (`lib/edge-node/revoke.ts`): trust revoked, node token cleared, live certificates revoked, one transaction. The admin server action, the janitor and enrollment all go through it.
- **Bounded supersession** (`lib/edge-node/stale-supersession.ts`): an installer-managed enrollment is retired only when another installer-managed candidate is **live** (heartbeat within the last hour) **and** it has been silent for at least a week. Two live candidates stay a human decision; nothing is retired without a live successor. The revocation reason names the superseding node.
- **Hourly `ops/edge-node-janitor`** (catalogued, kill-switch gated) plus the same sweep right after an auto-approved enrollment, so a re-install heals the conflict immediately.
- Readiness detail and the user guide (platform/edge-nodes.md, platform/index.md) say what heals on its own and what still needs a person.

The live conflict itself was cleared today by revoking the stale row (agent-driven, mirroring the action's transaction; recorded on BI-D4F79CE2).

## Design grounding
Extends the edge-node readiness contract (`readiness.ts`, selector unchanged) with a self-healing step on the existing EdgeNode/BootstrapToken rows and the runtime-target-janitor cron pattern (BI-AD949172). No new table or route.

## Verification
- vitest: edge-node, actions, enrollment, janitor, catalog parity and scheduling-map suites green (337 tests); web typecheck clean.
- Local-CI sandbox gate: **PASS** on the pushed head.
- Full build: cloud merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)