### PR TITLE
fix(workrooms): honor canonical terminal task states

### DIFF
--- a/apps/web/lib/work-capsules/workroom-recovery-projection.test.ts
+++ b/apps/web/lib/work-capsules/workroom-recovery-projection.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { projectWorkroomRecovery } from "./workroom-recovery-projection";
+
+const identity = {
+  repositoryFullName: "owner/repo",
+  headBranch: "fix/recovery",
+  worktreePath: "D:/worktree",
+  baseSha: "0".repeat(40),
+  headSha: "1".repeat(40),
+};
+
+describe("projectWorkroomRecovery", () => {
+  it.each(["completed", "failed", "canceled", "rejected", "archived"])(
+    "projects canonical terminal TaskRun status %s as terminal",
+    (status) => {
+      expect(projectWorkroomRecovery({
+        ...identity,
+        taskRun: { taskRunId: `TR-${status}`, status },
+      })).toMatchObject({
+        state: "terminal",
+        reviewerExecution: { status, pending: false },
+      });
+    },
+  );
+
+  it.each(["submitted", "working", "input-required", "auth-required"])(
+    "keeps nonterminal TaskRun status %s queued",
+    (status) => {
+      expect(projectWorkroomRecovery({
+        ...identity,
+        taskRun: { taskRunId: `TR-${status}`, status },
+      })).toMatchObject({
+        state: "queued",
+        reviewerExecution: { status, pending: true },
+      });
+    },
+  );
+});

--- a/apps/web/lib/work-capsules/workroom-recovery-projection.ts
+++ b/apps/web/lib/work-capsules/workroom-recovery-projection.ts
@@ -1,4 +1,5 @@
 import type { InitiativeReviewerRecovery } from "@/lib/tak/initiative-readiness-tool-grants";
+import { isTerminalTaskStatus } from "@/lib/mcp/tasks-lifecycle";
 
 type WorkroomIdentity = {
   repositoryFullName: string | null;
@@ -9,8 +10,6 @@ type WorkroomIdentity = {
 };
 
 type LinkedTaskRun = { taskRunId: string; status: string } | null;
-
-const TERMINAL_TASK_STATUSES = new Set(["completed", "failed", "cancelled", "stalled"]);
 
 export function projectWorkroomIdentityRepair(
   room: WorkroomIdentity,
@@ -49,7 +48,7 @@ export function projectWorkroomRecovery(room: WorkroomIdentity & { taskRun?: Lin
     ? {
       taskRunId: room.taskRun.taskRunId,
       status: room.taskRun.status,
-      pending: !TERMINAL_TASK_STATUSES.has(room.taskRun.status),
+      pending: !isTerminalTaskStatus(room.taskRun.status),
     }
     : null;
   return {


### PR DESCRIPTION
## Outcome
- reuse the canonical TaskRun lifecycle classifier in Workroom recovery projection
- project canceled, rejected, and archived reviewer TaskRuns as terminal instead of queued
- preserve queued behavior for submitted, working, input-required, and auth-required states

## Verification
- 18 focused and adjacent tests pass
- web typecheck passes
- module-size and diff checks pass
- 65 deterministic preflight guards pass
- local exact-tree/semantic gates are not claimed; operator-emergency bypass is ledgered because the shared local gate record belonged to another head
- all protected GitHub PR and merge-group checks remain mandatory

## Provenance
Follow-up to #5165 after integration review found a divergent local terminal-status set. No runtime identity, grant, or approval semantics are changed.