### PR TITLE
fix(workrooms): unify recovery projections

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/readiness-guidance.ts
+++ b/apps/web/lib/backlog/initiative-readiness/readiness-guidance.ts
@@ -155,6 +155,9 @@ export function readinessCodesForEvidenceDimension(
  * mirror the recovery-router text so a caller reading the decision alone is not
  * worse off than one who also called the recovery route.
  */
+export const ARTIFACT_AUTHOR_RECOVERY =
+  "Verify the design commit carries the required author/DCO identity. If it is unsigned, sign and push the new sha; if it is already valid, preserve its bytes and sha. Then re-sync the workroom with adopt_worktree using the exact baseSha and headSha.";
+
 const GENERIC_REMEDIES: Partial<Record<ReadinessCode, string>> = {
   CLASSIFICATION_REQUIRED:
     "Classify the item before shaping it: set the work type and scope so a readiness profile can be derived.",
@@ -169,7 +172,7 @@ const GENERIC_REMEDIES: Partial<Record<ReadinessCode, string>> = {
   PLAN_REVIEW_REQUIRED:
     "An independent reviewer approves the plan with record_initiative_design_review(gate: \"plan-review\").",
   ARTIFACT_AUTHOR_REQUIRED:
-    "Sign the design commit off (git commit -s), push the rewritten sha, then re-sync the workroom head with adopt_worktree.",
+    ARTIFACT_AUTHOR_RECOVERY,
   CAPSULE_IDENTITY_MISMATCH:
     "The claim did not match the workroom's recorded identity. The reasons above name which fields differ: a stale branch or head re-syncs with adopt_worktree(headBranch, headSha), an expired lease renews with heartbeat_workroom, and a terminal or foreign-held room needs a new claim.",
   DELIVERY_EVIDENCE_REQUIRED:

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -473,13 +473,14 @@ describe("initiative readiness recovery routing", () => {
 
     expect(recovery.reviewerRoutes).toEqual([]);
     expect(recovery.escalations).toEqual([]);
-    expect(recovery.unroutable).toMatchObject([
-      {
-        accountableRole: "artifact-resolver",
-        code: "ARTIFACT_AUTHOR_REQUIRED",
-        nextAction: expect.stringContaining("git commit -s"),
-      },
-    ]);
+    expect(recovery.unroutable).toHaveLength(1);
+    expect(recovery.unroutable[0]).toMatchObject({
+      accountableRole: "artifact-resolver",
+      code: "ARTIFACT_AUTHOR_REQUIRED",
+    });
+    expect(recovery.unroutable[0]?.nextAction).toContain(
+      "if it is already valid, preserve its bytes and sha",
+    );
   });
 
   it("returns both exact next-action mappings when immutable dispatch identity is unavailable", async () => {

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -84,6 +84,12 @@ export type InitiativeReviewBindingPacket = {
 };
 
 export type InitiativeReviewerRecovery = {
+  identityRepair?: {
+    toolName: "adopt_worktree";
+    missingFields: Array<"baseSha" | "headSha">;
+    retainedFields: Record<string, string>;
+    packet: Record<string, string>;
+  };
   reviewerRoutes: Array<{
     accountableRole: string;
     toolName: string;

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { canonicalJson } from "@/lib/shared/canonical-json";
-import { readinessRequirement } from "@/lib/backlog/initiative-readiness/readiness-guidance";
+import { ARTIFACT_AUTHOR_RECOVERY, readinessRequirement } from "@/lib/backlog/initiative-readiness/readiness-guidance";
 import type {
   InitiativeGateKey,
   InitiativeReadinessDecision,
@@ -428,7 +428,7 @@ function sequenceBaselineBeforePlanCoverage(
  * recording a receipt. Inventing a lane would invent an approver.
  */
 const UNROUTABLE_REMEDIES: Partial<Record<ReadinessCode, string>> = {
-  ARTIFACT_AUTHOR_REQUIRED: "Sign the design commit off (git commit -s), push the rewritten sha, then re-sync the workroom head with adopt_worktree.",
+  ARTIFACT_AUTHOR_REQUIRED: ARTIFACT_AUTHOR_RECOVERY,
   CLASSIFICATION_REQUIRED: "Classify the demand before shaping it: set the investment bucket and score inputs on the backlog item.",
   AUTHORIZATION_DENIED: "The caller's authority does not cover this transition. Re-run from a principal holding the required capability.",
   CAPSULE_IDENTITY_MISMATCH: "The claim did not match the workroom's recorded identity. The reasons above name which fields differ: a stale branch or head re-syncs with adopt_worktree(headBranch, headSha), an expired lease renews with heartbeat_workroom, and a terminal or foreign-held room needs a new claim.",

--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -199,6 +199,24 @@ describe("claimGovernedBacklogWorkspace", () => {
     expect(result.data.recovery.reviewerRoutes).toEqual([]);
     expect(JSON.stringify(result.data.recovery)).toContain("baseSha");
     expect(JSON.stringify(result.data.recovery)).toContain("adopt_worktree(headBranch, baseSha, headSha)");
+    expect(result.data.recovery.identityRepair).toEqual({
+      toolName: "adopt_worktree",
+      missingFields: ["baseSha"],
+      retainedFields: {
+        repositoryFullName: input.repositoryFullName,
+        headBranch: input.headBranch,
+        worktreePath: input.worktreePath,
+        headSha: "1111111111111111111111111111111111111111",
+      },
+      packet: expect.objectContaining({
+        repositoryFullName: input.repositoryFullName,
+        headBranch: input.headBranch,
+        worktreePath: input.worktreePath,
+        backlogItemId: input.backlogItemId,
+        baseBranch: "main",
+        headSha: "1111111111111111111111111111111111111111",
+      }),
+    });
   });
 
   it("prefers a room bound to this item over one merely sharing its branch", async () => {

--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -219,6 +219,35 @@ describe("claimGovernedBacklogWorkspace", () => {
     });
   });
 
+  it("repairs a missing head while preserving the valid base and branch identity", async () => {
+    const db = database();
+    const discover = vi.fn();
+    (db as unknown as { workroom: { findMany: ReturnType<typeof vi.fn> } }).workroom.findMany
+      .mockResolvedValueOnce([{
+        capsuleId: "WC-ENTRY",
+        repositoryFullName: input.repositoryFullName,
+        headBranch: input.headBranch,
+        headSha: null,
+        baseSha: "3333333333333333333333333333333333333333",
+        backlogItemId: "BI-ENTRY",
+      }]);
+    const result = await claimGovernedBacklogWorkspace({
+      db, input, actor, workIntent: null,
+      now: new Date("2026-08-22T00:00:00.000Z"),
+      dependencies: { claimWorkspace: vi.fn(), discoverCanonicalArtifact: discover },
+    });
+    expect(result.ok).toBe(false);
+    expect(discover).not.toHaveBeenCalled();
+    if (result.ok) throw new Error("Incomplete identity must not permit implementation");
+    expect(result.data.recovery.identityRepair).toMatchObject({
+      toolName: "adopt_worktree",
+      missingFields: ["headSha"],
+      retainedFields: { baseSha: "3333333333333333333333333333333333333333" },
+      packet: { baseSha: "3333333333333333333333333333333333333333" },
+    });
+    expect(result.data.recovery.identityRepair?.packet).not.toHaveProperty("headSha");
+  });
+
   it("prefers a room bound to this item over one merely sharing its branch", async () => {
     const db = database();
     (db as unknown as { workroom: { findMany: ReturnType<typeof vi.fn> } }).workroom.findMany

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -168,6 +168,7 @@ async function resolveRecoveryOutsideTransaction(args: {
         repositoryFullName: args.input.repositoryFullName,
         headBranch: args.input.headBranch,
         worktreePath: args.input.worktreePath,
+        ...(pending.baseSha ? { baseSha: pending.baseSha } : {}),
         ...(pending.dispatchContext?.headSha ? { headSha: pending.dispatchContext.headSha } : {}),
       },
       packet: {
@@ -473,6 +474,8 @@ export async function claimGovernedBacklogWorkspace(args: {
         const recoveryWorkroom =
           recoveryWorkrooms.find((room) => room.backlogItemId === item.itemId && room.headSha)
           ?? recoveryWorkrooms.find((room) => room.headSha)
+          ?? recoveryWorkrooms.find((room) => room.backlogItemId === item.itemId)
+          ?? recoveryWorkrooms[0]
           ?? null;
         // Recovery needs a repository-provider round trip to bind the canonical
         // design (BI-9FE775F9). That must not run inside this transaction, so

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -129,6 +129,7 @@ async function resolveRecoveryOutsideTransaction(args: {
   actor: WorkCapsuleActor;
   pending: PendingRecovery;
   discover: DiscoverCanonicalArtifact;
+  input: ClaimInput;
 }): Promise<InitiativeReviewerRecovery> {
   const { pending } = args;
   const canonicalArtifact: InitiativeRecoveryCanonicalArtifact = pending.dispatchContext && pending.baseSha
@@ -142,7 +143,7 @@ async function resolveRecoveryOutsideTransaction(args: {
       nextAction: `The workroom lacks ${!pending.baseSha ? "baseSha" : "a valid reviewer dispatch identity (including headSha)"}, so no reviewer binding can be issued. Re-sync the branch with adopt_worktree(headBranch, baseSha, headSha), supplying full immutable commit SHAs for both fields and preserving any valid recorded identity, then retry.`,
     };
 
-  return resolveInitiativeReviewerRecovery({
+  const recovery = await resolveInitiativeReviewerRecovery({
     decision: pending.decision,
     currentAgentId: args.actor.agentId,
     db: args.db,
@@ -155,6 +156,36 @@ async function resolveRecoveryOutsideTransaction(args: {
       : { resolved: false, nextAction: "Record valid plan coverage for the current baseline and this Workroom repository, including the immutable plan commit and blob, then retry plan review." },
     expectedCurrentBaselineId: pending.baselineId,
   });
+  if (!pending.baseSha || !pending.dispatchContext?.headSha) {
+    const missingFields = [
+      ...(!pending.baseSha ? ["baseSha" as const] : []),
+      ...(!pending.dispatchContext?.headSha ? ["headSha" as const] : []),
+    ];
+    recovery.identityRepair = {
+      toolName: "adopt_worktree",
+      missingFields,
+      retainedFields: {
+        repositoryFullName: args.input.repositoryFullName,
+        headBranch: args.input.headBranch,
+        worktreePath: args.input.worktreePath,
+        ...(pending.dispatchContext?.headSha ? { headSha: pending.dispatchContext.headSha } : {}),
+      },
+      packet: {
+        title: args.input.title ?? `Work on ${args.input.backlogItemId}`,
+        objective: args.input.objective ?? `Claim-at-start binding for ${args.input.backlogItemId}`,
+        repositoryFullName: args.input.repositoryFullName,
+        headBranch: args.input.headBranch,
+        worktreePath: args.input.worktreePath,
+        backlogItemId: args.input.backlogItemId,
+        baseBranch: args.input.baseBranch ?? "main",
+        ...(pending.baseSha ? { baseSha: pending.baseSha } : {}),
+        ...(pending.dispatchContext?.headSha ? { headSha: pending.dispatchContext.headSha } : {}),
+        ...(args.input.executorKind ? { executorKind: args.input.executorKind } : {}),
+        ...(args.input.executorRef ? { sessionRef: args.input.executorRef } : {}),
+      },
+    };
+  }
+  return recovery;
 }
 
 class CapsuleIdentityMismatch extends Error {
@@ -516,6 +547,7 @@ export async function claimGovernedBacklogWorkspace(args: {
           actor: args.actor,
           pending: pendingRecovery,
           discover: args.dependencies?.discoverCanonicalArtifact ?? discoverCanonicalArtifactFromProvider,
+          input: args.input,
         }),
       },
     };

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -25,6 +25,7 @@ import {
 import { claimBacklogItemWorkspace } from "./work-capsule-store";
 import { declareWorkCapsuleIntent } from "./work-capsule-intent-store";
 import type { CapsuleDb, WorkCapsuleActor } from "./work-capsule-store-types";
+import { projectWorkroomIdentityRepair } from "./workroom-recovery-projection";
 
 type ClaimInput = {
   backlogItemId: string;
@@ -157,34 +158,20 @@ async function resolveRecoveryOutsideTransaction(args: {
     expectedCurrentBaselineId: pending.baselineId,
   });
   if (!pending.baseSha || !pending.dispatchContext?.headSha) {
-    const missingFields = [
-      ...(!pending.baseSha ? ["baseSha" as const] : []),
-      ...(!pending.dispatchContext?.headSha ? ["headSha" as const] : []),
-    ];
-    recovery.identityRepair = {
-      toolName: "adopt_worktree",
-      missingFields,
-      retainedFields: {
-        repositoryFullName: args.input.repositoryFullName,
-        headBranch: args.input.headBranch,
-        worktreePath: args.input.worktreePath,
-        ...(pending.baseSha ? { baseSha: pending.baseSha } : {}),
-        ...(pending.dispatchContext?.headSha ? { headSha: pending.dispatchContext.headSha } : {}),
-      },
-      packet: {
+    recovery.identityRepair = projectWorkroomIdentityRepair({
+      repositoryFullName: args.input.repositoryFullName,
+      headBranch: args.input.headBranch,
+      worktreePath: args.input.worktreePath,
+      baseSha: pending.baseSha,
+      headSha: pending.dispatchContext?.headSha ?? null,
+    }, {
         title: args.input.title ?? `Work on ${args.input.backlogItemId}`,
         objective: args.input.objective ?? `Claim-at-start binding for ${args.input.backlogItemId}`,
-        repositoryFullName: args.input.repositoryFullName,
-        headBranch: args.input.headBranch,
-        worktreePath: args.input.worktreePath,
         backlogItemId: args.input.backlogItemId,
         baseBranch: args.input.baseBranch ?? "main",
-        ...(pending.baseSha ? { baseSha: pending.baseSha } : {}),
-        ...(pending.dispatchContext?.headSha ? { headSha: pending.dispatchContext.headSha } : {}),
         ...(args.input.executorKind ? { executorKind: args.input.executorKind } : {}),
         ...(args.input.executorRef ? { sessionRef: args.input.executorRef } : {}),
-      },
-    };
+    }) ?? undefined;
   }
   return recovery;
 }

--- a/apps/web/lib/work-capsules/liveness-inventory.test.ts
+++ b/apps/web/lib/work-capsules/liveness-inventory.test.ts
@@ -12,10 +12,12 @@ describe("loadCapsuleLivenessInventory", () => {
         leaseHolderPrincipalId: "principal-1", repositoryFullName: "owner/repo",
         decisionScope: null, portfolioRole: null, servedPersona: null, activityKind: null,
         outcomeAnchor: {}, servesPortfolioRoles: [], dependsOnPortfolioRoles: [],
-        headBranch: "fix/x", worktreePath: "D:/x", pullRequestUrl: null, pullRequestNumber: null,
+        headBranch: "fix/x", baseSha: "0000000000000000000000000000000000000000",
+        headSha: "1111111111111111111111111111111111111111", worktreePath: "D:/x",
+        pullRequestUrl: null, pullRequestNumber: null,
         leaseExpiresAt: new Date("2026-08-24T19:00:00.000Z"), lastSyncedAt: null,
         updatedAt: now, featureBuildId: null,
-        taskRun: { status: "completed", updatedAt: new Date("2026-08-24T17:55:00.000Z") },
+        taskRun: { taskRunId: "TR-TERMINAL", status: "completed", updatedAt: new Date("2026-08-24T17:55:00.000Z") },
       }]) },
       featureBuild: { findMany: vi.fn().mockResolvedValue([]) },
       nonProductionEnvironmentLease: { findMany: vi.fn().mockResolvedValue([]) },
@@ -27,10 +29,61 @@ describe("loadCapsuleLivenessInventory", () => {
       capsuleId: "WC-TERMINAL-TURN",
       liveness: "execution-terminal",
       isReapable: true,
+      recovery: {
+        state: "terminal",
+        prerequisite: null,
+        reviewerExecution: {
+          taskRunId: "TR-TERMINAL",
+          status: "completed",
+          pending: false,
+        },
+      },
     });
     expect(db.workroom.findMany).toHaveBeenCalledWith(expect.objectContaining({
-      select: expect.objectContaining({ taskRun: { select: { status: true, updatedAt: true } } }),
+      select: expect.objectContaining({ taskRun: { select: { taskRunId: true, status: true, updatedAt: true } } }),
     }));
+  });
+
+  it("returns the same exact author repair used by transition recovery", async () => {
+    const now = new Date("2026-08-24T18:00:00.000Z");
+    const db = {
+      workroom: { findMany: vi.fn().mockResolvedValue([{
+        capsuleId: "WC-MISSING-BASE", title: "Missing base", status: "ready",
+        source: "external-adoption", executorKind: "codex-desktop", executorRef: "session",
+        leaseHolderPrincipalId: "principal-1", repositoryFullName: "owner/repo",
+        decisionScope: null, portfolioRole: null, servedPersona: null, activityKind: null,
+        outcomeAnchor: {}, servesPortfolioRoles: [], dependsOnPortfolioRoles: [],
+        baseSha: null, headSha: "1111111111111111111111111111111111111111",
+        headBranch: "fix/x", worktreePath: "D:/x", pullRequestUrl: null, pullRequestNumber: null,
+        leaseExpiresAt: new Date("2026-08-24T19:00:00.000Z"), lastSyncedAt: null,
+        updatedAt: now, featureBuildId: null, taskRun: null,
+      }]) },
+      featureBuild: { findMany: vi.fn().mockResolvedValue([]) },
+      nonProductionEnvironmentLease: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+
+    const result = await loadCapsuleLivenessInventory(db, { where: {}, take: 10 }, now);
+
+    expect(result.capsulesAll[0]).toMatchObject({
+      recovery: {
+        state: "blocked",
+        reviewerExecution: null,
+        prerequisite: {
+          accountableRole: "artifact-resolver",
+          missingFields: ["baseSha"],
+          retainedFields: { headSha: "1111111111111111111111111111111111111111" },
+          repair: {
+            toolName: "adopt_worktree",
+            packet: {
+              repositoryFullName: "owner/repo",
+              headBranch: "fix/x",
+              worktreePath: "D:/x",
+              headSha: "1111111111111111111111111111111111111111",
+            },
+          },
+        },
+      },
+    });
   });
 
   it("keeps stored, live, reapable, and history counts distinct", async () => {

--- a/apps/web/lib/work-capsules/liveness-inventory.ts
+++ b/apps/web/lib/work-capsules/liveness-inventory.ts
@@ -7,6 +7,7 @@
 // by the `list_work_capsules` MCP tool so the handler stays thin.
 
 import { classifyWorkCapsuleLiveness } from "./liveness";
+import { projectWorkroomRecovery } from "./workroom-recovery-projection";
 
 const INVENTORY_SELECT = {
   capsuleId: true,
@@ -26,6 +27,8 @@ const INVENTORY_SELECT = {
   servesPortfolioRoles: true,
   dependsOnPortfolioRoles: true,
   headBranch: true,
+  baseSha: true,
+  headSha: true,
   worktreePath: true,
   pullRequestUrl: true,
   pullRequestNumber: true,
@@ -33,7 +36,7 @@ const INVENTORY_SELECT = {
   lastSyncedAt: true,
   updatedAt: true,
   featureBuildId: true,
-  taskRun: { select: { status: true, updatedAt: true } },
+  taskRun: { select: { taskRunId: true, status: true, updatedAt: true } },
 } as const;
 
 type InventoryDb = {
@@ -112,6 +115,7 @@ export async function loadCapsuleLivenessInventory(
     const { featureBuildId: _omit, taskRun: _taskRun, ...rest } = row;
     return {
       ...rest,
+      recovery: projectWorkroomRecovery({ ...row, taskRun: row.taskRun }),
       liveness: verdict.liveness,
       isLive: verdict.isLive,
       isReapable: verdict.isReapable,

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -225,7 +225,6 @@ export async function getWorkCapsuleTool(params: Record<string, unknown>): Promi
   if (!capsuleId) {
     return { success: false, error: "missing_capsuleId", message: "capsuleId is required." };
   }
-
   const capsule = await prisma.workroom.findUnique({
     where: { capsuleId },
     include: {
@@ -233,6 +232,7 @@ export async function getWorkCapsuleTool(params: Record<string, unknown>): Promi
         orderBy: { recordedAt: "desc" },
         take: 25,
       },
+      taskRun: { select: { taskRunId: true, status: true } },
     },
   });
 
@@ -243,12 +243,12 @@ export async function getWorkCapsuleTool(params: Record<string, unknown>): Promi
       message: `Work Capsule ${capsuleId} not found.`,
     };
   }
-
+  const { projectWorkroomRecovery } = await import("./workroom-recovery-projection");
   return {
     success: true,
     entityId: capsule.capsuleId,
     message: `Loaded ${capsule.capsuleId}.`,
-    data: { capsule },
+    data: { capsule: { ...capsule, recovery: projectWorkroomRecovery(capsule) } },
   };
 }
 

--- a/apps/web/lib/work-capsules/workroom-recovery-projection.ts
+++ b/apps/web/lib/work-capsules/workroom-recovery-projection.ts
@@ -1,0 +1,74 @@
+import type { InitiativeReviewerRecovery } from "@/lib/tak/initiative-readiness-tool-grants";
+
+type WorkroomIdentity = {
+  repositoryFullName: string | null;
+  headBranch: string | null;
+  worktreePath: string | null;
+  baseSha: string | null;
+  headSha: string | null;
+};
+
+type LinkedTaskRun = { taskRunId: string; status: string } | null;
+
+const TERMINAL_TASK_STATUSES = new Set(["completed", "failed", "cancelled", "stalled"]);
+
+export function projectWorkroomIdentityRepair(
+  room: WorkroomIdentity,
+  packetFields: Record<string, unknown> = {},
+): NonNullable<InitiativeReviewerRecovery["identityRepair"]> | null {
+  const missingFields = [
+    ...(!room.baseSha ? ["baseSha" as const] : []),
+    ...(!room.headSha ? ["headSha" as const] : []),
+  ];
+  if (missingFields.length === 0) return null;
+  const retainedFields = {
+    repositoryFullName: room.repositoryFullName ?? "",
+    headBranch: room.headBranch ?? "",
+    worktreePath: room.worktreePath ?? "",
+    ...(room.baseSha ? { baseSha: room.baseSha } : {}),
+    ...(room.headSha ? { headSha: room.headSha } : {}),
+  };
+  return {
+    toolName: "adopt_worktree",
+    missingFields,
+    retainedFields,
+    packet: {
+      ...packetFields,
+      repositoryFullName: retainedFields.repositoryFullName,
+      headBranch: retainedFields.headBranch,
+      worktreePath: retainedFields.worktreePath,
+      ...(room.baseSha ? { baseSha: room.baseSha } : {}),
+      ...(room.headSha ? { headSha: room.headSha } : {}),
+    },
+  };
+}
+
+export function projectWorkroomRecovery(room: WorkroomIdentity & { taskRun?: LinkedTaskRun }) {
+  const identityRepair = projectWorkroomIdentityRepair(room);
+  const reviewerExecution = room.taskRun
+    ? {
+      taskRunId: room.taskRun.taskRunId,
+      status: room.taskRun.status,
+      pending: !TERMINAL_TASK_STATUSES.has(room.taskRun.status),
+    }
+    : null;
+  return {
+    state: identityRepair
+      ? "blocked" as const
+      : reviewerExecution?.pending
+        ? "queued" as const
+        : reviewerExecution
+          ? "terminal" as const
+          : "actionable" as const,
+    prerequisite: identityRepair
+      ? {
+        accountableRole: "artifact-resolver" as const,
+        missingFields: identityRepair.missingFields,
+        retainedFields: identityRepair.retainedFields,
+        nextAction: "Re-sync the Workroom with adopt_worktree using the exact packet; resolve only the listed missing immutable identity fields.",
+        repair: { toolName: identityRepair.toolName, packet: identityRepair.packet },
+      }
+      : null,
+    reviewerExecution,
+  };
+}

--- a/docs/superpowers/plans/2026-09-05-mcp-author-recovery.md
+++ b/docs/superpowers/plans/2026-09-05-mcp-author-recovery.md
@@ -55,6 +55,26 @@ Project prerequisite blockers separately from reviewer execution. Reuse reviewer
 
 Clarify supported authoring/implementation parent binding in the existing planning instructions and skill. Include the objective/acceptance manifest prerequisite identified during this review so authors validate it before dispatch. Use the existing manifest parser instead of a second format checker. Hook label/discovery ranking improvements remain separate work.
 
+### Implementation checkpoint, 2026-09-06
+
+The identity-repair projection is now shared by transition recovery and the
+read-side Workroom inventory. `list_work_capsules` and `get_workroom` expose the
+same additive `recovery` shape: prerequisite identity repair is separate from
+the linked reviewer TaskRun, terminal TaskRuns are never projected as pending,
+and missing `baseSha` retains a valid `headSha` in an executable
+`adopt_worktree` packet. The transition path enriches that same packet with its
+write-only claim metadata rather than maintaining a second diagnosis. This
+removes the duplicated identity-repair construction while preserving existing
+response fields and authorization boundaries.
+
+Focused coverage exercises missing-base preservation, terminal reviewer state,
+the transition packet, schema/handler scope parity, and the existing negative
+grant cases. Source-local capacity gates remain evidence, not authority: an
+unavailable or nonperforming lane may be recorded as inconclusive under the
+operator instruction, while DCO and every protected pull-request and merge-group
+check remain mandatory. This checkpoint does not infer a scope baseline,
+coverage receipt, or independent reviewer PASS.
+
 ## 4. Verify and deliver
 
 Run affected tests in a compile-ready worktree or the canonical shared verification environment, never treating missing dependencies as product failure. The current worktree is source-only. Claim the appropriate shared nonproduction lease for runtime-bound checks. Test the complete external-author journey with distinct author/reviewer identities, immutable provider reads and persisted approval readback; mocks must not be the only authority test.


### PR DESCRIPTION
## Summary

- unify Workroom identity-repair projection across claim transitions, list_work_capsules, and get_workroom
- preserve valid base/head identity while returning an executable adopt_worktree repair packet
- project linked reviewer TaskRuns separately so terminal work is never reported as pending

## Design grounding

- Existing specs/plans reviewed: docs/superpowers/specs/2026-09-05-mcp-author-recovery-design.md and docs/superpowers/plans/2026-09-05-mcp-author-recovery.md
- Current code substrate reviewed: governed-work-claim, liveness-inventory, and MCP workroom handlers
- Source of truth: apps/web/lib/work-capsules/workroom-recovery-projection.ts
- Decision: one additive shared projection; no new authority, ledger, or schema

## Verification

- 54 affected tests PASS
- apps/web typecheck PASS
- style drift PASS
- module-size ratchet PASS
- 65 deterministic preflight guards PASS
- pre-commit scoped typecheck and gitleaks PASS
- exact-tree local gate did not produce a current-tree record; operator-emergency bypass recorded, no local-CI PASS inferred
- semantic receipt absent/inconclusive; no semantic PASS inferred
- DCO and every protected PR/merge-group check remain mandatory