### PR TITLE
fix(self-upgrade): a registry read that fails for a non-HTTP reason now names itself

### DIFF
--- a/apps/web/lib/self-upgrade/registry-release.test.ts
+++ b/apps/web/lib/self-upgrade/registry-release.test.ts
@@ -364,7 +364,14 @@ describe("registry-unavailable carries the HTTP status", () => {
     expect(result.detail).toBe(`HTTP ${status}`);
   });
 
-  it("leaves detail unset when the failure is not an HTTP status", async () => {
+  // BI-1E8C1930 — this used to assert `detail` stayed UNSET for a non-HTTP
+  // failure, on the reasoning that a detail which is not a status would mislead.
+  // A live install disproved it: the update control vanished, every page load
+  // logged a bare `registry-unavailable`, and the whole GHCR chain succeeded
+  // when replayed by hand in the same container. The evidence excluded every
+  // lane that explains itself and said nothing about the one that does not.
+  // Silence was the misleading part.
+  it("names the error class when the failure is not an HTTP status", async () => {
     const transportFactory = vi.fn(() => ({
       fetch: vi.fn(async () => {
         throw new TypeError("fetch failed");
@@ -382,6 +389,127 @@ describe("registry-unavailable carries the HTTP status", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toBe("registry-unavailable");
-    expect(result.detail).toBeUndefined();
+    expect(result.detail).toBe("TypeError: fetch failed");
+  });
+
+  // Undici reports a transport fault as a bare TypeError with the real
+  // condition nested underneath, so reading `code` off the top-level error
+  // finds nothing. This is the shape that actually reaches production.
+  it("reports the nested undici cause code", async () => {
+    const nested = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("Connect Timeout Error"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      }),
+    });
+    const transportFactory = vi.fn(() => ({
+      fetch: vi.fn(async () => {
+        throw nested;
+      }),
+      close: vi.fn(async () => undefined),
+    })) as never;
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.detail).toBe("TypeError: fetch failed (UND_ERR_CONNECT_TIMEOUT)");
+  });
+
+  it("finds a code nested more than one level down", async () => {
+    const deep = new TypeError("fetch failed", {
+      cause: new Error("socket layer", {
+        cause: Object.assign(new Error("certificate rejected"), {
+          code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+        }),
+      }),
+    });
+    const transportFactory = vi.fn(() => ({
+      fetch: vi.fn(async () => {
+        throw deep;
+      }),
+      close: vi.fn(async () => undefined),
+    })) as never;
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.detail).toBe(
+      "TypeError: fetch failed (UNABLE_TO_VERIFY_LEAF_SIGNATURE)",
+    );
+  });
+
+  // A registry read carries bearer tokens and signed redirect URLs, and this
+  // string reaches a log an operator reads. The message is bounded so a long
+  // error can never spill one into it.
+  it("bounds the message it reports", async () => {
+    const transportFactory = vi.fn(() => ({
+      fetch: vi.fn(async () => {
+        throw new Error("x".repeat(500));
+      }),
+      close: vi.fn(async () => undefined),
+    })) as never;
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.detail).toBe(`Error: ${"x".repeat(120)}`);
+  });
+
+  it("survives a throw that is not an Error at all", async () => {
+    const transportFactory = vi.fn(() => ({
+      fetch: vi.fn(async () => {
+        throw "registry exploded";
+      }),
+      close: vi.fn(async () => undefined),
+    })) as never;
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("registry-unavailable");
+    expect(result.detail).toBe("non-error throw (string)");
+  });
+
+  // The HTTP lane must keep its exact status text — the new detail must not
+  // start decorating failures that already explain themselves.
+  it("leaves an HTTP failure's detail exactly as it was", async () => {
+    const transportFactory = vi.fn(() => ({
+      fetch: vi.fn(async () => new Response("", { status: 429 })),
+      close: vi.fn(async () => undefined),
+    })) as never;
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.detail).toBe("HTTP 429");
   });
 });

--- a/apps/web/lib/self-upgrade/registry-release.ts
+++ b/apps/web/lib/self-upgrade/registry-release.ts
@@ -114,6 +114,50 @@ function createRegistryTransport(): RegistryTransport {
   };
 }
 
+/**
+ * Name a failure that is NOT a `RegistryReadError` — BI-1E8C1930.
+ *
+ * `registry-unavailable` has three lanes that already explain themselves: the
+ * non-OK responses carry `HTTP <status>`, and a resolution that throws out to
+ * the caller is logged separately. The fourth lane said nothing at all. Anything
+ * thrown inside `readCandidate` that was not a `RegistryReadError` collapsed to
+ * a bare `registry-unavailable`, so the one failure mode with no explanation was
+ * the only one left unexplained.
+ *
+ * That is not hypothetical: on a live install the update control disappeared
+ * entirely, every page load reproduced `release-target-unavailable:
+ * registry-unavailable` with no detail, and the whole GHCR chain — token, index,
+ * manifest, config blob, 307 redirect — succeeded when replayed by hand inside
+ * the same container. The evidence was sufficient to exclude every OTHER lane
+ * and insufficient to say anything about this one.
+ *
+ * Undici reports transport faults as a bare `TypeError("fetch failed")` with the
+ * real condition nested underneath, sometimes more than one level down, so the
+ * chain is walked for the first `code` rather than read at the top level.
+ *
+ * Deliberately narrow: error class, the first `code` found, and a bounded slice
+ * of the message. A registry read handles bearer tokens and signed redirect
+ * URLs, and this string goes to a log an operator reads, so the full message is
+ * never emitted.
+ */
+function describeUnexpectedFailure(error: unknown): string {
+  if (!(error instanceof Error)) return `non-error throw (${typeof error})`;
+  let code: string | undefined;
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current instanceof Error; depth += 1) {
+    const candidate = (current as { code?: unknown }).code;
+    if (typeof candidate === "string" && candidate.length > 0) {
+      code = candidate;
+      break;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  const message = error.message.slice(0, 120);
+  return code
+    ? `${error.name}: ${message} (${code})`
+    : `${error.name}: ${message}`;
+}
+
 function sha256(body: Uint8Array): string {
   return `sha256:${createHash("sha256").update(body).digest("hex")}`;
 }
@@ -443,10 +487,16 @@ export async function readRegistryReleaseCandidate(input: {
       return await readCandidate(transport.fetch);
     } catch (error) {
       if (error instanceof RegistryReadError || attempt === maxAttempts) {
+        // A non-RegistryReadError reaching here used to return the bare reason,
+        // leaving the only unexplained lane also the only silent one
+        // (BI-1E8C1930). It now names itself like every other failure does.
+        const detail = error instanceof RegistryReadError
+          ? error.detail
+          : describeUnexpectedFailure(error);
         return {
           ok: false,
           reason: error instanceof RegistryReadError ? error.reason : "registry-unavailable",
-          ...(error instanceof RegistryReadError && error.detail ? { detail: error.detail } : {}),
+          ...(detail ? { detail } : {}),
         };
       }
     } finally {


### PR DESCRIPTION
## What

A registry read that fails for a non-HTTP reason now names the error class and its cause code, instead of returning a bare `registry-unavailable`.

## Why

`registry-unavailable` has four lanes. Three of them explain themselves — the three `!response.ok` sites carry `HTTP <status>` (#4952), and a resolution that throws out to the caller is logged as `release-target-resolution-threw` (#4868). The fourth said nothing at all: anything thrown inside `readCandidate` that was not a `RegistryReadError` collapsed to the bare reason.

So the only failure mode with no explanation was also the only one left unexplained.

That is not a hypothetical gap. On this install the update control **disappeared entirely**:

```
Update availability could not be verified
No update action available
Available: unknown        Target: unknown
```

No button, no "check now" control, and the scheduled check would run the same resolution. The install could not be upgraded through the supported path at all.

Every page load reproduced the same line, five times across an hour:

```
02:16:28Z  [self-upgrade] release-target-unavailable: registry-unavailable
02:20:03Z  [self-upgrade] release-target-unavailable: registry-unavailable
03:10:17Z  [self-upgrade] release-target-unavailable: registry-unavailable
03:10:57Z  [self-upgrade] release-target-unavailable: registry-unavailable
03:11:19Z  [self-upgrade] release-target-unavailable: registry-unavailable
```

Meanwhile the whole GHCR chain, replayed by hand **inside the same container**, succeeded end to end and resolved `:latest` to exactly the expected revision:

```
index:    200  amd64: sha256:f0805986d73a…
manifest: 200  config: sha256:bdcebb113e19…
blob:     307  loc: https://pkg-containers.githubusercontent.com/ghcrblobs11/…
follow:   200  revision: c772c185dbb67bf64b6ecc5abd224eec79784cf8
```

Token hop, manifest index, platform manifest, config blob, 307 redirect and the `pkg-containers.githubusercontent.com` allowlist hop all work. The fault also **survived a portal restart**, which rules out process-local dispatcher state.

The absences were the only evidence available, and they were enough to exclude every lane that explains itself — and nothing more. The root cause is still unknown. That is the point: it is unknown *because* this lane is silent.

## Changes

`describeUnexpectedFailure` reports three things and no more:

- the error class,
- the first `code` found by walking the `cause` chain,
- a bounded slice of the message.

The chain is **walked** rather than read at the top level because undici reports transport faults as a bare `TypeError("fetch failed")` with the real condition nested underneath, sometimes more than one level down. Reading `code` off the top-level error finds nothing — which is exactly the shape that reaches production.

The message is capped at 120 characters deliberately. A registry read handles bearer tokens and signed redirect URLs, and this string goes to a log an operator reads, so the full message is never emitted.

The detail already had plumbing to the operator-facing line; I traced it rather than assuming it, because a fix that doesn't reach the log is inert. `release-target.ts:186` forwards `release.detail`, `:127` attaches it to the unavailable target, and `verified-release-target.ts`'s `describeUnavailable` renders `reason (detail)`.

## This reverses a deliberate decision of mine

#4952 added a test asserting `detail` stays **unset** for a non-HTTP failure, on the reasoning that a detail which is not a status would be misleading. The live incident disproved it — silence was the misleading part.

The test is replaced rather than deleted, and the reasoning is recorded where the old assertion stood, so the next person sees why it flipped instead of flipping it back.

## Scope

Observability only. No resolution logic, ordering, reason code or return shape changes. The HTTP lane keeps its exact `HTTP <status>` text under a test that pins it, so this cannot start decorating failures that already explain themselves.

## Verification

```
pnpm --filter web exec vitest run lib/self-upgrade/ lib/actions/self-upgrade
  Test Files  62 passed (62)
       Tests  833 passed (833)

pnpm --filter web typecheck          # clean
pnpm --filter web build              # clean
node scripts/check-guards.mjs        # Guard loop OK — 38 guards passed (33 self-tests)
node scripts/check-module-size.mjs   # OK — 63 files over 800 LOC, unchanged
```

Six new cases: the plain error class, the nested undici cause code, a code two levels down, the message bound, a non-`Error` throw, and the HTTP lane held unchanged.

Confirmed to fail without the fix, isolated to one line: neutralising `describeUnexpectedFailure` gives **5 failed / 14 passed** — and the HTTP-lane test is among the 14 that still pass, which is the correct split.

## Not verified

**This does not fix the outage — it makes the outage legible.** The underlying reason `:latest` cannot be resolved on this install is still unknown, and stays unknown until this ships and the next resolution names its own cause. That is the first thing to check afterwards; BI-1E8C1930 carries the reordered candidate list to test against whatever the log then says.

## Change classification

- [x] **Source-only change** (isolated unit logic; no route, schema, or UX surface)
- [x] Unit tests for affected files, confirmed failing without the fix
- [x] Typecheck clean
- [x] Production build clean
- [x] Guard loop clean

Local-CI-Override: operator-emergency: operator directed skipping local gates on this host — the local-CI pool is structurally single-slot and not usable here. 833 unit tests, typecheck, production build, the 38-guard loop and the module-size ratchet were run in the worktree; protected GitHub checks and the merge queue still apply.

Refs: BI-1E8C1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
