### PR TITLE
fix(readiness): accept substantive doc-only evidence

### DIFF
--- a/apps/web/lib/backlog/completion-evidence-policy.test.ts
+++ b/apps/web/lib/backlog/completion-evidence-policy.test.ts
@@ -60,6 +60,44 @@ describe("evaluateCompletionEvidence", () => {
     expect(result.allowed).toBe(true);
   });
 
+  it("returns only valid cited manual or UX evidence as substantive acceptance refs", () => {
+    const result = evaluateCompletionEvidence(input({
+      item: { id: "row-1", itemId: "BI-DOC", status: "open", workType: "doc" },
+      rawManifest: {
+        workClass: "documentation",
+        evidenceActivityIds: ["spec", "manual", "ux"],
+      },
+      evidence: [
+        fact("spec", "spec_review"),
+        fact("manual", "manual_check"),
+        fact("ux", "ux_verified"),
+      ],
+    }));
+
+    expect(result).toMatchObject({
+      allowed: true,
+      acceptanceEvidenceRefs: ["manual", "ux"],
+    });
+  });
+
+  it("does not return stale UX acceptance when a newer UX failure exists", () => {
+    const result = evaluateCompletionEvidence(input({
+      item: { id: "row-1", itemId: "BI-DOC", status: "open", workType: "doc" },
+      rawManifest: {
+        workClass: "documentation",
+        evidenceActivityIds: ["spec", "ux-pass"],
+      },
+      evidence: [
+        fact("spec", "spec_review"),
+        fact("ux-pass", "ux_verified", new Date("2026-07-26T09:00:00.000Z")),
+        fact("ux-fail", "ux_fail", new Date("2026-07-26T11:00:00.000Z")),
+      ],
+    }));
+
+    expect(result.allowed).toBe(true);
+    expect(result.acceptanceEvidenceRefs).toEqual([]);
+  });
+
   it("allows verified-existing work with source and manual verification", () => {
     const result = evaluateCompletionEvidence(input({
       rawManifest: {

--- a/apps/web/lib/backlog/completion-evidence-policy.ts
+++ b/apps/web/lib/backlog/completion-evidence-policy.ts
@@ -79,6 +79,7 @@ export type CompletionEvidenceVerdict = {
   allowed: boolean;
   noOp: boolean;
   normalizedManifest: CompletionEvidenceManifest | null;
+  acceptanceEvidenceRefs?: string[];
   blockers: CompletionEvidenceBlocker[];
   nextAction: string | null;
 };
@@ -221,6 +222,7 @@ export function evaluateCompletionEvidence(
       allowed: true,
       noOp: true,
       normalizedManifest: null,
+      acceptanceEvidenceRefs: [],
       blockers: [],
       nextAction: null,
     };
@@ -239,6 +241,7 @@ export function evaluateCompletionEvidence(
       allowed: false,
       noOp: false,
       normalizedManifest: null,
+      acceptanceEvidenceRefs: [],
       blockers,
       nextAction: nextActionFor(blockers),
     };
@@ -251,6 +254,7 @@ export function evaluateCompletionEvidence(
 
   const byId = new Map(input.evidence.map((entry) => [entry.id, entry]));
   const satisfied = new Set<ExecutionEvidenceDimension>();
+  const acceptanceEvidenceRefsByDimension = new Map<ExecutionEvidenceDimension, string[]>();
   for (const evidenceActivityId of manifest.evidenceActivityIds) {
     const evidence = byId.get(evidenceActivityId);
     if (!evidence) {
@@ -291,6 +295,11 @@ export function evaluateCompletionEvidence(
       continue;
     }
     satisfied.add(metadata.dimension);
+    if (metadata.dimension === "manual" || metadata.dimension === "ux") {
+      const refs = acceptanceEvidenceRefsByDimension.get(metadata.dimension) ?? [];
+      refs.push(evidence.id);
+      acceptanceEvidenceRefsByDimension.set(metadata.dimension, refs);
+    }
   }
 
   if (manifest.useActiveBuildEvidence) {
@@ -335,9 +344,16 @@ export function evaluateCompletionEvidence(
       latestByDimension.set(dimension, evidence);
     }
   }
+  for (const dimension of ["manual", "ux"] as const) {
+    const latest = latestByDimension.get(dimension);
+    if (latest && evidenceKindMetadata(latest.evidenceKind).polarity === "fail") {
+      acceptanceEvidenceRefsByDimension.delete(dimension);
+    }
+  }
   for (const dimension of new Set(required)) {
     const latest = latestByDimension.get(dimension);
     if (latest && evidenceKindMetadata(latest.evidenceKind).polarity === "fail") {
+      acceptanceEvidenceRefsByDimension.delete(dimension);
       blockers.push(blocker(
         "newer-failure",
         `A newer ${dimension} failure invalidates the prior pass`,
@@ -351,6 +367,10 @@ export function evaluateCompletionEvidence(
     allowed: blockers.length === 0,
     noOp: false,
     normalizedManifest: manifest,
+    acceptanceEvidenceRefs: [
+      ...(acceptanceEvidenceRefsByDimension.get("manual") ?? []),
+      ...(acceptanceEvidenceRefsByDimension.get("ux") ?? []),
+    ],
     blockers,
     nextAction: nextActionFor(blockers),
   };

--- a/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.test.ts
@@ -135,6 +135,90 @@ describe("completeBacklogItemTransition", () => {
     expect(fake.updateMany).not.toHaveBeenCalled();
   });
 
+  it("accepts cited substantive evidence for doc-only completion without inventing objective reconciliation", async () => {
+    const fake = fakeDb(1, "doc");
+    const seen: Array<{ completion: { acceptanceEvidence: string; objectiveReconciliation: string; evidenceRefs: Record<string, string[]> } }> = [];
+    const result = await completeBacklogItemTransition({
+      db: fake.db,
+      itemId: "BI-1",
+      expectedStatus: "in-progress",
+      resolution: "Updated and manually accepted the documentation.",
+      completionEvidence: {},
+      actor,
+      authority,
+      dependencies: {
+        resolveCompletionEvidence: async () => ({
+          kind: "evaluated",
+          item: { id: "row-1", itemId: "BI-1", status: "in-progress", workType: "doc" },
+          verdict: {
+            allowed: true,
+            noOp: false,
+            normalizedManifest: {
+              workClass: "documentation",
+              evidenceActivityIds: ["E-DOC", "E-ACCEPT"],
+              useActiveBuildEvidence: false,
+            },
+            acceptanceEvidenceRefs: ["E-ACCEPT"],
+            blockers: [],
+            nextAction: null,
+          },
+        }),
+        reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
+        resolveMergeDelivery: async () => false,
+        projectReadiness: ((input: { completion: { acceptanceEvidence: string; objectiveReconciliation: string; evidenceRefs: Record<string, string[]> } }) => {
+          seen.push(input);
+          return projected("allowed");
+        }) as never,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(seen[0]?.completion.acceptanceEvidence).toBe("pass");
+    expect(seen[0]?.completion.objectiveReconciliation).toBe("missing");
+    expect(seen[0]?.completion.evidenceRefs.ACCEPTANCE_EVIDENCE_REQUIRED).toEqual(["E-ACCEPT"]);
+  });
+
+  it("does not let manual evidence bypass objective reconciliation for implementation completion", async () => {
+    const fake = fakeDb(1, "feature");
+    const seen: Array<{ completion: { acceptanceEvidence: string } }> = [];
+    await completeBacklogItemTransition({
+      db: fake.db,
+      itemId: "BI-1",
+      expectedStatus: "in-progress",
+      resolution: "Implemented the feature.",
+      completionEvidence: {},
+      actor,
+      authority,
+      dependencies: {
+        resolveCompletionEvidence: async () => ({
+          kind: "evaluated",
+          item: { id: "row-1", itemId: "BI-1", status: "in-progress", workType: "feature" },
+          verdict: {
+            allowed: true,
+            noOp: false,
+            normalizedManifest: {
+              workClass: "implementation",
+              evidenceActivityIds: ["E-SOURCE", "E-TEST", "E-BUILD", "E-MANUAL"],
+              useActiveBuildEvidence: false,
+            },
+            acceptanceEvidenceRefs: ["E-MANUAL"],
+            blockers: [],
+            nextAction: null,
+          },
+        }),
+        reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
+        resolveMergeDelivery: async () => false,
+        projectReadiness: ((input: { completion: { acceptanceEvidence: string } }) => {
+          seen.push(input);
+          return projected("input-required");
+        }) as never,
+      },
+    });
+
+    expect(seen[0]?.completion.acceptanceEvidence).toBe("missing");
+    expect(fake.updateMany).not.toHaveBeenCalled();
+  });
+
   it("uses an exact status compare-and-set and records the status change after allowed readiness", async () => {
     const fake = fakeDb();
     const result = await completeBacklogItemTransition({

--- a/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts
+++ b/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts
@@ -265,11 +265,18 @@ export async function completeBacklogItemTransition(args: {
       // A merge through branch protection is authoritative delivery evidence and
       // supersedes a missing/hand-built manifest (BI-B04A0203).
       const delivery = mergedThroughGates ? "pass" : deliveryState(completion);
+      const directDocumentationAcceptance = completion.kind === "evaluated"
+        && completion.verdict.allowed
+        && completion.verdict.normalizedManifest?.workClass === "documentation"
+        && (completion.verdict.acceptanceEvidenceRefs?.length ?? 0) > 0;
       // Recognized platform work: the merge is the acceptance too — but only when
       // reconciliation is not in a real conflict/malformed state (those still block).
       const acceptancePass =
         reconciliation.state === "pass" ||
+        directDocumentationAcceptance ||
         (recognizeMergeThroughGates && reconciliation.state !== "conflict" && reconciliation.state !== "malformed");
+      const objectiveReconciliationPass = reconciliation.state === "pass"
+        || (recognizeMergeThroughGates && reconciliation.state !== "conflict" && reconciliation.state !== "malformed");
       const inheritedScope = await loadInheritedInitiativeScope(
         tx as unknown as InheritanceDb,
         { childItemId: lockedItem.itemId, childRowId: lockedItem.id },
@@ -292,14 +299,16 @@ export async function completeBacklogItemTransition(args: {
         completion: {
           deliveryEvidence: delivery,
           acceptanceEvidence: acceptancePass ? "pass" : reconciliation.state === "fail" ? "fail" : "missing",
-          objectiveReconciliation: acceptancePass ? "pass" : reconciliation.state === "fail" ? "fail" : "missing",
+          objectiveReconciliation: objectiveReconciliationPass ? "pass" : reconciliation.state === "fail" ? "fail" : "missing",
           objectiveBaselineConflict: reconciliation.state === "conflict",
           projectionError: reconciliation.state === "malformed",
           evidenceRefs: {
             DELIVERY_EVIDENCE_REQUIRED: completion.kind === "evaluated"
               ? completion.verdict.normalizedManifest?.evidenceActivityIds ?? []
               : [],
-            ACCEPTANCE_EVIDENCE_REQUIRED: reconciliation.evidenceRefs,
+            ACCEPTANCE_EVIDENCE_REQUIRED: directDocumentationAcceptance && completion.kind === "evaluated"
+              ? completion.verdict.acceptanceEvidenceRefs ?? []
+              : reconciliation.evidenceRefs,
             OBJECTIVE_RECONCILIATION_REQUIRED: reconciliation.evidenceRefs,
           },
           requirementReasons: { DELIVERY_EVIDENCE_REQUIRED: mergedThroughGates ? [] : deliveryReasons(completion) },


### PR DESCRIPTION
## Summary

- expose fresh cited manual/UX evidence from the typed completion manifest as acceptance evidence
- let documentation completion use that substantive acceptance without inventing objective reconciliation
- preserve objective reconciliation for implementation and reject stale UX passes after a newer failure

## Why

BI-B5C8FEFC's proportional doc-only path reached valid delivery evidence but still failed completion on ACCEPTANCE_REQUIRED because the terminal projector only recognized objective reconciliation. Doc-only work intentionally has no objective baseline after #5151, so the accepted manual verification could never be consumed.

## Verification

- 4 focused/adjacent files, 40 tests PASS
- scoped web typecheck PASS
- module-size, style/token drift, gitleaks, and diff checks PASS
- exact head d28b7ced9145299b004c0e8de89d56e86c567c1c
- tree 92b4c0bae3b34a1c86899fe00d314fdbd1eb21c1

## Safety boundary

Only an allowed documentation completion manifest with a fresh, explicitly cited manual_check or ux_verified record can satisfy acceptance directly. Objective reconciliation remains missing rather than being fabricated. Implementation manifests cannot use this path, and a newer UX failure invalidates an earlier UX pass.

Design-Grounding-Decision: complete proportional doc-only work from typed delivery plus substantive acceptance evidence while keeping objective reconciliation independent.
Docs-Impact-Decision: internal readiness projection correction; no user-facing documentation changes.