### PR TITLE
fix(review): a rejected terminal writer surfaces its rejection to the caller (BI-A57B6185)

### DIFF
--- a/apps/web/lib/mcp-task-execution.test.ts
+++ b/apps/web/lib/mcp-task-execution.test.ts
@@ -275,17 +275,82 @@ describe("remote task terminal-writer postcondition", () => {
       terminalWriterAttempt: 2,
     });
 
+    // BI-A57B6185: the writer ran and refused. That is a packet problem, and
+    // the caller must see the writer's own error, not "missing writer".
     expect(outcome).toMatchObject({
       kind: "result",
       result: {
         status: "input-required",
         idempotentReplay: true,
         resumable: true,
-        waitReason: "missing-terminal-writer",
+        waitReason: "terminal-writer-rejected",
+        structuredContent: {
+          error: "terminal_writer_rejected",
+          writerToolName,
+          attempt: 2,
+          writerRejection: { error: "CANONICAL_DESIGN_REQUIRED", message: "No canonical receipt was created." },
+          action: "fix-packet-and-resume",
+        },
       },
     });
+    expect(JSON.stringify((outcome as unknown as { result: { content: unknown } }).result.content)).toContain("CANONICAL_DESIGN_REQUIRED: No canonical receipt was created.");
+    expect(db.updateTaskRun).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        progressPayload: expect.objectContaining({
+          terminalWriterWait: expect.objectContaining({
+            writerRejection: expect.objectContaining({ error: "CANONICAL_DESIGN_REQUIRED" }),
+          }),
+        }),
+      }),
+    }));
     expect(db.updateTaskRun).not.toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({ status: "completed" }),
+    }));
+  });
+
+  it("BI-A57B6185 never escalates a rejected writer to select-different-reviewer, even on attempt 3", async () => {
+    autonomous.execute.mockResolvedValue({
+      content: "The governed writer rejected the packet.",
+      executedTools: [{
+        name: writerToolName,
+        args: { decision: "pass" },
+        result: {
+          success: false,
+          error: "CANONICAL_DESIGN_AMBIGUOUS",
+          message: "No live workroom for this subject records head abc123. Sync the branch head with adopt_worktree then retry.",
+        },
+      }],
+      failure: { kind: "terminal-writer-missing", message: "generic loop text that must not win" },
+    });
+
+    const outcome = await executeRemoteTaskAttempt({
+      run: { id: "run-internal", taskRunId: "TR-MCP-WRITER-REJECTED-3", contextId: "thread-1" },
+      threadId: "thread-1",
+      token: { tokenId: "PAT-WRITER-REJECTED", userId: "user-1", capability: "write", source: "pat" },
+      userContext: { platformRole: "developer", isSuperuser: false },
+      parsed,
+      idempotentReplay: true,
+      resumeKind: "terminal-writer",
+      capacityAttempt: 1,
+      terminalWriterAttempt: 3,
+    });
+
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        status: "input-required",
+        resumable: true,
+        waitReason: "terminal-writer-rejected",
+        structuredContent: { error: "terminal_writer_rejected", attempt: 3 },
+      },
+    });
+    const content = JSON.stringify((outcome as unknown as { result: { content: unknown } }).result.content);
+    expect(content).toContain("adopt_worktree");
+    expect(content).not.toContain("omitted");
+    expect(db.updateTaskRun).not.toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        progressPayload: expect.objectContaining({ terminalWriterEscalation: expect.anything() }),
+      }),
     }));
   });
 

--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -30,7 +30,11 @@ import type {
 } from "./mcp-task-submit";
 import { withTaskRunApprovalLocation } from "./mcp/external-approval-location-lookup";
 import {
+  TERMINAL_WRITER_REJECTED_WAIT_REASON,
   createTerminalWriterEscalation,
+  lastTerminalWriterRejection,
+  terminalWriterRejectionMessage,
+  terminalWriterRejectionStructuredContent,
   terminalWriterEscalationMessage,
   terminalWriterEscalationStructuredContent,
   terminalWriterEscalationWaitReason,
@@ -366,11 +370,20 @@ export async function executeRemoteTaskAttempt(input: {
       && terminalToolPolicy
     ) {
       const terminalWriterAttempt = input.terminalWriterAttempt ?? 1;
-      const terminalWriterFailureMessage = result.failure?.kind === "terminal-writer-missing"
+      // BI-A57B6185: a writer that ran and REFUSED is a packet problem. Surface
+      // its error verbatim, never count it as an omitted attempt, and never
+      // advise switching reviewer: the next reviewer hits the same rejection.
+      const writerRejection = lastTerminalWriterRejection(
+        terminalToolPolicy.writerToolName,
+        terminalWriterExecutions,
+      );
+      const terminalWriterFailureMessage = writerRejection
+        ? terminalWriterRejectionMessage(terminalToolPolicy.writerToolName, writerRejection)
+        : result.failure?.kind === "terminal-writer-missing"
         ? result.failure.message
         : writerResult && receiptExpected && !persistedOutcome ? result.content
         : describeTerminalWriterFailure(terminalToolPolicy, terminalWriterExecutions);
-      const escalation = terminalWriterRetryIsExhausted(terminalWriterAttempt)
+      const escalation = !writerRejection && terminalWriterRetryIsExhausted(terminalWriterAttempt)
         ? createTerminalWriterEscalation({
             writerToolName: terminalToolPolicy.writerToolName,
             attempt: terminalWriterAttempt,
@@ -396,6 +409,7 @@ export async function executeRemoteTaskAttempt(input: {
               ...(terminalWriterFailureMessage.includes("did not honor the required writer tool-call contract")
                 ? { noncompliance: "prose-without-required-writer" }
                 : {}),
+              ...(writerRejection ? { writerRejection } : {}),
             },
             ...(escalation ? { terminalWriterEscalation: escalation } : {}),
           },
@@ -412,12 +426,22 @@ export async function executeRemoteTaskAttempt(input: {
           resumable: escalation ? false : true,
           waitReason: escalation
             ? terminalWriterEscalationWaitReason(escalation)
+            : writerRejection
+            ? TERMINAL_WRITER_REJECTED_WAIT_REASON
             : "missing-terminal-writer",
           content: remoteTaskContent(
             escalation ? terminalWriterEscalationMessage(escalation) : terminalWriterFailureMessage,
           ),
           ...(escalation
             ? { structuredContent: terminalWriterEscalationStructuredContent(escalation) }
+            : writerRejection
+            ? {
+                structuredContent: terminalWriterRejectionStructuredContent(
+                  terminalToolPolicy.writerToolName,
+                  terminalWriterAttempt,
+                  writerRejection,
+                ),
+              }
             : {}),
           executedToolCount: result.executedTools?.length ?? 0,
           isError: false,

--- a/apps/web/lib/mcp-task-terminal-writer-escalation.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer-escalation.test.ts
@@ -29,4 +29,15 @@ describe("recoverTerminalWriterEscalation", () => {
   it("keeps a pre-marker wait below the retry ceiling resumable", () => {
     expect(recoverTerminalWriterEscalation(legacyWait(2))).toBeNull();
   });
+
+  it("BI-A57B6185 never escalates a wait that carries a writer rejection, whatever the attempt", () => {
+    const wait = legacyWait(4);
+    (wait.terminalWriterWait as Record<string, unknown>)["writerRejection"] = {
+      schemaVersion: 1,
+      error: "CANONICAL_DESIGN_AMBIGUOUS",
+      message: "No live workroom records head abc123.",
+      observedAt: "2026-09-06T19:07:46.000Z",
+    };
+    expect(recoverTerminalWriterEscalation(wait)).toBeNull();
+  });
 });

--- a/apps/web/lib/mcp-task-terminal-writer-escalation.ts
+++ b/apps/web/lib/mcp-task-terminal-writer-escalation.ts
@@ -9,6 +9,61 @@ export type TerminalWriterEscalation = {
   observedAt: string;
 };
 
+/**
+ * BI-A57B6185: the governed writer WAS called and refused the packet. This is
+ * not a missing writer. The packet is wrong (stale head, malformed objective
+ * link, ...) and the writer's own error names the fix. It must never count as
+ * an "omitted" attempt, never escalate to select-different-reviewer, and must
+ * reach the caller verbatim.
+ */
+export type TerminalWriterRejection = {
+  schemaVersion: 1;
+  error: string;
+  message: string;
+  observedAt: string;
+};
+
+export const TERMINAL_WRITER_REJECTED_WAIT_REASON = "terminal-writer-rejected";
+
+type WriterExecutionRecord = {
+  name: string;
+  result: { success: boolean; error?: string; message?: string };
+};
+
+/** Last failed call of the writer, as a rejection, or null when the writer never ran or succeeded. */
+export function lastTerminalWriterRejection(
+  writerToolName: string,
+  records: readonly WriterExecutionRecord[],
+  observedAt = new Date().toISOString(),
+): TerminalWriterRejection | null {
+  const last = records.filter((record) => record.name === writerToolName).at(-1);
+  if (!last || last.result.success) return null;
+  return {
+    schemaVersion: 1,
+    error: nonEmptyString(last.result.error) ?? "writer-rejected",
+    message: nonEmptyString(last.result.message) ?? "The writer returned no message.",
+    observedAt,
+  };
+}
+
+export function terminalWriterRejectionMessage(writerToolName: string, rejection: TerminalWriterRejection): string {
+  return `${writerToolName} was called and rejected the packet: ${rejection.error}: ${rejection.message} Fix the packet and resume the same TaskRun; switching reviewer will not help.`;
+}
+
+export function terminalWriterRejectionStructuredContent(
+  writerToolName: string,
+  attempt: number,
+  rejection: TerminalWriterRejection,
+) {
+  return {
+    error: "terminal_writer_rejected",
+    attempt,
+    writerToolName,
+    writerRejection: { error: rejection.error, message: rejection.message },
+    action: "fix-packet-and-resume",
+  };
+}
+
 function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
@@ -63,6 +118,10 @@ export function recoverTerminalWriterEscalation(value: unknown): TerminalWriterE
   const wait = progress["terminalWriterWait"];
   if (!wait || typeof wait !== "object" || Array.isArray(wait)) return null;
   const waitRecord = wait as Record<string, unknown>;
+  // A recorded rejection is a packet problem, not an omitted writer: never
+  // manufacture a retry-exhausted escalation from it on replay (BI-A57B6185).
+  const rejection = waitRecord["writerRejection"];
+  if (rejection && typeof rejection === "object" && !Array.isArray(rejection)) return null;
   const writerToolName = nonEmptyString(waitRecord["writerToolName"]);
   const attempt = Number(waitRecord["attempt"]);
   if (

--- a/docs/superpowers/specs/2026-09-07-terminal-writer-rejection-surfaces-to-caller-design.md
+++ b/docs/superpowers/specs/2026-09-07-terminal-writer-rejection-surfaces-to-caller-design.md
@@ -1,0 +1,63 @@
+---
+status: active
+title: A rejected terminal writer surfaces its rejection to the caller
+backlog_item: BI-A57B6185
+decision_interaction: DI-F648E26A7FAE
+---
+
+# A rejected terminal writer surfaces its rejection to the caller
+
+- **Date:** 2026-09-07
+- **Scope:** platform — MCP remote task execution, terminal-writer wait and escalation
+- **Backlog item:** `BI-A57B6185`
+- **Profile:** fix
+- **Status:** Design — implemented in this branch.
+
+**OBJ-WRITER-REJECTION-1:** When the governed terminal writer is called and rejects the review packet, the caller of request_coworker receives the writer's own error code and message, the wait is classified as a rejection rather than a missing writer, and no attempt count or reviewer-switch escalation is charged against it.
+
+## 1. Defect, on a named ref
+
+Observed live on 2026-09-06 while closing BI-B19BE117 (this operator install, deployed portal `998d1c4cbaa`, source main `f0f8fcd9dc1`):
+
+| Time | Writer call (`ToolExecution.result`) | What the caller was told |
+| --- | --- | --- |
+| 17:55:42 | `CANONICAL_DESIGN_REQUIRED: AC-1 has a malformed objective link.` | `waitReason: missing-terminal-writer` — "did not produce a receipt or approval envelope" |
+| 18:18:30, 18:46:44, 19:07:46 | `CANONICAL_DESIGN_AMBIGUOUS: No live workroom … has head 3af4c61 … Sync the branch head with adopt_worktree …` | same, then `terminal_writer_retry_exhausted` — "The required writer was omitted on three attempts. … select a different eligible reviewer/provider" |
+
+Both rejections were author-side and named their own fix. Neither reached the caller. The escalation text was false on both counts: the writer was not omitted, and a different reviewer hits the identical rejection because the packet, not the reviewer, is wrong. Cost: four dispatches, one alternate-reviewer dispatch, one mis-diagnosed backlog item, and a Postgres read of `ToolExecution.result` to learn what one line in the response would have said.
+
+Source at `origin/main` (`b5a236a0a62`):
+
+- `apps/web/lib/mcp-task-execution.ts` — the `terminal-writer-missing` branch treats a failed writer execution and an absent writer execution identically: `waitReason` is always `missing-terminal-writer`, `structuredContent` is only set on escalation, and `terminalWriterRetryIsExhausted(attempt)` fires regardless of whether the writer ran.
+- `apps/web/lib/mcp-task-terminal-writer-escalation.ts` — `recoverTerminalWriterEscalation` re-derives a retry-exhausted escalation from any `missing-terminal-writer` wait at attempt ≥ 3 on replay, so even a caller that reads the ledger cannot stop the escalation.
+- `apps/web/lib/tak/terminal-tool-policy.ts` `terminalWriterFailureMessage` (since #5129) does include the last error and message in prose, but the execution layer discards it whenever the loop reports `failure.kind === "terminal-writer-missing"`, which it always does on this path.
+
+Candidate causes ruled out by running, not reading: reader budget (BI-E8237EAE) — the same reviewer passed design-spec on the same blob minutes earlier; reviewer capability — the alternate holder of `initiative_design_review` produced the identical rejection; provider rotation (#5129) — the writer was called on every attempt.
+
+## 2. Fix sequence
+
+1. `mcp-task-terminal-writer-escalation.ts`: add `TerminalWriterRejection`, `lastTerminalWriterRejection(writerToolName, executions)`, `terminalWriterRejectionMessage`, `terminalWriterRejectionStructuredContent`, `TERMINAL_WRITER_REJECTED_WAIT_REASON`; make `recoverTerminalWriterEscalation` return null when the persisted wait carries `writerRejection`.
+2. `mcp-task-execution.ts`: in the `terminal-writer-missing` branch, derive the rejection from the writer executions; when present, emit `waitReason: terminal-writer-rejected`, `structuredContent.error: terminal_writer_rejected` with `writerRejection: { error, message }` and `action: fix-packet-and-resume`, persist `writerRejection` inside `terminalWriterWait`, keep `resumable: true`, and never create an escalation.
+3. Tests: `mcp-task-execution.test.ts` (rejected writer at attempt 2 surfaces code and message; rejected writer at attempt 3 does not escalate and does not say "omitted"); `mcp-task-terminal-writer-escalation.test.ts` (a wait with `writerRejection` never recovers into an escalation).
+
+## 3. Acceptance criteria
+
+| Criterion | Objective | Statement |
+| --- | --- | --- |
+| AC-1 | OBJ-WRITER-REJECTION-1 | A writer execution with `success:false` yields `waitReason: terminal-writer-rejected` and `structuredContent.writerRejection` carrying the writer's `error` and `message` verbatim |
+| AC-2 | OBJ-WRITER-REJECTION-1 | The same case at attempt 3 stays resumable, records no `terminalWriterEscalation`, and its content never says the writer was omitted |
+| AC-3 | OBJ-WRITER-REJECTION-1 | On replay, a persisted wait carrying `writerRejection` never recovers into a retry-exhausted escalation |
+| AC-4 | OBJ-WRITER-REJECTION-1 | A genuine no-show (no writer execution) still yields `missing-terminal-writer` and still escalates at attempt 3 |
+
+## 4. Non-goals
+
+- Changing the writer's own validation (CANONICAL_DESIGN_* rules) or the reader budget.
+- Offering alternate reviewer routes in the recovery packet; that is BI-A57B6185's acceptance item 2 and is out of this fix's blast radius.
+
+## 5. Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-A57B6185`
+- Receipt: `blocked-by: coverage is recorded against this design doc once the branch head is bound to the Workroom; see the fix sequence above`
+- Rationale: three files, one behaviour; shipping the escalation guard without the execution branch (or vice versa) leaves the caller with contradictory signals.
+- Dependencies: none


### PR DESCRIPTION
## Summary

When the governed terminal writer runs and refuses the packet (stale head, malformed objective link, …), the TaskRun reported `missing-terminal-writer`, charged the refusal as an omitted attempt, and after three attempts told the caller to switch reviewer. The writer's own error was only visible in `ToolExecution.result`. Closing BI-B19BE117 cost four dispatches and a mis-diagnosed backlog item to learn what one line would have said.

Now a failed writer execution yields `waitReason: terminal-writer-rejected`, `structuredContent.writerRejection` with the error and message verbatim, `action: fix-packet-and-resume`, stays resumable, and never escalates. A persisted wait carrying `writerRejection` never recovers into an escalation on replay. A genuine no-show is unchanged.

## Verification

- Red-then-green: the three new assertions fail against `origin/main` source (3 failed / 15 passed) and pass with this change (18/18); the eight task-execution suites pass (52/52).
- Workspace typecheck clean; pull-request policy profile 8/8; local-CI gate PASS on f3116f7.

## Design grounding

Specs/plans reviewed: `docs/superpowers/plans/2026-09-06-required-terminal-writer-enforcement.md`, `docs/superpowers/specs/2026-09-02-capacity-deferral-is-not-a-writer-failure-design.md`. Code substrate reviewed: `apps/web/lib/mcp-task-execution.ts`, `apps/web/lib/mcp-task-terminal-writer-escalation.ts`, `apps/web/lib/tak/terminal-tool-policy.ts`. Source of truth: `docs/superpowers/specs/2026-09-07-terminal-writer-rejection-surfaces-to-caller-design.md`. Decision: extend the existing wait/escalation contract with a rejection branch.

Convergence-Impact-Decision: auto-converges — portal app source only; reaches every install with the ordinary image rebuild on the next self-upgrade, no install state or env involved

Backlog: BI-A57B6185 · Workroom: WC-52AA2364

🤖 Generated with [Claude Code](https://claude.com/claude-code)