### PR TITLE
fix(attention): address a stalled room by its canonical work-case key (BI-6F2CC21B)

### DIFF
--- a/apps/web/lib/attention/sources/workroom-stall.test.ts
+++ b/apps/web/lib/attention/sources/workroom-stall.test.ts
@@ -11,13 +11,52 @@
 // The threshold is deliberately not 1. A single paused tick is ordinary — a room
 // between cycles, a quiescent gate. An hour of consecutive refusals is a stall.
 
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
+import { encodeWorkCaseKey } from "@/lib/work-management/case-key";
 import {
   STALL_TICK_THRESHOLD,
   projectRoomStall,
   type RoomStallRow,
 } from "./workroom-stall";
+
+const APP_ROOT = new URL("../../../app", import.meta.url).pathname;
+
+// Walk the App Router tree the way Next.js does: route groups "(shell)" are
+// transparent, and a "[param]" directory matches any single segment. Returns
+// false when no directory chain can consume every segment of the path.
+function routeExists(href: string): boolean {
+  const segments = href.split("?")[0].split("/").filter(Boolean).map(decodeURIComponent);
+
+  function walk(dir: string, remaining: string[]): boolean {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    } catch {
+      return false;
+    }
+    if (remaining.length === 0) return true;
+    const [head, ...tail] = remaining;
+    for (const entry of entries) {
+      // A route group adds nesting without consuming a URL segment.
+      if (entry.startsWith("(") && entry.endsWith(")")) {
+        if (walk(join(dir, entry), remaining)) return true;
+        continue;
+      }
+      if (entry === head || (entry.startsWith("[") && entry.endsWith("]"))) {
+        if (walk(join(dir, entry), tail)) return true;
+      }
+    }
+    return false;
+  }
+
+  return segments.length > 0 && walk(APP_ROOT, segments);
+}
 
 function pause(reason: string, deviations: string[] = []): unknown {
   return {
@@ -212,5 +251,37 @@ describe("projectRoomStall over escalating rooms", () => {
 
   it("counts an escalation streak the same way it counts a pause streak", () => {
     expect(projectRoomStall(row({ drive: escalating(), consecutivePauses: 1 }))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The room the card points at must exist (BI-6F2CC21B).
+//
+// The operator reported that no "Open room" button on the Needs-you inbox
+// worked. This source emitted `/ea/workrooms/<capsuleId>`, a path with no
+// dynamic segment behind it, so every card 404'd — a total failure that shipped
+// because nothing asserted the link resolved. The canonical room address
+// already existed (encodeWorkCaseKey, used by the workrooms index); this source
+// hand-built a second shape instead of composing it.
+//
+// These two tests are deliberately a pair. The first pins the address to the
+// canonical helper, so a hand-built path fails. The second walks the real App
+// Router tree, so renaming the route fails the test rather than the operator's
+// inbox.
+
+describe("the emitted room link is reachable", () => {
+  it("addresses the room by its canonical work-case key, not a hand-built path", () => {
+    const item = projectRoomStall(row());
+    const expected = `/workspace/cases/${encodeWorkCaseKey({
+      sourceType: "work-capsule",
+      sourceId: "WC-A69BCABB",
+    })}`;
+    expect(item?.deepLink).toBe(expected);
+    expect(item?.actions?.[0]?.href).toBe(expected);
+  });
+
+  it("emits a path that resolves to a real App Router route", () => {
+    const item = projectRoomStall(row());
+    expect(routeExists(item?.deepLink ?? "")).toBe(true);
   });
 });

--- a/apps/web/lib/attention/sources/workroom-stall.ts
+++ b/apps/web/lib/attention/sources/workroom-stall.ts
@@ -9,6 +9,7 @@
 
 import type { prisma } from "@dpf/db";
 
+import { encodeWorkCaseKey } from "@/lib/work-management/case-key";
 import { resolveRoomOwner, type RoomOwner } from "@/lib/work-management/room-owner-ladder";
 import { STANDING_SHAPES } from "@/lib/work-management/standing-operations-shapes";
 
@@ -100,6 +101,13 @@ export function projectRoomStall(row: RoomStallRow): AttentionItem | null {
   // is the finding. It goes to the operator, who can appoint one.
   const overseer = readOverseerPrincipalRef(drive);
 
+  // The room's address is composed, never hand-built: a path spelled out here is
+  // a path nothing keeps honest, and the operator finds out by clicking (BI-6F2CC21B).
+  const roomHref = `/workspace/cases/${encodeWorkCaseKey({
+    sourceType: "work-capsule",
+    sourceId: row.capsuleId,
+  })}`;
+
   // Naming who should drive turns a diagnosis into a one-step instruction.
   const suggestion =
     row.ladderOwner === undefined
@@ -129,8 +137,8 @@ export function projectRoomStall(row: RoomStallRow): AttentionItem | null {
       irreversible: false,
     },
     createdAtIso: row.updatedAt.toISOString(),
-    actions: [{ kind: "open-in-context", label: "Open room", href: `/ea/workrooms/${row.capsuleId}` }],
-    deepLink: `/ea/workrooms/${row.capsuleId}`,
+    actions: [{ kind: "open-in-context", label: "Open room", href: roomHref }],
+    deepLink: roomHref,
     audience: { operator: true, ...(overseer ? { assigneePrincipalId: overseer } : {}) },
     ...(row.portfolioRole && PORTFOLIO_BY_ROLE[row.portfolioRole]
       ? { portfolio: PORTFOLIO_BY_ROLE[row.portfolioRole] }


### PR DESCRIPTION
Operator report, 2026-09-07: none of the **Open room** buttons on the Living Business / "60 things need you today" inbox work.

## Root cause

`apps/web/lib/attention/sources/workroom-stall.ts` emitted `/ea/workrooms/<capsuleId>` as both the action href and the deep link. There is no dynamic segment under `apps/web/app/(shell)/ea/workrooms/` — only `page.tsx` — so every such URL 404s. It was the only call site producing that shape, which is why the failure was total rather than intermittent.

The canonical room address already existed and is used by the workrooms index itself (`encodeWorkCaseKey` -> `/workspace/cases/[caseKey]`). This source hand-built a second shape instead of composing it, and nothing asserted the link resolved, so a total failure shipped unnoticed.

## Change

- Compose the room address from `encodeWorkCaseKey`. No new route, no new contract — this removes a divergent one.
- Two paired tests: one pins the address to the canonical helper; the other walks the real App Router tree (route groups transparent, `[param]` dirs as wildcards) so a renamed route fails the test rather than the operator's inbox.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs` + `plans` searched for room reachability / case projection (1822 files) — no spec owns room addressing, which is itself the gap, now tracked as **BI-00727E59**.
- Current code substrate reviewed: `apps/web/lib/ea/workroom-architecture.ts` (already composes the canonical address), `apps/web/lib/work-management/case-key.ts`, `apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx`, `apps/web/app/(shell)/ea/workrooms/`.
- Source of truth: `encodeWorkCaseKey` for the address, `/workspace/cases/[caseKey]` for the route. AGENTS.md §1 single-source-of-truth.
- Decision: reuse the existing helper; assert reachability so the invariant is enforced rather than assumed.

## Verification

- `vitest lib/attention/sources/workroom-stall.test.ts` — 2 new tests fail before, 21/21 pass after
- `vitest lib/attention` — 334 passed (29 files)
- `tsc --noEmit` — clean
- Local-CI gate passed on gated sha `20b2d06391be`, production build compiled successfully

## Scope

This PR alone does **not** clear the operator-visible symptom. The destination case page still 404s for most rooms (**BI-EBEB77E2**, loader ignores the `Workroom.workItemId` FK — 405/462 active rooms) and crashes for standing rooms (**BI-97B24FB5**, `finite_room_has_cycle`). Landed separately, one concern per PR.

Refs: BI-6F2CC21B · EP-00B120A1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Evidence: cmtrdqknikdgx01r9vk9v6amy
