### PR TITLE
fix(self-upgrade): a declined unattended tick says so, and the status stops contradicting the throttle (BI-3CA18934)

### DIFF
--- a/apps/web/lib/mcp/packs/self-upgrade-pack.consumer.test.ts
+++ b/apps/web/lib/mcp/packs/self-upgrade-pack.consumer.test.ts
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   readSelfUpgradeSupport: vi.fn(),
   resolveReleaseBatchStatus: vi.fn(),
   getLatestRun: vi.fn(),
+  getLastCheckedAt: vi.fn(),
+  getScheduledDecline: vi.fn(),
 }));
 
 vi.mock("@/lib/self-upgrade/request", () => ({
@@ -22,6 +24,16 @@ vi.mock("@/lib/self-upgrade/release-batch-status", () => ({
 }));
 vi.mock("@/lib/self-upgrade/run-store", () => ({
   getLatestRun: mocks.getLatestRun,
+}));
+vi.mock("@/lib/self-upgrade/last-check", () => ({
+  getLastCheckedAt: mocks.getLastCheckedAt,
+}));
+// Keep the real schedule arithmetic; stub only its DB reader, so the status the
+// test asserts is produced by the same functions the cron gate uses.
+vi.mock("@/lib/self-upgrade/scheduled-gate", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/self-upgrade/scheduled-gate")>()),
+  getScheduledDecline: mocks.getScheduledDecline,
+  recordScheduledDecline: vi.fn(),
 }));
 
 import { selfUpgradePack } from "./self-upgrade-pack";
@@ -56,6 +68,8 @@ describe("self-upgrade MCP tools on consumer installs", () => {
       support,
     });
     mocks.getLatestRun.mockResolvedValue(null);
+    mocks.getLastCheckedAt.mockResolvedValue(null);
+    mocks.getScheduledDecline.mockResolvedValue(null);
   });
 
   it("returns the queued artifact-native dispatch result", async () => {
@@ -75,8 +89,44 @@ describe("self-upgrade MCP tools on consumer installs", () => {
   it("reports enabled and routine-upgrade eligible", async () => {
     expect(await call("get_self_upgrade_queue_status")).toMatchObject({
       success: true,
-      data: { supported: true, enabled: true, routineUpgradeEligible: true },
+      data: {
+        supported: true,
+        enabled: true,
+        routineUpgradeEligible: true,
+        releaseBatchEligible: true,
+        nextScheduledCheckAt: null,
+        scheduledGate: null,
+      },
     });
+  });
+
+  it("BI-3CA18934: is NOT routine-eligible while the unattended check is throttled, and says when it is due", async () => {
+    mocks.getSelfUpgradeConfig.mockResolvedValue({ enabled: true, sourceMode: "upstream", checkIntervalHours: 24 });
+    mocks.getLastCheckedAt.mockResolvedValue(new Date(Date.now() - 2 * 60 * 60 * 1000));
+    mocks.getScheduledDecline.mockResolvedValue({
+      reason: "interval-not-elapsed",
+      at: new Date().toISOString(),
+    });
+
+    const result = await call("get_self_upgrade_queue_status") as unknown as {
+      data: { routineUpgradeEligible: boolean; releaseBatchEligible: boolean; nextScheduledCheckAt: string | null; checkIntervalHours: number; scheduledGate: { reason: string } | null };
+    };
+
+    // The release batch still allows an upgrade; the unattended path does not.
+    expect(result.data.releaseBatchEligible).toBe(true);
+    expect(result.data.routineUpgradeEligible).toBe(false);
+    expect(result.data.checkIntervalHours).toBe(24);
+    expect(result.data.nextScheduledCheckAt).not.toBeNull();
+    expect(result.data.scheduledGate).toMatchObject({ reason: "interval-not-elapsed" });
+  });
+
+  it("BI-3CA18934: drops a stale decline recorded before the last successful check", async () => {
+    mocks.getSelfUpgradeConfig.mockResolvedValue({ enabled: true, sourceMode: "upstream", checkIntervalHours: 24 });
+    mocks.getLastCheckedAt.mockResolvedValue(new Date("2026-09-07T05:39:09.895Z"));
+    mocks.getScheduledDecline.mockResolvedValue({ reason: "outside-window", at: "2026-09-07T04:00:00.000Z" });
+
+    const result = await call("get_self_upgrade_queue_status") as unknown as { data: { scheduledGate: unknown } };
+    expect(result.data.scheduledGate).toBeNull();
   });
 
   it("reports that the promoter is release-managed", async () => {

--- a/apps/web/lib/mcp/packs/self-upgrade-pack.ts
+++ b/apps/web/lib/mcp/packs/self-upgrade-pack.ts
@@ -203,11 +203,24 @@ async function getSelfUpgradeQueueStatusTool(): Promise<ToolResult> {
       import("@/lib/self-upgrade/run-store"),
     ]);
   const config = await getSelfUpgradeConfig();
-  const [batch, latestRun] = await Promise.all([
+  const { getLastCheckedAt } = await import("@/lib/self-upgrade/last-check");
+  const { declineIsCurrent, nextScheduledCheckAt } = await import("@/lib/self-upgrade/scheduled-gate");
+  const { getScheduledDecline } = await import("@/lib/self-upgrade/scheduled-gate");
+  const [batch, latestRun, lastCheckedAt, decline] = await Promise.all([
     resolveReleaseBatchStatus({ fresh: true, config }),
     getLatestRun(),
+    getLastCheckedAt(),
+    getScheduledDecline(),
   ]);
   const support = batch.support;
+  // BI-3CA18934: the unattended path is throttled by checkIntervalHours and
+  // gated by window/cooldown/blackout, none of which this status consulted. It
+  // reported routineUpgradeEligible:true while the next unattended check was 22
+  // hours away, so a merged fix looked imminent and never arrived. Report the
+  // schedule, and never call the routine path eligible while it would decline.
+  const nextScheduledCheck = nextScheduledCheckAt(lastCheckedAt, config.checkIntervalHours, new Date());
+  const scheduledGate = declineIsCurrent(decline, lastCheckedAt) ? decline : null;
+  const releaseBatchEligible = support.enabled && batch.eligible;
   return {
     success: true,
     message: support.message ?? batch.summary,
@@ -218,7 +231,12 @@ async function getSelfUpgradeQueueStatusTool(): Promise<ToolResult> {
       targetKind: support.targetKind,
       sourceMode: config.sourceMode,
       batchingApplicable: support.supported && batch.applicable,
-      routineUpgradeEligible: support.enabled && batch.eligible,
+      releaseBatchEligible,
+      routineUpgradeEligible: releaseBatchEligible && nextScheduledCheck === null,
+      lastCheckedAt: lastCheckedAt?.toISOString() ?? null,
+      checkIntervalHours: config.checkIntervalHours,
+      nextScheduledCheckAt: nextScheduledCheck?.toISOString() ?? null,
+      scheduledGate: scheduledGate ? { reason: scheduledGate.reason, at: scheduledGate.at } : null,
       reason: support.supported ? batch.reason : support.reason,
       pendingPrCount: batch.pendingCount,
       batchMinPendingPrs: batch.minPendingPrs,

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -57,6 +57,7 @@ import {
   failQuiescenceSwap,
 } from "@/lib/self-upgrade/quiescence";
 import { rejectDuplicateSelfUpgradeDelivery } from "@/lib/self-upgrade/delivery-admission";
+import { evaluateScheduledGate, recordScheduledDecline } from "@/lib/self-upgrade/scheduled-gate";
 import {
   SELF_UPGRADE_CRON,
   SELF_UPGRADE_EVENT,
@@ -97,6 +98,11 @@ export async function runSelfUpgrade(
     extra: Record<string, unknown> = {},
   ): Promise<Record<string, unknown>> {
     if (params.runId) await skipRun(params.runId, persistedReason);
+    // BI-3CA18934: the scheduled cron carries no runId, so without this a
+    // declined unattended tick left NO trace at all — no row, no reason — and
+    // the only evidence was the absence of a run, which reads like a broken
+    // scheduler. Record it where the status tool can retrieve it.
+    else if (params.scheduled) await recordScheduledDecline(persistedReason, now);
     return {
       skipped: true,
       reason,
@@ -151,49 +157,12 @@ export async function runSelfUpgrade(
   // timezone can't be scheduled safely (any local hour could be peak), so it skips
   // with a distinct reason and the Upgrade Center prompts for a timezone — a clean
   // no-op (no drain, no cooldown), never a silent never-runs.
+  // Every unattended gate — blackout, window, interval — now lives in
+  // scheduled-gate.ts beside the status that reports it (BI-3CA18934).
   if (params.scheduled && !params.force) {
-    // Operator blackout gate (BI-59591B14): a declared no-change period pauses the
-    // unattended upgrade. A self-upgrade is a disruptive (standard) change, so it
-    // respects the same blackouts that gate other changes — unless the blackout
-    // excepts self-upgrade. Manual / force bypass. Clean no-op skip (no drain, no
-    // cooldown); it resumes automatically once the blackout ends. This is the
-    // proactive guard quiescence can't provide (a blackout may be declared ahead
-    // of time with nothing yet running).
-    const blackout = await getActiveSelfUpgradeBlackout(now);
-    if (blackout) {
-      return await skipAttempt(
-        "blackout-period",
-        `blackout-period: ${blackout.name} until ${blackout.endAt.toISOString()}`,
-        { blackoutUntil: blackout.endAt.toISOString() },
-      );
-    }
-    const { schedule, timezone, timezoneKnown, lowTrafficWindows } =
-      await resolveOperatingScheduleForSystem();
-    const auto =
-      config.maintenanceWindows.length > 0
-        ? null
-        : resolveAutoUpgradeWindow({ schedule, timeZone: timezone, timezoneKnown, lowTrafficWindows });
-    if (auto?.kind === "needs-timezone") {
-      return await skipAttempt("no-window-needs-timezone");
-    }
-    const explicitWindows =
-      config.maintenanceWindows.length > 0
-        ? config.maintenanceWindows
-        : auto?.kind === "auto-overnight"
-          ? auto.windows
-          : undefined;
-    const allowed = isUpgradeWindowOpen({ explicitWindows, schedule, timeZone: timezone });
-    if (!allowed) return await skipAttempt("outside-window");
-  }
-
-  // checkIntervalHours throttle: only the scheduled cron is rate-limited, so the
-  // hourly tick polls no more often than the operator configured. Manual/forced
-  // runs are never throttled (the operator is asking now) but still reset the
-  // clock below.
-  if (params.scheduled && !params.dryRun && !params.force) {
-    const lastCheckedAt = await getLastCheckedAt();
-    if (!isCheckIntervalElapsed(lastCheckedAt, config.checkIntervalHours, now)) {
-      return await skipAttempt("interval-not-elapsed");
+    const decline = await evaluateScheduledGate({ config, now, dryRun: params.dryRun });
+    if (decline) {
+      return await skipAttempt(decline.reason, decline.persistedReason ?? decline.reason, decline.extra ?? {});
     }
   }
 

--- a/apps/web/lib/self-upgrade/scheduled-gate.test.ts
+++ b/apps/web/lib/self-upgrade/scheduled-gate.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { isCheckIntervalElapsed } from "./last-check";
+import {
+  declineIsCurrent,
+  nextScheduledCheckAt,
+  scheduledCheckIsThrottled,
+} from "./scheduled-gate";
+
+const NOW = new Date("2026-09-07T07:04:00Z");
+// The live values that produced BI-3CA18934.
+const LAST_CHECKED = new Date("2026-09-07T05:39:09.895Z");
+
+describe("nextScheduledCheckAt", () => {
+  it("BI-3CA18934: reports the next unattended check a full interval after the last one", () => {
+    expect(nextScheduledCheckAt(LAST_CHECKED, 24, NOW)?.toISOString())
+      .toBe("2026-09-08T05:39:09.895Z");
+  });
+
+  it("is null when a check has never run", () => {
+    expect(nextScheduledCheckAt(null, 24, NOW)).toBeNull();
+  });
+
+  it("is null when the interval is non-positive (no throttle)", () => {
+    expect(nextScheduledCheckAt(LAST_CHECKED, 0, NOW)).toBeNull();
+  });
+
+  it("is null once the interval has elapsed", () => {
+    const after = new Date("2026-09-08T06:00:00Z");
+    expect(nextScheduledCheckAt(LAST_CHECKED, 24, after)).toBeNull();
+  });
+
+  it("never disagrees with the gate the cron actually applies", () => {
+    const cases: Array<[Date | null, number, Date]> = [
+      [LAST_CHECKED, 24, NOW],
+      [LAST_CHECKED, 24, new Date("2026-09-08T05:39:09.895Z")],
+      [LAST_CHECKED, 1, NOW],
+      [null, 24, NOW],
+      [LAST_CHECKED, -1, NOW],
+    ];
+    for (const [last, hours, now] of cases) {
+      expect(scheduledCheckIsThrottled(last, hours, now))
+        .toBe(!isCheckIntervalElapsed(last, hours, now));
+    }
+  });
+});
+
+describe("declineIsCurrent", () => {
+  it("keeps a decline recorded after the last successful check", () => {
+    expect(declineIsCurrent(
+      { reason: "interval-not-elapsed", at: "2026-09-07T07:00:00Z" },
+      LAST_CHECKED,
+    )).toBe(true);
+  });
+
+  it("BI-3CA18934: drops a decline that predates the last check (the throttle lifted)", () => {
+    expect(declineIsCurrent(
+      { reason: "outside-window", at: "2026-09-07T04:00:00Z" },
+      LAST_CHECKED,
+    )).toBe(false);
+  });
+
+  it("is false with no decline, and tolerates a malformed timestamp", () => {
+    expect(declineIsCurrent(null, LAST_CHECKED)).toBe(false);
+    expect(declineIsCurrent({ reason: "cooldown", at: "not-a-date" }, LAST_CHECKED)).toBe(false);
+  });
+});

--- a/apps/web/lib/self-upgrade/scheduled-gate.ts
+++ b/apps/web/lib/self-upgrade/scheduled-gate.ts
@@ -1,0 +1,165 @@
+// apps/web/lib/self-upgrade/scheduled-gate.ts
+//
+// BI-3CA18934. The scheduled cron fires hourly but declines most ticks:
+// checkIntervalHours (default 24) throttles it, and the window, cooldown,
+// blackout and promoter prechecks decline before that. Every one of those
+// declines used to vanish — `skipAttempt` persists only through
+// `skipRun(runId, …)` and the cron passes no runId — so the sole evidence was
+// the ABSENCE of a run, which reads exactly like a broken scheduler. It was
+// read that way: a merged fix sat undeployed and the operator was told the
+// upgrade was eligible while the next unattended check was 22 hours out.
+//
+// Two pieces, both cheap: a durable trace of the last scheduled decline, and
+// the pure arithmetic for when the next unattended check becomes due. Neither
+// changes upgrade POLICY — the interval and window remain the operator's.
+
+import { prisma } from "@dpf/db";
+
+import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
+import { resolveAutoUpgradeWindow } from "@/lib/self-upgrade/auto-window";
+import { getActiveSelfUpgradeBlackout } from "@/lib/self-upgrade/blackout";
+import type { SelfUpgradeConfig } from "@/lib/self-upgrade/config";
+import { getLastCheckedAt, isCheckIntervalElapsed } from "@/lib/self-upgrade/last-check";
+import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
+
+const DECLINE_CONFIG_KEY = "self_upgrade.lastScheduledDecline";
+
+/** A gate declined the unattended tick: the reason, plus what the caller reports. */
+export type ScheduledGateDecline = {
+  reason: string;
+  persistedReason?: string;
+  extra?: Record<string, unknown>;
+};
+
+// Reuse the real config type: a hand-rolled shape here would drift from the
+// window/interval contract the rest of the upgrade path applies.
+type ScheduledGateConfig = Pick<SelfUpgradeConfig, "maintenanceWindows" | "checkIntervalHours">;
+
+/**
+ * Every gate that declines an UNATTENDED tick before any drain, in order.
+ * Extracted from runSelfUpgrade so the gates and the status that reports them
+ * live in one module and cannot drift (BI-3CA18934). Returns null when the
+ * unattended path may proceed. Manual and forced runs never reach here: the
+ * operator is asking now.
+ *
+ * Blackout (BI-59591B14): a declared no-change period pauses the unattended
+ * upgrade, since a self-upgrade is a disruptive change; it resumes on its own
+ * once the blackout ends.
+ *
+ * Window: an explicit operator-configured maintenanceWindows array wins;
+ * otherwise, for an effectively-24/7 store with a known timezone, an
+ * auto-selected low-traffic overnight window (BI-A6382FB9) — without which a
+ * 24/7 store would never open a window and scheduled upgrades would never run;
+ * otherwise the operating-hours "store closed" derivation. A 24/7 store with no
+ * derivable timezone cannot be scheduled safely (any local hour could be peak),
+ * so it declines with a distinct reason and the Upgrade Center prompts for a
+ * timezone — never a silent never-runs.
+ *
+ * Interval: only the scheduled cron is rate-limited, so the hourly tick polls
+ * no more often than the operator configured.
+ *
+ * Every decline here is a clean no-op: no drain, no cooldown.
+ */
+export async function evaluateScheduledGate(args: {
+  config: ScheduledGateConfig;
+  now: Date;
+  dryRun?: boolean;
+}): Promise<ScheduledGateDecline | null> {
+  const { config, now } = args;
+  const blackout = await getActiveSelfUpgradeBlackout(now);
+  if (blackout) {
+    return {
+      reason: "blackout-period",
+      persistedReason: `blackout-period: ${blackout.name} until ${blackout.endAt.toISOString()}`,
+      extra: { blackoutUntil: blackout.endAt.toISOString() },
+    };
+  }
+  const { schedule, timezone, timezoneKnown, lowTrafficWindows } =
+    await resolveOperatingScheduleForSystem();
+  const auto = config.maintenanceWindows.length > 0
+    ? null
+    : resolveAutoUpgradeWindow({ schedule, timeZone: timezone, timezoneKnown, lowTrafficWindows });
+  if (auto?.kind === "needs-timezone") return { reason: "no-window-needs-timezone" };
+  const explicitWindows = config.maintenanceWindows.length > 0
+    ? config.maintenanceWindows
+    : auto?.kind === "auto-overnight" ? auto.windows : undefined;
+  if (!isUpgradeWindowOpen({ explicitWindows, schedule, timeZone: timezone })) {
+    return { reason: "outside-window" };
+  }
+  if (!args.dryRun) {
+    const lastCheckedAt = await getLastCheckedAt();
+    if (!isCheckIntervalElapsed(lastCheckedAt, config.checkIntervalHours, now)) {
+      return { reason: "interval-not-elapsed" };
+    }
+  }
+  return null;
+}
+
+export type ScheduledDecline = {
+  reason: string;
+  at: string;
+};
+
+/**
+ * When the next unattended check becomes due. Null when it is due now (never
+ * checked, or a non-positive interval, which means no throttle). Mirrors
+ * `isCheckIntervalElapsed` exactly so the status a caller reads and the gate
+ * the cron applies can never disagree.
+ */
+export function nextScheduledCheckAt(
+  lastCheckedAt: Date | null,
+  intervalHours: number,
+  now: Date,
+): Date | null {
+  if (!lastCheckedAt) return null;
+  if (!(intervalHours > 0)) return null;
+  const next = new Date(lastCheckedAt.getTime() + intervalHours * 60 * 60 * 1000);
+  return next.getTime() <= now.getTime() ? null : next;
+}
+
+/** True when the unattended path is throttled right now. */
+export function scheduledCheckIsThrottled(
+  lastCheckedAt: Date | null,
+  intervalHours: number,
+  now: Date,
+): boolean {
+  return nextScheduledCheckAt(lastCheckedAt, intervalHours, now) !== null;
+}
+
+/**
+ * Keep a decline only while it still explains the present. A decline recorded
+ * before the last successful check describes a throttle that has since lifted,
+ * and reporting it would be its own kind of lie.
+ */
+export function declineIsCurrent(
+  decline: ScheduledDecline | null,
+  lastCheckedAt: Date | null,
+): boolean {
+  if (!decline) return false;
+  const at = new Date(decline.at);
+  if (Number.isNaN(at.getTime())) return false;
+  if (!lastCheckedAt) return true;
+  return at.getTime() >= lastCheckedAt.getTime();
+}
+
+/** Record why an unattended tick declined. Never throws into the caller. */
+export async function recordScheduledDecline(reason: string, now: Date): Promise<void> {
+  const value = { reason, at: now.toISOString() };
+  try {
+    await prisma.platformConfig.upsert({
+      where: { key: DECLINE_CONFIG_KEY },
+      update: { value },
+      create: { key: DECLINE_CONFIG_KEY, value },
+    });
+  } catch {
+    // Observability must never break the upgrade path it observes.
+  }
+}
+
+export async function getScheduledDecline(): Promise<ScheduledDecline | null> {
+  const row = await prisma.platformConfig.findUnique({ where: { key: DECLINE_CONFIG_KEY } });
+  const value = row?.value as { reason?: unknown; at?: unknown } | null;
+  const reason = typeof value?.reason === "string" ? value.reason : null;
+  const at = typeof value?.at === "string" ? value.at : null;
+  return reason && at ? { reason, at } : null;
+}

--- a/docs/superpowers/plans/2026-09-07-scheduled-upgrade-decline-is-observable-plan.md
+++ b/docs/superpowers/plans/2026-09-07-scheduled-upgrade-decline-is-observable-plan.md
@@ -1,0 +1,36 @@
+---
+status: active
+title: A declined unattended upgrade tick says so — fix plan
+backlog_item: BI-3CA18934
+design: docs/superpowers/specs/2026-09-07-scheduled-upgrade-decline-is-observable-design.md
+---
+
+# A declined unattended upgrade tick says so — fix plan
+
+- **Backlog item:** `BI-3CA18934` (fix profile, atomic)
+- **Design:** [`2026-09-07-scheduled-upgrade-decline-is-observable-design.md`](../specs/2026-09-07-scheduled-upgrade-decline-is-observable-design.md)
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-3CA18934`
+- Receipt: `blocked-by: the coverage receipt is minted against this plan blob once it is on the bound Workroom head; recorded on the next push`
+- Rationale: the trace and the status are one contract. Recording declines that
+  nothing reports leaves the operator exactly as blind; reporting a schedule
+  with no decline reason still cannot say why a due tick did not run.
+- Dependencies: none
+
+| Key | Requirement refs | Contract refs | Flow refs | Verification refs |
+| --- | --- | --- | --- | --- |
+| scheduled-decline-observable | OBJ-UPGRADE-VISIBILITY-1 | self_upgrade.lastScheduledDecline, nextScheduledCheckAt, releaseBatchEligible | record the decline when skipAttempt has no runId and the attempt is scheduled; report the schedule and gate in the queue status | AC-1, AC-2, AC-3, AC-4 |
+
+## Fix sequence (all complete)
+
+1. `apps/web/lib/self-upgrade/scheduled-gate.ts`: pure `nextScheduledCheckAt` / `scheduledCheckIsThrottled` / `declineIsCurrent`, plus durable `recordScheduledDecline` / `getScheduledDecline`.
+2. `apps/web/lib/queue/functions/self-upgrade.ts`: a scheduled `skipAttempt` with no runId records its reason.
+3. `apps/web/lib/mcp/packs/self-upgrade-pack.ts`: report the schedule and gate; `routineUpgradeEligible` requires an unthrottled unattended path; `releaseBatchEligible` preserves the previous meaning.
+4. Tests: AC-1 and AC-4 in `scheduled-gate.test.ts`, AC-2 and AC-3 in `self-upgrade-pack.consumer.test.ts`.
+
+## Verification
+
+Red-then-green: the new assertions fail against `origin/main` source and pass with the fix. OBJ-UPGRADE-VISIBILITY-1 is covered by AC-1, AC-2, AC-3, AC-4.

--- a/docs/superpowers/specs/2026-09-07-scheduled-upgrade-decline-is-observable-design.md
+++ b/docs/superpowers/specs/2026-09-07-scheduled-upgrade-decline-is-observable-design.md
@@ -1,0 +1,50 @@
+---
+status: active
+title: A declined unattended upgrade tick says so, and the queue status stops contradicting the throttle
+backlog_item: BI-3CA18934
+---
+
+# A declined unattended upgrade tick says so
+
+- **Date:** 2026-09-07
+- **Scope:** platform — self-upgrade scheduled path, self-upgrade MCP status
+- **Backlog item:** `BI-3CA18934`
+- **Profile:** fix
+- **Status:** Design — implemented in this branch.
+
+**OBJ-UPGRADE-VISIBILITY-1:** An operator or agent reading the self-upgrade status can tell whether the unattended path will run, why it declined if it did, and when the next unattended check is due, without inferring any of it from the absence of a run.
+
+## 1. Defect, on a named ref
+
+Measured on this operator install on 2026-09-07. Release `v2026.09.07-small-shape-completion.1` at `9afc62c` published and verified at 06:28. At 07:04 the install still ran revision `0713430`, which predates it, and `SelfUpgradeRun` held no row for the 06:00 or 07:00 tick.
+
+The scheduler was behaving correctly. `self_upgrade.lastCheckedAt` was `2026-09-07T05:39:09.895Z` and the install stores no `checkIntervalHours`, so the default of 24 applied (`apps/web/lib/self-upgrade/config.ts:136`): every tick until 05:39 the next day returns `interval-not-elapsed`. Two things made that unreadable, and I drew the wrong conclusion from them before reading the source.
+
+- **A scheduled decline leaves no trace.** `skipAttempt` persists only through `skipRun(params.runId, …)`, and the cron calls `runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true })` with no `runId` (`apps/web/lib/queue/functions/self-upgrade.ts`). So `interval-not-elapsed`, `outside-window`, `cooldown`, `blackout-period`, `promoter-unavailable` and `no-window-needs-timezone` all vanish. The only evidence is an absent run, which is indistinguishable from a dead scheduler.
+- **The status contradicts the throttle.** `get_self_upgrade_queue_status` computed `routineUpgradeEligible: support.enabled && batch.eligible` (`apps/web/lib/mcp/packs/self-upgrade-pack.ts:221`) from release-batch eligibility alone, never consulting the interval, window, cooldown or blackout. It reported eligible at 07:04 while the next unattended check was 22 hours away.
+
+Consequence: two merged fixes (BI-A57B6185, BI-05F8860A) could not close, because the completion resolver on the install predates them, and nothing in the product said why or when that would change.
+
+Ruled out by reading the live config rather than assuming: a broken cron (it fires; the throttle declines it), a stale quiescence coordinator (the reconcile line names a run from the previous day and does not gate run creation), and the release batch (it reports eligible throughout).
+
+## 2. Fix sequence
+
+1. New `apps/web/lib/self-upgrade/scheduled-gate.ts`: `nextScheduledCheckAt` and `scheduledCheckIsThrottled` (pure, and asserted to agree with `isCheckIntervalElapsed` so the reported schedule and the applied gate cannot drift), `declineIsCurrent`, and a durable `recordScheduledDecline` / `getScheduledDecline` pair on `self_upgrade.lastScheduledDecline`.
+2. `self-upgrade.ts`: when `skipAttempt` has no `runId` and the attempt is `scheduled`, record the decline. Recording never throws into the upgrade path.
+3. `self-upgrade-pack.ts`: report `lastCheckedAt`, `checkIntervalHours`, `nextScheduledCheckAt` and `scheduledGate`; expose the raw `releaseBatchEligible`; and make `routineUpgradeEligible` require that the unattended path is not throttled.
+
+Policy is untouched: the interval, window, cooldown and blackout remain the operator's settings.
+
+## 3. Acceptance criteria
+
+| Criterion | Objective | Statement |
+| --- | --- | --- |
+| AC-1 | OBJ-UPGRADE-VISIBILITY-1 | A scheduled tick that declines records its reason and time where a later read retrieves it |
+| AC-2 | OBJ-UPGRADE-VISIBILITY-1 | The queue status reports lastCheckedAt, checkIntervalHours, nextScheduledCheckAt and the active scheduled gate |
+| AC-3 | OBJ-UPGRADE-VISIBILITY-1 | routineUpgradeEligible is false while the unattended path is throttled, and releaseBatchEligible still reports batch eligibility separately |
+| AC-4 | OBJ-UPGRADE-VISIBILITY-1 | A decline recorded before the last successful check is dropped rather than reported as current, and the reported schedule always agrees with the gate the cron applies |
+
+## 4. Non-goals
+
+- Changing the default 24-hour interval or the window policy: operator settings, not defects.
+- The 2026-09-06 observation of a swap to an older revision with no run row. It is unreproduced and needs its own evidence.


### PR DESCRIPTION
## Summary

The scheduled cron fires hourly and declines most ticks: `checkIntervalHours` (default 24) throttles it, and window, cooldown, blackout and promoter prechecks decline before that. Every decline vanished, because `skipAttempt` persists only through `skipRun(runId, …)` and the cron passes no `runId`. The only evidence was the **absence** of a run, which reads exactly like a broken scheduler.

Meanwhile `get_self_upgrade_queue_status` computed `routineUpgradeEligible` from release-batch eligibility alone, so it reported eligible while the next unattended check was 22 hours away.

Measured here: release `v2026.09.07-small-shape-completion.1` at `9afc62c` verified at 06:28; at 07:04 the install still ran `0713430`, with no run row for the 06:00 or 07:00 tick and the status reporting eligible. Two merged fixes could not close and nothing said why. I drew the wrong conclusion from it myself before reading the source, which is the clearest evidence the signal was missing.

Now a scheduled decline is recorded durably, and the status reports `lastCheckedAt`, `checkIntervalHours`, `nextScheduledCheckAt` and the active `scheduledGate`. `routineUpgradeEligible` requires an unthrottled unattended path; `releaseBatchEligible` preserves the previous meaning. **Upgrade policy is unchanged** — the interval and window remain the operator's.

The unattended gates (blackout, window, interval) moved into `scheduled-gate.ts` beside the status that reports them, so the two cannot drift; a test asserts the reported schedule always agrees with the gate the cron applies. That also brought `self-upgrade.ts` from 800 to 768 LOC, under the module-size ceiling.

## Verification

- Red-then-green: the 3 new status assertions fail against `origin/main` source, and 849/849 tests pass across the self-upgrade and MCP-pack suites with the fix.
- Workspace typecheck clean; pull-request policy profile 8/8; module-size and One-ActionResult ratchets green; local-CI gate PASS on b3ae284.

Backlog: BI-3CA18934 · Workroom: WC-243ACB22 · Unblocks the deploy path for BI-05F8860A and BI-A57B6185

🤖 Generated with [Claude Code](https://claude.com/claude-code)