### PR TITLE
fix(work): a completed stage earns the receipt that advances the shape (BI-76B35820)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2459,6 +2459,7 @@
         "who-answers-for-a-room",
         "nesting-has-to-be-written-not-just-declared",
         "who-may-coordinate-authority-and-a-gate-with-no-key",
+        "a-completed-stage-earns-a-receipt",
         "related-references"
       ]
     },

--- a/apps/web/lib/queue/functions/workroom-drive.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.ts
@@ -16,6 +16,12 @@ import {
   resolveCoordinatorEligibility,
 } from "@/lib/work-management/coordinator-eligibility";
 import { planCoordinationBindings } from "@/lib/authority/coordination-bindings";
+import {
+  carryReceipts,
+  earnStageReceipts,
+  workroomStageTaskTitle,
+  type CompletedRun,
+} from "@/lib/work-management/stage-receipts";
 import { planContainmentRelations } from "@/lib/work-management/standing-room-nesting";
 
 import { gateAtEntry } from "../quiescence-gates";
@@ -55,6 +61,10 @@ export type WorkroomDriveRoom = {
   participants: ProjectableWorkroomParticipantAssignment[];
   currentStageKey: string | null;
   receipts: { stageKey: string; kind: string }[];
+  /** Task runs for this room's stages, used to earn stage receipts. */
+  stageRuns?: CompletedRun[];
+  /** The cycle the stored receipts belong to, so a rollover can clear them. */
+  lastCycleKey?: string | null;
   budgetUsage: { kind: string; used: number }[];
   stopConditionHits: string[];
   reviewDue: boolean;
@@ -139,7 +149,13 @@ export async function applyDrivePlan(input: {
     taskId: plan.taskId,
     lastRunAt: now.toISOString(),
     lastCycleKey: plan.cycle?.cycleKey ?? null,
-    receipts: room.receipts,
+    // A new cycle starts its stages again, so last cycle's receipts must not
+    // satisfy this cycle's — the same defect inverted.
+    receipts: carryReceipts({
+      receipts: room.receipts,
+      previousCycleKey: room.lastCycleKey ?? null,
+      currentCycleKey: plan.cycle?.cycleKey ?? null,
+    }),
     budgetUsage: room.budgetUsage,
     stopConditionHits: room.stopConditionHits,
     reviewDue: room.reviewDue,
@@ -213,7 +229,7 @@ export async function applyDrivePlan(input: {
       taskId: plan.taskId,
       agentId: plan.agentId,
       ownerUserId: room.ownerUserId,
-      title: `Workroom ${room.capsuleId} / ${plan.stageKey}`,
+      title: workroomStageTaskTitle(room.capsuleId, plan.stageKey ?? ""),
       prompt: `Execute Workroom ${room.capsuleId} stage ${plan.stageKey} for shape ${plan.shapeKey}@${plan.shapeVersion}. Stay inside the declared grants. Do not skip stages, widen authority, or invent occupants.`,
       now,
     });
@@ -272,6 +288,8 @@ export async function runWorkroomDriveJob(
       jsiSchemePresent(prisma as unknown as Record<string, unknown>),
     ];
     rooms = await loadStandingRooms(bindings, schemePresent);
+    const runsByRoom = await loadStageRuns(rooms.map((room) => room.capsuleId));
+    rooms = rooms.map((room) => ({ ...room, stageRuns: runsByRoom.get(room.capsuleId) ?? [] }));
   }
   const effects = deps?.effects ?? liveEffects();
   const plans: WorkroomDriveResult["plans"] = [];
@@ -283,6 +301,15 @@ export async function runWorkroomDriveJob(
   for (const room of rooms) {
     const shape = resolveWorkShapeClaim(room.scopeClaims);
     const stored = readStoredWorkroomDriveState(room.workspaceState);
+    // A completed stage run earns the receipt that lets the shape advance.
+    // Receipts were read in three places and written in none, so every room
+    // re-dispatched its first stage forever (BI-76B35820).
+    const earnedReceipts = earnStageReceipts({
+      capsuleId: room.capsuleId,
+      currentStageKey: room.currentStageKey ?? stored.currentStageKey,
+      runs: room.stageRuns ?? [],
+      existing: room.receipts.length > 0 ? room.receipts : stored.receipts,
+    }) as { stageKey: string; kind: string }[];
     const plan = resolveDrivePlan({
       roomId: room.capsuleId,
       definition: shape ? readWorkShapeDefinitionContract(shape) : null,
@@ -293,7 +320,7 @@ export async function runWorkroomDriveJob(
         presencePrincipalRefs: [],
       }),
       currentStageKey: room.currentStageKey ?? stored.currentStageKey,
-      receipts: room.receipts.length > 0 ? room.receipts : stored.receipts,
+      receipts: earnedReceipts,
       budgetUsage: room.budgetUsage.length > 0 ? room.budgetUsage : stored.budgetUsage,
       stopConditionHits: room.stopConditionHits.length > 0 ? room.stopConditionHits : stored.stopConditionHits,
       reviewDue: room.reviewDue || stored.reviewDue,
@@ -308,7 +335,12 @@ export async function runWorkroomDriveJob(
       reason: plan.reason,
       taskId: plan.taskId,
     });
-    const outcome = await applyDrivePlan({ room, plan, now, effects });
+    const outcome = await applyDrivePlan({
+      room: { ...room, receipts: earnedReceipts, lastCycleKey: stored.lastCycleKey ?? null },
+      plan,
+      now,
+      effects,
+    });
     if (outcome === "dispatched") dispatched += 1;
     else if (outcome === "attention") attention += 1;
     else if (outcome === "stopped") stopped += 1;
@@ -471,6 +503,41 @@ export async function reconcileCoordinationBindings(): Promise<number> {
     // and refuse, which is the safe pre-existing behaviour.
     return 0;
   }
+}
+
+/**
+ * Completed stage runs for the rooms being driven, titled by
+ * workroomStageTaskTitle. One query per tick rather than one per room.
+ *
+ * Only terminal statuses are read: a working run must not earn a receipt, and a
+ * failed one must re-dispatch rather than advance.
+ */
+async function loadStageRuns(capsuleIds: readonly string[]): Promise<Map<string, CompletedRun[]>> {
+  const byRoom = new Map<string, CompletedRun[]>();
+  if (capsuleIds.length === 0) return byRoom;
+  try {
+    const { prisma } = await import("@dpf/db");
+    const rows = await prisma.taskRun.findMany({
+      where: {
+        status: "completed",
+        OR: capsuleIds.map((capsuleId) => ({ title: { startsWith: `Workroom ${capsuleId} / ` } })),
+      },
+      select: { title: true, status: true },
+      orderBy: { startedAt: "desc" },
+      take: 500,
+    });
+    for (const row of rows) {
+      // "Workroom <capsuleId> / <stage>"
+      const capsuleId = row.title.split(" ")[1] ?? "";
+      const bucket = byRoom.get(capsuleId);
+      if (bucket) bucket.push(row);
+      else byRoom.set(capsuleId, [row]);
+    }
+  } catch {
+    // No runs read means no receipts earned: rooms re-dispatch, which is the
+    // safe pre-existing behaviour rather than a false advance.
+  }
+  return byRoom;
 }
 
 async function loadCoordinationBindings(): Promise<

--- a/apps/web/lib/work-management/stage-receipts.test.ts
+++ b/apps/web/lib/work-management/stage-receipts.test.ts
@@ -1,0 +1,141 @@
+// Stage advance (BI-76B35820).
+//
+// Measured before this: twelve rooms dispatching every 15 minutes, 48 completed
+// task runs, and COUNT(DISTINCT stageKey) = 1 on every one of them.
+// WC-A69BCABB ran `sweep` five times and never reached `raise` or `decide`.
+// Receipts were read in three places and written in none.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  STAGE_COMPLETION_RECEIPT_KIND,
+  carryReceipts,
+  earnStageReceipts,
+  stageRunCompleted,
+  workroomStageTaskTitle,
+} from "./stage-receipts";
+
+const run = (stage: string, status = "completed") => ({
+  title: workroomStageTaskTitle("WC-A69BCABB", stage),
+  status,
+});
+
+describe("workroomStageTaskTitle", () => {
+  it("matches the title the dispatcher writes", () => {
+    // The observed live value. If this drifts from the dispatcher, stages stop
+    // advancing silently — the whole defect, reintroduced.
+    expect(workroomStageTaskTitle("WC-A69BCABB", "sweep")).toBe("Workroom WC-A69BCABB / sweep");
+  });
+});
+
+describe("stageRunCompleted", () => {
+  it("sees the current stage's completed run", () => {
+    expect(
+      stageRunCompleted({ capsuleId: "WC-A69BCABB", currentStageKey: "sweep", runs: [run("sweep")] }),
+    ).toBe(true);
+  });
+
+  it("does not count a FAILED run as completion", () => {
+    // A failure must re-dispatch, not advance. Laundering a failure into
+    // progress would move the room past work that never happened.
+    expect(
+      stageRunCompleted({
+        capsuleId: "WC-A69BCABB",
+        currentStageKey: "sweep",
+        runs: [run("sweep", "failed")],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not count a still-working run", () => {
+    expect(
+      stageRunCompleted({
+        capsuleId: "WC-A69BCABB",
+        currentStageKey: "sweep",
+        runs: [run("sweep", "working")],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not count another stage's completion", () => {
+    expect(
+      stageRunCompleted({ capsuleId: "WC-A69BCABB", currentStageKey: "sweep", runs: [run("raise")] }),
+    ).toBe(false);
+  });
+
+  it("does not count another room's run of the same stage name", () => {
+    const otherRoom = { title: workroomStageTaskTitle("WC-OTHER", "sweep"), status: "completed" };
+    expect(
+      stageRunCompleted({ capsuleId: "WC-A69BCABB", currentStageKey: "sweep", runs: [otherRoom] }),
+    ).toBe(false);
+  });
+});
+
+describe("earnStageReceipts", () => {
+  it("records a receipt so the stage can advance", () => {
+    const receipts = earnStageReceipts({
+      capsuleId: "WC-A69BCABB",
+      currentStageKey: "sweep",
+      runs: [run("sweep")],
+      existing: [],
+    });
+    expect(receipts).toEqual([{ stageKey: "sweep", kind: STAGE_COMPLETION_RECEIPT_KIND }]);
+  });
+
+  it("is idempotent — five completed sweeps do not make five receipts", () => {
+    const existing = [{ stageKey: "sweep", kind: STAGE_COMPLETION_RECEIPT_KIND }];
+    const receipts = earnStageReceipts({
+      capsuleId: "WC-A69BCABB",
+      currentStageKey: "sweep",
+      runs: [run("sweep"), run("sweep")],
+      existing,
+    });
+    expect(receipts).toBe(existing);
+  });
+
+  it("returns the same reference when nothing was earned, so no write is needed", () => {
+    const existing: Array<{ stageKey: string; kind: string }> = [];
+    expect(
+      earnStageReceipts({
+        capsuleId: "WC-A69BCABB",
+        currentStageKey: "sweep",
+        runs: [run("sweep", "failed")],
+        existing,
+      }),
+    ).toBe(existing);
+  });
+
+  it("earns nothing when the room has no current stage", () => {
+    const existing: Array<{ stageKey: string; kind: string }> = [];
+    expect(
+      earnStageReceipts({ capsuleId: "WC-A69BCABB", currentStageKey: null, runs: [run("sweep")], existing }),
+    ).toBe(existing);
+  });
+});
+
+describe("carryReceipts", () => {
+  it("keeps receipts within the same cycle", () => {
+    const receipts = [{ stageKey: "sweep", kind: STAGE_COMPLETION_RECEIPT_KIND }];
+    expect(
+      carryReceipts({ receipts, previousCycleKey: "s@1.0.0:2026-09-06", currentCycleKey: "s@1.0.0:2026-09-06" }),
+    ).toBe(receipts);
+  });
+
+  it("clears them when the cycle rolls, so tomorrow's run does not skip every stage", () => {
+    // The same defect inverted: a daily watch would run once and then satisfy
+    // every stage forever from yesterday's receipts.
+    expect(
+      carryReceipts({
+        receipts: [{ stageKey: "sweep", kind: STAGE_COMPLETION_RECEIPT_KIND }],
+        previousCycleKey: "s@1.0.0:2026-09-06",
+        currentCycleKey: "s@1.0.0:2026-09-07",
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps receipts when either cycle key is unknown rather than discarding progress", () => {
+    const receipts = [{ stageKey: "sweep", kind: STAGE_COMPLETION_RECEIPT_KIND }];
+    expect(carryReceipts({ receipts, previousCycleKey: null, currentCycleKey: "s:1" })).toBe(receipts);
+    expect(carryReceipts({ receipts, previousCycleKey: "s:1", currentCycleKey: null })).toBe(receipts);
+  });
+});

--- a/apps/web/lib/work-management/stage-receipts.ts
+++ b/apps/web/lib/work-management/stage-receipts.ts
@@ -1,0 +1,103 @@
+// A completed stage earns a receipt, and a receipt is what advances the shape
+// (BI-76B35820).
+//
+// `nextStageKey` advances only when the current stage has a receipt. Receipts
+// were READ in three places and WRITTEN in none — always `[]`, so every room
+// re-dispatched stage one on every tick, forever. Twelve rooms did that at a
+// 15-minute cadence: WC-A69BCABB ran `sweep` five times and never reached
+// `raise` or `decide`.
+//
+// It also looked healthy. `action: dispatch_agent` reads as success on every
+// surface; only the stage histogram showed the loop.
+//
+// This is the eleventh read-with-no-writer in this program, so the correlation
+// key gets a single builder used by BOTH the dispatch and the lookup — writer
+// and reader drift is the exact failure this keeps taking.
+
+/** The ScheduledAgentTask/TaskRun title for a room's stage.
+ *
+ *  The ONLY correlation between a dispatch and its completed run. Used by the
+ *  dispatcher when it creates the task and by the receipt reader when it looks
+ *  for completion; if these two ever disagree, stages silently stop advancing
+ *  again. One function, two callers, no drift. */
+export function workroomStageTaskTitle(capsuleId: string, stageKey: string): string {
+  return `Workroom ${capsuleId} / ${stageKey}`;
+}
+
+export type StageReceipt = {
+  stageKey: string;
+  kind: string;
+};
+
+export type CompletedRun = {
+  title: string;
+  status: string;
+};
+
+/** Receipt kind recorded when a dispatched stage's own task run completes. */
+export const STAGE_COMPLETION_RECEIPT_KIND = "stage-run-completed";
+
+/**
+ * Whether the room's current stage has now earned a receipt.
+ *
+ * ONLY a completed run earns one. A failed or still-working run earns nothing,
+ * so the stage stays current and is re-dispatched next tick — which is the
+ * correct retry, and keeps a failure from being laundered into progress.
+ */
+export function stageRunCompleted(input: {
+  capsuleId: string;
+  currentStageKey: string | null;
+  runs: readonly CompletedRun[];
+}): boolean {
+  if (!input.currentStageKey) return false;
+  const title = workroomStageTaskTitle(input.capsuleId, input.currentStageKey);
+  return input.runs.some((run) => run.title === title && run.status === "completed");
+}
+
+/**
+ * The room's receipts after this tick's observation.
+ *
+ * Idempotent: a stage that already holds a receipt does not gain a second.
+ * Returns the SAME array reference when nothing changed, so a caller can cheaply
+ * tell whether a write is needed.
+ */
+export function earnStageReceipts(input: {
+  capsuleId: string;
+  currentStageKey: string | null;
+  runs: readonly CompletedRun[];
+  existing: readonly StageReceipt[];
+}): readonly StageReceipt[] {
+  if (!input.currentStageKey) return input.existing;
+  if (input.existing.some((receipt) => receipt.stageKey === input.currentStageKey)) {
+    return input.existing;
+  }
+  if (!stageRunCompleted(input)) return input.existing;
+  return [
+    ...input.existing,
+    { stageKey: input.currentStageKey, kind: STAGE_COMPLETION_RECEIPT_KIND },
+  ];
+}
+
+/**
+ * Receipts carried into the next tick.
+ *
+ * A cycle is one pass through the shape. When the cycle rolls over the room
+ * starts its stages again, so last cycle's receipts must not satisfy this
+ * cycle's stages — otherwise a daily watch would run once and then skip every
+ * stage forever, which is the same defect inverted.
+ *
+ * ⟦runtime: at the exact tick a cycle rolls over, resolution has already run
+ * against the previous cycle's receipts, so a room can advance one stage early
+ * at the boundary. Bounded and self-correcting (the next tick resolves against
+ * the cleared set); noted rather than gold-plated because the alternative is
+ * deriving the cycle key in a second place — BI-76B35820⟧
+ */
+export function carryReceipts(input: {
+  receipts: readonly StageReceipt[];
+  previousCycleKey: string | null;
+  currentCycleKey: string | null;
+}): readonly StageReceipt[] {
+  if (input.currentCycleKey === null) return input.receipts;
+  if (input.previousCycleKey === null) return input.receipts;
+  return input.currentCycleKey === input.previousCycleKey ? input.receipts : [];
+}

--- a/apps/web/lib/work-management/workroom-drive-state.test.ts
+++ b/apps/web/lib/work-management/workroom-drive-state.test.ts
@@ -11,6 +11,7 @@ describe("readStoredWorkroomDriveState", () => {
         budgetUsage: [{ kind: "findings-per-run", used: 4 }, { kind: "bad", used: "4" }],
         stopConditionHits: ["substrate-failed", 2],
         reviewDue: true,
+        lastCycleKey: null,
       },
     })).toEqual({
       currentStageKey: "raise",
@@ -18,6 +19,7 @@ describe("readStoredWorkroomDriveState", () => {
       budgetUsage: [{ kind: "findings-per-run", used: 4 }],
       stopConditionHits: ["substrate-failed"],
       reviewDue: true,
+      lastCycleKey: null,
     });
   });
 
@@ -28,6 +30,7 @@ describe("readStoredWorkroomDriveState", () => {
       budgetUsage: [],
       stopConditionHits: [],
       reviewDue: false,
+      lastCycleKey: null,
     });
   });
 });

--- a/apps/web/lib/work-management/workroom-drive-state.ts
+++ b/apps/web/lib/work-management/workroom-drive-state.ts
@@ -6,6 +6,9 @@ export type StoredWorkroomDriveState = {
   budgetUsage: { kind: string; used: number }[];
   stopConditionHits: string[];
   reviewDue: boolean;
+  /** The cycle the stored receipts belong to. A rollover clears them, so last
+   *  cycle's receipts cannot satisfy this cycle's stages (BI-76B35820). */
+  lastCycleKey: string | null;
 };
 
 /** Read only verifier-relevant observations from the persisted runner snapshot. */
@@ -36,5 +39,6 @@ export function readStoredWorkroomDriveState(workspaceState: unknown): StoredWor
       ? drive.stopConditionHits.filter((entry): entry is string => typeof entry === "string")
       : [],
     reviewDue: drive?.reviewDue === true,
+    lastCycleKey: typeof drive?.lastCycleKey === "string" ? drive.lastCycleKey : null,
   };
 }

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -616,6 +616,42 @@ nobody needing to remember.
 
 `unknown` still blocks. Only `eligible` and `not-applicable` satisfy the gate.
 
+## A completed stage earns a receipt
+
+`nextStageKey` advances only when the current stage holds a receipt. Receipts were
+READ in three places — the drive state reader, the plan resolver, the conformance
+observation — and WRITTEN in none. Always `[]`, so every room re-dispatched its
+first stage on every tick, forever.
+
+Measured on this install once the rooms started dispatching: twelve rooms,
+`COUNT(DISTINCT stageKey) = 1` on all of them, and 15-28 completed task runs each
+of that one stage. `WC-A69BCABB` ran `sweep` 28 times and never reached `raise`
+or `decide`.
+
+Three things made it hard to see:
+
+- **It looks healthy.** `action: dispatch_agent` on every room reads as success.
+  Only the stage histogram shows the loop.
+- **Real work happens.** The coworkers ran and completed. Nothing errored.
+- **The stall source does not cover it.** `workroom-stall` watches
+  `{pause, escalate}`; a room looping on stage one is dispatching, so it raises
+  no attention. An estate can burn model capacity indefinitely while every
+  surface is green.
+
+The rules:
+
+- **Only a completed run earns a receipt.** A failed or working run earns
+  nothing, so the stage stays current and re-dispatches — the correct retry, and
+  it keeps a failure from being laundered into progress.
+- **Earning is idempotent.** Twenty-eight completed sweeps produce one receipt.
+- **A cycle rollover clears them.** Otherwise a daily watch would run once and
+  then satisfy every stage forever from yesterday's receipts — the same defect
+  inverted.
+- **The correlation key has ONE builder.** `workroomStageTaskTitle` is used by
+  the dispatcher that writes the task title and by the reader that looks for its
+  completion. Writer/reader drift is precisely how this class of defect recurs,
+  so the two callers share the function rather than the format.
+
 ## Related references
 
 - [Workroom vocabulary boundary](workroom-vocabulary-boundary.md) — what the word means at each layer


### PR DESCRIPTION
## Rooms dispatch forever and never advance

`nextStageKey` advances only when the current stage holds a receipt. Receipts were **read** in three places — the drive state reader, the plan resolver, the conformance observation — and **written in none**. Always `[]`, so every room re-dispatched its first stage on every tick, forever.

Measured on this install once the rooms started dispatching:

```
capsule       stage      completed runs
WC-A69BCABB   sweep      28
WC-6159CC0E   read       27
WC-6F4AE604   scan       27
WC-9B26C12E   classify   27
WC-C9ECBE09   read       27
WC-C9320161   assemble   25
WC-D40E9C3C   draft      25
WC-0A92C30D   read       24
WC-2845744F   sync       23
WC-12224280   measure    19
WC-21EBAD7B   read       15
WC-B02C8BFA   read       15
```

`COUNT(DISTINCT stageKey) = 1` on all twelve. `WC-A69BCABB` ran `sweep` 28 times and never reached `raise` or `decide`. `dependency-advisory-watch` exists to sweep advisories **and** raise findings **and** hand over the accept/patch/defer decision — it did step one, repeatedly, at a 15-minute cadence.

## Why it was hard to see

- **It looks healthy.** `action: dispatch_agent` on every room reads as success. Only the stage histogram shows the loop.
- **Real work happens.** The coworkers ran and completed. Nothing errored.
- **The stall source doesn't cover it.** `workroom-stall` watches `{pause, escalate}` — a room looping on stage one is *dispatching*, so it raises no attention. The estate burned model capacity every quarter hour while every surface stayed green.

## The rules

- **Only a completed run earns a receipt.** A failed or working run earns nothing, so the stage stays current and re-dispatches — the correct retry, and it stops a failure being laundered into progress.
- **Earning is idempotent.** 28 completed sweeps produce one receipt.
- **A cycle rollover clears receipts.** Otherwise a daily watch runs once and then satisfies every stage forever from yesterday's — the same defect inverted.
- **The correlation key has one builder.** `workroomStageTaskTitle` is used by the dispatcher that writes the task title *and* by the reader that looks for its completion. This is the eleventh read-with-no-writer in this program, and writer/reader drift is exactly how the class recurs — so the two callers share a function rather than a format.

## Verified

Title parse checked against the live database: it resolves all twelve rooms to their real completed runs (table above is that query's output).

**Known boundary, recorded in the code rather than gold-plated:** at the exact tick a cycle rolls over, resolution has already run against the previous cycle's receipts, so a room can advance one stage early. Bounded and self-correcting on the next tick; the alternative was deriving the cycle key in a second place.

## Design grounding

- Reviewed: `docs/superpowers/specs/2026-09-03-coordinated-workrooms-design.md` (source of truth), `work-shapes-and-the-decision-gate.md`, `drive-resolution.ts` (`nextStageKey`), `workroom-drive-state.ts`, `workroom-drive.ts`
- Decision: defect fix within the existing design; no new spec, no new contract. The receipt shape already existed — this gives it its first writer.

## Verification

- 65 pregate preflight guards clean
- 896 tests pass (104 files) — 13 new; two existing stored-state assertions updated for the added `lastCycleKey`
- `tsc --noEmit`: exit 0
- Live-database correlation verified

**The heavy local-CI build was NOT run and is NOT passed** — fenced on `host-capacity-lost:host-memory-low`. Recorded `operator-emergency` override; cloud merge queue is the adjudicating build per AGENTS.md §4.

`BI-76B35820`

Local-CI-Override: operator-emergency: heavy build unrun (NOT passed) — local-CI fenced on host-capacity-lost:host-memory-low. Fast tier clean (65 preflight guards, 896 tests, tsc --noEmit exit 0, live-database correlation). Cloud merge queue is the adjudicating build per AGENTS.md 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
