### PR TITLE
fix(work-shapes): the PIR gate is queried by its Prisma member, not its database value (BI-D36E2916)

### DIFF
--- a/apps/web/lib/work-capsules/declare-break-fix.test.ts
+++ b/apps/web/lib/work-capsules/declare-break-fix.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { BREAK_FIX_SHAPE_REF, declareBreakFix, findMissedPir } from "./declare-break-fix";
+import { BREAK_FIX_SHAPE_REF, PIR_GATE_WIRE_KEY, declareBreakFix, findMissedPir } from "./declare-break-fix";
 
 const now = new Date("2026-09-06T23:00:00Z");
 const human = { userId: "user-1", agentId: null, principalId: "PRN-1" };
@@ -58,6 +58,26 @@ describe("declareBreakFix (BI-F2FEC1EB)", () => {
     const result = await declareBreakFix({ db: db({ history }), itemId: "BI-ONE", reason: "x", actor: human, now });
     expect(result).toMatchObject({ ok: false, error: "break_fix_pir_missed", data: { backlogItemId: "row-old" } });
     expect(findMissedPir([...history, { id: "b", backlogItemId: "row-old", kind: "initiative_gate_receipt", gateKey: "post-implementation-review", recordedAt: now, payload: {} }], now)).toBeNull();
+  });
+
+  it("queries the PIR gate by its Prisma member and reads receipts back in either spelling", async () => {
+    // Live acceptance on v2026.09.07-work-shape-taxonomy.1 threw here: the
+    // hyphenated wire key is the mapped DATABASE value, and Prisma rejects it
+    // in a where clause. Only the underscore member is a valid filter.
+    const store = db();
+    await declareBreakFix({ db: store, itemId: "BI-ONE", reason: "x", actor: human, now });
+    const filter = store.backlogItemActivity.findMany.mock.calls[0]?.[0] as { where: { OR: Array<{ gateKey?: string }> } };
+    const receiptClause = filter.where.OR.find((clause) => "gateKey" in clause);
+    expect(receiptClause?.gateKey).toBe("post_implementation_review");
+    expect(receiptClause?.gateKey).not.toBe(PIR_GATE_WIRE_KEY);
+
+    // Prisma hands the member back with underscores; the reader must still see it.
+    const declared = { id: "a", backlogItemId: "row-old", kind: "break_fix_declared", gateKey: null, recordedAt: new Date("2026-09-01T00:00:00Z"), payload: { schemaVersion: 1, declaredAt: "2026-09-01T00:00:00.000Z", pirDueAt: "2026-09-03T00:00:00.000Z" } };
+    for (const spelling of ["post_implementation_review", PIR_GATE_WIRE_KEY]) {
+      const receipt = { id: "b", backlogItemId: "row-old", kind: "initiative_gate_receipt", gateKey: spelling, recordedAt: now, payload: {} };
+      expect(findMissedPir([declared, receipt], now)).toBeNull();
+    }
+    expect(findMissedPir([declared], now)).toMatchObject({ backlogItemId: "row-old" });
   });
 
   it("needs a live Workroom and refuses a double declaration", async () => {

--- a/apps/web/lib/work-capsules/declare-break-fix.ts
+++ b/apps/web/lib/work-capsules/declare-break-fix.ts
@@ -59,12 +59,29 @@ function declaration(payload: unknown): BreakFixDeclaration | null {
   return row as unknown as BreakFixDeclaration;
 }
 
+/**
+ * The post-implementation-review gate has two spellings and they are not
+ * interchangeable (found by live acceptance on v2026.09.07-work-shape-taxonomy.1).
+ * `InitiativeGateKey` declares the member as `post_implementation_review` and
+ * `@map`s it to the hyphenated database value, so a Prisma `where` clause must
+ * use the underscore member — the hyphenated string is rejected outright — while
+ * receipts, tool grants and readiness codes carry the hyphenated wire key.
+ * Rows read back through Prisma come out as the underscore member, so every
+ * comparison normalises first, the same way the readiness entry adapter does.
+ */
+export const PIR_GATE_WIRE_KEY = "post-implementation-review";
+const PIR_GATE_PRISMA_KEY = "post_implementation_review";
+
+function normalizeGateKey(value: string | null | undefined): string | null {
+  return value?.replaceAll("_", "-") ?? null;
+}
+
 /** Pure: has the declarer an earlier break-fix whose PIR window closed without a receipt? */
 export function findMissedPir(
   rows: ReadonlyArray<{ backlogItemId: string; kind: string; gateKey?: string | null; recordedAt: Date; payload: unknown; [extra: string]: unknown }>,
   now: Date,
 ): { backlogItemId: string; pirDueAt: string } | null {
-  const reviewed = new Set(rows.filter((row) => row.kind === "initiative_gate_receipt" && row.gateKey === "post-implementation-review").map((row) => row.backlogItemId));
+  const reviewed = new Set(rows.filter((row) => row.kind === "initiative_gate_receipt" && normalizeGateKey(row.gateKey) === PIR_GATE_WIRE_KEY).map((row) => row.backlogItemId));
   for (const row of rows) {
     if (row.kind !== BREAK_FIX_DECLARED_KIND) continue;
     const declared = declaration(row.payload);
@@ -120,7 +137,7 @@ export async function declareBreakFix(args: {
   const history = await args.db.backlogItemActivity.findMany({
     where: { OR: [
       { kind: BREAK_FIX_DECLARED_KIND, payload: { path: ["declaredByUserId"], equals: args.actor.userId } },
-      { kind: "initiative_gate_receipt", gateKey: "post-implementation-review" },
+      { kind: "initiative_gate_receipt", gateKey: PIR_GATE_PRISMA_KEY },
     ] },
     select: { id: true, backlogItemId: true, kind: true, gateKey: true, recordedAt: true, payload: true },
     take: 500,


### PR DESCRIPTION
fix(work-shapes): the PIR gate is queried by its Prisma member, not its database value (BI-D36E2916)

Found by live acceptance of the work-shape taxonomy on the reference install
running v2026.09.07-work-shape-taxonomy.1: declare_break_fix threw, so the
expedite lane could not be declared at all.

InitiativeGateKey declares the member as post_implementation_review and maps it
to the database value "post-implementation-review". A Prisma where clause takes
the member; the hyphenated form is rejected outright. Rows come back as the
member too, so the missed-PIR read-back never matched either and that refusal
would have stayed silent.

- declare-break-fix names both spellings: PIR_GATE_WIRE_KEY for receipts, tool
  grants and readiness codes, and the Prisma member for the query.
- findMissedPir normalises the gate key on read, the same way the readiness
  entry adapter has always done.

Tests: the filter is asserted to carry the Prisma member and not the wire key,
and a PIR receipt is recognised in either spelling while a declaration with no
receipt still reports the miss. Suite green; web typecheck clean.

Design-Grounding-Decision: repairs docs/superpowers/specs/2026-09-02-work-shape-taxonomy-and-proportional-gates-design.md §4 as shipped; no design change
Docs-Impact-Decision: none — behaviour now matches the runbook note already merged for the expedite lane
Process-Spine-Decision: defect found by the plan's own live-acceptance step; filed as BI-D36E2916 and fixed here
Seed-Fit-Decision: global-default
Convergence-Impact-Decision: auto-converges — application code only; the next self-upgrade carries it with the portal image, and the enum value it queries already migrated with the lane

Signed-off-by: Mark Bodman <markdbodman@gmail.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
