### PR TITLE
fix(authority): a null review binding is no binding, not an invalid one

### DIFF
--- a/apps/web/lib/govern/authority/resolve-coworker-tool-authority.test.ts
+++ b/apps/web/lib/govern/authority/resolve-coworker-tool-authority.test.ts
@@ -158,6 +158,55 @@ describe("resolveBoundInitiativeReviewItem", () => {
       .toBe("BI-47ACE2C7");
   });
 
+  // Observed 2026-09-06. summon_coworker persists the initiativeReviewBinding key
+  // unconditionally, so an ORDINARY dispatch that has no review binding at all
+  // arrives with the key present and JSON null. `=== undefined` slipped past it,
+  // the parse of null failed, and the authority gate rejected every governed tool
+  // with "verified authority context is unavailable". A compliance coworker asked
+  // to research a statutory rate loaded its tools and then had search_public_web
+  // refused twice — failing closed on the absence of something that was never
+  // required. mcp-task-capacity-resume.ts already treated null and undefined
+  // alike; this gate did not.
+  it("treats a persisted null binding as no binding, not as an invalid one", () => {
+    const ordinaryDispatch = {
+      ...task,
+      a2aMetadata: {
+        trigger: "external-mcp",
+        sourceRef: { kind: "mcp-token", id: "PAT-BI47" },
+        initiativeReviewBinding: null,
+      },
+    };
+    expect(resolveBoundInitiativeReviewItem(ordinaryDispatch, "search_public_web")).toBeNull();
+    expect(() => resolveBoundInitiativeReviewItem(ordinaryDispatch, "search_public_web")).not.toThrow();
+  });
+
+  it("still treats an absent binding key as no binding", () => {
+    const noKey = {
+      ...task,
+      a2aMetadata: {
+        trigger: "external-mcp",
+        sourceRef: { kind: "mcp-token", id: "PAT-BI47" },
+      },
+    };
+    expect(resolveBoundInitiativeReviewItem(noKey, "search_public_web")).toBeNull();
+  });
+
+  // The fix must not soften the real guard: a binding that is PRESENT and
+  // malformed is still a fail-closed error, because that is a review dispatch
+  // whose identity cannot be trusted.
+  it("still fails closed on a present but unparseable binding", () => {
+    const malformed = {
+      ...task,
+      a2aMetadata: {
+        trigger: "external-mcp",
+        sourceRef: { kind: "mcp-token", id: "PAT-BI47" },
+        initiativeReviewBinding: { writerToolName: "record_initiative_evidence" },
+      },
+    };
+    expect(() => resolveBoundInitiativeReviewItem(malformed, "record_initiative_evidence"))
+      .toThrow("invalid immutable initiative review binding");
+  });
+
   it("fails closed when the executing writer differs from the immutable binding", () => {
     expect(() => resolveBoundInitiativeReviewItem(task, "record_initiative_design_review"))
       .toThrow("writer tool does not match");

--- a/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
+++ b/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
@@ -107,7 +107,20 @@ export function resolveBoundInitiativeReviewItem(
 ): string | null {
   if (!task) return null;
   const metadata = objectRecord(task.a2aMetadata);
-  if (!metadata || metadata["initiativeReviewBinding"] === undefined) return null;
+  // `== null` catches BOTH an absent key and a persisted JSON null. It used to
+  // be `=== undefined`, which a JSON null slips past: summon_coworker stores the
+  // key unconditionally, so an ORDINARY dispatch with no review binding at all
+  // arrived here as `null`, fell through to parseInitiativeReviewBinding(null),
+  // and threw "invalid immutable initiative review binding". The gate then
+  // rejected every governed tool on that task with "verified authority context
+  // is unavailable".
+  //
+  // Observed 2026-09-06: the Compliance Officer was dispatched to research a
+  // statutory rate, loaded its tools successfully, and had search_public_web
+  // rejected twice. Nothing about that task involved an initiative review. This
+  // failed closed on the absence of a thing that was never required, which is
+  // the one direction a fail-closed check must not fire in.
+  if (!metadata || metadata["initiativeReviewBinding"] == null) return null;
   const sourceRef = objectRecord(metadata["sourceRef"]);
   if (
     metadata["trigger"] !== "external-mcp"


### PR DESCRIPTION
`summon_coworker` persists the `initiativeReviewBinding` key **unconditionally**. So an ordinary coworker dispatch — one with no initiative review anywhere in it — reaches the authority gate with the key present and JSON `null`.

The guard tested `=== undefined`, which a JSON null slips straight past. It fell through to `parseInitiativeReviewBinding(null)`, got `null` back, and threw *"invalid immutable initiative review binding"*. The gate then rejected **every governed tool** on that task with *"verified authority context is unavailable"*.

**Blast radius: every ordinary coworker summon over external MCP.** Not one task.

## How it surfaced

Driving the first live use of BI-8E1FD1BD. The Compliance Officer was dispatched to research US federal FICA rates from irs.gov, loaded `propose_statutory_rate`, `search_public_web` and `fetch_public_website` successfully, and then:

```
search_public_web rejected: verified authority context is unavailable
[governed-execute] "The external TaskRun has an invalid immutable initiative review binding."
```

Twice. Then the run completed having proposed nothing, with the summary *"All three tools loaded. Now researching from primary sources."* — an intention, not a result.

Nothing about that task involved a review. The gate failed closed on the **absence of something that was never required**, which is the one direction a fail-closed check must not fire in: it protects nothing, it just removes the coworker's ability to do its job.

## The fix

`== null` now covers both the absent key and the persisted null.

`mcp-task-capacity-resume.ts` already treats `null` and `undefined` alike (lines 107-108). So this restores a contract the codebase had already settled, rather than inventing one — the authority gate was the outlier.

**The real guard is untouched**, and a test pins that: a binding that is *present and malformed* still throws, because that is a review dispatch whose identity cannot be trusted. Loosening that would be the actual security regression, so it is asserted explicitly rather than left to reviewer trust.

## Verification

- Local-CI gate **passed** at `535dbebe1e09`, evidence `cmtqfuuhh0qgf01qwwd3zvtv9` — no override
- 830 tests across 85 files pass (`lib/govern`, `lib/mcp-task`), including three new cases: null binding, absent key, and present-but-malformed
- `pnpm --filter web build` exits 0

## Note on the other half

`summon_coworker` writing the key as null rather than omitting it is the upstream cause and is worth tidying separately. Fixing the gate is the correct defensive change because it also repairs every TaskRun row already persisted that way — a write-site fix alone would leave those broken.

Docs-Impact-Decision: internal authority-gate null handling. No route, contract or user-guide surface changes.

Design-Grounding-Decision: no-contract-change (widens an existing guard's absent-value check to cover a persisted null; no change to what a valid binding means or to any fail-closed path)