### PR TITLE
fix(workroom): pause the drive after a dispatch with no completing receipt

### DIFF
--- a/apps/web/lib/queue/functions/workroom-drive.test.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.test.ts
@@ -132,6 +132,33 @@ describe("runWorkroomDriveJob (BI-FCD639D9)", () => {
     expect(fx.persist.mock.calls[0]?.[0]?.activityKind).toBe("workroom-drive-attention");
   });
 
+  it("does not re-dispatch the same agent stage when the prior tick produced no completing receipt", async () => {
+    const fx = effects();
+    const now = new Date("2026-09-01T00:00:00.000Z");
+    const first = await runWorkroomDriveJob(now, { listRooms: async () => [room()], effects: fx });
+    expect(first.dispatched).toBe(1);
+    const snapshot = fx.persist.mock.calls[0]?.[0]?.snapshot as Record<string, unknown>;
+    expect(snapshot.action).toBe("dispatch_agent");
+    const second = await runWorkroomDriveJob(now, {
+      listRooms: async () => [room({
+        workspaceState: { workroomDrive: snapshot },
+        currentStageKey: typeof snapshot.stageKey === "string" ? snapshot.stageKey : "sweep",
+      })],
+      effects: fx,
+    });
+    expect(second.dispatched).toBe(0);
+    expect(second.skipped).toBe(1);
+    expect(fx.upsertAgentTask).toHaveBeenCalledTimes(1);
+    const secondSnapshot = fx.persist.mock.calls.at(-1)?.[0]?.snapshot as Record<string, unknown>;
+    expect(secondSnapshot).toMatchObject({
+      action: "pause",
+      reason: "executor_writeback_unavailable",
+    });
+    expect(secondSnapshot.receipts).toEqual(
+      expect.arrayContaining([{ stageKey: snapshot.stageKey, kind: "blocked" }]),
+    );
+  });
+
   it("contains delivery notification reconciliation failure after preserving the drive result", async () => {
     const fx = effects();
     const reconcileNotifications = vi.fn().mockRejectedValue(new Error("notification unavailable"));

--- a/apps/web/lib/queue/functions/workroom-drive.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.ts
@@ -37,12 +37,17 @@ import { readWorkroomPostureClaim } from "@/lib/work-management/workroom-posture
 import { readWorkShapeDefinitionContract } from "@/lib/work-management/work-shapes";
 import { resolveWorkShapeClaim } from "@/lib/work-management/workroom-shape-claim";
 import {
+  EXECUTOR_WRITEBACK_UNAVAILABLE_REASON,
   resolveDrivePlan,
   workroomDriveTaskId,
   type DrivePlan,
 } from "@/lib/work-management/drive-resolution";
 import type { WorkroomCoordinatorEligibility } from "@/lib/work-management/workroom-shape-conformance";
-import { readStoredWorkroomDriveState } from "@/lib/work-management/workroom-drive-state";
+import {
+  priorDriveFromStored,
+  readStoredWorkroomDriveState,
+} from "@/lib/work-management/workroom-drive-state";
+import { WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND } from "@/lib/work-management/workroom-drive-receipts";
 
 export type WorkroomDriveRoom = {
   id: string;
@@ -130,6 +135,16 @@ export async function applyDrivePlan(input: {
   effects: WorkroomDriveEffects;
 }): Promise<"dispatched" | "attention" | "stopped" | "skipped"> {
   const { room, plan, now, effects } = input;
+  const receipts = [...room.receipts];
+  if (
+    plan.reason === EXECUTOR_WRITEBACK_UNAVAILABLE_REASON
+    && plan.stageKey
+    && !receipts.some((receipt) =>
+      receipt.stageKey === plan.stageKey && receipt.kind === WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND
+    )
+  ) {
+    receipts.push({ stageKey: plan.stageKey, kind: WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND });
+  }
   const snapshot = {
     kind: "workroom-drive",
     version: 1,
@@ -139,7 +154,7 @@ export async function applyDrivePlan(input: {
     taskId: plan.taskId,
     lastRunAt: now.toISOString(),
     lastCycleKey: plan.cycle?.cycleKey ?? null,
-    receipts: room.receipts,
+    receipts,
     budgetUsage: room.budgetUsage,
     stopConditionHits: room.stopConditionHits,
     reviewDue: room.reviewDue,
@@ -301,6 +316,7 @@ export async function runWorkroomDriveJob(
       substrateEmpty: room.substrateEmpty,
       coordinatorEligibility: room.coordinatorEligibility,
       now,
+      priorDrive: priorDriveFromStored(stored),
     });
     plans.push({
       roomId: room.capsuleId,

--- a/apps/web/lib/work-management/drive-resolution.test.ts
+++ b/apps/web/lib/work-management/drive-resolution.test.ts
@@ -322,4 +322,83 @@ describe("resolveDrivePlan (BI-FCD639D9)", () => {
     expect(plan.taskId).toBeNull();
     expect(plan.ledger.join(" ")).toMatch(/raised nothing/i);
   });
+
+  it("dispatches an agent stage on the first tick when no prior drive snapshot exists", () => {
+    const plan = resolveDrivePlan(baseInput({
+      currentStageKey: "scan",
+      receipts: [],
+      priorDrive: null,
+    }));
+    expect(plan.action).toBe("dispatch_agent");
+    expect(plan.stageKey).toBe("scan");
+    expect(plan.taskId).not.toBeNull();
+  });
+
+  it("pauses instead of re-dispatching when the prior tick dispatched the same stage and no completing receipt arrived", () => {
+    const plan = resolveDrivePlan(baseInput({
+      currentStageKey: "scan",
+      receipts: [],
+      priorDrive: { action: "dispatch_agent", reason: "agent_stage", stageKey: "scan" },
+    }));
+    expect(plan.action).toBe("pause");
+    expect(plan.reason).toBe("executor_writeback_unavailable");
+    expect(plan.stageKey).toBe("scan");
+    expect(plan.taskId).toBeNull();
+    expect(plan.agentId).toBeNull();
+    expect(plan.ledger.join(" ")).toMatch(/writeback|receipt/i);
+  });
+
+  it("keeps the pause on later ticks until a completing receipt appears", () => {
+    const plan = resolveDrivePlan(baseInput({
+      currentStageKey: "scan",
+      receipts: [{ stageKey: "scan", kind: "blocked" }],
+      priorDrive: {
+        action: "pause",
+        reason: "executor_writeback_unavailable",
+        stageKey: "scan",
+      },
+    }));
+    expect(plan.action).toBe("pause");
+    expect(plan.reason).toBe("executor_writeback_unavailable");
+    expect(plan.taskId).toBeNull();
+  });
+
+  it("does not treat a blocked receipt as completing, so the stage does not advance", () => {
+    const plan = resolveDrivePlan(baseInput({
+      currentStageKey: "scan",
+      receipts: [{ stageKey: "scan", kind: "blocked" }],
+    }));
+    expect(plan.stageKey).toBe("scan");
+    expect(plan.action).toBe("pause");
+    expect(plan.reason).toBe("executor_writeback_unavailable");
+  });
+
+  it("resumes dispatch of the next agent stage once a completing receipt lands", () => {
+    const twoAgent: WorkShapeDefinitionContract = {
+      ...definition,
+      stages: [
+        definition.stages[0],
+        {
+          key: "raise",
+          title: "Raise",
+          accountablePrincipalRef: "agent:watcher",
+          advance: { kind: "status-change", condition: "raised" },
+          evidence: ["assurance-finding"],
+        },
+      ],
+    };
+    const plan = resolveDrivePlan(baseInput({
+      definition: twoAgent,
+      currentStageKey: "scan",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      priorDrive: {
+        action: "pause",
+        reason: "executor_writeback_unavailable",
+        stageKey: "scan",
+      },
+    }));
+    expect(plan.action).toBe("dispatch_agent");
+    expect(plan.stageKey).toBe("raise");
+    expect(plan.reason).toBe("agent_stage");
+  });
 });

--- a/apps/web/lib/work-management/drive-resolution.ts
+++ b/apps/web/lib/work-management/drive-resolution.ts
@@ -24,6 +24,19 @@ import {
   type WorkroomShapeConformance,
   type WorkroomShapeConformanceDeviation,
 } from "./workroom-shape-conformance";
+import {
+  EXECUTOR_WRITEBACK_UNAVAILABLE_REASON,
+  WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND,
+  isCompletingWorkroomDriveReceipt,
+  type PriorWorkroomDrive,
+} from "./workroom-drive-receipts";
+
+export {
+  EXECUTOR_WRITEBACK_UNAVAILABLE_REASON,
+  WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND,
+  isCompletingWorkroomDriveReceipt,
+} from "./workroom-drive-receipts";
+export type { PriorWorkroomDrive } from "./workroom-drive-receipts";
 
 export type DriveAction =
   | "do_not_wake"
@@ -63,6 +76,8 @@ export type DriveResolutionInput = {
   trigger?: WorkShapeTriggerClass;
   /** Test/override only. Production callers omit this and the next permitted stage is derived. */
   proposedStageKey?: string | null;
+  /** Last persisted drive tick. Used to fail closed when a dispatch produced no writeback. */
+  priorDrive?: PriorWorkroomDrive | null;
 };
 
 export type DrivePlan = {
@@ -126,7 +141,9 @@ function nextStageKey(
 ): string | null {
   if (definition.stages.length === 0) return null;
   if (!currentStageKey) return definition.stages[0]?.key ?? null;
-  const currentHasReceipt = receipts.some((receipt) => receipt.stageKey === currentStageKey);
+  const currentHasReceipt = receipts.some((receipt) =>
+    isCompletingWorkroomDriveReceipt(receipt, currentStageKey),
+  );
   if (!currentHasReceipt) return currentStageKey;
   const index = definition.stages.findIndex((stage) => stage.key === currentStageKey);
   if (index < 0 || index + 1 >= definition.stages.length) return null;
@@ -291,6 +308,49 @@ export function resolveDrivePlan(input: DriveResolutionInput): DrivePlan {
       cycle,
       ledger: [`Stage ${stage.key} has no dispatchable agent principal.`],
     });
+  }
+
+  const completing = input.receipts.some((receipt) =>
+    isCompletingWorkroomDriveReceipt(receipt, stage.key),
+  );
+  const blocked = input.receipts.some(
+    (receipt) =>
+      receipt.stageKey === stage.key && receipt.kind === WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND,
+  );
+  const prior = input.priorDrive;
+  const alreadyTriedWriteback = Boolean(
+    !completing
+    && (
+      blocked
+      || (
+        prior
+        && prior.stageKey === stage.key
+        && (
+          prior.action === "dispatch_agent"
+          || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE_REASON
+        )
+      )
+    ),
+  );
+  if (alreadyTriedWriteback) {
+    return {
+      action: "pause",
+      reason: EXECUTOR_WRITEBACK_UNAVAILABLE_REASON,
+      roomId: input.roomId,
+      shapeKey: input.definition.key,
+      shapeVersion: input.definition.version,
+      stageKey: stage.key,
+      accountablePrincipalRef: stage.accountablePrincipalRef,
+      agentId: null,
+      attentionPrincipalRef: null,
+      taskId: null,
+      conformance,
+      cycle,
+      deviations: [],
+      ledger: [
+        `Stage ${stage.key} already dispatched without a completing receipt; pause until writeback exists.`,
+      ],
+    };
   }
 
   return {

--- a/apps/web/lib/work-management/workroom-drive-receipts.ts
+++ b/apps/web/lib/work-management/workroom-drive-receipts.ts
@@ -1,0 +1,17 @@
+/** Receipt kind written once when a dispatched agent stage produces no writeback. */
+export const WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND = "blocked";
+
+export const EXECUTOR_WRITEBACK_UNAVAILABLE_REASON = "executor_writeback_unavailable";
+
+export type PriorWorkroomDrive = {
+  action: string;
+  reason: string;
+  stageKey: string | null;
+};
+
+export function isCompletingWorkroomDriveReceipt(
+  receipt: { stageKey: string; kind: string },
+  stageKey: string,
+): boolean {
+  return receipt.stageKey === stageKey && receipt.kind !== WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND;
+}

--- a/apps/web/lib/work-management/workroom-drive-state.test.ts
+++ b/apps/web/lib/work-management/workroom-drive-state.test.ts
@@ -18,6 +18,8 @@ describe("readStoredWorkroomDriveState", () => {
       budgetUsage: [{ kind: "findings-per-run", used: 4 }],
       stopConditionHits: ["substrate-failed"],
       reviewDue: true,
+      lastAction: null,
+      lastReason: null,
     });
   });
 
@@ -28,6 +30,23 @@ describe("readStoredWorkroomDriveState", () => {
       budgetUsage: [],
       stopConditionHits: [],
       reviewDue: false,
+      lastAction: null,
+      lastReason: null,
+    });
+  });
+
+  it("projects the last drive action so the next tick can fail closed", () => {
+    expect(readStoredWorkroomDriveState({
+      workroomDrive: {
+        action: "dispatch_agent",
+        reason: "agent_stage",
+        stageKey: "scan",
+        receipts: [],
+      },
+    })).toMatchObject({
+      currentStageKey: "scan",
+      lastAction: "dispatch_agent",
+      lastReason: "agent_stage",
     });
   });
 });

--- a/apps/web/lib/work-management/workroom-drive-state.ts
+++ b/apps/web/lib/work-management/workroom-drive-state.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@/lib/shared/coerce";
+import type { PriorWorkroomDrive } from "./workroom-drive-receipts";
 
 export type StoredWorkroomDriveState = {
   currentStageKey: string | null;
@@ -6,6 +7,8 @@ export type StoredWorkroomDriveState = {
   budgetUsage: { kind: string; used: number }[];
   stopConditionHits: string[];
   reviewDue: boolean;
+  lastAction: string | null;
+  lastReason: string | null;
 };
 
 /** Read only verifier-relevant observations from the persisted runner snapshot. */
@@ -36,5 +39,16 @@ export function readStoredWorkroomDriveState(workspaceState: unknown): StoredWor
       ? drive.stopConditionHits.filter((entry): entry is string => typeof entry === "string")
       : [],
     reviewDue: drive?.reviewDue === true,
+    lastAction: typeof drive?.action === "string" ? drive.action : null,
+    lastReason: typeof drive?.reason === "string" ? drive.reason : null,
+  };
+}
+
+export function priorDriveFromStored(stored: StoredWorkroomDriveState): PriorWorkroomDrive | null {
+  if (!stored.lastAction) return null;
+  return {
+    action: stored.lastAction,
+    reason: stored.lastReason ?? "",
+    stageKey: stored.currentStageKey,
   };
 }

--- a/apps/web/lib/work-management/workroom-shape-conformance.ts
+++ b/apps/web/lib/work-management/workroom-shape-conformance.ts
@@ -14,6 +14,7 @@ import {
 import type { WorkroomParticipantRole, WorkroomParticipantView } from "./room-types";
 import type { WorkShapeDefinitionContract } from "./work-shapes";
 import { ok, type ActionSuccess } from "@/lib/shared/action-result";
+import { isCompletingWorkroomDriveReceipt } from "./workroom-drive-receipts";
 
 export const WORKROOM_SHAPE_CONFORMANCE_DEVIATIONS = [
   "unresolved_work_shape",
@@ -338,7 +339,9 @@ export function evaluateWorkroomShapeConformance(
     input.proposedStageKey &&
     input.currentStageKey &&
     proposedIndex === currentIndex &&
-    input.receipts.some((receipt) => receipt.stageKey === input.currentStageKey)
+    input.receipts.some((receipt) =>
+      isCompletingWorkroomDriveReceipt(receipt, input.currentStageKey!),
+    )
   ) {
     deviations.push({
       code: "out_of_order_stage",
@@ -357,7 +360,9 @@ export function evaluateWorkroomShapeConformance(
 
   if (proposedIndex > 0) {
     const prior = input.definition.stages[proposedIndex - 1];
-    const hasReceipt = input.receipts.some((receipt) => receipt.stageKey === prior.key);
+    const hasReceipt = input.receipts.some((receipt) =>
+      isCompletingWorkroomDriveReceipt(receipt, prior.key),
+    );
     if (!hasReceipt) {
       deviations.push({
         code: "missing_prerequisite_receipt",


### PR DESCRIPTION
## Summary

Standing Workrooms were re-dispatching the same agent stage every 15 minutes because `resolveDrivePlan` treated an empty receipt list as still eligible. After a dispatch, the next tick now pauses with `executor_writeback_unavailable`, records a `blocked` receipt once, and does not treat `blocked` as completing. A later completing receipt unblocks the next stage.

This is the Coordinated Workrooms Phase A joined seam for BI-76B35820: stop the silent capacity burn. It does not invent `execute_workroom_stage`; that remains BI-CAP-AB63E190.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-09-03-coordinated-workrooms-design.md`
  - `docs/superpowers/plans/2026-09-03-coordinated-workrooms.md`
  - `docs/superpowers/plans/2026-08-29-proactive-workrooms.md` (drive runner)
- Current code substrate reviewed:
  - `apps/web/lib/work-management/drive-resolution.ts`
  - `apps/web/lib/queue/functions/workroom-drive.ts`
  - `apps/web/lib/work-management/workroom-shape-conformance.ts`
  - `apps/web/lib/attention/sources/workroom-stall.ts`
- Source of truth: Coordinated Workrooms Phase A observable (a dispatched stage that cannot write back must not loop) plus BI-FCD639D9's existing pause/stop dispositions.
- Decision: extend the existing drive resolver; no new table, scheduler, or MCP tool.

## Verification

- Targeted Vitest: drive-resolution, workroom-drive job, drive-state, shape-conformance, stall source — 73 tests passed.
- Pre-commit scoped typecheck passed.
- Local-CI pregate: gate passed for this branch.

## Trailers

Design-Grounding-Decision: specs/plans reviewed docs/superpowers/plans/2026-09-03-coordinated-workrooms.md and docs/superpowers/specs/2026-09-03-coordinated-workrooms-design.md; code substrate reviewed apps/web/lib/work-management/drive-resolution.ts, workroom-drive.ts, workroom-shape-conformance.ts; extending Phase A joined seam, no new table.
Docs-Impact-Decision: no documented user-facing route change; drive pause is server-owned reconcile behaviour already covered by stall attention.
Process-Spine-Decision: bug fix to existing drive runner; no new process skill or spec required beyond the existing coordinated-workrooms plan.
