### PR TITLE
feat(work-management): roll executors up as named workers with delegated subagents

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1194,6 +1194,9 @@
     "apps/web/lib/work-management/work-unit.ts": [
       "docs/founder-kernel/wiki/principles/universal-work-formula.md"
     ],
+    "apps/web/lib/work-management/worker-rollup.ts": [
+      "docs/architecture/workroom-vocabulary-boundary.md"
+    ],
     "apps/web/lib/work-management/workspace-case-loader.ts": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
@@ -2659,6 +2662,7 @@
     ],
     "docs/architecture/workroom-vocabulary-boundary.md": [
       "apps/web/lib/work-management/human-accountability.ts",
+      "apps/web/lib/work-management/worker-rollup.ts",
       "scripts/check-prose-lint.ts"
     ],
     "docs/design/golden-triangle-design.md": [

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2494,6 +2494,7 @@
         "implemented-projection-seam",
         "composition-duration-and-evidence",
         "human-accountability-is-not-coordination-execution-or-access",
+        "an-executor-is-a-teammate-not-a-surface",
         "naming-rules",
         "a-known-tension-accepted-deliberately",
         "what-is-deliberately-not-renamed-yet",

--- a/apps/web/lib/work-management/worker-rollup.test.ts
+++ b/apps/web/lib/work-management/worker-rollup.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  groupDelegatedWorkers,
+  rollUpNamedWorkers,
+  selectWorkerPage,
+  WORKER_PROGRESS_FRESH_WINDOW_MS,
+  type WorkerSessionInput,
+} from "./worker-rollup";
+
+const NOW = new Date("2026-09-07T12:00:00.000Z");
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+function session(over: Partial<WorkerSessionInput> & { workerId: string }): WorkerSessionInput {
+  return {
+    displayName: `Worker ${over.workerId}`,
+    executorKind: "claude",
+    state: "working",
+    currentTask: null,
+    lastProgressAt: ago(1_000),
+    ...over,
+  };
+}
+
+describe("rollUpNamedWorkers", () => {
+  it("keeps one identity across surfaces instead of a row per connection", () => {
+    const workers = rollUpNamedWorkers([
+      session({ workerId: "w1", executorKind: "claude" }),
+      session({ workerId: "w1", executorKind: "codex" }),
+      session({ workerId: "w1", executorKind: "grok" }),
+    ], NOW);
+    expect(workers).toHaveLength(1);
+    expect(workers[0]!.executorKinds).toEqual(["claude", "codex", "grok"]);
+  });
+
+  it("describes the worker from its freshest observation", () => {
+    const workers = rollUpNamedWorkers([
+      session({ workerId: "w1", currentTask: "old task", lastProgressAt: ago(60_000) }),
+      session({ workerId: "w1", currentTask: "Checking invoice matching", lastProgressAt: ago(1_000), executorKind: "codex" }),
+    ], NOW);
+    expect(workers[0]!.currentTask).toBe("Checking invoice matching");
+    expect(workers[0]!.lastProgressAt).toBe(ago(1_000).toISOString());
+  });
+
+  it("will not report working without a recent observation", () => {
+    const [stale] = rollUpNamedWorkers([
+      session({ workerId: "w1", state: "working", lastProgressAt: ago(WORKER_PROGRESS_FRESH_WINDOW_MS + 1_000) }),
+    ], NOW);
+    expect(stale!.state).toBe("idle");
+
+    const [none] = rollUpNamedWorkers([session({ workerId: "w2", state: "working", lastProgressAt: null })], NOW);
+    expect(none!.state).toBe("unknown");
+  });
+
+  it("keeps waiting and idle as reported, since they are not claims about now", () => {
+    const workers = rollUpNamedWorkers([
+      session({ workerId: "a", state: "waiting", lastProgressAt: null }),
+      session({ workerId: "b", state: "idle", lastProgressAt: null }),
+    ], NOW);
+    expect(workers.map((w) => `${w.workerId}:${w.state}`).sort()).toEqual(["a:waiting", "b:idle"]);
+  });
+
+  it("distinguishes a root worker from one whose delegator was never recorded", () => {
+    const workers = rollUpNamedWorkers([
+      session({ workerId: "root", delegatedByWorkerId: null }),
+      session({ workerId: "orphan" }),
+    ], NOW);
+    expect(workers.find((w) => w.workerId === "root")!.parentage).toEqual({ kind: "root" });
+    expect(workers.find((w) => w.workerId === "orphan")!.parentage).toEqual({ kind: "unknown" });
+  });
+
+  it("counts direct subagents on the delegating worker", () => {
+    const workers = rollUpNamedWorkers([
+      session({ workerId: "planner", delegatedByWorkerId: null }),
+      session({ workerId: "s1", delegatedByWorkerId: "planner" }),
+      session({ workerId: "s2", delegatedByWorkerId: "planner" }),
+    ], NOW);
+    expect(workers.find((w) => w.workerId === "planner")!.subagentCount).toBe(2);
+  });
+
+  it("collapses conflicting delegators to unknown rather than picking one", () => {
+    const [worker] = rollUpNamedWorkers([
+      session({ workerId: "w", delegatedByWorkerId: "a" }),
+      session({ workerId: "w", delegatedByWorkerId: "b", executorKind: "codex" }),
+    ], NOW);
+    expect(worker!.parentage).toEqual({ kind: "unknown" });
+  });
+
+  it("prefers a recorded parent over an unrecorded observation of the same worker", () => {
+    const [worker] = rollUpNamedWorkers([
+      session({ workerId: "w" }),
+      session({ workerId: "w", delegatedByWorkerId: "planner", executorKind: "codex" }),
+    ], NOW);
+    expect(worker!.parentage).toEqual({ kind: "delegated", byWorkerId: "planner" });
+  });
+
+  it("orders attention first, then recency, then id", () => {
+    const workers = rollUpNamedWorkers([
+      session({ workerId: "idle-1", state: "idle", lastProgressAt: null }),
+      session({ workerId: "work-old", state: "working", lastProgressAt: ago(5_000) }),
+      session({ workerId: "wait-1", state: "waiting", lastProgressAt: null }),
+      session({ workerId: "work-new", state: "working", lastProgressAt: ago(1_000) }),
+    ], NOW);
+    expect(workers.map((w) => w.workerId)).toEqual(["wait-1", "work-new", "work-old", "idle-1"]);
+  });
+});
+
+describe("groupDelegatedWorkers", () => {
+  it("groups subagents under the worker that delegated them", () => {
+    const groups = groupDelegatedWorkers(rollUpNamedWorkers([
+      session({ workerId: "planner", delegatedByWorkerId: null }),
+      session({ workerId: "s1", delegatedByWorkerId: "planner" }),
+      session({ workerId: "s2", delegatedByWorkerId: "planner" }),
+    ], NOW));
+    const planner = groups.find((g) => g.parent?.workerId === "planner")!;
+    expect(planner.members.map((m) => m.workerId).sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("keeps unrecorded parentage in its own labelled group", () => {
+    const groups = groupDelegatedWorkers(rollUpNamedWorkers([
+      session({ workerId: "root", delegatedByWorkerId: null }),
+      session({ workerId: "mystery" }),
+    ], NOW));
+    const unknown = groups.find((g) => g.unknownParentage)!;
+    expect(unknown.parent).toBeNull();
+    expect(unknown.members.map((m) => m.workerId)).toEqual(["mystery"]);
+  });
+
+  it("does not promote a child to root when its parent is not visible", () => {
+    const groups = groupDelegatedWorkers(rollUpNamedWorkers([
+      session({ workerId: "child", delegatedByWorkerId: "hidden-by-authorization" }),
+    ], NOW));
+    const unknown = groups.find((g) => g.unknownParentage)!;
+    expect(unknown.members.map((m) => m.workerId)).toEqual(["child"]);
+    expect(groups.some((g) => g.parent?.workerId === "child")).toBe(false);
+  });
+
+  it("gives a mid-chain delegator its own group", () => {
+    const groups = groupDelegatedWorkers(rollUpNamedWorkers([
+      session({ workerId: "top", delegatedByWorkerId: null }),
+      session({ workerId: "mid", delegatedByWorkerId: "top" }),
+      session({ workerId: "leaf", delegatedByWorkerId: "mid" }),
+    ], NOW));
+    expect(groups.find((g) => g.parent?.workerId === "mid")!.members.map((m) => m.workerId)).toEqual(["leaf"]);
+  });
+});
+
+describe("selectWorkerPage", () => {
+  const hundred = rollUpNamedWorkers(
+    Array.from({ length: 100 }, (_, i) => session({
+      workerId: `agent-${String(i).padStart(3, "0")}`,
+      displayName: `Agent ${i}`,
+      delegatedByWorkerId: i === 0 ? null : "agent-000",
+      currentTask: i % 10 === 0 ? "Reconciling ledger" : `Step ${i}`,
+      lastProgressAt: ago(i * 100),
+    })),
+    NOW,
+  );
+
+  it("pages a hundred agents without hiding them behind a number", () => {
+    expect(hundred).toHaveLength(100);
+    let cursor: string | null = null;
+    let pages = 0;
+    const seen = new Set<string>();
+    do {
+      const page: ReturnType<typeof selectWorkerPage> = selectWorkerPage({ workers: hundred, pageSize: 20, cursor });
+      expect(page.workers.length).toBeLessThanOrEqual(20);
+      for (const w of page.workers) seen.add(w.workerId);
+      cursor = page.nextCursor;
+      pages += 1;
+    } while (cursor && pages < 20);
+    expect(seen.size).toBe(100);
+    expect(pages).toBe(5);
+  });
+
+  it("reports how many matched so a page can say twelve of a hundred", () => {
+    const page = selectWorkerPage({ workers: hundred, pageSize: 20 });
+    expect(page.matched).toBe(100);
+    expect(page.partial).toBe(true);
+  });
+
+  it("finds a worker among a hundred by name or by what it is doing", () => {
+    expect(selectWorkerPage({ workers: hundred, query: "Agent 42" }).matched).toBe(1);
+    expect(selectWorkerPage({ workers: hundred, query: "reconciling ledger" }).matched).toBe(10);
+  });
+
+  it("reports a complete page as not partial", () => {
+    const page = selectWorkerPage({ workers: hundred.slice(0, 3), pageSize: 20 });
+    expect(page.partial).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("keeps the delegating worker's subagent count truthful at a hundred", () => {
+    expect(hundred.find((w) => w.workerId === "agent-000")!.subagentCount).toBe(99);
+  });
+});

--- a/apps/web/lib/work-management/worker-rollup.ts
+++ b/apps/web/lib/work-management/worker-rollup.ts
@@ -1,0 +1,239 @@
+/**
+ * Named workers and delegated subagents on a room (PWA-03, PWA-06).
+ *
+ * An executor is a teammate, not a surface. The same worker reached through
+ * Claude Code, Codex, Grok or the portal is one identity with one session on the
+ * room, so a roster must deduplicate by identity rather than listing a row per
+ * connection. Multi-agent orchestration rolls up the same way: a planner and its
+ * specialists are one worker with subagents beneath it, never N peers.
+ *
+ * A hundred subagents must stay inspectable without either extreme. Hiding them
+ * behind a running count answers nothing, and giving each its own top-level
+ * destination floods navigation. They are grouped under the worker that
+ * delegated them, paged, and searchable.
+ *
+ * Delegation is not dependency. A worker's parent is the worker that delegated
+ * it, recorded at delegation time. Where that was never recorded it stays
+ * `unknown` — inferring a parent from timing or co-membership would invent a
+ * chain of command that nobody established.
+ *
+ * Pure and DB-free: the server action reads rows and applies authorization, then
+ * calls this.
+ */
+
+export const WORKER_STATES = ["working", "waiting", "idle", "unknown"] as const;
+export type WorkerState = (typeof WORKER_STATES)[number];
+
+/** How recent a progress observation must be to report a worker as working. */
+export const WORKER_PROGRESS_FRESH_WINDOW_MS = 120_000;
+
+export type WorkerSessionInput = {
+  /** Canonical worker identity. The same worker on two surfaces shares this. */
+  workerId: string;
+  displayName: string;
+  /** Which surface observed this session; never part of identity. */
+  executorKind: string;
+  state: WorkerState;
+  /** What this worker is doing right now, in words. */
+  currentTask: string | null;
+  lastProgressAt: Date | string | null;
+  /**
+   * The worker that delegated this one. `null` means it is a root worker;
+   * `undefined` means nobody recorded it and it must stay unknown.
+   */
+  delegatedByWorkerId?: string | null;
+};
+
+export type NamedWorker = {
+  workerId: string;
+  displayName: string;
+  /** Every surface this one identity was observed on, sorted and deduplicated. */
+  executorKinds: string[];
+  state: WorkerState;
+  currentTask: string | null;
+  lastProgressAt: string | null;
+  /** Explicitly one of: a parent id, no parent, or not recorded. */
+  parentage: { kind: "root" } | { kind: "delegated"; byWorkerId: string } | { kind: "unknown" };
+  /** Direct subagents delegated by this worker. */
+  subagentCount: number;
+};
+
+function toMs(value: Date | string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function laterOf(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.max(a, b);
+}
+
+/** A recorded parent wins over an absent one; conflicting parents collapse to unknown. */
+function mergeParentage(
+  current: NamedWorker["parentage"] | undefined,
+  next: WorkerSessionInput["delegatedByWorkerId"],
+): NamedWorker["parentage"] {
+  const incoming: NamedWorker["parentage"] =
+    next === undefined ? { kind: "unknown" } : next === null ? { kind: "root" } : { kind: "delegated", byWorkerId: next };
+  if (!current) return incoming;
+  if (current.kind === "unknown") return incoming;
+  if (incoming.kind === "unknown") return current;
+  if (current.kind === "delegated" && incoming.kind === "delegated") {
+    // Two surfaces naming different delegators is a conflict, not a vote.
+    return current.byWorkerId === incoming.byWorkerId ? current : { kind: "unknown" };
+  }
+  return current.kind === "delegated" ? current : incoming;
+}
+
+/** Working is a claim about now, so it needs a recent observation to survive. */
+function reconcileState(state: WorkerState, lastProgressMs: number | null, nowMs: number): WorkerState {
+  if (state !== "working") return state;
+  if (lastProgressMs === null) return "unknown";
+  return nowMs - lastProgressMs <= WORKER_PROGRESS_FRESH_WINDOW_MS ? "working" : "idle";
+}
+
+/**
+ * Roll sessions up into one entry per worker identity.
+ *
+ * Ordering is deterministic: attention-bearing states first, then most recent
+ * progress, then worker id.
+ */
+export function rollUpNamedWorkers(
+  sessions: readonly WorkerSessionInput[],
+  now: Date | number,
+): NamedWorker[] {
+  const nowMs = typeof now === "number" ? now : now.getTime();
+  const byId = new Map<string, NamedWorker & { _progressMs: number | null }>();
+
+  for (const session of sessions) {
+    const existing = byId.get(session.workerId);
+    const progressMs = toMs(session.lastProgressAt);
+    if (!existing) {
+      byId.set(session.workerId, {
+        workerId: session.workerId,
+        displayName: session.displayName,
+        executorKinds: [session.executorKind],
+        state: session.state,
+        currentTask: session.currentTask,
+        lastProgressAt: null,
+        parentage: mergeParentage(undefined, session.delegatedByWorkerId),
+        subagentCount: 0,
+        _progressMs: progressMs,
+      });
+      continue;
+    }
+    if (!existing.executorKinds.includes(session.executorKind)) existing.executorKinds.push(session.executorKind);
+    // The freshest observation describes what the worker is doing.
+    if (progressMs !== null && (existing._progressMs === null || progressMs > existing._progressMs)) {
+      existing.state = session.state;
+      existing.currentTask = session.currentTask;
+    }
+    existing._progressMs = laterOf(existing._progressMs, progressMs);
+    existing.parentage = mergeParentage(existing.parentage, session.delegatedByWorkerId);
+  }
+
+  for (const worker of byId.values()) {
+    if (worker.parentage.kind === "delegated") {
+      const parent = byId.get(worker.parentage.byWorkerId);
+      if (parent) parent.subagentCount += 1;
+    }
+  }
+
+  const priority: Record<WorkerState, number> = { waiting: 0, working: 1, idle: 2, unknown: 3 };
+  return [...byId.values()]
+    .map(({ _progressMs, ...worker }) => ({
+      ...worker,
+      executorKinds: [...worker.executorKinds].sort((a, b) => a.localeCompare(b, "en-US")),
+      state: reconcileState(worker.state, _progressMs, nowMs),
+      lastProgressAt: _progressMs === null ? null : new Date(_progressMs).toISOString(),
+      _progressMs,
+    }))
+    .sort((a, b) =>
+      priority[a.state] !== priority[b.state] ? priority[a.state] - priority[b.state]
+        : (b._progressMs ?? -1) !== (a._progressMs ?? -1) ? (b._progressMs ?? -1) - (a._progressMs ?? -1)
+          : a.workerId.localeCompare(b.workerId, "en-US"),
+    )
+    .map(({ _progressMs, ...worker }) => worker);
+}
+
+export type WorkerGroup = {
+  /** The delegating worker, or null for the unknown-parentage group. */
+  parent: NamedWorker | null;
+  /** Present only on the unknown group, so the UI can label it honestly. */
+  unknownParentage: boolean;
+  members: NamedWorker[];
+};
+
+/**
+ * Group workers under whoever delegated them, keeping unrecorded parentage in
+ * its own labelled group rather than folded under a plausible parent.
+ */
+export function groupDelegatedWorkers(workers: readonly NamedWorker[]): WorkerGroup[] {
+  const byId = new Map(workers.map((worker) => [worker.workerId, worker]));
+  const roots = workers.filter((worker) => worker.parentage.kind === "root");
+  const unknown = workers.filter((worker) => worker.parentage.kind === "unknown");
+  const groups: WorkerGroup[] = roots.map((parent) => ({
+    parent,
+    unknownParentage: false,
+    members: workers.filter((w) => w.parentage.kind === "delegated" && w.parentage.byWorkerId === parent.workerId),
+  }));
+  // A delegator that is itself delegated still owns its own group.
+  for (const worker of workers) {
+    if (worker.parentage.kind !== "delegated") continue;
+    if (worker.subagentCount === 0) continue;
+    groups.push({
+      parent: worker,
+      unknownParentage: false,
+      members: workers.filter((w) => w.parentage.kind === "delegated" && w.parentage.byWorkerId === worker.workerId),
+    });
+  }
+  // A recorded parent we cannot see (filtered by authorization, or not loaded)
+  // must not silently promote its children to roots.
+  const orphaned = workers.filter(
+    (w) => w.parentage.kind === "delegated" && !byId.has(w.parentage.byWorkerId),
+  );
+  if (unknown.length > 0 || orphaned.length > 0) {
+    groups.push({ parent: null, unknownParentage: true, members: [...unknown, ...orphaned] });
+  }
+  return groups;
+}
+
+export type WorkerPage = {
+  workers: NamedWorker[];
+  nextCursor: string | null;
+  partial: boolean;
+  /** Total matching the query before paging, so the UI can say "12 of 100". */
+  matched: number;
+};
+
+/**
+ * One bounded, searchable page of workers.
+ *
+ * Search matches the worker's name or what it is currently doing, which is how
+ * an operator actually looks for one among a hundred.
+ */
+export function selectWorkerPage(input: {
+  workers: readonly NamedWorker[];
+  pageSize?: number;
+  cursor?: string | null;
+  query?: string | null;
+}): WorkerPage {
+  const pageSize = Math.max(1, input.pageSize ?? 20);
+  const needle = input.query?.trim().toLocaleLowerCase("en-US") ?? "";
+  const matched = needle
+    ? input.workers.filter((w) =>
+        w.displayName.toLocaleLowerCase("en-US").includes(needle)
+        || (w.currentTask ?? "").toLocaleLowerCase("en-US").includes(needle))
+    : [...input.workers];
+  const startIndex = input.cursor ? matched.findIndex((w) => w.workerId === input.cursor) + 1 : 0;
+  const slice = matched.slice(startIndex, startIndex + pageSize);
+  const partial = startIndex + slice.length < matched.length;
+  return {
+    workers: slice,
+    nextCursor: partial ? slice[slice.length - 1]?.workerId ?? null : null,
+    partial,
+    matched: matched.length,
+  };
+}

--- a/docs/architecture/workroom-vocabulary-boundary.md
+++ b/docs/architecture/workroom-vocabulary-boundary.md
@@ -151,6 +151,33 @@ is, rooms with no explicit assignment resolve to that setup state, which is the
 intended behaviour rather than a defect. Recording it is a schema change with
 its own migration acceptance.
 
+## An executor is a teammate, not a surface
+
+The same worker reached through Claude Code, Codex, Grok or the portal is one
+identity with one session on the room. A roster deduplicates by identity rather
+than listing a row per connection, and multi-agent orchestration rolls up the
+same way: a planner and its specialists are one worker with subagents beneath
+it, never N peers competing for attention.
+
+`rollUpNamedWorkers` in
+[`apps/web/lib/work-management/worker-rollup.ts`](../../apps/web/lib/work-management/worker-rollup.ts)
+performs that rollup. A worker is described from its freshest observation, and
+`working` is a claim about now: without a recent progress observation it
+degrades to idle, and with none at all to unknown. `waiting` and `idle` are not
+claims about now and are reported as given.
+
+Delegation is not dependency. A worker's parent is the worker that delegated it,
+recorded at delegation time. Where that was never recorded the parentage stays
+`unknown`, and where two surfaces name different delegators it collapses to
+`unknown` rather than taking a vote. A child whose parent is not visible — hidden
+by authorization, or simply not loaded — is never promoted to a root, because
+that would present a subagent as an independent worker.
+
+A hundred subagents stay inspectable without either extreme: hiding them behind
+a running count answers nothing, and giving each a top-level destination floods
+navigation. They are grouped under the worker that delegated them, paged, and
+searchable by name or by what they are currently doing.
+
 ## Naming rules
 
 - One stem, one casing: **`Workroom`** — never `WorkRoom`, `work-room` or


### PR DESCRIPTION
Rolls executors up as named workers with their delegated subagents. Deliverable D4 of the portfolio work activity refactoring (BI-C41AB195).

## An executor is a teammate, not a surface

The same worker reached through Claude Code, Codex, Grok or the portal is one identity with one session on the room. `rollUpNamedWorkers` deduplicates by identity rather than listing a row per connection, so multi-agent orchestration rolls up the same way: a planner and its specialists are one worker with subagents beneath it, never N peers competing for attention.

A worker is described from its freshest observation, and `working` is a claim about now. Without a recent progress observation it degrades to `idle`; with none at all, to `unknown`. `waiting` and `idle` are not claims about now and are reported as given.

## Delegation is not dependency

A worker's parent is whoever delegated it, recorded at delegation time. Three cases are handled explicitly rather than guessed:

- Never recorded stays `unknown`. Inferring a parent from timing or co-membership would invent a chain of command nobody established.
- Two surfaces naming different delegators collapse to `unknown` rather than taking a vote.
- A child whose parent is not visible — hidden by authorization, or simply not loaded — is never promoted to a root, because that would present a subagent as an independent worker.

## A hundred subagents, inspectable

Both extremes fail: hiding them behind a running count answers nothing, and giving each a top-level destination floods navigation. They are grouped under their delegator, paged, and searchable by name or by what they are currently doing.

## Verification

18 unit tests. The hundred-agent case is exercised directly: 100 agents page in exactly 5 bounded pages with every agent seen once, search matches by name and by current task, `matched` is reported so a page can say "12 of 100", and the delegator's subagent count stays truthful at 99.

Also covered: one identity across three surfaces, freshest-observation wins, `working` degrading without recent evidence, root versus unrecorded parentage, conflicting delegators, mid-chain delegators owning their own group, and an invisible parent not promoting its child.

Typecheck clean. Local CI gate passed on merged code at `d994902f63a3`.

Pure and DB-free, following `work-item-presence.ts`: the server action reads rows and applies authorization, then calls this.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-09-07-portfolio-work-activity-design.md` (PWA-03, PWA-06, contract C3, verification V2); `docs/superpowers/plans/2026-09-07-portfolio-work-activity.md` (D4)
- Current code substrate reviewed: `room-types.ts` (`WorkroomParticipantWorkState`), `room-participant-assignment.ts` (persisted roster projection), `portfolio-activity-projection.ts` (the sibling projection from D3)
- Decision: deduplicate on worker identity and keep unrecorded parentage explicit, rather than inferring a delegation chain.

## Governance status

No initiative gate receipts, for the reason filed as BI-F2E199B1. The operator directed this work to proceed. Enforced repository gates all pass; no skip used.

Backlog: BI-C41AB195. Umbrella BI-8DACBA07.

Local-CI-Evidence: cmtrecacckxmx01r9hiy7yiiw

🤖 Generated with [Claude Code](https://claude.com/claude-code)
