### PR TITLE
fix(release): re-pin hwdsl2/whisper-server to the current registry digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -989,7 +989,7 @@ services:
   dpf-stt:
     profiles: ["runtime-local-speech", "tts"]
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-09-03 (the prior 8f76c4f9… digest was deleted from the
+    # resolved on 2026-09-07 (the prior 29d01f2e… digest was deleted from the
     # registry — Release Image Manifest Guard caught it again). The registry
     # owner re-pushes :latest periodically and prunes the previous index, so
     # this digest must be re-resolved every time the guard fails. Bump
@@ -999,7 +999,7 @@ services:
     # the sidecar won't start, set DPF_STT_IMAGE in .env to a reachable ref
     # (e.g. hwdsl2/whisper-server:latest) then `docker compose up -d dpf-stt`,
     # and open a PR re-resolving the digest here (this is that PR's pattern).
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:29d01f2e47e4f72b5475ce36fc987bb369f53fa5e5cf6b5a924ada69e1820b3f}
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:257302e5ea7efb041546d1b5d8ee11bcba2235711ab94f08c4dcc54be074ac36}
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:8f76c4f99069b533b54866388f6a6cb1cb47cfde14762dc7af0b22dd58721df2";
-const CURRENT_STT_DIGEST =
   "hwdsl2/whisper-server@sha256:29d01f2e47e4f72b5475ce36fc987bb369f53fa5e5cf6b5a924ada69e1820b3f";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:257302e5ea7efb041546d1b5d8ee11bcba2235711ab94f08c4dcc54be074ac36";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
## Summary

Every release since `9afc62c` fails **E2E install verification (release mode)** at the digest-pinned manifest check:

```
[missing] hwdsl2/whisper-server@sha256:29d01f2e...
no such manifest: docker.io/hwdsl2/whisper-server@sha256:29d01f2e...
```

The upstream owner re-pushes `:latest` roughly weekly, retiring the old index digest. `docker manifest inspect` confirms `29d01f2e` is gone and `:latest` now resolves to `257302e5`, which is what this branch pins.

**The automation already caught this and could not finish.** `.github/workflows/stt-digest-watch.yml` ran at 12:27 today, detected the new digest, and pushed this branch — then failed at `gh pr create`:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

So the branch is the bot's own verified work; only the PR was blocked. I am opening it by hand and filing the permission defect separately, because until this merges **no release can verify**, and three merged fixes (BI-A57B6185, BI-05F8860A, BI-3CA18934) cannot reach any install.

## Verification

- `docker manifest inspect` on the old digest: `no such manifest`.
- Docker Hub tags API: `latest` = `sha256:257302e5ea7efb041546d1b5d8ee11bcba2235711ab94f08c4dcc54be074ac36`, matching this diff.
- The watcher's own `applyRepin` unit tests passed in that run; only PR creation failed.

Process-Spine-Decision: a registry digest refresh produced by the existing watcher automation; the durable knowledge lives in stt-digest-watch.yml, and the permission defect that stopped it is filed separately
Convergence-Impact-Decision: auto-converges — docker-compose.yml is composed from the new release assets by promote.sh, so an existing install picks up the new STT pin on its next self-upgrade; no install state, env or seed involved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: a third-party image digest refresh; the pinned digest is an implementation detail of the STT service and no documented behaviour, route or user-guide page changes
