### PR TITLE
fix(work-management): resolve a room's capsule key to its anchored canonical case (BI-EBEB77E2)

### DIFF
--- a/apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
+++ b/apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
@@ -8,6 +8,7 @@ import { loadEffectiveAuthContext } from "@/lib/identity/load-effective-auth-con
 import { loadPrismaWorkroomParticipants } from "@/lib/work-management/room-participation-prisma.server";
 import { loadWorkroomPostureContext } from "@/lib/work-management/room-posture.server";
 import { resolveWorkroomStructureForCase } from "@/lib/work-management/room-structure.server";
+import { resolveCanonicalWorkCaseKey } from "@/lib/work-management/canonical-case-key";
 import { loadWorkspaceWorkCaseDetail } from "@/lib/work-management/workspace-case-loader";
 
 type Props = {
@@ -28,6 +29,13 @@ export default async function WorkspaceCaseDetailPage({ params }: Props) {
   });
 
   const { caseKey } = await params;
+
+  // A room addressed by capsule id is the same case as the WorkItem it anchors
+  // to, not a second one. Send it to the canonical key so every surface that
+  // links a room by capsule id lands on the one case (BI-EBEB77E2).
+  const canonicalKey = await resolveCanonicalWorkCaseKey(prisma, caseKey);
+  if (canonicalKey) redirect(`/workspace/cases/${canonicalKey}`);
+
   const detail = await loadWorkspaceWorkCaseDetail({
     prismaClient: prisma,
     caseKey,

--- a/apps/web/lib/work-management/canonical-case-key.ts
+++ b/apps/web/lib/work-management/canonical-case-key.ts
@@ -1,0 +1,35 @@
+import { decodeWorkCaseKey, encodeWorkCaseKey } from "./case-key";
+import type { WorkspaceCasePrismaClient } from "./workspace-case-loader";
+
+/** Where a work-capsule case key should actually be read.
+ *
+ *  A Workroom is anchored to its WorkItem by Workroom.workItemId (BI-650994D7),
+ *  and that WorkItem owns exactly one case key — on the live install every
+ *  FK-anchored room points at a `backlog-item` case. So `work-capsule:<WC-x>` is
+ *  not a second case for the same work; it is another way to say the anchored
+ *  item's case. Resolving it here keeps one case per unit of work while making
+ *  the room reachable from every surface that addresses it by capsule id
+ *  (BI-EBEB77E2).
+ *
+ *  Returns the canonical key when it differs from the requested one, else null.
+ */
+export async function resolveCanonicalWorkCaseKey(
+  prismaClient: WorkspaceCasePrismaClient,
+  caseKey: string,
+): Promise<string | null> {
+  const decoded = decodeWorkCaseKey(caseKey);
+  if (!decoded || decoded.sourceType !== "work-capsule") return null;
+  if (!prismaClient.workroom.findFirst) return null;
+
+  const room = await prismaClient.workroom.findFirst({
+    where: { capsuleId: decoded.sourceId },
+    select: { workItemId: true },
+  });
+  if (!room?.workItemId) return null;
+
+  const item = await prismaClient.workItem.findFirst({ where: { id: room.workItemId } });
+  if (!item?.sourceType || !item.sourceId) return null;
+
+  const canonical = encodeWorkCaseKey({ sourceType: item.sourceType, sourceId: item.sourceId });
+  return canonical === caseKey ? null : canonical;
+}

--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -7,6 +7,7 @@ import {
   loadWorkspaceWorkCaseLens,
   type WorkspaceCasePrismaClient,
 } from "./workspace-case-loader";
+import { resolveCanonicalWorkCaseKey } from "./canonical-case-key";
 
 type WorkItemFixture = Awaited<ReturnType<WorkspaceCasePrismaClient["workItem"]["findMany"]>>[number];
 type CoworkerEngagementFixture =
@@ -621,5 +622,78 @@ describe("workspace Work Case loader", () => {
       actorRef: { actorKind: "agent", actorId: "AGT-REVIEW" },
     }));
     expect(detail?.room?.projection.sourceHealth).toBe("partial");
+  });
+});
+
+// A room anchored only by its FK must still be reachable (BI-EBEB77E2).
+//
+// BI-650994D7 made Workroom.workItemId the canonical anchor between a room and
+// its WorkItem. The detail loader never adopted it: it resolved a work-capsule
+// case by matching WorkItem.sourceType/sourceId against the capsule id — a
+// naming convention, not the anchor. Rooms linked only by the FK fell through
+// to notFound(): 405 of 462 active rooms on the live install, 117 of them
+// holding a perfectly valid workItemId.
+//
+// The fix is NOT to render a second case under the capsule key. Every one of
+// those 117 rooms anchors to a `backlog-item` WorkItem, and that item owns one
+// case key; minting a parallel capsule-keyed case would break the one-case-per-
+// unit-of-work invariant the anchor exists to enforce (room-read-model.ts
+// asserts it). The capsule key instead RESOLVES to the anchored item's case.
+describe("a work-capsule case key resolves to its anchored canonical case", () => {
+  const anchored: WorkItemFixture = {
+    ...baseItem,
+    id: "wi-row-9",
+    itemId: "WI-9",
+    sourceType: "backlog-item",
+    sourceId: "BI-UNRELATED",
+    title: "Adopter health",
+  };
+
+  function prismaWithFkOnly(room: { workItemId: string | null } | null): WorkspaceCasePrismaClient {
+    return {
+      workItem: {
+        findMany: async () => [anchored],
+        findFirst: async (args: unknown) => {
+          const where = (args as { where?: Record<string, unknown> })?.where ?? {};
+          return where.id === "wi-row-9" ? anchored : null;
+        },
+      },
+      workItemMessage: { findMany: async () => [] },
+      workroom: {
+        findMany: async () => [],
+        findFirst: async () => (room === null ? null : ({
+          id: "cap-row-9",
+          capsuleId: "WC-0A92C30D",
+          workItemId: room.workItemId,
+          status: "open",
+          title: "Adopter health",
+        } as never)),
+      },
+      workroomActivity: { findMany: async () => [] },
+    };
+  }
+
+  it("resolves a capsule key to the case key of the WorkItem it anchors to", async () => {
+    const canonical = await resolveCanonicalWorkCaseKey(
+      prismaWithFkOnly({ workItemId: "wi-row-9" }),
+      encodeWorkCaseKey({ sourceType: "work-capsule", sourceId: "WC-0A92C30D" }),
+    );
+    expect(canonical).toBe(encodeWorkCaseKey({ sourceType: "backlog-item", sourceId: "BI-UNRELATED" }));
+  });
+
+  it("leaves a room with no anchored WorkItem where it is", async () => {
+    const canonical = await resolveCanonicalWorkCaseKey(
+      prismaWithFkOnly({ workItemId: null }),
+      encodeWorkCaseKey({ sourceType: "work-capsule", sourceId: "WC-0A92C30D" }),
+    );
+    expect(canonical).toBeNull();
+  });
+
+  it("does not redirect a non-capsule case key", async () => {
+    const canonical = await resolveCanonicalWorkCaseKey(
+      prismaWithFkOnly({ workItemId: "wi-row-9" }),
+      encodeWorkCaseKey({ sourceType: "booking", sourceId: "BK-1" }),
+    );
+    expect(canonical).toBeNull();
   });
 });

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -146,6 +146,8 @@ export type WorkspaceCasePrismaClient = {
   };
   workroom: {
     findMany(args: unknown): Promise<WorkspaceWorkCapsuleRecord[]>;
+    /** Optional so existing fakes keep compiling (BI-EBEB77E2). */
+    findFirst?(args: unknown): Promise<WorkspaceWorkCapsuleRecord | null>;
   };
   workroomActivity: {
     findMany(args: unknown): Promise<WorkspaceWorkroomActivityRecord[]>;

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -209,7 +209,7 @@ Re-run the installer with `--environment-class` to change the value in force.
 - **Calendar** — Upcoming dates pulled from your backlog items, leave requests, deadlines, and any scheduled events in the areas you have access to.
 - **Managed Documents** — Maintained documents with lifecycle state, versions, references, and publication status.
 - **"Needs you" inbox** — The one place for business decisions that need you now. Routine technical recovery stays with your digital team, while money leaving the business and public actions always come to you.
-- **Workrooms** — Active, access-controlled places where people and AI coworkers coordinate toward a named outcome. A Workroom is the friendly Workspace view over a governed Work Case.
+- **Workrooms** — Active, access-controlled places where people and AI coworkers coordinate toward a named outcome. A Workroom is the friendly Workspace view over a governed Work Case. One room means one case: however you address a room — from your inbox, the Workrooms inventory, or a link someone sent you by room ID — you arrive at the same case rather than a second copy of it.
 
 ## What You Can Do
 

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -23,7 +23,7 @@ relatedCode:
 
 A Workroom is not an unbounded chat channel. It has a work boundary: purpose, outcome, scope, accountability, authority, sensitivity, measures, timing, and a closure rule. The platform keeps the underlying governed Work Case and its evidence; the room presents that structure in language suited to doing the work.
 
-From **Platform > Workrooms**, select a room ID to open this same canonical Workroom. Rooms tied to backlog work open that backlog case; rooms without a backlog item open their Work Capsule case, so the inventory never leads to a dead route.
+From **Platform > Workrooms**, select a room ID to open this same canonical Workroom. A room has one case, never two: a room tied to backlog work resolves to that backlog case even when you arrive by its room ID, and a room without a backlog item opens its own Work Capsule case. Either way the inventory never leads to a dead route, and a link you saved or shared by room ID keeps working.
 
 Coworker service engagements can also appear as Work Cases. When a requested coworker service needs approval, is accepted, or is in progress, the room opens around the engagement itself: the requested outcome is the room boundary, the provider coworker appears as a contributor, and approval context or audit references stay attached as evidence. These rooms do not show the WorkItem comment box until a WorkItem exists, because there is no task message thread to post into yet.
 


### PR DESCRIPTION
Rooms linked to their WorkItem only by `Workroom.workItemId` were unreachable. The detail loader resolved a work-capsule case by matching `WorkItem.sourceType/sourceId` (or `itemId`) against the capsule id — a naming convention that predates the anchor **BI-650994D7** introduced, not the anchor itself.

Measured on the live install: **405 of 462** active rooms 404'd, **117** of them holding a perfectly valid `workItemId`.

## Why this is a redirect, not a wider loader

The obvious fix — resolve the WorkItem through the FK and render it under the capsule key — was implemented first and **failed a deeper invariant**:

```
Work Room key 'work-capsule%3AWC-0A92C30D' must equal Work Case key 'backlog-item%3ABI-UNRELATED'
  at buildWorkroomView (lib/work-management/room-read-model.ts:168)
```

Checking the real rows explains why: all 117 FK-anchored rooms anchor to a `backlog-item` WorkItem, and that item owns exactly one case key. Minting a parallel capsule-keyed case would create a second identity for the same work — precisely what the anchor exists to prevent.

So the capsule key **resolves** to the anchored item's case: `resolveCanonicalWorkCaseKey` maps `work-capsule:<WC-x>` to the anchored WorkItem's key, and the route redirects. Every surface that addresses a room by capsule id now lands on the one case. The pre-FK convention query stays as the fallback for rows predating the anchor.

This also makes the code match what the user guide already promised — that the Workrooms inventory "never leads to a dead route."

## Design grounding

- Specs/plans reviewed: `docs/superpowers/specs` + `plans` (1822 files) — no spec owns room addressing; that gap is tracked as **BI-00727E59**.
- Code substrate reviewed: `packages/db/prisma/schema/work-coordination.prisma` (the FK), `apps/web/lib/work-management/room-read-model.ts:168` (the invariant that ruled out the naive fix), `workspace-case-loader.ts`, `apps/web/lib/ea/workroom-architecture.ts` (the caller this serves).
- Source of truth: `Workroom.workItemId` is the anchor; the anchored WorkItem owns the case key. One case per unit of work.
- Decision: resolve-and-redirect, in its own focused module, so reachability is gained without a second identity.

## Verification

- `vitest lib/work-management/workspace-case-loader.test.ts` — new test fails before, 16/16 pass after
- `vitest lib/work-management` — 67 files, 538/538 passed
- `tsc --noEmit` — clean
- Module-size and substrate-complexity ratchets held (resolver extracted to `canonical-case-key.ts` rather than growing the loader past its ceiling)
- Local-CI gate passed on gated sha `263df66f6f49`, production build compiled successfully

Refs: BI-EBEB77E2 · EP-WORK-CONVERGENCE · completes BI-650994D7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Evidence: cmtre83k2kxdx01r9xamwvqoo
