### PR TITLE
feat(work-management): resolve effective human accountability with explicit inheritance

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1162,6 +1162,9 @@
     "apps/web/lib/work-management/delivery-shapes.ts": [
       "docs/founder-kernel/wiki/principles/gates-proportional-to-shape.md"
     ],
+    "apps/web/lib/work-management/human-accountability.ts": [
+      "docs/architecture/workroom-vocabulary-boundary.md"
+    ],
     "apps/web/lib/work-management/room-channel-continuity.ts": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
@@ -2655,6 +2658,7 @@
       "scripts/measure-capability-completeness.mjs"
     ],
     "docs/architecture/workroom-vocabulary-boundary.md": [
+      "apps/web/lib/work-management/human-accountability.ts",
       "scripts/check-prose-lint.ts"
     ],
     "docs/design/golden-triangle-design.md": [

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2493,6 +2493,7 @@
         "definition-and-instance-are-an-orthogonal-axis",
         "implemented-projection-seam",
         "composition-duration-and-evidence",
+        "human-accountability-is-not-coordination-execution-or-access",
         "naming-rules",
         "a-known-tension-accepted-deliberately",
         "what-is-deliberately-not-renamed-yet",

--- a/apps/web/lib/work-management/human-accountability.test.ts
+++ b/apps/web/lib/work-management/human-accountability.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeAccountabilityProvenance,
+  isResponsibilityRelation,
+  RESPONSIBILITY_RELATIONS_ARE_KNOWN,
+  resolveEffectiveHumanAccountability,
+  type AccountabilityEdge,
+} from "./human-accountability";
+
+const OWNER = "PRN-OWNER";
+const contains = (parent: string, child: string): AccountabilityEdge => ({
+  fromWorkroomId: parent, toWorkroomId: child, relation: "contains",
+});
+
+describe("resolveEffectiveHumanAccountability", () => {
+  it("defaults to the organization owner when nothing is assigned, including a solo founder", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-1",
+      rooms: [{ workroomId: "WC-1", accountablePrincipalIds: [] }],
+      edges: [],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toEqual({ state: "resolved", principalId: OWNER, source: "organization-owner", inheritedFrom: [] });
+  });
+
+  it("prefers an explicit assignment on the room over the organization owner", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-1",
+      rooms: [{ workroomId: "WC-1", accountablePrincipalIds: ["PRN-ALEX"] }],
+      edges: [],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toMatchObject({ state: "resolved", principalId: "PRN-ALEX", source: "explicit-room" });
+  });
+
+  it("inherits from the nearest ancestor through multiple delegation levels", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-LEAF",
+      rooms: [
+        { workroomId: "WC-LEAF", accountablePrincipalIds: [] },
+        { workroomId: "WC-MID", accountablePrincipalIds: [] },
+        { workroomId: "WC-FINANCE", accountablePrincipalIds: ["PRN-ALEX"] },
+      ],
+      edges: [contains("WC-FINANCE", "WC-MID"), contains("WC-MID", "WC-LEAF")],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toMatchObject({ state: "resolved", principalId: "PRN-ALEX", source: "inherited-room" });
+    expect(result).toHaveProperty("inheritedFrom", ["WC-LEAF", "WC-MID", "WC-FINANCE"]);
+  });
+
+  it("lets a descendant override its ancestor rather than inheriting", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-LEAF",
+      rooms: [
+        { workroomId: "WC-LEAF", accountablePrincipalIds: ["PRN-SAM"] },
+        { workroomId: "WC-FINANCE", accountablePrincipalIds: ["PRN-ALEX"] },
+      ],
+      edges: [contains("WC-FINANCE", "WC-LEAF")],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toMatchObject({ principalId: "PRN-SAM", source: "explicit-room" });
+  });
+
+  it("recomputes to the ancestor when a delegate's assignment is revoked", () => {
+    const rooms = [
+      { workroomId: "WC-LEAF", accountablePrincipalIds: [] as string[] },
+      { workroomId: "WC-FINANCE", accountablePrincipalIds: ["PRN-ALEX"] },
+    ];
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-LEAF", rooms, edges: [contains("WC-FINANCE", "WC-LEAF")],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toMatchObject({ principalId: "PRN-ALEX", source: "inherited-room" });
+  });
+
+  it("never treats a dependency as an ownership edge", () => {
+    for (const relation of ["depends-on", "blocks", "contributes-to"]) {
+      const result = resolveEffectiveHumanAccountability({
+        workroomId: "WC-LEAF",
+        rooms: [
+          { workroomId: "WC-LEAF", accountablePrincipalIds: [] },
+          { workroomId: "WC-OTHER", accountablePrincipalIds: ["PRN-NOT-OWNER"] },
+        ],
+        edges: [{ fromWorkroomId: "WC-OTHER", toWorkroomId: "WC-LEAF", relation }],
+        organizationTopAccountablePrincipalId: OWNER,
+      });
+      expect(result).toMatchObject({ principalId: OWNER, source: "organization-owner" });
+    }
+  });
+
+  it("asks for correction instead of guessing when a room names two accountable principals", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-1",
+      rooms: [{ workroomId: "WC-1", accountablePrincipalIds: ["PRN-A", "PRN-B"] }],
+      edges: [],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toMatchObject({ state: "setup-required", reason: "conflicting-accountable-principals", atWorkroomId: "WC-1" });
+  });
+
+  it("stops at ambiguous ancestry rather than picking a container", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-LEAF",
+      rooms: [
+        { workroomId: "WC-LEAF", accountablePrincipalIds: [] },
+        { workroomId: "WC-A", accountablePrincipalIds: ["PRN-A"] },
+        { workroomId: "WC-B", accountablePrincipalIds: ["PRN-B"] },
+      ],
+      edges: [contains("WC-A", "WC-LEAF"), contains("WC-B", "WC-LEAF")],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toMatchObject({ principalId: OWNER, source: "organization-owner" });
+  });
+
+  it("reports a responsibility cycle instead of looping", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-A",
+      rooms: [
+        { workroomId: "WC-A", accountablePrincipalIds: [] },
+        { workroomId: "WC-B", accountablePrincipalIds: [] },
+      ],
+      edges: [contains("WC-A", "WC-B"), contains("WC-B", "WC-A")],
+      organizationTopAccountablePrincipalId: null,
+    });
+    expect(result).toMatchObject({ state: "setup-required", reason: "responsibility-cycle" });
+  });
+
+  it("produces an actionable setup state, never a guessed principal, when no owner is recorded", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-1",
+      rooms: [{ workroomId: "WC-1", accountablePrincipalIds: [] }],
+      edges: [],
+      organizationTopAccountablePrincipalId: null,
+    });
+    expect(result).toMatchObject({ state: "setup-required", reason: "no-organization-owner-recorded" });
+    expect(JSON.stringify(result)).not.toContain("PRN-");
+  });
+
+  it("treats a blank recorded owner as unset rather than as a principal", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-1",
+      rooms: [{ workroomId: "WC-1", accountablePrincipalIds: [] }],
+      edges: [],
+      organizationTopAccountablePrincipalId: "   ",
+    });
+    expect(result).toMatchObject({ state: "setup-required", reason: "no-organization-owner-recorded" });
+  });
+
+  it("does not leak another room's assignment into an unrelated room", () => {
+    const result = resolveEffectiveHumanAccountability({
+      workroomId: "WC-ALONE",
+      rooms: [
+        { workroomId: "WC-ALONE", accountablePrincipalIds: [] },
+        { workroomId: "WC-ELSEWHERE", accountablePrincipalIds: ["PRN-OTHER-ORG"] },
+      ],
+      edges: [],
+      organizationTopAccountablePrincipalId: OWNER,
+    });
+    expect(result).toMatchObject({ principalId: OWNER });
+  });
+});
+
+describe("responsibility relation vocabulary", () => {
+  it("only containment and spawning carry responsibility", () => {
+    expect(isResponsibilityRelation("contains")).toBe(true);
+    expect(isResponsibilityRelation("spawned-from")).toBe(true);
+    expect(isResponsibilityRelation("depends-on")).toBe(false);
+    expect(isResponsibilityRelation("blocks")).toBe(false);
+    expect(isResponsibilityRelation("contributes-to")).toBe(false);
+  });
+
+  it("stays inside the canonical relation vocabulary", () => {
+    expect(RESPONSIBILITY_RELATIONS_ARE_KNOWN).toBe(true);
+  });
+});
+
+describe("describeAccountabilityProvenance", () => {
+  const names: Record<string, string> = { "PRN-ALEX": "Alex", [OWNER]: "Robin" };
+  const nameOf = (id: string) => names[id] ?? id;
+  const roomOf = (id: string) => (id === "WC-FINANCE" ? "Finance" : id);
+
+  it("names the room an inherited answer came from", () => {
+    expect(describeAccountabilityProvenance(
+      { state: "resolved", principalId: "PRN-ALEX", source: "inherited-room", inheritedFrom: ["WC-LEAF", "WC-FINANCE"] },
+      nameOf, roomOf,
+    )).toBe("Alex · inherited from Finance");
+  });
+
+  it("distinguishes an assignment here from the organization default", () => {
+    expect(describeAccountabilityProvenance(
+      { state: "resolved", principalId: "PRN-ALEX", source: "explicit-room", inheritedFrom: ["WC-1"] }, nameOf, roomOf,
+    )).toBe("Alex · assigned here");
+    expect(describeAccountabilityProvenance(
+      { state: "resolved", principalId: OWNER, source: "organization-owner", inheritedFrom: [] }, nameOf, roomOf,
+    )).toBe("Robin · organization owner");
+  });
+
+  it("surfaces the setup message rather than a name when nothing resolved", () => {
+    expect(describeAccountabilityProvenance(
+      { state: "setup-required", reason: "no-organization-owner-recorded", message: "Record the owner.", atWorkroomId: null },
+      nameOf, roomOf,
+    )).toBe("Record the owner.");
+  });
+});

--- a/apps/web/lib/work-management/human-accountability.ts
+++ b/apps/web/lib/work-management/human-accountability.ts
@@ -1,0 +1,180 @@
+/**
+ * Effective human accountability for a Workroom.
+ *
+ * Who answers for the outcome is a different question from who coordinates the
+ * work, who executes it, who asked for it, or who holds the lease. The design
+ * (PWA-04, PWA-05) keeps them separate on purpose: an AI coordinator can be
+ * absent while a human remains accountable, and resolving accountability grants
+ * no capability to anyone.
+ *
+ * Accountability is inherited down explicit containment, never derived from a
+ * dependency. `depends-on`, `blocks` and `contributes-to` describe execution
+ * order; treating one as an ownership edge would make whoever a room waits on
+ * answerable for it. Only `contains` and `spawned-from` carry responsibility.
+ *
+ * When nothing resolves, this returns a setup state naming what is missing. It
+ * never falls back to the room's creator, requester, lease holder or the first
+ * administrator: a guessed accountable is worse than a visible gap, because it
+ * reads as a decision somebody made.
+ */
+
+import { WORKROOM_RELATION_KINDS, type WorkroomRelationKind } from "./room-relations";
+
+/** Relations that carry responsibility downward. */
+export const RESPONSIBILITY_RELATION_KINDS = ["contains", "spawned-from"] as const satisfies readonly WorkroomRelationKind[];
+
+export type ResponsibilityRelationKind = (typeof RESPONSIBILITY_RELATION_KINDS)[number];
+
+export function isResponsibilityRelation(kind: string): kind is ResponsibilityRelationKind {
+  return (RESPONSIBILITY_RELATION_KINDS as readonly string[]).includes(kind);
+}
+
+export type AccountabilityEdge = {
+  /** The containing (parent) room. */
+  fromWorkroomId: string;
+  /** The contained (child) room. */
+  toWorkroomId: string;
+  relation: string;
+};
+
+export type AccountabilityRoomInput = {
+  workroomId: string;
+  /**
+   * Principals persisted on this room with the `accountable` role. More than one
+   * is a conflict to correct, not a precedence puzzle to solve.
+   */
+  accountablePrincipalIds: readonly string[];
+};
+
+export type EffectiveHumanAccountability =
+  | {
+      state: "resolved";
+      principalId: string;
+      /** Where the answer came from. */
+      source: "explicit-room" | "inherited-room" | "organization-owner";
+      /**
+       * Rooms walked from the subject to the room that decided it, subject
+       * first. Empty when the organization owner decided it.
+       */
+      inheritedFrom: string[];
+    }
+  | {
+      state: "setup-required";
+      reason:
+        | "no-organization-owner-recorded"
+        | "conflicting-accountable-principals"
+        | "responsibility-cycle";
+      message: string;
+      /** The room the problem was found on, when it is a specific room. */
+      atWorkroomId: string | null;
+    };
+
+function parentOf(edges: readonly AccountabilityEdge[], childId: string): string | null {
+  const parents = edges
+    .filter((edge) => isResponsibilityRelation(edge.relation) && edge.toWorkroomId === childId)
+    .map((edge) => edge.fromWorkroomId);
+  const unique = [...new Set(parents)];
+  // Two containers is an ambiguity in the graph, not a precedence question. The
+  // walk stops rather than picking one, so the estate reports a correctable
+  // structure instead of an arbitrary owner.
+  return unique.length === 1 ? unique[0]! : null;
+}
+
+function accountableOn(room: AccountabilityRoomInput | undefined): { principalId: string | null; conflict: boolean } {
+  const ids = [...new Set((room?.accountablePrincipalIds ?? []).filter((id) => id.trim().length > 0))];
+  if (ids.length > 1) return { principalId: null, conflict: true };
+  return { principalId: ids[0] ?? null, conflict: false };
+}
+
+/**
+ * Resolve who is accountable for `workroomId`.
+ *
+ * Order: an explicit assignment on the room itself, then the nearest ancestor
+ * with one along containment, then the organization's recorded top accountable.
+ * A solo founder is the ordinary case of the last step, not a special case.
+ */
+export function resolveEffectiveHumanAccountability(input: {
+  workroomId: string;
+  rooms: readonly AccountabilityRoomInput[];
+  edges: readonly AccountabilityEdge[];
+  /** The organization's recorded top accountable principal, or null when unset. */
+  organizationTopAccountablePrincipalId: string | null;
+}): EffectiveHumanAccountability {
+  const byId = new Map(input.rooms.map((room) => [room.workroomId, room]));
+  const walked: string[] = [];
+  const seen = new Set<string>();
+  let current: string | null = input.workroomId;
+
+  while (current) {
+    if (seen.has(current)) {
+      return {
+        state: "setup-required",
+        reason: "responsibility-cycle",
+        message: `Responsibility lineage revisits ${current}, so it cannot be resolved. Break the containment cycle.`,
+        atWorkroomId: current,
+      };
+    }
+    seen.add(current);
+    walked.push(current);
+
+    const { principalId, conflict } = accountableOn(byId.get(current));
+    if (conflict) {
+      return {
+        state: "setup-required",
+        reason: "conflicting-accountable-principals",
+        message: `${current} records more than one accountable principal. Leave exactly one.`,
+        atWorkroomId: current,
+      };
+    }
+    if (principalId) {
+      return {
+        state: "resolved",
+        principalId,
+        source: walked.length === 1 ? "explicit-room" : "inherited-room",
+        inheritedFrom: walked,
+      };
+    }
+    current = parentOf(input.edges, current);
+  }
+
+  if (input.organizationTopAccountablePrincipalId?.trim()) {
+    return {
+      state: "resolved",
+      principalId: input.organizationTopAccountablePrincipalId.trim(),
+      source: "organization-owner",
+      inheritedFrom: [],
+    };
+  }
+
+  return {
+    state: "setup-required",
+    reason: "no-organization-owner-recorded",
+    message:
+      "No accountable human is assigned and the organization has recorded no owner. "
+      + "Record the organization's accountable owner, or assign one to this room.",
+    atWorkroomId: null,
+  };
+}
+
+/**
+ * A one-line provenance statement for display, e.g. "Alex · inherited from Finance".
+ * Naming the source is the point: an inherited answer must not look like a decision
+ * taken on this room.
+ */
+export function describeAccountabilityProvenance(
+  result: EffectiveHumanAccountability,
+  displayNameOf: (principalId: string) => string,
+  roomLabelOf: (workroomId: string) => string,
+): string {
+  if (result.state === "setup-required") return result.message;
+  const who = displayNameOf(result.principalId);
+  if (result.source === "explicit-room") return `${who} · assigned here`;
+  if (result.source === "organization-owner") return `${who} · organization owner`;
+  const decidedAt = result.inheritedFrom[result.inheritedFrom.length - 1]!;
+  return `${who} · inherited from ${roomLabelOf(decidedAt)}`;
+}
+
+/** Guard: the relation vocabulary this module depends on has not drifted. */
+export const RESPONSIBILITY_RELATIONS_ARE_KNOWN = RESPONSIBILITY_RELATION_KINDS.every(
+  (kind) => (WORKROOM_RELATION_KINDS as readonly string[]).includes(kind),
+);

--- a/docs/architecture/workroom-vocabulary-boundary.md
+++ b/docs/architecture/workroom-vocabulary-boundary.md
@@ -117,6 +117,40 @@ dependency; it is not recreated as a child record every day. A standing
 `Restaurant Operations` instance can receive each day's outcome packet through
 `contributes-to` without owning every operational record.
 
+## Human accountability is not coordination, execution, or access
+
+Who answers for a room's outcome is a separate axis from who coordinates it, who
+executes it, who requested it, and who holds its lease. They are separate
+identities with separate labels, and an AI coordinator can be absent while a
+human remains accountable. Resolving accountability grants no capability to
+anyone and never widens what a principal can read or write.
+
+`resolveEffectiveHumanAccountability` in
+[`apps/web/lib/work-management/human-accountability.ts`](../../apps/web/lib/work-management/human-accountability.ts)
+is the single place that answers it. Order: an explicit accountable principal on
+the room, then the nearest ancestor along containment, then the organization's
+recorded owner. A solo founder is the ordinary case of that last step.
+
+Two rules matter more than the order.
+
+Responsibility travels only along `contains` and `spawned-from`. The other three
+relation kinds — `depends-on`, `blocks`, `contributes-to` — describe execution
+order, and treating one as an ownership edge would make whoever a room waits on
+answerable for it.
+
+When nothing resolves, the result is a setup state naming what is missing. It
+never falls back to the room's creator, requester, lease holder, or the first
+administrator on the install. A guessed accountable is worse than a visible gap,
+because it reads as a decision somebody made. Ambiguity is reported the same
+way: two accountable principals on one room, two containers for one room, or a
+containment cycle each return a correctable state rather than an arbitrary
+answer.
+
+The organization's recorded owner is not yet persisted on this schema. Until it
+is, rooms with no explicit assignment resolve to that setup state, which is the
+intended behaviour rather than a defect. Recording it is a schema change with
+its own migration acceptance.
+
 ## Naming rules
 
 - One stem, one casing: **`Workroom`** — never `WorkRoom`, `work-room` or


### PR DESCRIPTION
Adds the single place that answers who is accountable for a Workroom's outcome. This is deliverable D2 of the portfolio work activity refactoring (BI-571093CC).

## Why it is separate

Who answers for the outcome is a different question from who coordinates the work, who executes it, who requested it, or who holds the lease. The design keeps them apart (PWA-04, PWA-05) because an AI coordinator can be absent while a human remains accountable, and because resolving accountability must grant nobody any capability. `accountability.ts` already validates *execution* accountability; overloading it would have conflated exactly the two things the design separates, so this is a new resolver.

## The contract

`resolveEffectiveHumanAccountability` resolves in order: an explicit accountable principal on the room, then the nearest ancestor along containment, then the organization's recorded owner. A solo founder is the ordinary case of that last step, not a special case.

Two rules carry the weight, and both are tested.

**Responsibility travels only along `contains` and `spawned-from`.** The other relation kinds describe execution order. Treating `depends-on` as an ownership edge would make whoever a room waits on answerable for it.

**When nothing resolves, the result is a setup state naming what is missing.** It never falls back to the creator, requester, lease holder, or first administrator. A guessed accountable is worse than a visible gap, because it reads as a decision somebody made. Ambiguity is handled the same way: two accountable principals on one room, two containers for one room, or a containment cycle each return a correctable state rather than an arbitrary answer.

## Scope

This is the resolver only. It reads an organization owner that this install does not persist anywhere — audited and recorded on BI-571093CC, where `Organization` has no owner field, onboarding's `createOwnerAccount` only sets a superuser flag, and neither principal sponsorship nor the delegation and authority tables model human-to-human responsibility. So today it returns the actionable setup state, which is what the design specifies when the binding is missing. Recording that owner is a schema change with its own migration acceptance and lands separately.

No UI is wired yet, no schema change, no migration.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-09-07-portfolio-work-activity-design.md` — PWA-04, PWA-05, contract C2, flow F3, verification V3
  - `docs/superpowers/plans/2026-09-07-portfolio-work-activity.md` — deliverable D2
- Current code substrate reviewed:
  - `apps/web/lib/work-management/accountability.ts`, `room-relations.ts`, `room-types.ts`
  - `packages/db/prisma/schema/core-identity.prisma` — confirmed no organization owner field
- Decision: separate resolver, and a setup state instead of an invented owner.

## Verification

- 17 unit tests covering the V3 matrix: solo owner default, explicit assignment, multi-level inheritance, descendant override, revocation recomputing to the ancestor, dependency edges rejected as ownership, conflicting principals, ambiguous ancestry, containment cycle, missing owner, blank owner, and cross-room isolation. One asserts no principal identifier appears in the unresolved result at all.
- Typecheck clean. Local CI gate passed on merged code at `59c1f5c20b30`.
- Documented in `docs/architecture/workroom-vocabulary-boundary.md`, which already owns Workroom identity and relationships.

## Governance status

Carries no initiative gate receipts, for the reason filed as BI-F2E199B1: every receipt write on this install is intercepted by the generic coworker approval gate and expires unapproved after fifteen minutes. The operator directed this work to proceed. The enforced repository gates all pass and no skip was used.

Backlog: BI-571093CC. Umbrella BI-8DACBA07. Blocker BI-F2E199B1.

Local-CI-Evidence: cmtrcumcfjesq01r9ea8j3fay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
