### PR TITLE
feat(work-management): project bounded portfolio activity with truthful symbols

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1165,6 +1165,9 @@
     "apps/web/lib/work-management/human-accountability.ts": [
       "docs/architecture/workroom-vocabulary-boundary.md"
     ],
+    "apps/web/lib/work-management/portfolio-activity-projection.ts": [
+      "docs/architecture/workroom-vocabulary-boundary.md"
+    ],
     "apps/web/lib/work-management/room-channel-continuity.ts": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
@@ -2662,6 +2665,7 @@
     ],
     "docs/architecture/workroom-vocabulary-boundary.md": [
       "apps/web/lib/work-management/human-accountability.ts",
+      "apps/web/lib/work-management/portfolio-activity-projection.ts",
       "apps/web/lib/work-management/worker-rollup.ts",
       "scripts/check-prose-lint.ts"
     ],

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2494,6 +2494,7 @@
         "implemented-projection-seam",
         "composition-duration-and-evidence",
         "human-accountability-is-not-coordination-execution-or-access",
+        "what-an-activity-symbol-is-allowed-to-claim",
         "an-executor-is-a-teammate-not-a-surface",
         "naming-rules",
         "a-known-tension-accepted-deliberately",

--- a/apps/web/lib/work-management/portfolio-activity-projection.test.ts
+++ b/apps/web/lib/work-management/portfolio-activity-projection.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveActivitySignal,
+  EVIDENCE_STALE_WINDOW_MS,
+  EXECUTION_FRESH_WINDOW_MS,
+  projectPortfolioActivityPage,
+  selectRepresentativeActivities,
+  type RoomActivityInput,
+} from "./portfolio-activity-projection";
+
+const NOW = new Date("2026-09-07T12:00:00.000Z");
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+function room(over: Partial<RoomActivityInput> & { roomId: string }): RoomActivityInput {
+  return {
+    title: `Room ${over.roomId}`,
+    portfolioRole: "foundational",
+    branchId: "b-1",
+    href: `/workspace/cases/${over.roomId}`,
+    status: "working",
+    latestAction: null,
+    blocker: null,
+    evidenceAt: null,
+    ...over,
+  };
+}
+
+describe("deriveActivitySignal", () => {
+  it("animates only on fresh execution evidence", () => {
+    const fresh = deriveActivitySignal(room({ roomId: "a", evidenceAt: ago(1_000) }), NOW);
+    expect(fresh).toMatchObject({ state: "executing", animate: true });
+  });
+
+  it("ages into stale rather than spinning forever", () => {
+    const stale = deriveActivitySignal(room({ roomId: "a", evidenceAt: ago(EVIDENCE_STALE_WINDOW_MS + 1) }), NOW);
+    expect(stale).toMatchObject({ state: "stale", animate: false });
+  });
+
+  it("distinguishes no evidence from old evidence", () => {
+    expect(deriveActivitySignal(room({ roomId: "a", evidenceAt: null }), NOW)).toMatchObject({ state: "unknown", animate: false });
+  });
+
+  it("treats evidence past the fresh window but inside stale as queued, not executing", () => {
+    const between = deriveActivitySignal(room({ roomId: "a", evidenceAt: ago(EXECUTION_FRESH_WINDOW_MS + 1_000) }), NOW);
+    expect(between.state).toBe("queued");
+    expect(between.animate).toBe(false);
+  });
+
+  it("never animates a blocked, waiting, queued, completed, stale or unknown room", () => {
+    const cases: RoomActivityInput[] = [
+      room({ roomId: "b", blocker: "needs review", evidenceAt: ago(1_000) }),
+      room({ roomId: "w", awaitingPerson: true, evidenceAt: ago(1_000) }),
+      room({ roomId: "q", queued: true, evidenceAt: ago(1_000) }),
+      room({ roomId: "c", verifiedComplete: true, evidenceAt: ago(1_000) }),
+      room({ roomId: "s", evidenceAt: ago(EVIDENCE_STALE_WINDOW_MS + 1) }),
+      room({ roomId: "u" }),
+    ];
+    for (const input of cases) expect(deriveActivitySignal(input, NOW).animate).toBe(false);
+  });
+
+  it("does not let recent evidence override a verified receipt or a blocker", () => {
+    expect(deriveActivitySignal(room({ roomId: "c", verifiedComplete: true, evidenceAt: ago(1) }), NOW).state).toBe("completed");
+    expect(deriveActivitySignal(room({ roomId: "b", blocker: "waiting", evidenceAt: ago(1) }), NOW).state).toBe("blocked");
+  });
+
+  it("carries an accessible label and the deciding evidence timestamp", () => {
+    const signal = deriveActivitySignal(room({ roomId: "a", evidenceAt: ago(1_000) }), NOW);
+    expect(signal.label).toBe("Working now");
+    expect(signal.evidenceAt).toBe(ago(1_000).toISOString());
+  });
+});
+
+describe("selectRepresentativeActivities", () => {
+  it("puts unresolved attention before live execution and completion", () => {
+    const picked = selectRepresentativeActivities([
+      room({ roomId: "done", verifiedComplete: true }),
+      room({ roomId: "run", evidenceAt: ago(1_000), latestAction: "Checking invoice matching" }),
+      room({ roomId: "stuck", blocker: "Waiting for release review" }),
+    ], NOW, 3);
+    expect(picked.map((p) => p.roomId)).toEqual(["stuck", "run", "done"]);
+  });
+
+  it("states a concrete action or blocker rather than a count", () => {
+    const picked = selectRepresentativeActivities([
+      room({ roomId: "run", evidenceAt: ago(1_000), latestAction: "Checking invoice matching" }),
+      room({ roomId: "stuck", blocker: "Waiting for release review" }),
+    ], NOW, 2);
+    expect(picked[0]!.statement).toBe("Blocked: Waiting for release review");
+    expect(picked[1]!.statement).toBe("Checking invoice matching");
+    for (const p of picked) expect(p.statement).not.toMatch(/^\d+$/);
+  });
+
+  it("says so plainly when no concrete action was recorded", () => {
+    const [only] = selectRepresentativeActivities([room({ roomId: "x", title: "Payroll run" })], NOW, 1);
+    expect(only!.statement).toBe("Payroll run · unknown");
+  });
+
+  it("is deterministic when priority and recency tie", () => {
+    const rooms = [room({ roomId: "z" }), room({ roomId: "a" }), room({ roomId: "m" })];
+    const first = selectRepresentativeActivities(rooms, NOW, 3).map((p) => p.roomId);
+    const second = selectRepresentativeActivities([...rooms].reverse(), NOW, 3).map((p) => p.roomId);
+    expect(first).toEqual(["a", "m", "z"]);
+    expect(second).toEqual(first);
+  });
+
+  it("gives every representative a resolvable destination", () => {
+    const picked = selectRepresentativeActivities([room({ roomId: "x" })], NOW, 1);
+    expect(picked[0]!.href).toBe("/workspace/cases/x");
+  });
+
+  it("honours the bound and returns nothing when asked for none", () => {
+    const rooms = Array.from({ length: 20 }, (_, i) => room({ roomId: `r-${i}` }));
+    expect(selectRepresentativeActivities(rooms, NOW, 3)).toHaveLength(3);
+    expect(selectRepresentativeActivities(rooms, NOW, 0)).toHaveLength(0);
+  });
+});
+
+describe("projectPortfolioActivityPage", () => {
+  it("counts a room once even when it arrives twice", () => {
+    const page = projectPortfolioActivityPage({
+      rooms: [room({ roomId: "dup" }), room({ roomId: "dup" }), room({ roomId: "other" })],
+      now: NOW,
+    });
+    expect(page.observedRooms).toBe(2);
+    expect(page.rows[0]!.roomCount).toBe(2);
+  });
+
+  it("labels a truncated read partial and pages deterministically without repeats", () => {
+    const rooms = Array.from({ length: 7 }, (_, i) => room({ roomId: `r-${i}`, branchId: `b-${i}` }));
+    const first = projectPortfolioActivityPage({ rooms, now: NOW, pageSize: 3 });
+    expect(first.partial).toBe(true);
+    expect(first.rows).toHaveLength(3);
+
+    const second = projectPortfolioActivityPage({ rooms, now: NOW, pageSize: 3, cursor: first.nextCursor });
+    const third = projectPortfolioActivityPage({ rooms, now: NOW, pageSize: 3, cursor: second.nextCursor });
+    expect(third.partial).toBe(false);
+    expect(third.nextCursor).toBeNull();
+
+    const seen = [...first.rows, ...second.rows, ...third.rows].map((r) => r.branchId);
+    expect(new Set(seen).size).toBe(7);
+    expect(seen).toEqual([...seen].sort((a, b) => a.localeCompare(b, "en-US")));
+  });
+
+  it("reports a complete read as not partial", () => {
+    const page = projectPortfolioActivityPage({ rooms: [room({ roomId: "a" })], now: NOW, pageSize: 50 });
+    expect(page.partial).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("counts rooms needing attention separately from the total", () => {
+    const page = projectPortfolioActivityPage({
+      rooms: [
+        room({ roomId: "ok", evidenceAt: ago(1_000) }),
+        room({ roomId: "stuck", blocker: "needs review" }),
+        room({ roomId: "waiting", awaitingPerson: true }),
+      ],
+      now: NOW,
+    });
+    expect(page.rows[0]!.roomCount).toBe(3);
+    expect(page.rows[0]!.attentionCount).toBe(2);
+  });
+
+  it("stays bounded at 1,000 rooms across 100 agents and never renders them all", () => {
+    const rooms = Array.from({ length: 1_000 }, (_, i) => room({
+      roomId: `r-${String(i).padStart(4, "0")}`,
+      branchId: `branch-${String(i % 40).padStart(3, "0")}`,
+      latestAction: `Agent ${i % 100} working step ${i}`,
+      evidenceAt: ago(i * 1_000),
+      blocker: i % 97 === 0 ? "waiting on review" : null,
+    }));
+
+    const started = Date.now();
+    const page = projectPortfolioActivityPage({ rooms, now: NOW, pageSize: 50, representativeLimit: 3 });
+    const elapsed = Date.now() - started;
+
+    // 40 branches fit in one page of 50, so the page is complete...
+    expect(page.rows).toHaveLength(40);
+    expect(page.partial).toBe(false);
+    // ...but it never emits a row per room: at most three statements per branch.
+    for (const row of page.rows) expect(row.representative.length).toBeLessThanOrEqual(3);
+    const emitted = page.rows.reduce((n, row) => n + row.representative.length, 0);
+    expect(emitted).toBeLessThanOrEqual(120);
+    expect(page.observedRooms).toBe(1_000);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it("pages a wide estate without ever exceeding the page bound", () => {
+    const rooms = Array.from({ length: 1_000 }, (_, i) => room({
+      roomId: `r-${String(i).padStart(4, "0")}`,
+      branchId: `branch-${String(i).padStart(4, "0")}`,
+    }));
+    let cursor: string | null = null;
+    let pages = 0;
+    const branches = new Set<string>();
+    do {
+      const page: ReturnType<typeof projectPortfolioActivityPage> =
+        projectPortfolioActivityPage({ rooms, now: NOW, pageSize: 50, cursor });
+      expect(page.rows.length).toBeLessThanOrEqual(50);
+      for (const row of page.rows) branches.add(row.branchId);
+      cursor = page.nextCursor;
+      pages += 1;
+    } while (cursor && pages < 100);
+    expect(branches.size).toBe(1_000);
+    expect(pages).toBe(20);
+  });
+});

--- a/apps/web/lib/work-management/portfolio-activity-projection.ts
+++ b/apps/web/lib/work-management/portfolio-activity-projection.ts
@@ -1,0 +1,274 @@
+/**
+ * Bounded portfolio activity projection (PWA-02, PWA-06, PWA-07).
+ *
+ * Turns rooms already placed on the portfolio axis into compact branch rows that
+ * say what is actually happening, without fanning out to every room or inventing
+ * certainty the evidence does not support.
+ *
+ * Three rules shape it.
+ *
+ * A count is not an answer. "12 rooms" tells an operator nothing they can act
+ * on, so every branch carries a bounded set of concrete statements — what is
+ * being done, or what is waiting — chosen attention-first.
+ *
+ * A symbol must be earned. Motion means fresh evidence of execution right now.
+ * A held lease, a claimed shape or a completed task are not that: a room whose
+ * last evidence is an hour old is stale, and a room with no evidence at all is
+ * unknown. Both say so rather than spinning.
+ *
+ * Reads are bounded and ordered deterministically, so paging is stable and a
+ * truncated page is labelled partial instead of being presented as a total.
+ *
+ * Pure and DB-free on purpose, following work-item-presence.ts: the server
+ * action reads rows and applies authorization, then calls this. Authorization
+ * must happen BEFORE projection, so hidden work cannot leak through a count or a
+ * representative summary.
+ */
+
+import type { WorkCapsulePortfolioRole } from "@/lib/work-capsules";
+
+/** Evidence is fresh enough to claim execution is happening now. */
+export const EXECUTION_FRESH_WINDOW_MS = 120_000;
+
+/** Beyond this, evidence is old enough that the room is reported stale. */
+export const EVIDENCE_STALE_WINDOW_MS = 900_000;
+
+/**
+ * What a row's symbol is allowed to say. `executing` is the only animated state
+ * and the only one that requires fresh evidence.
+ */
+export const ACTIVITY_SIGNAL_STATES = [
+  "executing",
+  "waiting-on-person",
+  "queued",
+  "blocked",
+  "completed",
+  "stale",
+  "unknown",
+] as const;
+
+export type ActivitySignalState = (typeof ACTIVITY_SIGNAL_STATES)[number];
+
+export type ActivitySignal = {
+  state: ActivitySignalState;
+  /** Only ever true for `executing`; drives motion, and reduced-motion still overrides in the UI. */
+  animate: boolean;
+  /** Accessible name; colour and motion never carry meaning alone. */
+  label: string;
+  /** When the deciding evidence was observed, or null when there is none. */
+  evidenceAt: string | null;
+};
+
+export type RoomActivityInput = {
+  roomId: string;
+  title: string;
+  portfolioRole: WorkCapsulePortfolioRole | null;
+  /** Deepest taxonomy node this room sits under, for branch grouping. */
+  branchId: string;
+  /** Canonical destination; every rendered row must have one (PWA-02). */
+  href: string;
+  status: string;
+  /** Latest concrete statement of what is happening, from source evidence. */
+  latestAction: string | null;
+  /** What is stopping it, when something is. */
+  blocker: string | null;
+  /** When the latest source evidence was observed. Null means no evidence. */
+  evidenceAt: Date | string | null;
+  /** True only when a governed receipt says the work is verified complete. */
+  verifiedComplete?: boolean;
+  /** True when the room is waiting on a human decision. */
+  awaitingPerson?: boolean;
+  /** True when the room is queued but not started. */
+  queued?: boolean;
+};
+
+const SIGNAL_LABELS: Record<ActivitySignalState, string> = {
+  executing: "Working now",
+  "waiting-on-person": "Waiting for a person",
+  queued: "Queued",
+  blocked: "Blocked",
+  completed: "Verified complete",
+  stale: "No recent signal",
+  unknown: "Unknown",
+};
+
+function toMs(value: Date | string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function iso(value: Date | string | null | undefined): string | null {
+  const ms = toMs(value);
+  return ms === null ? null : new Date(ms).toISOString();
+}
+
+/**
+ * Decide what a room's symbol may claim.
+ *
+ * Order matters: a verified receipt and a blocker are statements about the work
+ * that stay true regardless of how recently anything was observed. Only after
+ * those does freshness decide between executing, stale and unknown.
+ */
+export function deriveActivitySignal(room: RoomActivityInput, now: Date | number): ActivitySignal {
+  const nowMs = typeof now === "number" ? now : now.getTime();
+  const evidenceMs = toMs(room.evidenceAt);
+  const evidenceAt = iso(room.evidenceAt);
+  const signal = (state: ActivitySignalState): ActivitySignal => ({
+    state,
+    animate: state === "executing",
+    label: SIGNAL_LABELS[state],
+    evidenceAt,
+  });
+
+  if (room.verifiedComplete) return signal("completed");
+  if (room.blocker) return signal("blocked");
+  if (room.awaitingPerson) return signal("waiting-on-person");
+  if (room.queued) return signal("queued");
+  // No evidence is not the same as old evidence, and neither is execution.
+  if (evidenceMs === null) return signal("unknown");
+  const age = nowMs - evidenceMs;
+  if (age <= EXECUTION_FRESH_WINDOW_MS) return signal("executing");
+  if (age >= EVIDENCE_STALE_WINDOW_MS) return signal("stale");
+  return signal("queued");
+}
+
+/** Attention first, then live execution, then everything else. */
+const SIGNAL_PRIORITY: Record<ActivitySignalState, number> = {
+  blocked: 0,
+  "waiting-on-person": 1,
+  executing: 2,
+  queued: 3,
+  stale: 4,
+  unknown: 5,
+  completed: 6,
+};
+
+export type RepresentativeActivity = {
+  roomId: string;
+  /** A concrete statement, never a bare count. */
+  statement: string;
+  href: string;
+  signal: ActivitySignal;
+};
+
+function statementFor(room: RoomActivityInput, signal: ActivitySignal): string {
+  if (room.blocker) return `Blocked: ${room.blocker}`;
+  if (room.latestAction) return room.latestAction;
+  // No concrete action recorded — say that, rather than manufacturing one.
+  return `${room.title} · ${signal.label.toLocaleLowerCase("en-US")}`;
+}
+
+/**
+ * Choose the few activities that represent a collapsed branch.
+ *
+ * Unresolved attention first, then recent execution, then verified completion.
+ * Ties break on the room id so the choice is deterministic across reads: a
+ * branch must not reshuffle its summary just because two rooms are equally
+ * urgent.
+ */
+export function selectRepresentativeActivities(
+  rooms: readonly RoomActivityInput[],
+  now: Date | number,
+  limit = 3,
+): RepresentativeActivity[] {
+  if (limit <= 0) return [];
+  const scored = rooms.map((room) => {
+    const signal = deriveActivitySignal(room, now);
+    return { room, signal, priority: SIGNAL_PRIORITY[signal.state], at: toMs(room.evidenceAt) ?? -1 };
+  });
+  scored.sort((a, b) =>
+    a.priority !== b.priority ? a.priority - b.priority
+      : a.at !== b.at ? b.at - a.at
+        : a.room.roomId.localeCompare(b.room.roomId, "en-US"),
+  );
+  return scored.slice(0, limit).map(({ room, signal }) => ({
+    roomId: room.roomId,
+    statement: statementFor(room, signal),
+    href: room.href,
+    signal,
+  }));
+}
+
+export type BranchRow = {
+  branchId: string;
+  portfolioRole: WorkCapsulePortfolioRole | null;
+  /** Unique rooms in this branch on this page. Rooms are counted once. */
+  roomCount: number;
+  /** Rooms needing attention: blocked or waiting on a person. */
+  attentionCount: number;
+  representative: RepresentativeActivity[];
+};
+
+export type PortfolioActivityPage = {
+  rows: BranchRow[];
+  /** Opaque cursor for the next page, or null at the end. */
+  nextCursor: string | null;
+  /**
+   * True when more rooms exist beyond this page. A partial page is never
+   * presented as an estate total.
+   */
+  partial: boolean;
+  /** Unique rooms represented on this page. */
+  observedRooms: number;
+};
+
+/**
+ * Project one bounded page of branch rows.
+ *
+ * Ordering is by branch id, and rooms are deduplicated by id before counting, so
+ * a room reachable through two links is counted once. The cursor is the last
+ * branch id emitted, which keeps paging stable under insertion.
+ */
+export function projectPortfolioActivityPage(input: {
+  rooms: readonly RoomActivityInput[];
+  now: Date | number;
+  /** Max branches per page (PWA-07 targets 50 room rows per page). */
+  pageSize?: number;
+  /** Max representative activities per collapsed branch. */
+  representativeLimit?: number;
+  /** Resume after this branch id. */
+  cursor?: string | null;
+}): PortfolioActivityPage {
+  const pageSize = Math.max(1, input.pageSize ?? 50);
+  const representativeLimit = input.representativeLimit ?? 3;
+
+  const seen = new Set<string>();
+  const byBranch = new Map<string, RoomActivityInput[]>();
+  for (const room of input.rooms) {
+    if (seen.has(room.roomId)) continue;
+    seen.add(room.roomId);
+    const bucket = byBranch.get(room.branchId);
+    if (bucket) bucket.push(room);
+    else byBranch.set(room.branchId, [room]);
+  }
+
+  const orderedBranchIds = [...byBranch.keys()].sort((a, b) => a.localeCompare(b, "en-US"));
+  const startIndex = input.cursor
+    ? orderedBranchIds.findIndex((id) => id === input.cursor) + 1
+    : 0;
+  const slice = orderedBranchIds.slice(startIndex, startIndex + pageSize);
+  const partial = startIndex + slice.length < orderedBranchIds.length;
+
+  const rows = slice.map((branchId) => {
+    const rooms = byBranch.get(branchId)!;
+    const attentionCount = rooms.filter((room) => {
+      const state = deriveActivitySignal(room, input.now).state;
+      return state === "blocked" || state === "waiting-on-person";
+    }).length;
+    return {
+      branchId,
+      portfolioRole: rooms[0]!.portfolioRole,
+      roomCount: rooms.length,
+      attentionCount,
+      representative: selectRepresentativeActivities(rooms, input.now, representativeLimit),
+    };
+  });
+
+  return {
+    rows,
+    nextCursor: partial ? slice[slice.length - 1] ?? null : null,
+    partial,
+    observedRooms: rows.reduce((total, row) => total + row.roomCount, 0),
+  };
+}

--- a/docs/architecture/workroom-vocabulary-boundary.md
+++ b/docs/architecture/workroom-vocabulary-boundary.md
@@ -150,6 +150,35 @@ The organization's recorded owner is not yet persisted on this schema. Until it
 is, rooms with no explicit assignment resolve to that setup state, which is the
 intended behaviour rather than a defect. Recording it is a schema change with
 its own migration acceptance.
+## What an activity symbol is allowed to claim
+
+A count is not an answer. "12 rooms" tells an operator nothing they can act on,
+so a collapsed branch carries a bounded set of concrete statements — what is
+being done, or what is waiting — chosen attention-first, not a bare number.
+
+A symbol must be earned. Motion means fresh evidence of execution right now. A
+held lease, a claimed shape, a successful tool call and a completed task are not
+that. `deriveActivitySignal` in
+[`apps/web/lib/work-management/portfolio-activity-projection.ts`](../../apps/web/lib/work-management/portfolio-activity-projection.ts)
+resolves one of seven states — executing, waiting on a person, queued, blocked,
+completed, stale, unknown — and only `executing` animates.
+
+Three distinctions carry the intent. A verified receipt and a blocker are
+statements about the work and hold regardless of how recently anything was
+observed, so neither is overridden by a fresh heartbeat. No evidence at all is
+`unknown`, which is not the same as old evidence, which is `stale`; a
+disconnected client ages into stale rather than spinning indefinitely. And every
+representative statement carries the canonical destination of the room it
+describes, so a summary is always one click from the thing it summarises.
+
+Reads are bounded and ordered deterministically. Rooms are deduplicated by
+identity before counting, so a room reachable through two links is counted once,
+and rooms needing attention are counted separately from the branch total. A page
+that does not cover the estate reports itself as partial and hands back a cursor,
+rather than presenting its own size as a total.
+
+Authorization happens before projection, never after: filtering a rendered list
+would let hidden work leak through a count or a representative summary.
 
 ## An executor is a teammate, not a surface
 


### PR DESCRIPTION
Projects bounded portfolio activity with symbols that only claim what the evidence supports. Deliverable D3 of the portfolio work activity refactoring (BI-66F3E9E5).

## Why

Two things make an activity view untrustworthy: summarising a branch as a number, and animating a symbol that has not earned it.

**A count is not an answer.** "12 rooms" tells an operator nothing they can act on. Each collapsed branch now carries a bounded set of concrete statements — what is being done, or what is waiting — chosen attention-first.

**A symbol must be earned.** `deriveActivitySignal` resolves one of seven states, and only `executing` animates, and only on evidence fresher than two minutes. A held lease, a claimed shape, a successful tool call and a completed task are none of them.

## The distinctions that carry the intent

A verified receipt and a blocker are statements about the work, so neither is overridden by a fresh heartbeat. No evidence at all is `unknown`, which is not the same as old evidence, which is `stale` — a disconnected client ages into stale rather than spinning indefinitely. Every representative statement carries the canonical destination of the room it describes, so a summary is always one click from the thing it summarises.

## Bounded and deterministic

Rooms are deduplicated by identity before counting, so a room reachable through two links is counted once. Rooms needing attention are counted separately from the branch total, never folded into it. A page that does not cover the estate reports itself `partial` and hands back a cursor rather than presenting its own size as a total. Ordering is by branch id with ties broken on room id, so paging is stable and a branch does not reshuffle its summary because two rooms are equally urgent.

Pure and DB-free, following the established `work-item-presence.ts` pattern: the server action reads rows and applies authorization, then calls this. Authorization must precede projection, or hidden work leaks through a count or a summary.

## Verification

19 unit tests. Beyond the state machine and paging rules, two are the scale checks this refactoring owes:

- **1,000 rooms across 100 agents** emit at most three statements per branch and never a row per room — 40 branches, at most 120 statements, `observedRooms` 1,000.
- **A 1,000-branch estate** pages in exactly 20 bounded pages, no page over the bound, no repeats, every branch seen once.

Typecheck clean. Local CI gate passed on merged code at `a9dad629124b`.

This is the projection, measured on its own terms. Progressive disclosure in the running UI is D5's acceptance and is not claimed here.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-09-07-portfolio-work-activity-design.md` (PWA-02, PWA-06, PWA-07, contract C3); `docs/superpowers/plans/2026-09-07-portfolio-work-activity.md` (D3)
- Current code substrate reviewed: `room-activity.ts`, `room-types.ts`, `work-item-presence.ts` (the pure reader pattern followed here), `ea/workroom-architecture.ts` (placement from D1, merged in #5189)
- Decision: a pure projection composed by a server action, not a new ledger and not a client-side guarantee.

## Governance status

No initiative gate receipts, for the reason filed as BI-F2E199B1. The operator directed this work to proceed. Enforced repository gates all pass; no skip used.

Backlog: BI-66F3E9E5. Umbrella BI-8DACBA07. Depends on D1 (#5189, merged).

Local-CI-Evidence: cmtrh691wnygz01r93zisnst5

🤖 Generated with [Claude Code](https://claude.com/claude-code)


