### PR TITLE
feat(portfolio): resolve workroom placement with provenance instead of defaulting to Foundational

### DIFF
--- a/apps/web/app/(shell)/ea/workrooms/page.test.tsx
+++ b/apps/web/app/(shell)/ea/workrooms/page.test.tsx
@@ -9,12 +9,24 @@ vi.mock("@/lib/ea/workroom-architecture", () => ({
   loadWorkroomCoordination: vi.fn(async () => ({ readAt: "2026-09-06T12:00:00.000Z", truncated: true, rooms: [
     { roomId: "WC-REVIEW", title: "Review change", status: "blocked", teamId: null, assignedActorRef: null, parentItemId: null, href: "/workspace/cases/work-capsule%3AWC-REVIEW?operation=unmapped" },
   ] })),
-  loadWorkroomArchitecture: vi.fn(async () => [
-    { role: "foundational", label: "Foundational", definitions: [] },
-    { role: "manufactureAndDeliver", label: "Manufacture and Deliver", definitions: [] },
-    { role: "forEmployees", label: "For Employees", definitions: [] },
-    { role: "productsAndServicesSold", label: "Products and Services Sold", definitions: [] },
-  ]),
+  loadWorkroomArchitecture: vi.fn(async () => ({
+    bands: [
+      { role: "foundational", label: "Foundational", definitions: [] },
+      { role: "manufactureAndDeliver", label: "Manufacture and Deliver", definitions: [] },
+      { role: "forEmployees", label: "For Employees", definitions: [] },
+      { role: "productsAndServicesSold", label: "Products and Services Sold", definitions: [] },
+    ],
+    unplaced: [
+      {
+        id: "team-unplaced", name: "Mystery stream", valueStream: "vs", shape: "specialist-dispatch",
+        coordinationPattern: {}, isActive: true, participants: [], triggers: [], queues: [],
+        instanceCount: 0, eaProcessId: null, eaViewId: null,
+        placement: { role: null, source: "unresolved", reason: 'Portfolio "mystery-stream" matches no canonical portfolio role.' },
+      },
+    ],
+    truncated: true,
+    observed: 1,
+  })),
 }));
 
 import WorkroomArchitecturePage from "./page";
@@ -36,5 +48,16 @@ describe("WorkroomArchitecturePage", () => {
     const html = renderToStaticMarkup(await WorkroomArchitecturePage());
 
     expect(measureUxBudget(html).readingGradeLevel).toBeLessThanOrEqual(9);
+  });
+  it("shows unplaced work as a labelled exception outside the four portfolios", async () => {
+    const html = renderToStaticMarkup(await WorkroomArchitecturePage());
+    expect(html).toContain("Not placed in a portfolio");
+    expect(html).toContain("Mystery stream");
+    expect(html).toContain("matches no canonical portfolio role");
+  });
+
+  it("labels a truncated architecture read as partial rather than a total", async () => {
+    const html = renderToStaticMarkup(await WorkroomArchitecturePage());
+    expect(html).toContain("Partial read");
   });
 });

--- a/apps/web/app/(shell)/ea/workrooms/page.tsx
+++ b/apps/web/app/(shell)/ea/workrooms/page.tsx
@@ -24,7 +24,8 @@ function HumanGateList({ triggers }: { triggers: Array<{ triggerPoint: string; r
 
 export default async function WorkroomArchitecturePage({ searchParams }: { searchParams?: Promise<{ operation?: string }> } = {}) {
   const operation = (await searchParams)?.operation;
-  const [bands, coordination] = await Promise.all([loadWorkroomArchitecture(prisma), loadWorkroomCoordination(prisma, new Date(), { teamId: operation === "unmapped" ? null : operation })]);
+  const [architecture, coordination] = await Promise.all([loadWorkroomArchitecture(prisma), loadWorkroomCoordination(prisma, new Date(), { teamId: operation === "unmapped" ? null : operation })]);
+  const { bands, unplaced, truncated: architectureTruncated } = architecture;
   const definitions = bands.flatMap((band) => band.definitions);
   const instanceCount = definitions.reduce((total, definition) => total + definition.instanceCount, 0);
 
@@ -44,6 +45,7 @@ export default async function WorkroomArchitecturePage({ searchParams }: { searc
             ? "No Workroom plans are set yet."
             : `${definitions.length} Workroom plan${definitions.length === 1 ? "" : "s"} guide work in ${bands.filter((band) => band.definitions.length > 0).length} portfolios.`}
         </p>
+
         <Link data-owner-first-next-action href={definitions.length > 0 ? `#portfolio-${bands.find((band) => band.definitions.length > 0)?.role ?? "foundational"}` : "/ea/value-streams"} className="mt-3 inline-block text-xs font-medium text-[var(--dpf-accent)] hover:underline">
           {definitions.length > 0 ? "Review Workroom plans" : "Review value streams"}
         </Link>
@@ -54,6 +56,27 @@ export default async function WorkroomArchitecturePage({ searchParams }: { searc
         <StatCard label="Linked rooms" value={instanceCount} href="#coordination" hint="Includes completed work" />
         <StatCard label="Portfolios" value={`${bands.filter((band) => band.definitions.length > 0).length} / 4`} hint="All four stay in view" />
       </div>
+
+      {architectureTruncated ? (
+        <p className="mb-6 text-xs text-[var(--dpf-muted)]">Partial read: more plans exist than shown.</p>
+      ) : null}
+
+      {unplaced.length > 0 ? (
+        <Surface id="portfolio-unplaced" className="mb-6" rounded="xl">
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">Not placed in a portfolio · {unplaced.length}</h2>
+          <p className="my-2 text-xs text-[var(--dpf-muted)]">Outside the four portfolios until placement is corrected.</p>
+          <ul className="divide-y divide-[var(--dpf-border)]">
+            {unplaced.map((definition) => (
+              <li key={definition.id} className="py-3">
+                <p className="text-sm font-medium text-[var(--dpf-text)]">{definition.name}</p>
+                <p className="text-xs text-[var(--dpf-muted)]">
+                  {definition.placement.role === null ? definition.placement.reason : null}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </Surface>
+      ) : null}
 
       <Surface id="coordination" className="mb-6" rounded="xl">
         <details open={Boolean(operation)}>

--- a/apps/web/lib/ea/workroom-architecture.test.ts
+++ b/apps/web/lib/ea/workroom-architecture.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { loadWorkroomArchitecture, loadWorkroomCoordination } from "./workroom-architecture";
+import { loadWorkroomArchitecture, loadWorkroomCoordination, resolvePortfolioPlacement } from "./workroom-architecture";
 
 describe("loadWorkroomArchitecture", () => {
   it("links actual rooms and reports missing architecture placement without guessing", async () => {
@@ -43,10 +43,10 @@ describe("loadWorkroomArchitecture", () => {
 
     const result = await loadWorkroomArchitecture(db);
 
-    expect(result.map((band) => band.role)).toEqual([
+    expect(result.bands.map((band) => band.role)).toEqual([
       "foundational", "manufactureAndDeliver", "forEmployees", "productsAndServicesSold",
     ]);
-    expect(result[1]?.definitions[0]).toEqual(expect.objectContaining({
+    expect(result.bands[1]?.definitions[0]).toEqual(expect.objectContaining({
       name: "Animal intake",
       shape: "specialist-dispatch",
       instanceCount: 2,
@@ -55,6 +55,90 @@ describe("loadWorkroomArchitecture", () => {
       queues: [expect.objectContaining({ name: "Intake queue" })],
       eaViewId: "view-1",
     }));
-    expect(result[0]?.definitions).toEqual([]);
+    expect(result.bands[0]?.definitions).toEqual([]);
+    expect(result.unplaced).toEqual([]);
   });
 });
+
+describe("resolvePortfolioPlacement", () => {
+  it("prefers the recorded decision and names it as the deciding source", () => {
+    expect(resolvePortfolioPlacement({
+      coordinationPattern: { portfolioRole: "forEmployees" },
+      portfolio: { slug: "operations", name: "Operations" },
+    })).toEqual({ role: "forEmployees", source: "coordination-pattern" });
+  });
+
+  it("falls back to slug then name, reporting the weaker derivation honestly", () => {
+    expect(resolvePortfolioPlacement({ portfolio: { slug: "operations", name: "Anything" } }))
+      .toEqual({ role: "manufactureAndDeliver", source: "portfolio-slug" });
+    expect(resolvePortfolioPlacement({ portfolio: { slug: "nonsense", name: "Workforce" } }))
+      .toEqual({ role: "forEmployees", source: "portfolio-name" });
+  });
+
+  it("reports an unrecognised portfolio as unresolved rather than defaulting to Foundational", () => {
+    const placement = resolvePortfolioPlacement({ portfolio: { slug: "mystery-stream", name: "Mystery" } });
+    expect(placement.role).toBeNull();
+    expect(placement.source).toBe("unresolved");
+    expect(placement).toHaveProperty("reason", expect.stringContaining("mystery-stream"));
+  });
+
+  it("reports a team with no portfolio link as unresolved", () => {
+    const placement = resolvePortfolioPlacement({ portfolio: null });
+    expect(placement.role).toBeNull();
+    expect(placement).toHaveProperty("reason", "The team is linked to no portfolio.");
+  });
+});
+
+describe("loadWorkroomArchitecture placement truthfulness", () => {
+  it("keeps unresolved teams out of the four portfolios and in a separate exception group", async () => {
+    const db = { valueStreamTeam: { findMany: vi.fn().mockResolvedValue([
+      TEAM_PLACED,
+      TEAM_UNRESOLVED,
+    ]) } };
+    const projection = await loadWorkroomArchitecture(db);
+    expect(projection.bands).toHaveLength(4);
+    const foundational = projection.bands.find((band) => band.role === "foundational")!;
+    expect(foundational.definitions).toHaveLength(0);
+    expect(projection.bands.find((band) => band.role === "manufactureAndDeliver")!.definitions.map((d) => d.id)).toEqual(["team-1"]);
+    expect(projection.unplaced.map((d) => d.id)).toEqual(["team-2"]);
+    const total = projection.bands.reduce((n, band) => n + band.definitions.length, 0) + projection.unplaced.length;
+    expect(total).toBe(2);
+  });
+
+  it("carries placement provenance onto each definition", async () => {
+    const db = { valueStreamTeam: { findMany: vi.fn().mockResolvedValue([TEAM_PLACED]) } };
+    const projection = await loadWorkroomArchitecture(db);
+    expect(projection.bands.find((band) => band.role === "manufactureAndDeliver")!.definitions[0]!.placement)
+      .toEqual({ role: "manufactureAndDeliver", source: "coordination-pattern" });
+  });
+
+  it("labels a truncated read as partial instead of presenting it as complete", async () => {
+    const many = Array.from({ length: 201 }, (_, i) => ({ ...TEAM_PLACED, id: `team-${i}` }));
+    const db = { valueStreamTeam: { findMany: vi.fn().mockResolvedValue(many) } };
+    const projection = await loadWorkroomArchitecture(db);
+    expect(projection.truncated).toBe(true);
+    expect(projection.observed).toBe(200);
+    expect(db.valueStreamTeam.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 201 }));
+  });
+
+  it("reports a complete read as not truncated", async () => {
+    const db = { valueStreamTeam: { findMany: vi.fn().mockResolvedValue([TEAM_PLACED]) } };
+    const projection = await loadWorkroomArchitecture(db);
+    expect(projection.truncated).toBe(false);
+    expect(projection.observed).toBe(1);
+  });
+});
+
+const TEAM_PLACED = {
+        id: "team-1", name: "Team 1", valueStream: "vs", teamPattern: "specialist-dispatch",
+        coordinationPattern: { portfolioRole: "manufactureAndDeliver" }, eaProcessId: null, eaViewId: null,
+        portfolioId: "p", portfolio: { slug: "operations", name: "Operations" }, isActive: true,
+        roles: [], hitlGates: [], queues: [], workItems: [{ _count: { capsules: 1 } }],
+      };
+
+const TEAM_UNRESOLVED = {
+        id: "team-2", name: "Team 2", valueStream: "vs", teamPattern: "specialist-dispatch",
+        coordinationPattern: {}, eaProcessId: null, eaViewId: null,
+        portfolioId: "p", portfolio: { slug: "mystery-stream", name: "Mystery" }, isActive: true,
+        roles: [], hitlGates: [], queues: [], workItems: [{ _count: { capsules: 1 } }],
+      };

--- a/apps/web/lib/ea/workroom-architecture.ts
+++ b/apps/web/lib/ea/workroom-architecture.ts
@@ -56,7 +56,25 @@ export type WorkroomDefinition = {
   instanceCount: number;
   eaProcessId: string | null;
   eaViewId: string | null;
+  placement: PortfolioPlacement;
 };
+
+/**
+ * How a team's portfolio placement was decided. `unresolved` is a first-class
+ * outcome: a team nobody has classified is reported as such, never folded into
+ * a real portfolio. Reading a placement without its source cannot distinguish a
+ * decided classification from a coincidental string match, which is exactly the
+ * ambiguity that made the previous Foundational fallback untrustworthy.
+ */
+export type PortfolioPlacementSource =
+  | "coordination-pattern"
+  | "portfolio-slug"
+  | "portfolio-name"
+  | "unresolved";
+
+export type PortfolioPlacement =
+  | { role: WorkCapsulePortfolioRole; source: Exclude<PortfolioPlacementSource, "unresolved"> }
+  | { role: null; source: "unresolved"; reason: string };
 
 export type WorkroomPortfolioBand = {
   role: WorkCapsulePortfolioRole;
@@ -68,31 +86,78 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
-function portfolioRoleOf(team: any): WorkCapsulePortfolioRole {
-  const explicit = asRecord(team.coordinationPattern).portfolioRole;
-  if (typeof explicit === "string" && WORK_CAPSULE_PORTFOLIO_ROLES.includes(explicit as WorkCapsulePortfolioRole)) {
-    return explicit as WorkCapsulePortfolioRole;
-  }
-  const normalized = String(team.portfolio?.slug ?? team.portfolio?.name ?? "").replaceAll(/[^a-z]/gi, "").toLocaleLowerCase("en-US");
-  const aliases: Record<string, WorkCapsulePortfolioRole> = {
-    foundational: "foundational",
-    foundation: "foundational",
-    manufactureanddeliver: "manufactureAndDeliver",
-    manufacturinganddelivery: "manufactureAndDeliver",
-    operations: "manufactureAndDeliver",
-    foremployees: "forEmployees",
-    workforce: "forEmployees",
-    productsandservicessold: "productsAndServicesSold",
-    goodsandservicesforsale: "productsAndServicesSold",
-  };
-  return aliases[normalized] ?? "foundational";
+const PORTFOLIO_ALIASES: Record<string, WorkCapsulePortfolioRole> = {
+  foundational: "foundational",
+  foundation: "foundational",
+  manufactureanddeliver: "manufactureAndDeliver",
+  manufacturinganddelivery: "manufactureAndDeliver",
+  operations: "manufactureAndDeliver",
+  foremployees: "forEmployees",
+  workforce: "forEmployees",
+  productsandservicessold: "productsAndServicesSold",
+  goodsandservicesforsale: "productsAndServicesSold",
+};
+
+function normalizePortfolioKey(value: unknown): string {
+  return String(value ?? "").replaceAll(/[^a-z]/gi, "").toLocaleLowerCase("en-US");
 }
 
-export async function loadWorkroomArchitecture(db: ArchitectureDb): Promise<WorkroomPortfolioBand[]> {
+/**
+ * Resolve a team's portfolio placement from its authoritative source, and say
+ * which source decided it.
+ *
+ * Order is authority order: an explicit `coordinationPattern.portfolioRole` is a
+ * recorded decision and wins; the portfolio slug and then its display name are
+ * weaker derivations and are reported as such. When none of them resolves, the
+ * result is `unresolved` with a reason. It is deliberately not defaulted to
+ * Foundational — an unclassified team reported as Foundational is indistinguishable
+ * from a team genuinely in that portfolio, and the larger the unclassified set the
+ * more authoritative that wrong answer looks.
+ */
+export function resolvePortfolioPlacement(team: {
+  coordinationPattern?: unknown;
+  portfolio?: { slug?: string | null; name?: string | null } | null;
+}): PortfolioPlacement {
+  const explicit = asRecord(team.coordinationPattern).portfolioRole;
+  if (typeof explicit === "string" && WORK_CAPSULE_PORTFOLIO_ROLES.includes(explicit as WorkCapsulePortfolioRole)) {
+    return { role: explicit as WorkCapsulePortfolioRole, source: "coordination-pattern" };
+  }
+  const slugRole = PORTFOLIO_ALIASES[normalizePortfolioKey(team.portfolio?.slug)];
+  if (slugRole) return { role: slugRole, source: "portfolio-slug" };
+  const nameRole = PORTFOLIO_ALIASES[normalizePortfolioKey(team.portfolio?.name)];
+  if (nameRole) return { role: nameRole, source: "portfolio-name" };
+  const described = String(team.portfolio?.slug ?? team.portfolio?.name ?? "").trim();
+  return {
+    role: null,
+    source: "unresolved",
+    reason: described
+      ? `Portfolio "${described}" matches no canonical portfolio role.`
+      : "The team is linked to no portfolio.",
+  };
+}
+
+/**
+ * The four canonical portfolio bands, plus everything that could not be placed
+ * and whether the read was complete. `unplaced` is not a fifth portfolio: it is
+ * the exception group PWA-01 requires, and it exists so that unresolved work is
+ * discoverable and repairable without inflating a real portfolio's totals.
+ */
+export type WorkroomArchitectureProjection = {
+  bands: WorkroomPortfolioBand[];
+  unplaced: WorkroomDefinition[];
+  /** True when more teams exist than this bounded read returned. */
+  truncated: boolean;
+  /** Teams returned by this page; never presented as an estate total. */
+  observed: number;
+};
+
+const ARCHITECTURE_PAGE_SIZE = 200;
+
+export async function loadWorkroomArchitecture(db: ArchitectureDb): Promise<WorkroomArchitectureProjection> {
   const teams = await db.valueStreamTeam.findMany({
     where: { isActive: true },
     orderBy: [{ portfolioId: "asc" }, { name: "asc" }],
-    take: 200,
+    take: ARCHITECTURE_PAGE_SIZE + 1,
     select: {
       id: true,
       name: true,
@@ -120,14 +185,19 @@ export async function loadWorkroomArchitecture(db: ArchitectureDb): Promise<Work
     },
   });
 
+  const truncated = teams.length > ARCHITECTURE_PAGE_SIZE;
+  const page = truncated ? teams.slice(0, ARCHITECTURE_PAGE_SIZE) : teams;
+
   const bands = WORK_CAPSULE_PORTFOLIO_ROLES.map((role) => ({
     role,
     label: portfolioRoleLabel(role),
     definitions: [] as WorkroomDefinition[],
   }));
+  const unplaced: WorkroomDefinition[] = [];
   const byRole = new Map(bands.map((band) => [band.role, band]));
-  for (const team of teams) {
-    byRole.get(portfolioRoleOf(team))?.definitions.push({
+  for (const team of page) {
+    const placement = resolvePortfolioPlacement(team);
+    const definition: WorkroomDefinition = {
       id: team.id,
       name: team.name,
       valueStream: team.valueStream,
@@ -140,7 +210,12 @@ export async function loadWorkroomArchitecture(db: ArchitectureDb): Promise<Work
       instanceCount: team.workItems.reduce((total: number, item: any) => total + (item._count?.capsules ?? 0), 0),
       eaProcessId: team.eaProcessId,
       eaViewId: team.eaViewId,
-    });
+      placement,
+    };
+    // A room is counted once per scope: placed into exactly one band, or into
+    // the exception group. Never both, and never silently into Foundational.
+    if (placement.role === null) unplaced.push(definition);
+    else byRole.get(placement.role)?.definitions.push(definition);
   }
-  return bands;
+  return { bands, unplaced, truncated, observed: page.length };
 }

--- a/docs/user-guide/architecture/index.md
+++ b/docs/user-guide/architecture/index.md
@@ -20,7 +20,11 @@ The EA Modeler is a canvas-based tool for building and maintaining your organiza
 
 ## Workroom Definitions
 
-Open **Architecture > Workrooms** (`/ea/workrooms`) to review collaboration from the definition perspective. The page keeps all four portfolios visible, groups each Value Stream Team under its owning portfolio, and links the reusable shape to its process view and operational instances. Define or refine the underlying Value Stream Team when participants, queues, or approval triggers need to change; use **Operations > Workrooms** to inspect activity created from those definitions.
+Open **Architecture > Workrooms** (`/ea/workrooms`) to review collaboration from the definition perspective. The page keeps all four portfolios visible, groups each Value Stream Team under its owning portfolio, and links the reusable shape to its process view and operational instances.
+
+A team is placed in a portfolio from what the platform actually records: an explicit portfolio role on the team wins, and its portfolio slug or name are used only as weaker fallbacks. When none of those decides the question, the team is listed under **Not placed in a portfolio** with the reason, instead of being shown inside a portfolio nobody assigned it to. Those teams are counted separately, so a portfolio's total only ever counts teams that genuinely belong to it. Correct a placement by setting the team's portfolio role or linking it to the right portfolio.
+
+The page reads a bounded page of teams rather than the whole estate. When more exist than it shows, it says **Partial read**, so the counts above are never mistaken for an estate-wide total. Define or refine the underlying Value Stream Team when participants, queues, or approval triggers need to change; use **Operations > Workrooms** to inspect activity created from those definitions.
 
 ## What You Can Do
 

--- a/docs/ux-fit/2026-09-07-portfolio-placement-truthfulness.ux-fit.json
+++ b/docs/ux-fit/2026-09-07-portfolio-placement-truthfulness.ux-fit.json
@@ -1,0 +1,25 @@
+{
+  "version": "1",
+  "decidedOption": "notices-beside-the-content-they-qualify",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/ea/workrooms/page.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "improved",
+    "measured": {
+      "/ea/workrooms": {
+        "defaultVisibleWords": 191,
+        "leadBandWords": 9,
+        "primaryActions": 0,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
Makes the portfolio axis truthful. This is deliverable D1 of the portfolio work activity refactoring (BI-FB6389E0), the foundation the activity tree hangs on.

## The problem

Two behaviours in `apps/web/lib/ea/workroom-architecture.ts` made portfolio placement untrustworthy.

`portfolioRoleOf` ended in `aliases[normalized] ?? "foundational"`. A team whose portfolio matched no alias was reported as Foundational rather than as unknown, so a reader could not tell a team genuinely in that portfolio from one nobody had classified. The larger the unclassified set grew, the more authoritative the wrong answer looked.

`loadWorkroomArchitecture` also read 200 teams with no truncation signal, so a bounded page could be presented as a complete classification of the estate.

## The change

`resolvePortfolioPlacement` returns the role together with the source that decided it. An explicit `coordinationPattern.portfolioRole` is a recorded decision and wins; portfolio slug and name are weaker derivations, reported as such; anything else is `unresolved` with a reason.

Unresolved teams go to a labelled exception group outside the four portfolios, counted separately so they never inflate a real portfolio's total. The projection reports `truncated` and `observed`, and the page labels a partial read as partial.

The four canonical roles are unchanged and no parallel placement store is introduced. Nothing is written to the database: this corrects the derivation and leaves reconciliation of stored values as its own evidenced step.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-09-07-portfolio-work-activity-design.md` — requirement PWA-01, contract C1, verification V1
  - `docs/superpowers/plans/2026-09-07-portfolio-work-activity.md` — deliverable D1
- Current code substrate reviewed:
  - `apps/web/lib/ea/workroom-architecture.ts`, `apps/web/app/(shell)/ea/workrooms/page.tsx`, `apps/web/lib/work-capsules.ts`
- Decision: report placement with its deciding source and make unresolved a first-class outcome, rather than extending the alias table or backfilling a guess into the database.

## Verification

- Unit tests: 17 pass across the projection and the page, covering placement provenance, the unresolved outcome for both an unrecognised portfolio and a missing link, the exception group staying out of the four bands, once-per-scope counting, and truncation labelling.
- Typecheck: clean.
- Production build: passes.
- Local CI gate: passed on the merged code at `cd6618997670`, evidence `cmtrc0jb6ih3k01r9jez0lll6`.
- UX: notices were moved out of the lead band beside the content they qualify, holding `leadBandWords` at its frozen baseline of 9 while visible words fell from 222 to 191, with 0 axe violations measured. Manifest: `docs/ux-fit/2026-09-07-portfolio-placement-truthfulness.ux-fit.json`.
- Docs: the user guide now explains how placement is decided and what an unplaced team means.
- No schema or migration change.

## Governance status, stated plainly

This PR carries **no initiative gate receipts**, and that is not an oversight. Every receipt write on this install is intercepted by the generic coworker approval gate and expires unapproved after fifteen minutes, unannounced. That is filed as BI-F2E199B1 with evidence from nine reviewer dispatches across four gates and two writer tools, including one whose envelope expired while being watched. `AgentGovernanceProfile` is empty, so no configured policy is being overridden; the bypass a bound receipt is documented to receive simply does not apply, because the envelope is never associated with its TaskRun.

The defect blocks its own repair, since fixing it also requires a receipt. The operator directed this work to proceed. The xlarge umbrella BI-8DACBA07 was not claimed for implementation and was not reclassified; its decomposition refusal stands.

Backlog: BI-FB6389E0. Umbrella BI-8DACBA07. Blocker BI-F2E199B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Local-CI-Evidence: cmtrc0jb6ih3k01r9jez0lll6
