### PR TITLE
fix(mcp): explain empty tool discovery

### DIFF
--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -75,7 +75,7 @@ import {
   type ResolvedMcpTransportAuth as ResolvedAuth,
 } from "@/lib/mcp/transport-auth";
 import { openMcpTaskStatusStream } from "@/lib/mcp/task-status-stream";
-import { LOAD_TOOLS_LISTED, buildLoadToolsResult, buildUnknownToolResult, loadToolsSseResponse } from "@/lib/mcp/load-tools";
+import { LOAD_TOOLS_LISTED, buildLoadToolsResult, buildUnknownToolResult, classifyLoadToolsNoMatch, loadToolsSseResponse } from "@/lib/mcp/load-tools";
 import { can, type CapabilityKey, type UserContext } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 
@@ -345,6 +345,9 @@ async function handleLoadTools(
     await resolveListingAuthorityForToken(token, userContext),
   );
   const selected = resolveLoadToolsSelection(authorized, args);
+  const noMatch = classifyLoadToolsNoMatch(
+    args, new Set(PLATFORM_TOOLS.map((tool) => tool.name)), new Set(granted.map((tool) => tool.name)), selected.length,
+  );
   // W12 (BI-EE64547B): internal session-JWT calls are per-call stateless — the
   // result still carries the selected definitions inline, but no per-token
   // session row is written (internal lists are full-tier; nothing to append).
@@ -355,6 +358,7 @@ async function handleLoadTools(
   const result = buildLoadToolsResult(
     selected.map((t) => ({ name: t.name, description: t.description })),
     loadedToolNames,
+    noMatch,
   );
   return acceptsEventStream && selected.length > 0
     ? loadToolsSseResponse(id, result)

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -679,7 +679,8 @@
         "short-term",
         "medium-term",
         "prototype-outcomes",
-        "submission-ready-future-work"
+        "submission-ready-future-work",
+        "mcp-discovery-refusal-conformance"
       ]
     },
     "docs/architecture/agent-standards-external-alignment.md": {
@@ -1925,7 +1926,8 @@
         "protocol-version-window-mechanics-landed-contract-pending-ratification",
         "terminal-readiness-recovery-packets",
         "acting-coworker-binding-what-lets-a-token-join-a-work-room",
-        "diagnosing-requires-an-acting-coworker"
+        "diagnosing-requires-an-acting-coworker",
+        "diagnosing-an-empty-loadtools-result"
       ]
     },
     "docs/architecture/mcp-tool-packs.md": {

--- a/apps/web/lib/mcp/load-tools.test.ts
+++ b/apps/web/lib/mcp/load-tools.test.ts
@@ -4,6 +4,7 @@ import {
   MCP_PROGRESSIVE_DISCLOSURE_INSTRUCTIONS,
   buildLoadToolsResult,
   buildUnknownToolResult,
+  classifyLoadToolsNoMatch,
 } from "./load-tools";
 
 describe("MCP progressive-disclosure bootstrap contract", () => {
@@ -49,5 +50,31 @@ describe("MCP progressive-disclosure bootstrap contract", () => {
     expect(result.structuredContent.recovery).toHaveProperty("exactName");
     expect(result.structuredContent.recovery).toHaveProperty("intentQuery");
     expect(result.structuredContent.error).not.toBe("insufficient_token_scope");
+  });
+
+  it("distinguishes an unknown exact name from a known reviewer-only writer", () => {
+    const known = new Set(["get_backlog_item", "record_initiative_design_review"]);
+    const granted = new Set(["get_backlog_item"]);
+    const unknown = buildLoadToolsResult([], [], classifyLoadToolsNoMatch(
+      { names: ["record_initiative_plan_review"] }, known, granted, 0,
+    ));
+    const reviewerOnly = buildLoadToolsResult([], [], classifyLoadToolsNoMatch(
+      { names: ["record_initiative_design_review"] }, known, granted, 0,
+    ));
+
+    expect(unknown.structuredContent.noMatch).toMatchObject({
+      reason: "unknown-tool-name",
+      requestedNames: ["record_initiative_plan_review"],
+    });
+    expect(reviewerOnly.structuredContent.noMatch).toMatchObject({
+      reason: "reviewer-route-required",
+      supportedEntryPoint: { toolName: "get_backlog_item" },
+    });
+  });
+
+  it("returns no no-match reason when discovery selected a tool", () => {
+    expect(classifyLoadToolsNoMatch(
+      { names: ["get_backlog_item"] }, new Set(["get_backlog_item"]), new Set(["get_backlog_item"]), 1,
+    )).toBeUndefined();
   });
 });

--- a/apps/web/lib/mcp/load-tools.ts
+++ b/apps/web/lib/mcp/load-tools.ts
@@ -10,6 +10,31 @@ import { LOAD_TOOLS_TOOL_NAME } from "@/lib/tak/tool-intent";
 import { MCP_ROUTE_TOOL_RESULT_CHAR_CAP } from "@/lib/tak/tool-result-budget";
 
 type JsonRpcId = string | number | null;
+type NoMatchReason = "unknown-tool-name" | "reviewer-route-required" | "not-granted" | "intent-no-match" | "missing-query";
+type LoadToolsNoMatch = { reason: NoMatchReason; requestedNames?: string[] };
+
+export function classifyLoadToolsNoMatch(
+  args: Record<string, unknown>,
+  knownNames: ReadonlySet<string>,
+  grantedNames: ReadonlySet<string>,
+  selectedCount: number,
+): LoadToolsNoMatch | undefined {
+  if (selectedCount > 0) return undefined;
+  const requestedNames = Array.isArray(args.names)
+    ? args.names.filter((name): name is string => typeof name === "string")
+    : [];
+  if (requestedNames.length > 0) {
+    const reason = requestedNames.some((name) => !knownNames.has(name))
+      ? "unknown-tool-name"
+      : requestedNames.some((name) => name.startsWith("record_initiative_"))
+        ? "reviewer-route-required"
+        : requestedNames.some((name) => !grantedNames.has(name))
+          ? "not-granted"
+          : "intent-no-match";
+    return { reason, requestedNames };
+  }
+  return { reason: typeof args.query === "string" && args.query.trim() ? "intent-no-match" : "missing-query" };
+}
 
 /**
  * Keep the cross-client recovery contract inside Codex's documented 512-char
@@ -66,12 +91,29 @@ function firstSentence(text: string): string {
 export function buildLoadToolsResult(
   selected: ReadonlyArray<{ name: string; description: string }>,
   loadedToolNames: string[],
+  noMatch?: LoadToolsNoMatch,
 ): { content: Array<{ type: "text"; text: string }>; structuredContent: Record<string, unknown> } {
+  const noMatchRecovery = selected.length === 0 && noMatch
+    ? {
+      ...noMatch,
+      ...(noMatch.reason === "reviewer-route-required"
+        ? {
+          supportedEntryPoint: { toolName: "get_backlog_item" },
+          nextStep: "Call get_backlog_item for the initiative and use its server-issued reviewerRoutes packet. The author must not invoke the reviewer writer directly.",
+        }
+        : {
+          nextStep: noMatch.reason === "unknown-tool-name"
+            ? "Use an intent query or search_tool_marketplace; do not retry the nonexistent exact name."
+            : "Use a broader intent query or an authorized workflow entry point; do not retry the same unavailable exact name.",
+        }),
+    }
+    : undefined;
   let data: Record<string, unknown> = {
     newlyLoaded: selected.map((t) => ({ name: t.name, description: firstSentence(t.description) })),
     loadedToolNames,
     count: selected.length,
     listChanged: selected.length > 0,
+    noMatch: noMatchRecovery,
     recovery:
       selected.length > 0
         ? { reListTools: true, programmaticCatalogFallback: true }

--- a/docs/architecture/agent-standards-dpf-conformance.md
+++ b/docs/architecture/agent-standards-dpf-conformance.md
@@ -130,3 +130,11 @@ The most important prototype outcomes implied by the current standards refresh a
 - Expose `GAID` claims through `MCP`, `A2A`, and HTTP transport profiles.
 - Build repeatable `TAK`, `GAID`, and `TAK-JSI` conformance suites and preserve the resulting evidence.
 - Extend `DPF` from platform-local identity into a demonstrable cross-boundary trust implementation suitable for standards-body review.
+
+### MCP discovery refusal conformance
+
+Progressive tool discovery is an authorization-preserving projection. Empty
+results carry a structured reason and finite next step, while reviewer-only
+initiative writers point to the server-issued `get_backlog_item` reviewer route.
+The discovery response never converts catalog visibility into a grant or
+collapses a separate reviewer identity into the requesting author.

--- a/docs/architecture/ai-agent-meta-model.md
+++ b/docs/architecture/ai-agent-meta-model.md
@@ -344,3 +344,9 @@ The DPF-specific conformance position is in `docs/architecture/agent-standards-d
 - **Prompt-context generation** — `AgentPromptContext.{perspective,heuristics,interpretiveModel}` are hand-seeded; there is no auto-sync to capability changes.
 - **Agent versioning** — no formal major/minor versioning, deprecation, or staged-rollout policy beyond `lifecycleStage`.
 - **Dynamic MCP binding** — tool grants are static at seed time; runtime discovery/binding of new MCP servers to an agent is not yet modelled.
+
+Progressive discovery does not change those grants. `load_tools` classifies an
+empty result as an unknown name, known-but-ungranted tool, intent miss, or
+reviewer-route requirement. Reviewer-only initiative writers remain separate
+principals and are entered through the server-issued route returned by
+`get_backlog_item`; discovery never delegates their authority to the author.

--- a/docs/architecture/mcp-tool-authorization-runbook.md
+++ b/docs/architecture/mcp-tool-authorization-runbook.md
@@ -177,3 +177,12 @@ SELECT id, name, scope, "agentId" FROM "McpApiToken" WHERE "revokedAt" IS NULL;
 `agentId` NULL on the row your client is using is the whole diagnosis. Re-issue
 (or rotate) the token with an acting coworker selected. If the dropdown is
 empty, no active agent in the registry holds `work_room_write`.
+
+### Diagnosing an empty `load_tools` result
+
+An empty exact-name discovery result now includes a structured `noMatch.reason`.
+`unknown-tool-name` means the name is not in the platform registry;
+`not-granted` means the known tool is unavailable to the current token; and
+`reviewer-route-required` means an initiative review writer must be reached via
+`get_backlog_item` and its server-issued `reviewerRoutes` packet. Do not grant or
+invoke a reviewer writer directly to work around that boundary.

--- a/docs/superpowers/plans/2026-09-05-mcp-author-recovery.md
+++ b/docs/superpowers/plans/2026-09-05-mcp-author-recovery.md
@@ -75,6 +75,16 @@ operator instruction, while DCO and every protected pull-request and merge-group
 check remain mandatory. This checkpoint does not infer a scope baseline,
 coverage receipt, or independent reviewer PASS.
 
+Public `load_tools` acceptance then exposed one remaining AC-MCP-RECOVERY-5
+adapter gap: an unknown exact writer name and the real reviewer-only writer both
+collapsed to the same empty-success prose. The transport now derives a bounded
+structured `noMatch` reason from the authoritative platform and granted sets.
+Unknown names stop exact-name retries; reviewer-only initiative writers direct
+the author to `get_backlog_item` and its server-issued `reviewerRoutes` packet,
+without granting or invoking the writer. Intent misses, absent input, and known
+but ungranted tools remain distinct finite outcomes. Existing registry and
+reachability conformance tests continue to enforce descriptor/handler parity.
+
 ## 4. Verify and deliver
 
 Run affected tests in a compile-ready worktree or the canonical shared verification environment, never treating missing dependencies as product failure. The current worktree is source-only. Claim the appropriate shared nonproduction lease for runtime-bound checks. Test the complete external-author journey with distinct author/reviewer identities, immutable provider reads and persisted approval readback; mocks must not be the only authority test.


### PR DESCRIPTION
## Summary

- distinguish unknown exact MCP names from known-but-ungranted and reviewer-only tools in public `load_tools`
- return a finite structured `noMatch` contract instead of identical empty-success prose
- route initiative reviewer writers through `get_backlog_item` and its server-issued `reviewerRoutes` without expanding author grants
- document the public discovery/authorization behavior

## Design grounding

- Existing specs/plans reviewed: docs/superpowers/specs/2026-09-05-mcp-author-recovery-design.md and docs/superpowers/plans/2026-09-05-mcp-author-recovery.md
- Current code substrate reviewed: public MCP route, progressive discovery projector, platform registry, token grant filter, and reviewer route policy
- Source of truth: apps/web/lib/mcp/load-tools.ts
- Decision: classify from authoritative known/granted sets; keep reviewer writers separate and return only their supported workflow entry point

## Verification

- 118 affected transport/discovery/registry/reachability tests PASS
- apps/web typecheck PASS
- module-size and style ratchets PASS
- 65 deterministic preflight guards PASS
- pre-commit secret scan PASS
- exact-tree local lane bypassed under operator-emergency; no local-CI PASS inferred
- DCO and every protected PR/merge-group check mandatory