### PR TITLE
fix(readiness): close documentation-only work proportionally (BI-B5C8FEFC)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness-policy.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness-policy.test.ts
@@ -132,6 +132,19 @@ describe("evaluateInitiativeReadiness", () => {
     expect(evaluateInitiativeReadiness(facts(), "completion")).toMatchObject({ verdict: "input-required" });
   });
 
+  it("closes documentation-only work from delivery and acceptance evidence without inventing an objective baseline", () => {
+    const decision = evaluateInitiativeReadiness(facts({
+      profile: "doc-only",
+      deliveryEvidence: "pass",
+      acceptanceEvidence: "pass",
+      objectiveBaseline: "missing",
+      objectiveReconciliation: "missing",
+    }), "completion");
+
+    expect(decision.verdict).toBe("allowed");
+    expect(codes(decision)).toEqual([]);
+  });
+
   it("allows planning after canonical approved design evidence", () => {
     const decision = evaluateInitiativeReadiness(facts({
       canonicalDesign: "pass",

--- a/apps/web/lib/backlog/initiative-readiness/evaluate.ts
+++ b/apps/web/lib/backlog/initiative-readiness/evaluate.ts
@@ -105,13 +105,18 @@ function implementationRequirements(facts: InitiativeReadinessFacts): Requiremen
 }
 
 function completionRequirements(facts: InitiativeReadinessFacts): Requirement[] {
-  return [
+  const requirements = [
     ...implementationRequirements(facts),
     requirement("DELIVERY_EVIDENCE_REQUIRED", facts.deliveryEvidence, "delivery-coordinator"),
     requirement("ACCEPTANCE_EVIDENCE_REQUIRED", facts.acceptanceEvidence, "acceptance-reviewer"),
-    requirement("OBJECTIVE_BASELINE_REQUIRED", facts.objectiveBaseline, "design-checklist-reviewer"),
-    requirement("OBJECTIVE_RECONCILIATION_REQUIRED", facts.objectiveReconciliation, "acceptance-reviewer"),
   ];
+  if (facts.profile !== "doc-only") {
+    requirements.push(
+      requirement("OBJECTIVE_BASELINE_REQUIRED", facts.objectiveBaseline, "design-checklist-reviewer"),
+      requirement("OBJECTIVE_RECONCILIATION_REQUIRED", facts.objectiveReconciliation, "acceptance-reviewer"),
+    );
+  }
+  return requirements;
 }
 
 function requirementsFor(facts: InitiativeReadinessFacts, target: ReadinessTarget): Requirement[] {


### PR DESCRIPTION
## Summary
- stop requiring an impossible objective baseline/reconciliation for doc-only completion
- retain delivery and acceptance evidence as mandatory
- add focused policy coverage for the proportional closure contract

## Verification
- focused local Vitest: INCONCLUSIVE because the source-only worktree cannot resolve vitest/config, @vitejs/plugin-react, or dotenv
- pre-commit scoped typecheck: INCONCLUSIVE because apps/web/node_modules is unprovisioned (
ext unavailable)
- gitleaks: PASS
- git diff --check: PASS
- DCO signed commit
- all protected GitHub checks remain mandatory

## Coordination
PR #5150 owns plan-artifact routing. This PR does not touch its entry-adapter, TAK, or governed-work-claim files. Governed co-delivery agreement is recorded on WC-4C6E738A.