### PR TITLE
fix(promote): remove superseded image tags in chunks, not one call per tag (BI-A5FFE7A7)

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-cleanup.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-cleanup.test.ts
@@ -57,15 +57,43 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — cleanup sweep after a succe
       expect(r.status).toBe(0);
       const dockerCalls = readFileSync(dockerLog, "utf8").split("\n");
       const removed = dockerCalls.filter((line) => line.startsWith("rmi ") && line.includes("dpf-portal:v"));
-      // Newest two survive as rollback margin, the in-use one survives regardless of age.
-      expect(removed).toEqual([`rmi ${repo}:v2026.09.04-c.1`, `rmi ${repo}:v2026.09.03-b.1`, `rmi ${repo}:v2026.09.02-a.1`]);
-      expect(dockerCalls).not.toContain(`rmi ${repo}:v2026.09.05-running.1`);
+      // Newest two survive as rollback margin, the in-use one survives regardless
+      // of age. One call carries the whole chunk (BI-A5FFE7A7).
+      expect(removed).toEqual([`rmi ${repo}:v2026.09.04-c.1 ${repo}:v2026.09.03-b.1 ${repo}:v2026.09.02-a.1`]);
+      expect(removed.join(" ")).not.toContain("v2026.09.05-running.1");
       // Every self-upgrade repo is swept, and by version-tag reference only.
       for (const name of ["dpf-portal", "dpf-postgres", "dpf-promoter", "dpf-sandbox"]) {
         expect(dockerCalls).toContain(`images --filter reference=ghcr.io/opendigitalproductfactory/${name}:v* --format {{.Repository}}:{{.Tag}}`);
       }
       // Untag by reference, never force-remove by id: a layer shared with a kept tag must survive.
       expect(removed.every((line) => !line.includes(" -f "))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
+  it("removes a large backlog in chunks rather than one docker rmi per tag", () => {
+    // BI-A5FFE7A7: the first sweep on an install that predates the retention rule
+    // clears its entire history at once. Reclaiming 223 tags one call at a time
+    // took ~13 minutes by hand, and that time would be spent inside step=cleanup
+    // on every install the release reaches. 120 tags with a keep of 3 leaves 117
+    // removals, which must arrive as 50 + 50 + 17, not 117 separate calls.
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    const repo = "ghcr.io/opendigitalproductfactory/dpf-portal";
+    const tags = Array.from({ length: 120 }, (_, i) => `${repo}:v2026.09.06-backlog.${120 - i}`);
+    try {
+      const r = runPromote({ source, backup, targetSha: head, fakeBin, dockerLog, portalVersionTags: tags, imageKeep: 3 });
+      expect(r.status).toBe(0);
+      const removed = readFileSync(dockerLog, "utf8").split("\n")
+        .filter((line) => line.startsWith("rmi ") && line.includes("dpf-portal:v"));
+      expect(removed).toHaveLength(3);
+      expect(removed.map((line) => line.slice(4).trim().split(/\s+/).length)).toEqual([50, 50, 17]);
+      // The three newest are the rollback margin and are never passed to rmi.
+      const all = removed.join(" ");
+      for (const keep of tags.slice(0, 3)) expect(all).not.toContain(`${keep} `);
+      expect(all).toContain(tags[3]);
+      expect(all).toContain(tags[119]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/web/lib/self-upgrade/promote-script-functional.test-support.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test-support.ts
@@ -42,6 +42,13 @@ export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/** Park a `docker images` fixture on disk so the shim can `cat` it. */
+function writeTagFixture(backupDir: string, tags: string[]): string {
+  const path = join(backupDir, "portal-version-tags.txt");
+  writeFileSync(path, tags.length > 0 ? `${tags.join("\n")}\n` : "");
+  return path;
+}
+
 export function gitInit(dir: string): string {
   const env = {
     ...process.env,
@@ -132,7 +139,7 @@ case "$*" in
     ;;
   *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;
   "ps -a --format "*) [ -n "\${DPF_TEST_IMAGES_IN_USE:-}" ] && printf '%s\n' "$DPF_TEST_IMAGES_IN_USE" ;;
-  *"images --filter reference=ghcr.io/"*"/dpf-portal:v* --format "*) [ -n "\${DPF_TEST_PORTAL_VERSION_TAGS:-}" ] && printf '%s\n' "$DPF_TEST_PORTAL_VERSION_TAGS" ;;
+  *"images --filter reference=ghcr.io/"*"/dpf-portal:v* --format "*) [ -n "\${DPF_TEST_PORTAL_VERSION_TAGS_FILE:-}" ] && cat "$DPF_TEST_PORTAL_VERSION_TAGS_FILE" ;;
 esac
 exit 0
 `,
@@ -225,7 +232,11 @@ export function runPromote(opts: {
       ? [`export PROMOTE_COMPOSE_ENV_FILE=${shellQuote(toBashPath(opts.composeEnvFile))}`]
       : []),
     ...(opts.dockerLog ? [`export DOCKER_LOG=${shellQuote(toBashPath(opts.dockerLog))}`] : []),
-    ...(opts.portalVersionTags ? [`export DPF_TEST_PORTAL_VERSION_TAGS=${shellQuote(opts.portalVersionTags.join("\n"))}`] : []),
+    // Through a file, not the environment: a backlog-sized list is thousands of
+    // characters and the `bash -lc` payload truncates mid-quote well before the
+    // sweep runs (BI-A5FFE7A7). A file also matches how the real `docker images`
+    // output reaches the loop — a stream of lines.
+    ...(opts.portalVersionTags ? [`export DPF_TEST_PORTAL_VERSION_TAGS_FILE=${shellQuote(toBashPath(writeTagFixture(opts.backup, opts.portalVersionTags)))}`] : []),
     ...(opts.imagesInUse ? [`export DPF_TEST_IMAGES_IN_USE=${shellQuote(opts.imagesInUse.join("\n"))}`] : []),
     ...(opts.imageKeep !== undefined ? [`export PROMOTE_IMAGE_KEEP=${opts.imageKeep}`] : []),
     ...(opts.release ? [

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -1113,18 +1113,34 @@ if [[ $_dry_run -eq 0 ]]; then
   # PROMOTE_IMAGE_KEEP most recent others as a rollback margin, remove the rest
   # by repo:tag (untagging, never by id, so a shared layer stays if another tag
   # needs it). `docker images` lists newest first. Best-effort, volumes untouched.
+  #
+  # BI-A5FFE7A7: the candidates are removed in CHUNKS, not one `docker rmi` per
+  # tag. The first sweep on an install that predates this fix clears its whole
+  # backlog at once — reclaiming one such backlog by hand took ~13 minutes for
+  # 223 tags serially, and that time would be spent inside this step on every
+  # install the release reaches. `docker rmi` takes many references per call, so
+  # one call per chunk collapses that to seconds. A chunk that partially fails
+  # still removes its other references and never stops the sweep.
   _keep="${PROMOTE_IMAGE_KEEP:-3}"
   [[ "$_keep" =~ ^[0-9]+$ ]] || _keep=3
   _in_use="$(docker ps -a --format '{{.Image}}' 2>/dev/null | sort -u)"
   for _repo in dpf-portal dpf-postgres dpf-promoter dpf-sandbox; do
     _ref="ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/${_repo}"
     _kept=0
+    _chunk=()
     while IFS= read -r _tagged; do
       [[ -n "$_tagged" && "$_tagged" != *'<none>'* ]] || continue
       if grep -qxF -- "$_tagged" <<<"$_in_use"; then continue; fi
       if (( _kept < _keep )); then _kept=$((_kept + 1)); continue; fi
-      docker rmi "$_tagged" >/dev/null 2>&1 || true
+      _chunk+=("$_tagged")
+      if (( ${#_chunk[@]} >= 50 )); then
+        docker rmi "${_chunk[@]}" >/dev/null 2>&1 || true
+        _chunk=()
+      fi
     done < <(docker images --filter "reference=${_ref}:v*" --format '{{.Repository}}:{{.Tag}}' 2>/dev/null)
+    if (( ${#_chunk[@]} > 0 )); then
+      docker rmi "${_chunk[@]}" >/dev/null 2>&1 || true
+    fi
   done
 fi
 


### PR DESCRIPTION
## Why

BI-1172E86A (#5173) bounds the superseded version-tag pile, but its loop issues one `docker rmi` per tag. That cost is invisible in steady state, where an upgrade leaves a handful of tags behind, and severe exactly once: the first sweep on an install that predates the fix clears its entire history in a single run.

Measured, not estimated. Reclaiming that backlog by hand on this dev install used the shipped selection rule and took roughly 13 minutes:

| | |
|---|---|
| Tags removed | 223 (0 refused) |
| Wall clock | ~13 min, serial |
| Images before / after | 430.2 GB / 93.1 GB |

The same time would be spent inside `step=cleanup` on every install the release reaches, and it lands on all of them at once, on the first upgrade that carries the fix. It is best-effort and runs after every verify, so it cannot fail the upgrade or delay the swap, but it holds the promoter container open and churns customer disk for the whole window. Installs with longer histories are worse.

## What

Removal candidates accumulate into chunks of 50 and go out as one `docker rmi` per chunk.

Unchanged: the selection rule, protection of every tag a container still references, `PROMOTE_IMAGE_KEEP`, by-reference removal (never `-f`, never by id), and best-effort semantics. A chunk that partially fails still removes its other references and does not stop the sweep.

## Test harness note

The chunking test needs a backlog-sized fixture, and the shim was receiving its tag list through the environment. At 120 tags that export is over 8,000 characters and the `bash -lc` payload truncated mid-quote, so the script died with `unexpected EOF while looking for matching '` before the sweep ran. The fixture now goes through a file, which also matches how real `docker images` output reaches the loop: a stream of lines.

## Proof

- New test: 120 tags with a keep of 3 leaves 117 removals, asserted to arrive as 50 + 50 + 17 rather than 117 calls, with the three newest never passed to `rmi`.
- Existing retention test updated: the surviving in-use tag and the keep margin are proven against a single batched call.
- `promote-script*` suites: 67 pass across 4 files. `pregate-preflight`: 65 guards clean. Local-CI gate: PASS.

Backlog item: BI-A5FFE7A7
Workroom: WC-E5331F88
Docs-Impact-Decision: the runbook already describes what cleanup removes and that is unchanged; this alters only how many docker calls carry it
Convergence-Impact-Decision: self-upgrade-step — promote.sh step=cleanup carries this on every install at its next self-upgrade; no operator action

🤖 Generated with [Claude Code](https://claude.com/claude-code)
