### PR TITLE
fix(readiness): route plan review to covered plan artifact

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.test.ts
@@ -22,7 +22,7 @@ function projected(verdict: "allowed" | "input-required") {
     blockers: [],
     evaluatedAt: "2026-08-22T08:00:00.000Z",
   };
-  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, decision };
+  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, planArtifact: null, decision };
 }
 
 function fakeDb(casCount = 1, workType = "feature", itemOverrides: Record<string, unknown> = {}) {

--- a/apps/web/lib/backlog/initiative-readiness/build-terminal-transition.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/build-terminal-transition.test.ts
@@ -18,7 +18,7 @@ function projection(verdict: "allowed" | "input-required") {
     blockers: [],
     evaluatedAt: "2026-08-22T08:00:00.000Z",
   };
-  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, decision };
+  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, planArtifact: null, decision };
 }
 
 function fakeDb() {

--- a/apps/web/lib/backlog/initiative-readiness/entry-adapter.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/entry-adapter.test.ts
@@ -149,6 +149,22 @@ function terminalFixture(payloadOverride: Record<string, unknown> = {}) {
   };
 }
 
+describe("plan recovery locator", () => {
+  it.each(["current", "stale", "incomplete", "unsafe-path"])("exposes only a valid current-baseline locator: %s", (scenario) => {
+    const activities = readyActivities();
+    const coverage = activities.find((entry) => entry.kind === "plan_backlog_coverage")!;
+    const artifact = { kind: "repo-blob-at-commit", repositoryFullName: "owner/repo",
+      commitSha: "a".repeat(40), providerBlobId: "b".repeat(40),
+      path: scenario === "unsafe-path" ? "docs/superpowers/plans/../specs/a.md" : "docs/superpowers/plans/plan.md" };
+    coverage.payload = { ...coverage.payload, planPath: artifact.path, planArtifactRef: {
+      ...artifact, ...(scenario === "incomplete" ? { providerBlobId: "" } : {}),
+    }, ...(scenario === "stale" ? { scopeBaselineId: "old-baseline" } : {}) } as typeof coverage.payload;
+    const result = projectBacklogItemReadiness({ item, activities, target: "implementation", transitionObject,
+      authorization: "pass", capsuleIdentity: "pass", evaluatedAt: "2026-09-06T21:00:00.000Z" });
+    expect(result.planArtifact).toEqual(scenario === "current" ? artifact : null);
+  });
+});
+
 describe("projectBacklogItemReadiness", () => {
   it("preserves the enforced allowed completion decision for a done item", () => {
     const fixture = terminalFixture();

--- a/apps/web/lib/backlog/initiative-readiness/entry-adapter.ts
+++ b/apps/web/lib/backlog/initiative-readiness/entry-adapter.ts
@@ -3,6 +3,7 @@ import { evidenceKindMetadata, isExecutionEvidenceKind } from "../execution-evid
 import { evaluateInitiativeReadiness } from "./evaluate";
 import { deriveAuthoritativeReadinessProfile } from "./profiles";
 import type { InheritedInitiativeScope } from "./parent-scope-inheritance";
+import type { InitiativeArtifactRef } from "./receipt-schema";
 import { readinessCodesForEvidenceDimension } from "./readiness-guidance";
 import type {
   InitiativeReadinessDecision,
@@ -332,14 +333,16 @@ function unreadEvidenceByCode(
   return byCode;
 }
 
+type InitiativePlanArtifact = Extract<InitiativeArtifactRef, { kind: "repo-blob-at-commit" }>;
+
 function projectPlanCoverage(
   activities: readonly InitiativeReadinessActivity[],
   baseline: Baseline | null,
-): { state: ReadinessEvidenceState; planDigest: string | null } {
+): { state: ReadinessEvidenceState; planDigest: string | null; planArtifact: InitiativePlanArtifact | null } {
   const latest = [...activities]
     .filter((activity) => activity.kind === "plan_backlog_coverage")
     .sort((left, right) => right.recordedAt.getTime() - left.recordedAt.getTime() || right.id.localeCompare(left.id))[0];
-  if (!latest) return { state: "missing", planDigest: null };
+  if (!latest) return { state: "missing", planDigest: null, planArtifact: null };
   const payload = object(latest.payload);
   const artifact = object(payload?.planArtifactRef);
   if (!payload
@@ -353,9 +356,20 @@ function projectPlanCoverage(
     || !baseline
     || payload.scopeBaselineId !== baseline.baselineId
     || payload.scopeBaselineArtifactDigest !== baseline.artifactDigest) {
-    return { state: "malformed", planDigest: null };
+    return { state: "malformed", planDigest: null, planArtifact: null };
   }
-  return { state: "pass", planDigest: String(payload.planArtifactDigest) };
+  // Reuse this baseline-validated selection for dispatch too. Historical
+  // coverage can still project its digest without inventing missing locators.
+  const planArtifact: InitiativePlanArtifact | null =
+    typeof artifact.repositoryFullName === "string" && /^[^/\s]+\/[^/\s]+$/.test(artifact.repositoryFullName)
+      && typeof artifact.commitSha === "string" && /^[a-f0-9]{40}$/i.test(artifact.commitSha)
+      && typeof artifact.providerBlobId === "string" && /^[a-f0-9]{40}$/i.test(artifact.providerBlobId)
+      && typeof artifact.path === "string" && /^docs\/superpowers\/plans\/[A-Za-z0-9][A-Za-z0-9._/-]*\.md$/.test(artifact.path)
+      && !artifact.path.split("/").some((part) => part === "." || part === "..")
+      ? { kind: "repo-blob-at-commit", repositoryFullName: artifact.repositoryFullName,
+        commitSha: artifact.commitSha, path: artifact.path, providerBlobId: artifact.providerBlobId }
+      : null;
+  return { state: "pass", planDigest: String(payload.planArtifactDigest), planArtifact };
 }
 
 export function projectBacklogItemReadiness(args: {
@@ -398,6 +412,7 @@ export function projectBacklogItemReadiness(args: {
 }): {
   governed: boolean;
   baselineId: string | null;
+  planArtifact: InitiativePlanArtifact | null;
   /** Parent item whose scope this projection borrowed, or null when the item stands alone. */
   inheritedFrom: string | null;
   artifactHints: { hasSpec: boolean; hasPlan: boolean };
@@ -483,6 +498,7 @@ export function projectBacklogItemReadiness(args: {
   return {
     governed,
     baselineId: baseline.current?.baselineId ?? null,
+    planArtifact: projectedCoverage.planArtifact,
     inheritedFrom: inherited?.parentItemId ?? null,
     artifactHints: args.artifactHints ?? { hasSpec: false, hasPlan: false },
     decision: evaluateInitiativeReadiness(facts, args.target),

--- a/apps/web/lib/backlog/initiative-readiness/epic-terminal-transition.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/epic-terminal-transition.test.ts
@@ -17,7 +17,7 @@ function projected(verdict: "allowed" | "input-required") {
     })],
     evaluatedAt: "2026-08-22T08:00:00.000Z",
   };
-  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, decision };
+  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, planArtifact: null, decision };
 }
 
 function fakeDb(options?: { anchored?: boolean; childStatus?: string }) {

--- a/apps/web/lib/backlog/initiative-readiness/work-capsule-terminal-transition.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/work-capsule-terminal-transition.test.ts
@@ -13,7 +13,7 @@ function projected(verdict: "allowed" | "input-required") {
     unmet: verdict === "allowed" ? [] : [readinessRequirement({ code: "OBJECTIVE_RECONCILIATION_REQUIRED", state: "missing", accountableRole: "acceptance-reviewer" })],
     evaluatedAt: "2026-08-22T08:00:00.000Z",
   };
-  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, decision };
+  return { governed: true, baselineId: "BASE-1", inheritedFrom: null, artifactHints: { hasSpec: true, hasPlan: true }, planArtifact: null, decision };
 }
 
 function fakeDb() {

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -76,6 +76,42 @@ function inactiveGrantRow(grantKey: string, agentId: string, displayName: string
 }
 
 describe("initiative readiness recovery routing", () => {
+  it("binds plan review to the coverage plan while other reviews keep the design", async () => {
+    const planArtifact = {
+      resolved: true as const,
+      path: "docs/superpowers/plans/admission.md",
+      providerBlobId: "a".repeat(40),
+      commitSha: "b".repeat(40),
+    };
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision: { ...decision, unmet: [
+        readinessRequirement({ code: "PLAN_REVIEW_REQUIRED", state: "missing", accountableRole: "plan-reviewer" }),
+        readinessRequirement({ code: "SPEC_APPROVAL_REQUIRED", state: "missing", accountableRole: "design-checklist-reviewer" }),
+      ] },
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue(boundGrantRows("initiative_design_review", "AGT-REVIEW", "Reviewer")) } },
+      dispatchContext, canonicalArtifact, planArtifact,
+    });
+    const plan = recovery.reviewerRoutes.find((route) => route.gate === "plan-review")!.requestCoworker;
+    expect(plan.initiativeReviewBinding?.artifactRef).toMatchObject({
+      path: planArtifact.path, providerBlobId: planArtifact.providerBlobId, commitSha: planArtifact.commitSha,
+    });
+    expect(plan.objective).toContain(planArtifact.path);
+    expect(plan.requestKey).toContain(planArtifact.providerBlobId);
+    expect(recovery.reviewerRoutes.find((route) => route.gate === "spec-approval")?.requestCoworker.initiativeReviewBinding?.artifactRef.path).toBe(canonicalArtifact.path);
+  });
+
+  it("never substitutes the design when the plan artifact is unavailable", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision: { ...decision, unmet: [readinessRequirement({ code: "PLAN_REVIEW_REQUIRED", state: "missing", accountableRole: "plan-reviewer" })] },
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue(boundGrantRows("initiative_design_review", "AGT-REVIEW", "Reviewer")) } },
+      dispatchContext, canonicalArtifact,
+    });
+    expect(recovery.reviewerRoutes).toEqual([]);
+    expect(recovery.escalations[0]?.nextAction).toContain("plan coverage");
+  });
+
   it("requires the bound writer and file_read on the same production agent", async () => {
     const researchOnlyDecision: InitiativeReadinessDecision = {
       ...decision,

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -97,7 +97,7 @@ describe("initiative readiness recovery routing", () => {
       path: planArtifact.path, providerBlobId: planArtifact.providerBlobId, commitSha: planArtifact.commitSha,
     });
     expect(plan.objective).toContain(planArtifact.path);
-    expect(plan.requestKey).toContain(planArtifact.providerBlobId);
+    expect(plan.requestKey).toMatch(/:plan:[a-f0-9]{64}$/);
     expect(recovery.reviewerRoutes.find((route) => route.gate === "spec-approval")?.requestCoworker.initiativeReviewBinding?.artifactRef.path).toBe(canonicalArtifact.path);
   });
 
@@ -110,6 +110,23 @@ describe("initiative readiness recovery routing", () => {
     });
     expect(recovery.reviewerRoutes).toEqual([]);
     expect(recovery.escalations[0]?.nextAction).toContain("plan coverage");
+  });
+
+  it("reuses an exact plan request but separates changed paths and baselines", async () => {
+    const packet = async (path: string, baseline: string) => {
+      const recovery = await resolveInitiativeReviewerRecovery({
+        decision: { ...decision, unmet: [readinessRequirement({ code: "PLAN_REVIEW_REQUIRED", state: "missing", accountableRole: "plan-reviewer" })] },
+        currentAgentId: "AGT-AUTHOR",
+        db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue(boundGrantRows("initiative_design_review", "AGT-REVIEW", "Reviewer")) } },
+        dispatchContext, canonicalArtifact, expectedCurrentBaselineId: baseline,
+        planArtifact: { resolved: true, path, commitSha: "b".repeat(40), providerBlobId: "a".repeat(40) },
+      });
+      return recovery.reviewerRoutes[0]!.requestCoworker.requestKey;
+    };
+    const original = await packet("docs/superpowers/plans/one.md", "BASE-1");
+    expect(await packet("docs/superpowers/plans/one.md", "BASE-1")).toBe(original);
+    expect(await packet("docs/superpowers/plans/two.md", "BASE-1")).not.toBe(original);
+    expect(await packet("docs/superpowers/plans/one.md", "BASE-2")).not.toBe(original);
   });
 
   it("requires the bound writer and file_read on the same production agent", async () => {

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@/lib/shared/canonical-json";
 import { readinessRequirement } from "@/lib/backlog/initiative-readiness/readiness-guidance";
 import type {
   InitiativeGateKey,
@@ -499,10 +501,7 @@ function requestCoworkerPacket(args: {
     targetAgent: args.targetAgentId,
     objective,
     questionPacketSummary,
-    requestKey: `initiative-readiness:${args.decision.subject.id}:${args.gate}:${args.dispatch.headSha}${
-      args.gate === "plan-review" && args.artifact
-        ? `:plan:${reviewSha}:${args.artifact.providerBlobId}` : ""
-    }`,
+    requestKey: `initiative-readiness:${args.decision.subject.id}:${args.gate}:${args.dispatch.headSha}`,
     tier: 2 as const,
     enteredVia: "handoff" as const,
   };
@@ -547,7 +546,11 @@ function requestCoworkerPacket(args: {
         workroomRef: binding.workroomRef!,
       },
     })
-    : base.requestKey;
+    : args.gate === "plan-review"
+      ? `${base.requestKey}:plan:${createHash("sha256").update(canonicalJson({
+        binding, targetAgent: args.targetAgentId, objective,
+      })).digest("hex")}`
+      : base.requestKey;
   return {
     ...base,
     requestKey,

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -194,6 +194,8 @@ export async function resolveInitiativeReviewerRecovery(input: {
   db: ReviewerRouteDb;
   dispatchContext: InitiativeRecoveryDispatchContext | null;
   canonicalArtifact?: InitiativeRecoveryCanonicalArtifact | null;
+  /** Exact plan selected by the baseline-validated coverage projection. */
+  planArtifact?: InitiativeRecoveryCanonicalArtifact | null;
   expectedCurrentBaselineId?: string | null;
   eligibleEvidenceActivityIds?: readonly string[];
 }): Promise<InitiativeReviewerRecovery> {
@@ -289,7 +291,9 @@ export async function resolveInitiativeReviewerRecovery(input: {
       // rejects — the very defect this lane routing exists to end. Plan coverage
       // is not a review of immutable bytes, so it carries no artifact identity
       // and is not blocked by one being unresolvable (BI-9FE775F9).
-      const artifact = input.canonicalArtifact ?? null;
+      const artifact = entry.gate === "plan-review"
+        ? input.planArtifact ?? { resolved: false as const, nextAction: "Record valid plan coverage against the current baseline, then retry plan review. The design cannot substitute for the implementation plan." }
+        : input.canonicalArtifact ?? null;
       if (bindable && (!artifact || !artifact.resolved)) {
         // A route without a binding is not a lesser route — it is an unusable
         // one: `request_coworker` rejects `requiredToolNames` unless the binding
@@ -495,7 +499,10 @@ function requestCoworkerPacket(args: {
     targetAgent: args.targetAgentId,
     objective,
     questionPacketSummary,
-    requestKey: `initiative-readiness:${args.decision.subject.id}:${args.gate}:${args.dispatch.headSha}`,
+    requestKey: `initiative-readiness:${args.decision.subject.id}:${args.gate}:${args.dispatch.headSha}${
+      args.gate === "plan-review" && args.artifact
+        ? `:plan:${reviewSha}:${args.artifact.providerBlobId}` : ""
+    }`,
     tier: 2 as const,
     enteredVia: "handoff" as const,
   };

--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -125,6 +125,34 @@ function database(activities: unknown[] = []) {
 }
 
 describe("claimGovernedBacklogWorkspace", () => {
+  it.each([input.repositoryFullName, "other/repository"])("routes only the current baseline's same-repository coverage plan (%s)", async (repositoryFullName) => {
+    const planArtifactRef = { kind: "repo-blob-at-commit", repositoryFullName,
+      path: "docs/superpowers/plans/admission.md", commitSha: "a".repeat(40), providerBlobId: "b".repeat(40) };
+    const db = database([
+      { id: "baseline", kind: "initiative_scope_baseline", gateKey: null, recordedAt: new Date(), payload: {
+        schemaVersion: 1, baselineId: "baseline-current", subject: { kind: "backlog-item", id: "BI-ENTRY" },
+        profile: "feature", artifactDigest: "sha256:design", supersedesBaselineId: null,
+        objectiveStatements: [{ objectiveId: "OBJ-1" }], acceptanceStatements: [{ acceptanceId: "AC-1" }],
+        approvalReceiptId: "approval", authoritySnapshot: { decision: "allow" },
+      } },
+      { id: "coverage", kind: "plan_backlog_coverage", gateKey: null, recordedAt: new Date(), payload: {
+        schemaVersion: 2, decision: "atomic", planPath: planArtifactRef.path, planArtifactRef,
+        planArtifactDigest: "sha256:plan", scopeBaselineId: "baseline-current", scopeBaselineArtifactDigest: "sha256:design", deliverables: [],
+      } },
+    ]);
+    const result = await claimGovernedBacklogWorkspace({ db, input, actor, workIntent: "implementation",
+      dependencies: { claimWorkspace: vi.fn(), discoverCanonicalArtifact } });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const planRoute = result.data.recovery.reviewerRoutes.find((route) => route.gate === "plan-review");
+    if (repositoryFullName === input.repositoryFullName) {
+      expect(planRoute?.requestCoworker.initiativeReviewBinding?.artifactRef).toEqual(planArtifactRef);
+    } else {
+      expect(planRoute).toBeUndefined();
+      expect(result.data.recovery.escalations.some((entry) => entry.accountableRole === "plan-reviewer")).toBe(true);
+    }
+  });
+
   // BI-512214EA. Recovery used to require a Workroom already bound to the item,
   // but that binding is written by the successful-claim path — so a refused
   // claim could never find one, and every reviewer route came back empty. These

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -112,6 +112,7 @@ type PendingRecovery = {
   baselineId: string | null;
   dispatchContext: InitiativeRecoveryDispatchContext | null;
   baseSha: string | null;
+  planArtifact: ReturnType<typeof projectBacklogItemReadiness>["planArtifact"];
 };
 
 /**
@@ -144,6 +145,11 @@ async function resolveRecoveryOutsideTransaction(args: {
     db: args.db,
     dispatchContext: pending.dispatchContext,
     canonicalArtifact,
+    planArtifact: pending.planArtifact && pending.dispatchContext
+      && pending.planArtifact.repositoryFullName.toLowerCase() === pending.dispatchContext.repositoryFullName.toLowerCase()
+      ? { resolved: true, path: pending.planArtifact.path,
+        commitSha: pending.planArtifact.commitSha, providerBlobId: pending.planArtifact.providerBlobId }
+      : { resolved: false, nextAction: "Record valid plan coverage for the current baseline and this Workroom repository, including the immutable plan commit and blob, then retry plan review." },
     expectedCurrentBaselineId: pending.baselineId,
   });
 }
@@ -435,6 +441,7 @@ export async function claimGovernedBacklogWorkspace(args: {
         pendingRecovery = {
           decision: evaluated,
           baselineId: projection.baselineId,
+          planArtifact: projection.planArtifact,
           dispatchContext: recoveryWorkroom?.headSha ? {
             workroomId: recoveryWorkroom.capsuleId,
             repositoryFullName: recoveryWorkroom.repositoryFullName,

--- a/docs/architecture/backlog-and-planning-runbook.md
+++ b/docs/architecture/backlog-and-planning-runbook.md
@@ -1,5 +1,7 @@
 # Backlog & planning runbook
 
+Plan-review recovery binds the immutable plan recorded in valid coverage for the current scope baseline and Workroom repository. Design approval continues to bind the canonical design. If the plan commit, blob, or safe `docs/superpowers/plans/*.md` path is missing, stale, or belongs to another repository, record complete current plan coverage and retry readiness; a design cannot substitute for a plan. The plan-specific request key prevents replay of a historical review routed to the design. Historical receipts remain available for audit.
+
 **Status:** procedure reference. The *rules* — backlog lives in Postgres, plan before build, check epic overlap — live in [`AGENTS.md`](../../AGENTS.md) §6 and stay always-on. This file holds the tooling detail, hygiene cadence and enforced-gate list. Relocated by BI-0020D511 Phase 1; no rule was dropped.
 
 - **Backlog lives in PostgreSQL** (`Epic`, `BacklogItem`). Always query live state before planning or changing backlog work. → [kernel principle](../professions/portfolio-management/wiki/backlog-lives-in-postgresql.md)


### PR DESCRIPTION
Plan-review recovery selected the canonical design even when current plan coverage recorded a different immutable plan. For BI-06AE6833 this kept implementation blocked after design approval and plan coverage had already succeeded.

Reuse the baseline-validated coverage projection to route plan review to its exact plan commit and blob. Refuse incomplete, stale, unsafe, or foreign-repository plan identity with repair guidance. Keep design reviews on the design and distinguish the repaired plan request from historical design requests. The runbook documents the recovery behavior.

Validation: 103 affected tests across ten files pass; web typecheck passes; all 65 preflight guards pass. Four artifact-routing regressions failed before implementation; an additional failing retry test proved that the complete binding, including path and baseline, must identify the request. The updated committed tree received a passing semantic receipt (TR-GATE-E370684639CD4E537942DBFD): two independent review branches completed with zero blocking findings.

Live acceptance follows canonical release: retry the original covered-plan route, dispatch the independent reviewer, save its receipt, and confirm implementation readiness.

## Design grounding

Reviewed the initiative-readiness and goal-completion reconciliation design and existing entry-adapter, governed-work-claim, reviewer-route registry, and terminal recovery callers. Current baseline-valid plan coverage remains the source of plan identity. This is a repair to the established review contract, with no new gate, schema, approval, or reviewer role.

Backlog: BI-B5C8FEFC; unblocks BI-06AE6833 / WC-27D00458.

Local-CI-Override: operator-emergency: user explicitly authorized bypass of the redundant local sandbox to recover the weeks-stalled journey; sandbox build is skipped, not passed; affected tests, typecheck and preflight passed and protected cloud checks remain mandatory.
