### PR TITLE
fix(install): a reinstall dumps the live database before destroying it, and the backlog bundle carries the Workrooms (BI-F9939341)

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1283,6 +1283,10 @@
     "docs/testing/ci-observation-baseline.json": [
       "docs/testing/ci-evidence.md"
     ],
+    "dpf-reinstall.ps1": [
+      "docs/install/windows.md",
+      "docs/operations/disaster-recovery.md"
+    ],
     "dpf-start.ps1": [
       "docs/runbooks/bet5-windows-self-upgrade.md"
     ],
@@ -1740,6 +1744,7 @@
     ],
     "scripts/fresh-install.ps1": [
       "docs/install/scratch-install-rehearsal.md",
+      "docs/operations/disaster-recovery.md",
       "docs/testing/archetype-audit-plan.md"
     ],
     "scripts/gate-worktree.mjs": [
@@ -2778,6 +2783,9 @@
       "apps/web/scripts/issue-edge-bootstrap-token.ts",
       "services/edge-node/scripts/verify-lifecycle.ts"
     ],
+    "docs/install/windows.md": [
+      "dpf-reinstall.ps1"
+    ],
     "docs/install/worktree-janitor-schedule.md": [
       "scripts/install-worktree-janitor-schedule.sh",
       "scripts/worktree-janitor.mjs"
@@ -2820,8 +2828,10 @@
     "docs/operations/disaster-recovery.md": [
       "docker-compose.dev-against-live-db.yml",
       "docker-compose.yml",
+      "dpf-reinstall.ps1",
       "packages/db/src/seed-platform-backup.ts",
       "scripts/backup-postgres.sh",
+      "scripts/fresh-install.ps1",
       "scripts/restore-postgres.sh"
     ],
     "docs/operations/install.md": [

--- a/docs/install/scratch-install-rehearsal.md
+++ b/docs/install/scratch-install-rehearsal.md
@@ -2,7 +2,7 @@
 
 Use this rehearsal before promoting changes that affect install, setup, provider authorization, Build Studio, Work Capsules, sandbox promotion, or platform shell routing.
 
-The rehearsal is intentionally separate from `scripts/fresh-install.ps1`. The fresh-install script resets the local developer stack. The scratch rehearsal creates an isolated git worktree and Docker Compose project so first-run behavior can be checked beside the real install.
+The rehearsal is intentionally separate from `scripts/fresh-install.ps1`. The fresh-install script resets the local developer stack, and since BI-F9939341 it takes a full `pg_dump` into `$DPF_BACKUPS_HOST_PATH\pre-destructive\<date>resh-install-<ts>\` before `docker compose down -v`, refusing to continue if that dump fails (`-SkipPreDestructiveDump` overrides at the cost of every unmirrored row). The scratch rehearsal creates an isolated git worktree and Docker Compose project so first-run behavior can be checked beside the real install.
 
 ## What It Proves
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -217,9 +217,16 @@ uninstall, or a volume removal destroys them. Capture them first:
 pnpm --filter @dpf/db backlog:capture -- --out D:\DPF-backups\backlog\capture
 ```
 
-That writes one recovery bundle per epic, a manifest, and a list of anything it
-could not represent. Restore on another installation with
-`pnpm --filter @dpf/db backlog:reconcile -- <bundle.json> --apply`.
+That writes one recovery bundle per epic, a manifest, `workrooms.json` (the
+Workroom rows that bind each item to its branch, worktree, lease and evidence),
+and a list of anything it could not represent. Restore on another installation
+with `pnpm --filter @dpf/db backlog:reconcile -- <bundle.json> --apply`.
+
+`dpf-reinstall.ps1` and `scripts\fresh-install.ps1` also take a full `pg_dump`
+into `D:\DPF-backups\pre-destructive\<date>\` immediately before they run
+`docker compose down -v`, and refuse to continue if that dump fails.
+`-SkipPreDestructiveDump` is the only way past, and it costs every row that is
+not mirrored elsewhere (BI-F9939341).
 
 ## Docker memory
 

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -9,6 +9,8 @@ relatedCode:
   - packages/db/src/seed-platform-backup.ts
   - scripts/backup-postgres.sh
   - scripts/restore-postgres.sh
+  - dpf-reinstall.ps1
+  - scripts/fresh-install.ps1
 ---
 
 # Disaster recovery runbook
@@ -36,6 +38,7 @@ The DR-hardening epic (BIs shipped 2026-05-24) put recovery artifacts in **speci
 | Postgres rows (current state) | `$DPF_BACKUPS_HOST_PATH/postgres/<YYYY-MM-DDTHH-MM-SSZ>/dpf.dump` — nightly at 03:00 UTC | Admin UI `/admin/backups` → "Restore" wizard, OR `docker exec -i dpf-postgres-1 pg_restore --clean --if-exists -U dpf -d dpf < <dump>` |
 | Graph topology + vector/semantic memory | **Inside the Postgres dump above** — since BET-5 these are the `graph_node` / `graph_edge` tables and `pgvector` embeddings, not separate stores | Same Postgres restore; there is no separate graph or vector member to restore |
 | Postgres state from JUST BEFORE a destructive action | `$DPF_BACKUPS_HOST_PATH/pre-destructive/<date>/docker-volume-rm-pgdata-<ts>.dump` (or similar fingerprint per action) | Same restore wizard; treats it as any other dump |
+| Postgres state from JUST BEFORE `dpf-reinstall.ps1` or `scripts/fresh-install.ps1` ran `docker compose down -v` | `$DPF_BACKUPS_HOST_PATH/pre-destructive/<date>/dpf-reinstall-<ts>/dpf.dump` (or `fresh-install-<ts>/`), with `dpf.dump.sha256` and `manifest.json` beside it. Both scripts refuse to destroy the database if this dump fails; `-SkipPreDestructiveDump` is the only way past, and it says what it costs. This is what keeps Workrooms, decisions and unmirrored backlog rows alive across a reinstall (BI-F9939341). | Same restore wizard, or `docker exec -i dpf-postgres-1 pg_restore --clean --if-exists -U dpf -d dpf < dpf.dump` |
 | Uncommitted git work before `git reset --hard` | `git stash list` shows entries named `pre-destructive-snapshot <ts> <fingerprint>` | `git stash pop stash@{N}` |
 | `.env` + `.claude/settings.local.json` before install-dir rm | `$DPF_BACKUPS_HOST_PATH/pre-destructive/<date>/remove-item-recurse-*.essentials.zip` | `Expand-Archive <zip> -DestinationPath $DPF_DIR` |
 | Recent Claude Code session transcripts | `$DPF_BACKUPS_HOST_PATH/session-transcripts/<YYYY-MM-DD>/<session-id>.jsonl` — every PostToolUse (throttled to 2 min) + every SessionEnd | Copy back to `~/.claude/projects/D--DPF/<session-id>.jsonl`, then `/resume <session-id>` in Claude Code |

--- a/dpf-reinstall.ps1
+++ b/dpf-reinstall.ps1
@@ -8,8 +8,12 @@
 # What this does:
 #   1. Checks for uncommitted changes (warns you before destroying anything)
 #   2. Closes VS Code if it has the directory locked
-#   3. Stops all DPF Docker containers
-#   4. Removes all DPF Docker volumes (including PostgreSQL)
+#   3. Dumps the live PostgreSQL database to $DPF_DIR-backups\pre-destructive\
+#      (Workrooms, decisions and backlog rows survive the reinstall as a
+#      restorable pg_dump; BI-F9939341). Refuses to continue if the dump fails
+#      unless -SkipPreDestructiveDump is passed.
+#   4. Stops all DPF Docker containers and removes all DPF Docker volumes
+#      (including PostgreSQL)
 #   5. Removes DPF Docker images
 #   6. Removes bind-mount data directories
 #   7. Migrates any legacy in-tree backups under $DPF_DIR\backups\ to the
@@ -25,6 +29,7 @@
 
 param(
     [string]$InstallDir,
+    [switch]$SkipPreDestructiveDump,  # accept losing every unmirrored DB row
     [switch]$FromTemp  # internal flag -- do not use directly
 )
 
@@ -49,7 +54,7 @@ if (-not $FromTemp) {
     Copy-Item $MyInvocation.MyCommand.Definition $tempScript -Force
     Write-Host ""
     Write-Host "Re-launching from $tempScript so the project directory can be deleted..." -ForegroundColor Cyan
-    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $tempScript -InstallDir $DPF_DIR -FromTemp
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $tempScript -InstallDir $DPF_DIR -FromTemp -SkipPreDestructiveDump:$SkipPreDestructiveDump
     exit $LASTEXITCODE
 }
 
@@ -141,6 +146,84 @@ if ($vscodeLocked) {
     }
 } else {
     Write-Ok "No VS Code lock detected"
+}
+
+# --- Pre-destructive Postgres dump -----------------------------------------
+# `docker compose down -v` below destroys the database, and with it every
+# Workroom, decision and backlog row that is not already mirrored elsewhere
+# (BI-F9939341). The nightly backup is hours old and the backlog bundle does
+# not run from a consumer install, so the only honest move is to dump the live
+# database right here, right before the volume goes. The dump lands under the
+# operator backup root (outside the install directory) so the rm cannot touch
+# it, and restores with the same pg_restore the DR runbook documents.
+function Invoke-PreDestructivePostgresDump {
+    param(
+        [Parameter(Mandatory = $true)][string]$InstallDir,
+        [Parameter(Mandatory = $true)][string]$Trigger,
+        [switch]$Skip
+    )
+    if ($Skip) {
+        Write-Warn "Pre-destructive Postgres dump SKIPPED by -SkipPreDestructiveDump. Every row not already mirrored is gone after this step."
+        return $null
+    }
+    $pgUser = "dpf"; $pgDb = "dpf"; $container = "dpf-postgres-1"; $backupsRoot = $null
+    $envPath = Join-Path $InstallDir ".env"
+    if (Test-Path $envPath) {
+        foreach ($line in Get-Content $envPath) {
+            if ($line -match '^DPF_BACKUPS_HOST_PATH=(.+)$') { $backupsRoot = $Matches[1].Trim().Trim('"').Trim("'") }
+            elseif ($line -match '^POSTGRES_USER=(.+)$') { $pgUser = $Matches[1].Trim().Trim('"').Trim("'") }
+            elseif ($line -match '^POSTGRES_DB=(.+)$') { $pgDb = $Matches[1].Trim().Trim('"').Trim("'") }
+            elseif ($line -match '^DPF_PRODUCTION_DB_CONTAINER=(.+)$') { $container = $Matches[1].Trim().Trim('"').Trim("'") }
+        }
+    }
+    if (-not $backupsRoot) { $backupsRoot = "$InstallDir-backups" }
+
+    $running = docker ps --filter "name=^$container$" --format "{{.Names}}" 2>$null
+    if (-not $running) {
+        Write-Ok "No running Postgres container ($container); nothing to dump before teardown."
+        return $null
+    }
+
+    $now = (Get-Date).ToUniversalTime()
+    $target = Join-Path $backupsRoot ("pre-destructive\" + $now.ToString("yyyy-MM-dd") + "\" + $Trigger + "-" + $now.ToString("yyyy-MM-ddTHH-mm-ssZ"))
+    New-Item -ItemType Directory -Force -Path $target | Out-Null
+    $dump = Join-Path $target "dpf.dump"
+    Write-Host "  Dumping $pgDb from $container to $dump ..."
+    # cmd.exe redirection keeps the custom-format dump byte-exact; PowerShell
+    # redirection would re-encode it as text and corrupt it.
+    & cmd.exe /c "docker exec $container pg_dump -U $pgUser -Fc $pgDb > `"$dump`""
+    $exit = $LASTEXITCODE
+    $size = if (Test-Path $dump) { (Get-Item $dump).Length } else { 0 }
+    if ($exit -ne 0 -or $size -eq 0) {
+        if (Test-Path $dump) { Remove-Item $dump -Force }
+        Write-Fail "Pre-destructive Postgres dump FAILED (pg_dump exit=$exit, bytes=$size). Refusing to destroy the database. Fix the dump (is $container healthy? is $backupsRoot writable?) and re-run; pass -SkipPreDestructiveDump only if losing every unmirrored Workroom, decision and backlog row is acceptable."
+    }
+    $sha = (Get-FileHash -Path $dump -Algorithm SHA256).Hash.ToLower()
+    # LF-terminated so `sha256sum -c dpf.dump.sha256` works on any host (Set-Content would write CRLF).
+    [System.IO.File]::WriteAllText((Join-Path $target "dpf.dump.sha256"), "$sha  dpf.dump`n")
+    $manifest = [ordered]@{
+        schemaVersion = 1
+        trigger       = $Trigger
+        capturedAt    = $now.ToString("yyyy-MM-ddTHH:mm:ssZ")
+        container     = $container
+        database      = $pgDb
+        dumpFormat    = "pg_dump -Fc"
+        sizeBytes     = $size
+        sha256        = $sha
+        restore       = "docker exec -i <postgres> pg_restore --clean --if-exists -U $pgUser -d $pgDb < dpf.dump  (or /admin/backups -> Restore)"
+    }
+    ($manifest | ConvertTo-Json) | Set-Content -Path (Join-Path $target "manifest.json") -Encoding UTF8
+    Write-Ok ("Pre-destructive dump saved: {0} ({1:N1} MB, sha256 {2}...)" -f $dump, ($size / 1MB), $sha.Substring(0, 12))
+    return $target
+}
+
+# --- Step 2c: Dump the live database before anything destroys it ------------
+
+Write-Step "Preserving the live database (pre-destructive dump)"
+if (Test-Path "$DPF_DIR\docker-compose.yml") {
+    $preDestructiveDump = Invoke-PreDestructivePostgresDump -InstallDir $DPF_DIR -Trigger "dpf-reinstall" -Skip:$SkipPreDestructiveDump
+} else {
+    Write-Ok "No docker-compose.yml in $DPF_DIR; no database to preserve."
 }
 
 # --- Step 3: Stop Docker containers and remove volumes ---------------------

--- a/packages/db/scripts/capture-backlog-bundle.ts
+++ b/packages/db/scripts/capture-backlog-bundle.ts
@@ -5,7 +5,11 @@
 // a bundle, but nothing produced one, so work created on a development
 // installation had no path off it before teardown. This closes that loop.
 //
-// Writes one bundle per epic (the bundle schema is single-epic), plus a manifest.
+// Writes one bundle per epic (the bundle schema is single-epic), plus a manifest,
+// plus `workrooms.json`: the Workroom rows that bind each item to a branch,
+// worktree and evidence trail. Those rows live only in Postgres and a reinstall
+// destroys them (BI-F9939341); without them the backlog comes back but nobody
+// can tell which worktree on disk carries which item.
 // Everything it cannot represent is listed, never silently dropped.
 
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
@@ -13,8 +17,10 @@ import { resolve } from "node:path";
 
 import {
   buildBacklogRecoveryBundle,
+  buildWorkroomCaptureRecord,
   type BacklogCaptureItemRow,
   type BacklogCaptureSkip,
+  type WorkroomCaptureRow,
 } from "../src/backlog-recovery-bundle";
 import { prisma } from "../src/client";
 
@@ -29,7 +35,8 @@ function usage(): string {
   return [
     "Usage: pnpm --filter @dpf/db backlog:capture -- --out <dir> [--all] [--no-receipt]",
     "",
-    "Captures every not-done backlog item as reconcilable recovery bundles.",
+    "Captures every not-done backlog item as reconcilable recovery bundles, and every",
+    "non-archived Workroom (branch, worktree, lease, evidence) into workrooms.json.",
     "  --out <dir>    Directory to write bundles into (required).",
     "  --all          Include done items too, not just work that is not done.",
     "  --no-receipt   Do not record the capture receipt in PlatformConfig.",
@@ -38,7 +45,10 @@ function usage(): string {
   ].join("\n");
 }
 
-function parseArgs(argv: string[]): { out: string; all: boolean; receipt: boolean } {
+function parseArgs(rawArgv: string[]): { out: string; all: boolean; receipt: boolean } {
+  // `pnpm run script -- --out x` forwards the literal `--` on some pnpm versions;
+  // it is a separator, not an option, and used to abort the whole capture.
+  const argv = rawArgv.filter((arg) => arg !== "--");
   if (argv.includes("--help") || argv.includes("-h")) {
     process.stdout.write(`${usage()}\n`);
     process.exit(0);
@@ -76,7 +86,7 @@ function epicDescription(epic: { description?: string | null; title: string }): 
 }
 
 /** Files in the output directory that are records, not single-epic bundles. */
-const NON_BUNDLE_FILES = new Set(["manifest.json", "unassigned-items.json"]);
+const NON_BUNDLE_FILES = new Set(["manifest.json", "unassigned-items.json", "workrooms.json"]);
 
 /**
  * Map each epic to the bundle file already committed for it.
@@ -185,13 +195,28 @@ async function main(): Promise<void> {
 
   for (const epic of epics) {
     if (epic.items.length === 0) continue;
+    // The bundle contract requires a non-empty body, and one body-less item used
+    // to abort the ENTIRE capture (observed 2026-09-06: every other epic's work
+    // lost with it). The title describes the item as truthfully as anything
+    // available, so fall back to it rather than refuse to back up.
     const items = epic.items.map(
-      (item) => ({ ...item, epicId: epic.epicId }) as unknown as BacklogCaptureItemRow,
+      (item) =>
+        ({
+          ...item,
+          body: item.body?.trim() ? item.body : item.title,
+          epicId: epic.epicId,
+        }) as unknown as BacklogCaptureItemRow,
     );
     // Refreshing an epic keeps the identity and curation of its committed
     // bundle; only a genuinely new epic gets generated defaults.
     const prior = existing.get(epic.epicId);
-    const result = buildBacklogRecoveryBundle({
+    // One epic the bundle format cannot represent (a mirrored epic whose id is
+    // not EP-*, for example) must not abort every other epic's capture. It is
+    // listed under `skipped` with the contract violation, never dropped in
+    // silence — the manifest closes against unfinishedItemCount either way.
+    let result: ReturnType<typeof buildBacklogRecoveryBundle>;
+    try {
+      result = buildBacklogRecoveryBundle({
       bundleId: prior?.bundleId || `capture-${epic.epicId.toLowerCase()}`,
       description:
         prior?.description || `Backlog captured from this installation on ${capturedAt}.`,
@@ -207,6 +232,13 @@ async function main(): Promise<void> {
       epic: { ...epic, epicId: epic.epicId, description: epicDescription(epic) } as never,
       items,
     });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      for (const item of items) {
+        skipped.push({ itemId: item.itemId, reason: "epic-not-representable", detail });
+      }
+      continue;
+    }
     skipped.push(...result.skipped);
     if (!result.bundle) continue;
 
@@ -262,6 +294,59 @@ async function main(): Promise<void> {
     where: { status: { in: [...NOT_DONE_STATUSES] } },
   });
 
+  // Workrooms: what binds a backlog item to a branch, a worktree, a lease and
+  // its evidence. Archived rooms are the only ones left out by default; complete
+  // and abandoned rooms stay because their branch dispositions ARE the record
+  // (BI-F9939341). --all captures archived rooms too.
+  const workroomRows = await prisma.workroom.findMany({
+    where: args.all ? undefined : { status: { not: "archived" } },
+    orderBy: { capsuleId: "asc" },
+    select: {
+      capsuleId: true,
+      title: true,
+      objective: true,
+      status: true,
+      source: true,
+      executorKind: true,
+      executorRef: true,
+      backlogItemId: true,
+      epicId: true,
+      repositoryFullName: true,
+      baseBranch: true,
+      baseSha: true,
+      headBranch: true,
+      headSha: true,
+      worktreePath: true,
+      pullRequestUrl: true,
+      pullRequestNumber: true,
+      contributionMode: true,
+      branchTaxonomy: true,
+      idempotencyKey: true,
+      scopeClaims: true,
+      workspaceState: true,
+      verificationState: true,
+      leaseHolderPrincipalId: true,
+      createdAt: true,
+      updatedAt: true,
+      lastSyncedAt: true,
+      archivedAt: true,
+      activities: {
+        orderBy: { recordedAt: "asc" },
+        select: { id: true, kind: true, summary: true, payload: true, recordedAt: true },
+      },
+    },
+  });
+  const workrooms = buildWorkroomCaptureRecord(
+    workroomRows as unknown as WorkroomCaptureRow[],
+    capturedAt,
+  );
+  await writeFile(
+    resolve(args.out, "workrooms.json"),
+    `${JSON.stringify(workrooms, null, 2)}
+`,
+    "utf8",
+  );
+
   const manifest = {
     schemaVersion: 1,
     capturedAt,
@@ -270,6 +355,9 @@ async function main(): Promise<void> {
     capturedItemCount: capturedItems,
     unassignedItemCount: orphans.length,
     unfinishedItemCount,
+    workroomCount: workrooms.workroomCount,
+    workroomBoundBranchCount: workrooms.boundBranchCount,
+    workroomOpenCount: workrooms.openCount,
     skipped,
   };
   await writeFile(
@@ -286,6 +374,7 @@ async function main(): Promise<void> {
       bundlePath: args.out,
       itemCount: capturedItems,
       unfinishedItemCount,
+      workroomCount: workrooms.workroomCount,
     };
     await prisma.platformConfig.upsert({
       where: { key: CAPTURE_CONFIG_KEY },
@@ -298,6 +387,7 @@ async function main(): Promise<void> {
     [
       `Captured ${capturedItems} item(s) across ${written.length} bundle(s) into ${args.out}`,
       `Not-done items on this installation: ${unfinishedItemCount}`,
+      `Workrooms captured: ${workrooms.workroomCount} (${workrooms.boundBranchCount} bound to a branch, ${workrooms.openCount} open) -> workrooms.json`,
       orphans.length
         ? `Wrote ${orphans.length} item(s) with no epic to unassigned-items.json (not reconcilable — re-file them under an epic).`
         : "No items without an epic.",

--- a/packages/db/src/backlog-recovery-bundle.ts
+++ b/packages/db/src/backlog-recovery-bundle.ts
@@ -401,7 +401,9 @@ export async function reconcileBacklogRecoveryBundle(
 /** An item the capture could not represent, and why. Never silently dropped. */
 export interface BacklogCaptureSkip {
   itemId: string;
-  reason: "done-item-has-no-evidence-activity" | "item-has-no-epic";
+  reason: "done-item-has-no-evidence-activity" | "item-has-no-epic" | "epic-not-representable";
+  /** For `epic-not-representable`: the contract violation the bundle format raised. */
+  detail?: string;
 }
 
 /**
@@ -677,4 +679,113 @@ export function buildBacklogRecoveryBundle(input: {
 
   // Round-trip so an unreconcilable bundle fails at capture, not at recovery.
   return { bundle: parseBacklogRecoveryBundle(bundle), skipped };
+}
+
+// ── Workroom capture ─────────────────────────────────────────────────────────
+//
+// A backlog bundle preserves WHAT was asked for. It says nothing about WHERE the
+// work is: the Workroom rows that bind a backlog item to a branch, a worktree, a
+// lease holder and the evidence recorded along the way live only in Postgres and
+// die with it on reinstall (BI-F9939341). The teardown stance calls that work
+// "irreplaceable" and asks for a bundle before teardown, so the bundle has to
+// carry the Workrooms too. This record is a faithful, non-reconcilable capture:
+// a later slice rebinds it to worktrees that still exist on disk.
+
+export interface WorkroomCaptureActivityRow {
+  id: string;
+  kind: string;
+  summary: string;
+  payload: unknown;
+  recordedAt: Date | string;
+}
+
+export interface WorkroomCaptureRow {
+  capsuleId: string;
+  title: string;
+  objective: string;
+  status: string;
+  source: string;
+  executorKind: string | null;
+  executorRef: string | null;
+  backlogItemId: string | null;
+  epicId: string | null;
+  repositoryFullName: string | null;
+  baseBranch: string | null;
+  baseSha: string | null;
+  headBranch: string | null;
+  headSha: string | null;
+  worktreePath: string | null;
+  pullRequestUrl: string | null;
+  pullRequestNumber: number | null;
+  contributionMode: string | null;
+  branchTaxonomy: string | null;
+  idempotencyKey: string | null;
+  scopeClaims: unknown;
+  workspaceState: unknown;
+  verificationState: unknown;
+  leaseHolderPrincipalId: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+  lastSyncedAt: Date | string | null;
+  archivedAt: Date | string | null;
+  activities: WorkroomCaptureActivityRow[];
+}
+
+export interface WorkroomCaptureRecord {
+  schemaVersion: 1;
+  capturedAt: string;
+  /** Every Workroom in the record. */
+  workroomCount: number;
+  /** Workrooms that name a branch — the ones a reinstall would otherwise orphan on disk. */
+  boundBranchCount: number;
+  /** Workrooms in a non-terminal status: the work someone would still expect to find. */
+  openCount: number;
+  workrooms: Array<
+    Omit<WorkroomCaptureRow, "createdAt" | "updatedAt" | "lastSyncedAt" | "archivedAt" | "activities"> & {
+      createdAt: string;
+      updatedAt: string;
+      lastSyncedAt: string | null;
+      archivedAt: string | null;
+      activities: Array<Omit<WorkroomCaptureActivityRow, "recordedAt"> & { recordedAt: string }>;
+    }
+  >;
+}
+
+const TERMINAL_WORKROOM_STATUSES = new Set(["complete", "abandoned", "archived"]);
+
+function isoOrNull(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+/**
+ * Serialize Workroom rows into the bundle's `workrooms.json` record. Pure and
+ * deterministic: rows sort by `capsuleId`, activities by `recordedAt` then id,
+ * every date is ISO, and nothing is dropped — a Workroom with no branch is still
+ * a Workroom someone opened.
+ */
+export function buildWorkroomCaptureRecord(
+  rows: readonly WorkroomCaptureRow[],
+  capturedAt: string,
+): WorkroomCaptureRecord {
+  const workrooms = [...rows]
+    .sort((a, b) => a.capsuleId.localeCompare(b.capsuleId))
+    .map((row) => ({
+      ...row,
+      createdAt: isoOrNull(row.createdAt) as string,
+      updatedAt: isoOrNull(row.updatedAt) as string,
+      lastSyncedAt: isoOrNull(row.lastSyncedAt),
+      archivedAt: isoOrNull(row.archivedAt),
+      activities: [...row.activities]
+        .map((activity) => ({ ...activity, recordedAt: isoOrNull(activity.recordedAt) as string }))
+        .sort((a, b) => a.recordedAt.localeCompare(b.recordedAt) || a.id.localeCompare(b.id)),
+    }));
+  return {
+    schemaVersion: 1,
+    capturedAt,
+    workroomCount: workrooms.length,
+    boundBranchCount: workrooms.filter((room) => room.headBranch !== null && room.headBranch !== "").length,
+    openCount: workrooms.filter((room) => !TERMINAL_WORKROOM_STATUSES.has(room.status)).length,
+    workrooms,
+  };
 }

--- a/packages/db/src/installation-instance-stance.ts
+++ b/packages/db/src/installation-instance-stance.ts
@@ -124,7 +124,7 @@ function resolveTeardown(
     return {
       stance: "capture-required",
       rationale:
-        `This ${environmentClass} installation holds work that exists nowhere else, so capture a durable backlog bundle before any teardown.`,
+        `This ${environmentClass} installation holds work that exists nowhere else, so capture a durable backlog and Workroom bundle before any teardown.`,
     };
   }
   return {

--- a/packages/db/test/backlog-recovery-capture.test.ts
+++ b/packages/db/test/backlog-recovery-capture.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildBacklogRecoveryBundle,
+  buildWorkroomCaptureRecord,
   parseBacklogRecoveryBundle,
   type BacklogCaptureEpicRow,
   type BacklogCaptureItemRow,
+  type WorkroomCaptureRecord,
+  type WorkroomCaptureRow,
 } from "../src/backlog-recovery-bundle";
 
 const CAPTURED_AT = "2026-08-22T10:00:00.000Z";
@@ -236,5 +239,72 @@ describe("payload sanitisation", () => {
     });
     const payload = result.bundle?.items[0]?.activities[0]?.payload;
     expect(payload).toEqual({ note: "kept", nested: { detail: "also kept" } });
+  });
+});
+
+describe("buildWorkroomCaptureRecord", () => {
+  function room(overrides: Partial<WorkroomCaptureRow> = {}): WorkroomCaptureRow {
+    return {
+      capsuleId: "WC-00000001",
+      title: "Work on BI-TEST0001",
+      objective: "Claim-at-start binding for BI-TEST0001",
+      status: "working",
+      source: "external-adoption",
+      executorKind: "claude-desktop",
+      executorRef: "worktree:D:/DPF-worktrees/test",
+      backlogItemId: "BI-TEST0001",
+      epicId: "EP-TEST0001",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      baseBranch: "main",
+      baseSha: null,
+      headBranch: "fix/test",
+      headSha: "abc123",
+      worktreePath: "D:/DPF-worktrees/test",
+      pullRequestUrl: null,
+      pullRequestNumber: null,
+      contributionMode: "private",
+      branchTaxonomy: "fix",
+      idempotencyKey: null,
+      scopeClaims: [],
+      workspaceState: {},
+      verificationState: {},
+      leaseHolderPrincipalId: "principal-1",
+      createdAt: new Date("2026-09-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-09-02T00:00:00.000Z"),
+      lastSyncedAt: null,
+      archivedAt: null,
+      activities: [],
+      ...overrides,
+    };
+  }
+
+  it("keeps every Workroom, counts the branch-bound and open ones, and sorts deterministically", () => {
+    const record = buildWorkroomCaptureRecord(
+      [
+        room({ capsuleId: "WC-B", status: "abandoned", headBranch: null }),
+        room({
+          capsuleId: "WC-A",
+          activities: [
+            { id: "act-2", kind: "evidence", summary: "later", payload: {}, recordedAt: new Date("2026-09-02T00:00:00.000Z") },
+            { id: "act-1", kind: "claim", summary: "earlier", payload: { branch: "fix/test" }, recordedAt: new Date("2026-09-01T00:00:00.000Z") },
+          ],
+        }),
+      ],
+      CAPTURED_AT,
+    );
+
+    expect(record.schemaVersion).toBe(1);
+    expect(record.capturedAt).toBe(CAPTURED_AT);
+    expect(record.workroomCount).toBe(2);
+    expect(record.boundBranchCount).toBe(1);
+    expect(record.openCount).toBe(1);
+    expect(record.workrooms.map((r) => r.capsuleId)).toEqual(["WC-A", "WC-B"]);
+    expect(record.workrooms[0]?.activities.map((a) => a.id)).toEqual(["act-1", "act-2"]);
+    expect(record.workrooms[0]?.createdAt).toBe("2026-09-01T00:00:00.000Z");
+    expect(record.workrooms[1]?.headBranch).toBeNull();
+    // A JSON round-trip loses nothing the rebind slice will need.
+    const parsed = JSON.parse(JSON.stringify(record)) as WorkroomCaptureRecord;
+    expect(parsed.workrooms[0]?.worktreePath).toBe("D:/DPF-worktrees/test");
+    expect(parsed.workrooms[0]?.activities[0]?.payload).toEqual({ branch: "fix/test" });
   });
 });

--- a/scripts/fresh-install.ps1
+++ b/scripts/fresh-install.ps1
@@ -12,6 +12,7 @@
 
 param(
     [switch]$SkipDocker,
+    [switch]$SkipPreDestructiveDump,  # accept losing every unmirrored DB row
     [switch]$WithEdge
 )
 
@@ -21,6 +22,75 @@ function Write-Step($msg)  { Write-Host "`n $msg" -ForegroundColor Yellow }
 function Write-Ok($msg)    { Write-Host "   $msg" -ForegroundColor Green }
 function Write-Warn($msg)  { Write-Host "  ! $msg" -ForegroundColor Yellow }
 function Write-Fail($msg)  { Write-Host "   $msg" -ForegroundColor Red; exit 1 }
+
+# --- Pre-destructive Postgres dump -----------------------------------------
+# `docker compose down -v` below destroys the database, and with it every
+# Workroom, decision and backlog row that is not already mirrored elsewhere
+# (BI-F9939341). The nightly backup is hours old and the backlog bundle does
+# not run from a consumer install, so the only honest move is to dump the live
+# database right here, right before the volume goes. The dump lands under the
+# operator backup root (outside the install directory) so the rm cannot touch
+# it, and restores with the same pg_restore the DR runbook documents.
+function Invoke-PreDestructivePostgresDump {
+    param(
+        [Parameter(Mandatory = $true)][string]$InstallDir,
+        [Parameter(Mandatory = $true)][string]$Trigger,
+        [switch]$Skip
+    )
+    if ($Skip) {
+        Write-Warn "Pre-destructive Postgres dump SKIPPED by -SkipPreDestructiveDump. Every row not already mirrored is gone after this step."
+        return $null
+    }
+    $pgUser = "dpf"; $pgDb = "dpf"; $container = "dpf-postgres-1"; $backupsRoot = $null
+    $envPath = Join-Path $InstallDir ".env"
+    if (Test-Path $envPath) {
+        foreach ($line in Get-Content $envPath) {
+            if ($line -match '^DPF_BACKUPS_HOST_PATH=(.+)$') { $backupsRoot = $Matches[1].Trim().Trim('"').Trim("'") }
+            elseif ($line -match '^POSTGRES_USER=(.+)$') { $pgUser = $Matches[1].Trim().Trim('"').Trim("'") }
+            elseif ($line -match '^POSTGRES_DB=(.+)$') { $pgDb = $Matches[1].Trim().Trim('"').Trim("'") }
+            elseif ($line -match '^DPF_PRODUCTION_DB_CONTAINER=(.+)$') { $container = $Matches[1].Trim().Trim('"').Trim("'") }
+        }
+    }
+    if (-not $backupsRoot) { $backupsRoot = "$InstallDir-backups" }
+
+    $running = docker ps --filter "name=^$container$" --format "{{.Names}}" 2>$null
+    if (-not $running) {
+        Write-Ok "No running Postgres container ($container); nothing to dump before teardown."
+        return $null
+    }
+
+    $now = (Get-Date).ToUniversalTime()
+    $target = Join-Path $backupsRoot ("pre-destructive\" + $now.ToString("yyyy-MM-dd") + "\" + $Trigger + "-" + $now.ToString("yyyy-MM-ddTHH-mm-ssZ"))
+    New-Item -ItemType Directory -Force -Path $target | Out-Null
+    $dump = Join-Path $target "dpf.dump"
+    Write-Host "  Dumping $pgDb from $container to $dump ..."
+    # cmd.exe redirection keeps the custom-format dump byte-exact; PowerShell
+    # redirection would re-encode it as text and corrupt it.
+    & cmd.exe /c "docker exec $container pg_dump -U $pgUser -Fc $pgDb > `"$dump`""
+    $exit = $LASTEXITCODE
+    $size = if (Test-Path $dump) { (Get-Item $dump).Length } else { 0 }
+    if ($exit -ne 0 -or $size -eq 0) {
+        if (Test-Path $dump) { Remove-Item $dump -Force }
+        Write-Fail "Pre-destructive Postgres dump FAILED (pg_dump exit=$exit, bytes=$size). Refusing to destroy the database. Fix the dump (is $container healthy? is $backupsRoot writable?) and re-run; pass -SkipPreDestructiveDump only if losing every unmirrored Workroom, decision and backlog row is acceptable."
+    }
+    $sha = (Get-FileHash -Path $dump -Algorithm SHA256).Hash.ToLower()
+    # LF-terminated so `sha256sum -c dpf.dump.sha256` works on any host (Set-Content would write CRLF).
+    [System.IO.File]::WriteAllText((Join-Path $target "dpf.dump.sha256"), "$sha  dpf.dump`n")
+    $manifest = [ordered]@{
+        schemaVersion = 1
+        trigger       = $Trigger
+        capturedAt    = $now.ToString("yyyy-MM-ddTHH:mm:ssZ")
+        container     = $container
+        database      = $pgDb
+        dumpFormat    = "pg_dump -Fc"
+        sizeBytes     = $size
+        sha256        = $sha
+        restore       = "docker exec -i <postgres> pg_restore --clean --if-exists -U $pgUser -d $pgDb < dpf.dump  (or /admin/backups -> Restore)"
+    }
+    ($manifest | ConvertTo-Json) | Set-Content -Path (Join-Path $target "manifest.json") -Encoding UTF8
+    Write-Ok ("Pre-destructive dump saved: {0} ({1:N1} MB, sha256 {2}...)" -f $dump, ($size / 1MB), $sha.Substring(0, 12))
+    return $target
+}
 
 Write-Host ""
 Write-Host "  Open Digital Product Factory  Fresh Install (Windows)" -ForegroundColor Cyan
@@ -154,7 +224,10 @@ if (-not $SkipDocker) {
     Write-Step "Starting Docker services (PostgreSQL)"
 
     # Tear down any existing containers and volumes from a previous install
-    # so the database starts clean (required for onboarding to trigger).
+    # so the database starts clean (required for onboarding to trigger), but
+    # dump the live database first so nothing unmirrored is lost (BI-F9939341).
+    Write-Step "Preserving the live database (pre-destructive dump)"
+    $null = Invoke-PreDestructivePostgresDump -InstallDir $InstallRoot -Trigger "fresh-install" -Skip:$SkipPreDestructiveDump
     Write-Host "  Cleaning previous Docker state..."
     docker compose down -v 2>$null
 

--- a/scripts/lifecycle-surface-policy.mjs
+++ b/scripts/lifecycle-surface-policy.mjs
@@ -17,6 +17,31 @@ export const forbiddenOperationalPatterns = [
   { id: "neo4j-credential", pattern: /NEO4J_AUTH/ }, { id: "qdrant-env", pattern: /QDRANT_(?:URL|INTERNAL_URL)/ },
 ];
 
+// A lifecycle script that destroys the database must dump it first (BI-F9939341).
+// Workrooms, decisions and unmirrored backlog rows live only in Postgres; the
+// nightly backup is hours old and the backlog bundle does not run from a
+// consumer install, so `down -v` without a dump in the same script is data loss.
+// The prelude must be CALLED before the destructive line, not merely defined.
+export const destructivePreludes = [
+  { id: "reinstall-dumps-first", file: "dpf-reinstall.ps1", destructive: /^\s*docker compose down -v/, prelude: /Invoke-PreDestructivePostgresDump\s+-InstallDir/ },
+  { id: "fresh-install-dumps-first", file: "scripts/fresh-install.ps1", destructive: /^\s*docker compose down -v/, prelude: /Invoke-PreDestructivePostgresDump\s+-InstallDir/ },
+];
+
+/** Pure: the violations a single file's text raises against `destructivePreludes`. */
+export function findDestroyWithoutDump(file, text, preludes = destructivePreludes) {
+  const violations = [];
+  const lines = text.split(/\r?\n/);
+  for (const rule of preludes.filter((entry) => entry.file === file)) {
+    const destroyAt = lines.findIndex((line) => rule.destructive.test(line));
+    if (destroyAt === -1) continue;
+    const preludeAt = lines.findIndex((line) => rule.prelude.test(line) && !/^\s*function\b/.test(line));
+    if (preludeAt === -1 || preludeAt > destroyAt) {
+      violations.push({ file, line: destroyAt + 1, rule: rule.id, text: lines[destroyAt].trim() });
+    }
+  }
+  return violations;
+}
+
 // Compatibility exceptions must be exact and temporary. None are needed in the active surface today.
 export const legacyExceptions = [];
 export const expectedRemediation = [];
@@ -27,6 +52,7 @@ export async function auditLifecycleSurfaces(root) {
   const remediationHits = new Map(expectedRemediation.map((entry) => [entry.id, 0]));
   for (const file of activeLifecycleFiles) {
     const text = await readFile(resolve(root, file), "utf8");
+    violations.push(...findDestroyWithoutDump(file, text));
     for (const [index, line] of text.split(/\r?\n/).entries()) {
       for (const rule of forbiddenOperationalPatterns) {
         if (!rule.pattern.test(line)) continue;

--- a/scripts/lifecycle-surface-policy.test.mjs
+++ b/scripts/lifecycle-surface-policy.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { activeLifecycleFiles, assertHostStateWiring, auditLifecycleSurfaces, formatAuditFailure, legacyExceptions, promoterCopyInputs } from "./lifecycle-surface-policy.mjs";
+import { activeLifecycleFiles, assertHostStateWiring, auditLifecycleSurfaces, destructivePreludes, findDestroyWithoutDump, formatAuditFailure, legacyExceptions, promoterCopyInputs } from "./lifecycle-surface-policy.mjs";
 import { classifySensitivePath } from "./self-upgrade-sensitive-paths.mjs";
 import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
 
@@ -87,4 +87,29 @@ test("compose wires the resolved host state into portal and promoter", async () 
 test("upgrade-sensitive lifecycle entrypoints are owned by the N-1 classifier", () => {
   const runtimeEntrypoints = activeLifecycleFiles.filter((path) => /^(?:install-dpf|uninstall-dpf|dpf-reinstall|scripts\/(?:fresh-install|setup|verify-install|installer\/))/.test(path));
   assert.deepEqual(runtimeEntrypoints.filter((path) => !classifySensitivePath(path)), []);
+});
+
+test("a lifecycle script that destroys the database must call the pre-destructive dump first (BI-F9939341)", () => {
+  const file = "dpf-reinstall.ps1";
+  const dumpsFirst = [
+    "function Invoke-PreDestructivePostgresDump { param($InstallDir) }",
+    "$x = Invoke-PreDestructivePostgresDump -InstallDir $DPF_DIR -Trigger 'dpf-reinstall'",
+    "docker compose down -v --remove-orphans 2>$null",
+  ].join("\n");
+  assert.deepEqual(findDestroyWithoutDump(file, dumpsFirst), []);
+
+  const onlyDefined = [
+    "function Invoke-PreDestructivePostgresDump { param($InstallDir) }",
+    "docker compose down -v --remove-orphans 2>$null",
+  ].join("\n");
+  assert.deepEqual(findDestroyWithoutDump(file, onlyDefined).map((v) => v.rule), ["reinstall-dumps-first"]);
+
+  const dumpsAfter = [
+    "docker compose down -v --remove-orphans 2>$null",
+    "$x = Invoke-PreDestructivePostgresDump -InstallDir $DPF_DIR -Trigger 'dpf-reinstall'",
+  ].join("\n");
+  assert.equal(findDestroyWithoutDump(file, dumpsAfter).length, 1);
+
+  // Every destructive script the policy names is still in the audited inventory.
+  for (const rule of destructivePreludes) assert.ok(activeLifecycleFiles.includes(rule.file), rule.file);
 });


### PR DESCRIPTION
## Why

Workrooms bind a backlog item to its branch, worktree, lease holder and evidence trail. They live only in Postgres. `dpf-reinstall.ps1` and `scripts/fresh-install.ps1` ran `docker compose down -v` with no dump and no restore, and the teardown stance's "durable backlog bundle" captured Epic and BacklogItem only. Every reinstall therefore silently orphaned every worktree on disk. Measured on Arcamanus DEV 2026-09-06: 389 Workrooms, 305 bound branches, none of it in any bundle. BI-F9939341.

## What changes

- **Both install scripts dump before they destroy.** `Invoke-PreDestructivePostgresDump` runs `pg_dump -Fc` into `$DPF_BACKUPS_HOST_PATH\pre-destructive\<date>\<trigger>-<ts>\` (outside the install root) with an LF-terminated `dpf.dump.sha256` and a `manifest.json`, then `down -v` proceeds. A failed or empty dump refuses to continue. `-SkipPreDestructiveDump` is the only override and says what it costs. `dpf-reinstall.ps1` forwards the flag through its %TEMP% relaunch.
- **A guard keeps it that way.** `lifecycle-surface-policy` gains `destructivePreludes`: a lifecycle script containing `docker compose down -v` must call the dump before that line; a definition alone does not count. Pure helper with tests; the existing surface audit picks it up.
- **The backlog bundle carries the Workrooms.** `backlog:capture` writes `workrooms.json` (every non-archived Workroom with its activities; `--all` includes archived) through the pure `buildWorkroomCaptureRecord`, and the manifest and receipt report `workroomCount`.
- **Two capture aborts fixed on the same run.** A body-less item now falls back to its title (as the epic description already did), and an epic the bundle format cannot represent is listed as skipped `epic-not-representable` with the contract violation instead of killing the whole capture. The forwarded `--` separator is ignored.
- Docs: disaster-recovery runbook row and relatedCode edges, Windows install guide, scratch-rehearsal page; the capture-required stance now says "backlog and Workroom bundle".

Restore-and-rebind on first boot of the new install is slice 2: BI-E2507972.

## Verification on the live install

- Dump function exercised against the running `dpf-postgres-1`: 378 MB `dpf.dump`, `pg_restore -l` lists `WorkCapsule`, `WorkCapsuleActivity`, `WorkCapsuleParticipant`, `WorkCapsuleRelation`; `sha256sum -c dpf.dump.sha256` reports OK; manifest written. Both scripts parse clean under the PowerShell parser.
- `pnpm --filter @dpf/db backlog:capture -- --out <dir> --no-receipt` against the live database: 201 bundles, 877 items, 835 unassigned, 89 skipped as `epic-not-representable`, manifest closes against 1,801 not-done items; `workrooms.json` holds 379 rooms (304 bound to a branch, 258 open), 11 MB, spot-checked WC-F67191E5 with its branch, worktree and activities intact.
- `vitest`: backlog-recovery-capture 12 passed, installation-instance-stance passed; `node --test scripts/lifecycle-surface-policy.test.mjs` 8 passed.
- `pnpm run pregate:preflight` OK, 65 guards clean; `pnpm run pregate` PASS for HEAD 69bf2dbf3a8d.

## Design grounding

Existing specs/plans reviewed: docs/operations/disaster-recovery.md, docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md, docs/superpowers/plans/2026-05-17-postgres-backup-slice-2-restore.md, the installation-identity stance design (2026-08-22). Current code substrate reviewed: scripts/backup-postgres.sh, scripts/restore-postgres.sh, packages/db/scripts/capture-backlog-bundle.ts, packages/db/src/backlog-recovery-bundle.ts, scripts/governed-teardown.mjs. Source of truth: the same `pg_dump -Fc` the daily backup and the DR runbook already restore from. Decision: extend the existing capture and the existing dump format rather than add a new store or a new restore path.

Seed-Fit-Decision: global-default

Convergence-Impact-Decision: operator-action — existing installs pick the new scripts up on their next source pull; nothing changes at runtime until an operator runs dpf-reinstall.ps1 or fresh-install.ps1, and both are documented in docs/operations/disaster-recovery.md and docs/install/windows.md.

Docs-Impact-Decision: docs/testing/archetype-audit-plan.md links fresh-install.ps1 only as the reset step it invokes; the reset still happens, now preceded by a dump, and the plan's steps do not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
