### PR TITLE
fix(hooks): the SessionEnd reaper spares sibling worktrees' local-CI runs and releases only its own leases (BI-B0122A22)

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1763,6 +1763,9 @@
       "docs/install/platform-support-watchlist.md",
       "docs/operations/session-transcript-recovery.md"
     ],
+    "scripts/hooks/session-reaper.sh": [
+      "docs/architecture/branch-and-worktree-runbook.md"
+    ],
     "scripts/host-resource-runner.mjs": [
       "docs/architecture/dpf-patterns.md",
       "docs/operations/local-ci-sandbox-slots.md",
@@ -2375,6 +2378,7 @@
       "apps/web/lib/self-upgrade/local-changes-ledger.ts",
       "packages/dpf-skill-pack/hooks/root-clone-freshness.mjs",
       "scripts/dpf-bootstrap-agent-toolchain.ps1",
+      "scripts/hooks/session-reaper.sh",
       "scripts/worktree-janitor.mjs"
     ],
     "docs/architecture/build-gate-runbook.md": [

--- a/docs/architecture/branch-and-worktree-runbook.md
+++ b/docs/architecture/branch-and-worktree-runbook.md
@@ -85,6 +85,8 @@ The `SessionStart` `root-clone-freshness` hook (`packages/dpf-skill-pack/hooks/r
 
 The worktree janitor (`scripts/worktree-janitor.mjs`, fleet backstop; and the SessionEnd reaper) removes merged+clean worktrees. Two safety rails keep it from removing a worktree out from under work:
 
+The SessionEnd reaper (`scripts/hooks/session-reaper.sh`) also terminates the ending session's own node sidecars and releases the leases that session owns. It is scoped on purpose: a process counts as the session's only when its command line names the session's worktree *outside* `node_modules` (shared binaries prove nothing about ownership) and names no other worktree; and a lease is released only when its `ownerSessionId` is the ending session. A session started in the root clone therefore never reaps a sibling worktree's local-CI gate run, which is how three gate runs died by SIGTERM on 2026-09-06 (BI-B0122A22).
+
 - **Live-session gate.** A session writes a gitignored `.dpf-session-heartbeat.json` marker into its worktree, refreshed every turn by the `worktree-session-heartbeat` hook (SessionStart/Stop) and removed on SessionEnd. The janitor treats a fresh marker (TTL default 60 min, `DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN`) as `KEEP`, **outranking** Tier-A eligibility — because a live session's tree first becomes Tier-A the moment its own PR merges, which is exactly when it must not be reaped.
 - **Abandoned-merge quarantine.** A worktree with `MERGE_HEAD` present and **no** live session is classified `FLAG_ABANDONED_MERGE`: surfaced in the janitor summary and never auto-reaped, since an interrupted merge can hide un-reconciled work. A *live* session's in-progress merge is kept, not flagged.
 

--- a/scripts/hooks/lib/session-reaper-path.sh
+++ b/scripts/hooks/lib/session-reaper-path.sh
@@ -2,11 +2,40 @@
 
 # Return success only when a process command line names the exact worktree or a
 # true descendant. A raw substring check lets `/dpf` capture `/dpf-worktrees`.
+#
+# Two refinements (BI-B0122A22 follow-up, 2026-09-06):
+#
+# 1. A worktree's node_modules is a junction into the ROOT clone, so every
+#    worktree's vitest / next / tsc process carries `<root>/node_modules/...` in
+#    its argv. Those tokens prove nothing about which worktree the process serves,
+#    so they are stripped before matching. Three local-CI gate runs in sibling
+#    worktrees died by SIGTERM because a root-clone session's end matched them.
+# 2. The Git common dir lives under the ROOT clone (`<root>/.git/worktrees/<wt>/…`)
+#    and every worktree's local-CI runner is handed paths inside it
+#    (`--metadata-out <root>/.git/worktrees/<wt>/dpf-local-ci-metadata.json`), so
+#    those tokens are stripped too. Observed 2026-09-06: a root-clone session's end
+#    matched a sibling worktree's `local-integration-ci.mjs` on exactly that token.
+# 3. After stripping, a line that still names a DIFFERENT worktree (any
+#    `-worktrees/<name>` path that is not this one) belongs to that worktree, not
+#    to the ending session, even if it also references this path.
 dpf_process_line_matches_worktree() {
   _dpf_line=$1
   _dpf_worktree=$2
-  case "$_dpf_line" in
-    *"$_dpf_worktree"|*"$_dpf_worktree/"*|*"$_dpf_worktree "*) return 0 ;;
+  # Strip shared tokens: "<worktree>/node_modules/…" and "<worktree>/.git/…".
+  _dpf_stripped=$(printf '%s' "$_dpf_line" \
+    | sed "s#${_dpf_worktree}/node_modules/[^ ]*##g; s#${_dpf_worktree}/\.git[^ ]*##g")
+  case "$_dpf_stripped" in
+    *"$_dpf_worktree"|*"$_dpf_worktree/"*|*"$_dpf_worktree "*) ;;
     *) return 1 ;;
   esac
+  # A sibling worktree path that is not ours means the process is theirs.
+  _dpf_other=$(printf '%s' "$_dpf_stripped" \
+    | tr ' ' '\n' \
+    | grep -E -- '-worktrees/[^/ ]+' \
+    | sed -E 's#^(.*-worktrees/[^/ ]+).*$#\1#' \
+    | grep -v -x -- "$_dpf_worktree" \
+    | grep -v -- "^$_dpf_worktree/" \
+    | head -n 1)
+  [ -n "$_dpf_other" ] && return 1
+  return 0
 }

--- a/scripts/hooks/session-reaper.sh
+++ b/scripts/hooks/session-reaper.sh
@@ -48,23 +48,39 @@ mkdir -p "$STATE_DIR" 2>/dev/null || true
 REAPED_LEASE=false
 REAPED_COUNT=0
 
-# --- 1. Release any held nonprod lease / work capsule via the DPF MCP --------
+# --- 1. Release THIS session's nonprod lease(s) / work capsule via the DPF MCP
+#
+# Owner-scoped on purpose (BI-B0122A22): the release tool requires a leaseId and
+# the server refuses a release by a different owner, so we first list the live
+# leases, keep only the ones this session_id owns, and release each by id. The
+# former `{"environmentKey":...}` call was refused by the server every time and
+# only ever produced a misleading `lease_released:true` audit line.
 MCP_ENDPOINT="${DPF_MCP_URL:-http://127.0.0.1:3000/api/mcp/v1}"
-if [ -n "${DPF_MCP_BEARER_TOKEN:-}" ] && command -v curl >/dev/null 2>&1; then
-  for _call in \
-    'release_nonprod_environment_lease|{"environmentKey":"local-integration-ci"}' \
-    'release_capsule_scope|{}'; do
-    _name="${_call%%|*}"
-    _args="${_call#*|}"
-    _body="$(printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"%s","arguments":%s}}' "$_name" "$_args")"
-    if curl -s --max-time 5 -X POST "$MCP_ENDPOINT" \
-        -H "Authorization: Bearer ${DPF_MCP_BEARER_TOKEN}" \
-        -H "Content-Type: application/json" \
-        -H "Accept: application/json, text/event-stream" \
-        --data "$_body" >/dev/null 2>&1; then
+mcp_call() {
+  _body="$(printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"%s","arguments":%s}}' "$1" "$2")"
+  curl -s --max-time 5 -X POST "$MCP_ENDPOINT" \
+    -H "Authorization: Bearer ${DPF_MCP_BEARER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    --data "$_body" 2>/dev/null
+}
+if [ -n "${DPF_MCP_BEARER_TOKEN:-}" ] && [ -n "$SESSION_ID" ] && command -v curl >/dev/null 2>&1; then
+  _listing="$(mcp_call list_nonprod_environment_leases '{}')"
+  # The tool result travels as JSON text inside the JSON-RPC envelope; pull every
+  # leaseId whose ownerSessionId is this session, from active and queued alike.
+  _mine="$(printf '%s' "$_listing" \
+    | tr -d '\\' \
+    | grep -oE '"leaseId":"NPEL-[A-Z0-9]+"[^}]*"ownerSessionId":"'"$SESSION_ID"'"' \
+    | grep -oE 'NPEL-[A-Z0-9]+' \
+    | sort -u)"
+  for _lease in $_mine; do
+    if mcp_call release_nonprod_environment_lease \
+        "$(printf '{"leaseId":"%s","ownerSessionId":"%s"}' "$_lease" "$SESSION_ID")" \
+        | grep -q '"success":true'; then
       REAPED_LEASE=true
     fi
   done
+  mcp_call release_capsule_scope '{}' >/dev/null || true
 fi
 
 # --- 2. Reap THIS session's orphaned MCP/node sidecars -----------------------

--- a/scripts/hooks/session-reaper.test.mjs
+++ b/scripts/hooks/session-reaper.test.mjs
@@ -26,3 +26,53 @@ test("rejects canonical sibling worktrees and the shared local-CI runner", () =>
   assert.equal(matches("201 node /Users/example/dpf-worktrees/topic/server.js"), false);
   assert.equal(matches("202 node /Users/example/dpf-worktrees/.local-ci-runner/check.mjs"), false);
 });
+
+// BI-B0122A22 follow-up. A worktree's node_modules is a junction into the ROOT
+// clone, so every worktree's vitest/next/tsc process carries the root clone path
+// in argv. A root-clone session ending must not reap a sibling worktree's gate
+// run that merely resolved its binaries through the shared junction — that is
+// how three local-CI runs died by SIGTERM on 2026-09-06.
+test("does not treat a shared node_modules binary as this worktree's sidecar", () => {
+  assert.equal(
+    matches("301 node /Users/example/dpf/node_modules/.pnpm/vitest@4.1.10/node_modules/vitest/vitest.mjs run lib/x"),
+    false,
+  );
+  assert.equal(
+    matches("302 /Users/example/dpf/node_modules/.bin/next build"),
+    false,
+  );
+});
+
+test("a process that references another worktree is that worktree's, even via shared binaries", () => {
+  assert.equal(
+    matches("401 node /Users/example/dpf/node_modules/.bin/tsx /Users/example/dpf-worktrees/topic/scripts/x.ts"),
+    false,
+  );
+  assert.equal(
+    matches("402 node /Users/example/dpf/node_modules/.bin/tsx /Users/example/dpf-worktrees/topic/scripts/x.ts", "/Users/example/dpf-worktrees/topic"),
+    true,
+  );
+});
+
+test("still owns a real sidecar in this worktree that also loads shared binaries", () => {
+  assert.equal(
+    matches("501 node /Users/example/dpf/node_modules/.bin/tsx /Users/example/dpf/scripts/mcp-server.ts"),
+    true,
+  );
+});
+
+// The exact shape observed 2026-09-06 (argv truncated to the relevant tokens): the
+// Git common dir lives under the root clone, so a sibling worktree's runner names
+// `<root>/.git/worktrees/<sibling>/…` in its args. That token is the root clone's
+// plumbing, not the root-clone session's process.
+test("does not claim a sibling's local-CI runner because its metadata path is under the root .git", () => {
+  const line = "601 node /Users/example/dpf-worktrees/topic/scripts/local-integration-ci.mjs --candidate feat/topic "
+    + "--metadata-out /Users/example/dpf/.git/worktrees/topic/dpf-local-ci-metadata.json --migrate-deploy";
+  assert.equal(matches(line), false);
+  assert.equal(matches(line, "/Users/example/dpf-worktrees/topic"), true);
+});
+
+test("a root-clone process that only touches the root .git is still not proven ours by that token alone", () => {
+  assert.equal(matches("701 node /Users/example/dpf/scripts/x.mjs --git-dir /Users/example/dpf/.git"), true);
+  assert.equal(matches("702 node /opt/tool/x.mjs --git-dir /Users/example/dpf/.git"), false);
+});


### PR DESCRIPTION
## Summary

Three local-CI gate runs in sibling worktrees died by SIGTERM today at 0:20, 0:36 and 6:04 into the run, with no memory pressure and no fence message. The reaper's own audit log (`~/.claude/hook-state/session-reaper.log`) shows a `SessionEnd` from a session whose cwd was the **root clone** at each of those minutes, each reaping 2–7 node processes.

**Cause.** `scripts/hooks/session-reaper.sh` treats any node process whose argv names the ending worktree as that session's sidecar. The Git common dir lives under the root clone, and every worktree's runner is handed a path inside it:

```
node <sibling>/scripts/local-integration-ci.mjs … --metadata-out /Users/<u>/dpf/.git/worktrees/<sibling>/dpf-local-ci-metadata.json
```

so a root-clone session's end (subagents, helper sessions, other threads) matched every sibling's build child. The killed holder then stopped renewing its lease, the queued peer was admitted into the still-occupied slot, and two sessions took turns killing each other's builds.

**Fix.**
- `scripts/hooks/lib/session-reaper-path.sh`: strip `<worktree>/.git/…` and `<worktree>/node_modules/…` tokens before matching (shared plumbing proves nothing about ownership), and never claim a line that names a different worktree. Tests cover the exact observed argv shape.
- `scripts/hooks/session-reaper.sh`: release only leases whose `ownerSessionId` is the ending session, by leaseId. The old `{environmentKey}`-only call was refused by the server every time and only ever logged a false `lease_released:true`.
- `docs/architecture/branch-and-worktree-runbook.md` documents the scoping.

Related: BI-EB6DBAF0 / #5132 fixed the macOS memory sampler that masked this earlier in the day.

## Verification
- `node --test scripts/hooks/session-reaper.test.mjs`: 7 pass (two new red-then-green cases).
- Guard loop 38/38, prose-lint, docs-impact, convergence guards green.
- Local-CI sandbox gate: **PASS** on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)