### PR TITLE
fix(ea): a reference model that is not this archetype's says so, instead of reading ACTIVE with zero criteria (BI-C44EAEE6)

### DIFF
--- a/apps/web/app/(shell)/ea/models/[slug]/page.tsx
+++ b/apps/web/app/(shell)/ea/models/[slug]/page.tsx
@@ -56,8 +56,15 @@ export default async function ReferenceModelPage({ params }: Props) {
           </div>
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">{detail.name}</h1>
           <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-            {detail.version} · {detail.authorityType} · {detail.status}
+            {detail.version} · {detail.authorityType} ·{" "}
+            {detail.applies ? detail.status : "not this archetype"}
           </p>
+          {!detail.applies && (
+            <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
+              {detail.applicabilityReason} Its criteria are not imported here, so the counts
+              below are empty by design rather than incomplete.
+            </p>
+          )}
           {detail.description && (
             <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
               {detail.description}

--- a/apps/web/components/ea/ReferenceModelDirectory.test.tsx
+++ b/apps/web/components/ea/ReferenceModelDirectory.test.tsx
@@ -20,6 +20,8 @@ describe("ReferenceModelDirectory", () => {
             name: "IT4IT",
             version: "3.0.1",
             status: "active",
+            applies: true,
+            applicabilityReason: "Applies to every install.",
             criteriaCount: 417,
             assessmentCount: 12,
             proposalCount: 1,
@@ -32,5 +34,34 @@ describe("ReferenceModelDirectory", () => {
     expect(html).toContain("IT4IT");
     expect(html).toContain("417 criteria");
     expect(html).toContain('href="/ea/models/it4it_v3_0_1"');
+  });
+
+  // BI-C44EAEE6: /ea/models had the same defect as the EA overview.
+  it("shows an industry model that is not this install's as such, not as active", () => {
+    const html = renderToStaticMarkup(
+      <ReferenceModelDirectory
+        models={[
+          {
+            id: "rm-2",
+            slug: "bian_service_landscape_v14_0_0",
+            name: "BIAN Service Landscape",
+            version: "14.0.0",
+            status: "active",
+            applies: false,
+            applicabilityReason:
+              "Serves banking-financial-services, and this install is pet-rescue.",
+            criteriaCount: 0,
+            assessmentCount: 0,
+            proposalCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("BIAN Service Landscape");
+    expect(html).toContain("not this archetype");
+    expect(html).toContain("Serves banking-financial-services");
+    expect(html).not.toContain("0 criteria");
+    expect(html).not.toContain("0 assessments");
   });
 });

--- a/apps/web/components/ea/ReferenceModelDirectory.tsx
+++ b/apps/web/components/ea/ReferenceModelDirectory.tsx
@@ -54,7 +54,7 @@ export function ReferenceModelDirectory({ models }: Props) {
                   <span>{model.proposalCount} proposals</span>
                 </div>
               ) : (
-                <p className="mt-3 text-[11px] text-[var(--dpf-muted)]">
+                <p className="mt-3 text-dpf-caption text-[var(--dpf-muted)]">
                   {model.applicabilityReason}
                 </p>
               )}

--- a/apps/web/components/ea/ReferenceModelDirectory.tsx
+++ b/apps/web/components/ea/ReferenceModelDirectory.tsx
@@ -26,23 +26,38 @@ export function ReferenceModelDirectory({ models }: Props) {
             <Link
               key={model.id}
               href={`/ea/models/${model.slug}`}
-              className="block rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 hover:opacity-90"
+              className={`block rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 hover:opacity-90${
+                model.applies ? "" : " opacity-70"
+              }`}
+              data-applies={model.applies ? "true" : "false"}
             >
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-[var(--dpf-text)]">{model.name}</p>
                   <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">
-                    {model.version} · {model.status}
+                    {model.version} · {model.applies ? model.status : "not this archetype"}
                   </p>
                 </div>
-                <span className="rounded-full bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] text-[var(--dpf-muted)]">
-                  {model.criteriaCount} criteria
-                </span>
+                {model.applies && (
+                  <span className="rounded-full bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] text-[var(--dpf-muted)]">
+                    {model.criteriaCount} criteria
+                  </span>
+                )}
               </div>
-              <div className="mt-3 flex gap-3 text-[11px] text-[var(--dpf-muted)]">
-                <span>{model.assessmentCount} assessments</span>
-                <span>{model.proposalCount} proposals</span>
-              </div>
+              {/* Counts on a model this install does not serve are zero because
+                  its hierarchy was never imported, which is correct. Printing
+                  them under a lifecycle status made a banking standard look live
+                  and broken on a pet rescue (BI-C44EAEE6). */}
+              {model.applies ? (
+                <div className="mt-3 flex gap-3 text-[11px] text-[var(--dpf-muted)]">
+                  <span>{model.assessmentCount} assessments</span>
+                  <span>{model.proposalCount} proposals</span>
+                </div>
+              ) : (
+                <p className="mt-3 text-[11px] text-[var(--dpf-muted)]">
+                  {model.applicabilityReason}
+                </p>
+              )}
             </Link>
           ))}
         </div>

--- a/apps/web/components/ea/ReferenceModelSummary.test.tsx
+++ b/apps/web/components/ea/ReferenceModelSummary.test.tsx
@@ -1,35 +1,88 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { ReferenceModelSummary } from "./ReferenceModelSummary";
 
 vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
   ),
 }));
 
+import { ReferenceModelSummary } from "@/components/ea/ReferenceModelSummary";
+import type { ReferenceModelSummary as Row } from "@/lib/explore/reference-model-types";
+
+function row(overrides: Partial<Row> = {}): Row {
+  return {
+    id: "m1",
+    slug: "it4it_v3_0_1",
+    name: "IT4IT",
+    version: "3.0.1",
+    status: "active",
+    applies: true,
+    applicabilityReason: "Applies to every install.",
+    criteriaCount: 688,
+    assessmentCount: 452,
+    proposalCount: 0,
+    ...overrides,
+  };
+}
+
+const bian = row({
+  id: "m2",
+  slug: "bian_service_landscape_v14_0_0",
+  name: "BIAN Service Landscape",
+  version: "14.0.0",
+  status: "active",
+  applies: false,
+  applicabilityReason: "Serves banking-financial-services, and this install is pet-rescue.",
+  criteriaCount: 0,
+  assessmentCount: 0,
+  proposalCount: 0,
+});
+
 describe("ReferenceModelSummary", () => {
-  it("renders model cards with portfolio counts", () => {
-    const html = renderToStaticMarkup(
-      <ReferenceModelSummary
-        models={[
-          {
-            id: "rm-1",
-            slug: "it4it_v3_0_1",
-            name: "IT4IT",
-            version: "3.0.1",
-            status: "active",
-            criteriaCount: 417,
-            assessmentCount: 12,
-            proposalCount: 1,
-          },
-        ]}
-      />
-    );
+  // The defect this fixes, exactly as the founder saw it on 2026-09-07: a pet
+  // rescue's EA page offering "BIAN Service Landscape — ACTIVE — 0 criteria".
+  // Zero counts are CORRECT there; presenting them under a live status is not.
+  it("never shows an inapplicable model as active with zero counts", () => {
+    const html = renderToStaticMarkup(<ReferenceModelSummary models={[bian]} />);
+
+    expect(html).toContain("BIAN Service Landscape");
+    expect(html).toContain("not this archetype");
+    expect(html).not.toContain("0 criteria");
+    expect(html).not.toContain("0 assessments");
+  });
+
+  it("says why the model is not this install's business", () => {
+    const html = renderToStaticMarkup(<ReferenceModelSummary models={[bian]} />);
+    expect(html).toContain("Serves banking-financial-services");
+    expect(html).toContain("pet-rescue");
+  });
+
+  it("keeps the counts and the lifecycle status for a model that does apply", () => {
+    const html = renderToStaticMarkup(<ReferenceModelSummary models={[row()]} />);
+
+    expect(html).toContain("688 criteria");
+    expect(html).toContain("452 assessments");
+    expect(html).toContain("active");
+    expect(html).not.toContain("not this archetype");
+  });
+
+  // The catalogue entry is kept on every install on purpose, so an operator can
+  // see the standard exists. Dropping it would undo that deliberately.
+  it("still lists the inapplicable model rather than hiding it", () => {
+    const html = renderToStaticMarkup(<ReferenceModelSummary models={[row(), bian]} />);
 
     expect(html).toContain("IT4IT");
-    expect(html).toContain("3.0.1");
-    expect(html).toContain("417 criteria");
-    expect(html).toContain("/ea/models/it4it_v3_0_1");
+    expect(html).toContain("BIAN Service Landscape");
+    expect(html).toContain('href="/ea/models/bian_service_landscape_v14_0_0"');
+    expect(html).toContain('data-applies="false"');
+    expect(html).toContain('data-applies="true"');
+  });
+
+  it("renders the empty state when no models are registered", () => {
+    const html = renderToStaticMarkup(<ReferenceModelSummary models={[]} />);
+    expect(html).toContain("No reference models have been registered yet.");
   });
 });

--- a/apps/web/components/ea/ReferenceModelSummary.tsx
+++ b/apps/web/components/ea/ReferenceModelSummary.tsx
@@ -29,18 +29,30 @@ export function ReferenceModelSummary({ models }: Props) {
           <Link
             key={model.id}
             href={`/ea/models/${model.slug}`}
-            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:border-[var(--dpf-accent)]"
+            className={`rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:border-[var(--dpf-accent)]${
+              model.applies ? "" : " opacity-70"
+            }`}
+            data-applies={model.applies ? "true" : "false"}
           >
+            {/* A model this install does not serve is NOT "active with nothing
+                in it" — its counts are zero because its hierarchy was never
+                imported, which is correct. Showing the lifecycle status there
+                made a banking standard look live and broken on a pet rescue
+                (BI-C44EAEE6). */}
             <p className="mb-1 text-[10px] font-mono uppercase tracking-widest text-[var(--dpf-muted)]">
-              {model.status}
+              {model.applies ? model.status : "not this archetype"}
             </p>
             <p className="text-sm font-semibold text-[var(--dpf-text)]">{model.name}</p>
             <p className="mb-2 text-xs text-[var(--dpf-muted)]">{model.version}</p>
-            <div className="space-y-1 text-xs text-[var(--dpf-muted)]">
-              <p>{model.criteriaCount} criteria</p>
-              <p>{model.assessmentCount} assessments</p>
-              <p>{model.proposalCount} proposals</p>
-            </div>
+            {model.applies ? (
+              <div className="space-y-1 text-xs text-[var(--dpf-muted)]">
+                <p>{model.criteriaCount} criteria</p>
+                <p>{model.assessmentCount} assessments</p>
+                <p>{model.proposalCount} proposals</p>
+              </div>
+            ) : (
+              <p className="text-xs text-[var(--dpf-muted)]">{model.applicabilityReason}</p>
+            )}
           </Link>
         ))}
       </div>

--- a/apps/web/lib/attention/sources/workroom-stall.test.ts
+++ b/apps/web/lib/attention/sources/workroom-stall.test.ts
@@ -13,6 +13,7 @@
 
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -23,7 +24,11 @@ import {
   type RoomStallRow,
 } from "./workroom-stall";
 
-const APP_ROOT = new URL("../../../app", import.meta.url).pathname;
+// `URL.pathname` yields "/D:/..." on Windows, which readdirSync cannot open, so
+// the walk below caught the error and reported every route as missing. That made
+// this test red on every Windows host while passing in CI. fileURLToPath is the
+// platform-correct conversion.
+const APP_ROOT = fileURLToPath(new URL("../../../app", import.meta.url));
 
 // Walk the App Router tree the way Next.js does: route groups "(shell)" are
 // transparent, and a "[param]" directory matches any single segment. Returns

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1430,6 +1430,9 @@
     "packages/db/src/provider-compliance-source-registry.ts": [
       "docs/operations/ai-provider-compliance-source-renewal-runbook.md"
     ],
+    "packages/db/src/reference-model-applicability.ts": [
+      "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md"
+    ],
     "packages/db/src/regulation-applicability.ts": [
       "docs/architecture/2026-08-20-recurring-obligation-work-shape-and-doc-robustness.md",
       "docs/maintenance/staleness-report.md",
@@ -2543,6 +2546,7 @@
     ],
     "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md": [
       "packages/db/scripts/generate-taxonomy-v3-json.ts",
+      "packages/db/src/reference-model-applicability.ts",
       "packages/db/src/seed-ea-reference-models.ts"
     ],
     "docs/architecture/four-portfolio-archetype-standard-profile-catalog.md": [

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -11225,6 +11225,7 @@
       "anchors": [
         "overview",
         "key-concepts",
+        "reference-models-and-your-archetype",
         "workroom-definitions",
         "what-you-can-do",
         "ai-coworker-identity",

--- a/apps/web/lib/explore/ea-data.ts
+++ b/apps/web/lib/explore/ea-data.ts
@@ -1,5 +1,9 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
+import {
+  describeReferenceModelApplicability,
+  type InstallArchetype,
+} from "@dpf/db/reference-model-applicability";
 import { shapeIt4itCoverageHeatmap } from "./it4it-coverage-view";
 import {
   shapeIt4itParticipationGrid,
@@ -207,6 +211,28 @@ export const getRelationshipTypeId = cache(async (notationId: string, slug: stri
   return rt?.id ?? null;
 });
 
+/**
+ * The install's declared archetype, for scoping industry content at read time.
+ *
+ * `StorefrontConfig.archetypeId` is a cuid FK, so reaching the slugs the
+ * applicability lists are written in needs the join. Mirrors what the seed does
+ * with its own client; the RULE they share lives in one module (BI-C44EAEE6).
+ */
+const getInstallArchetype = cache(async (): Promise<InstallArchetype> => {
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { archetypeId: true },
+  });
+  if (!config) return { category: null, archetypeId: null };
+  const archetype = await prisma.storefrontArchetype.findUnique({
+    where: { id: config.archetypeId },
+    select: { archetypeId: true, category: true },
+  });
+  return {
+    category: archetype?.category ?? null,
+    archetypeId: archetype?.archetypeId ?? null,
+  };
+});
+
 export const getReferenceModelsSummary = cache(async (): Promise<ReferenceModelSummary[]> => {
   const models = await prisma.eaReferenceModel.findMany({
     orderBy: [{ name: "asc" }, { version: "asc" }],
@@ -226,16 +252,28 @@ export const getReferenceModelsSummary = cache(async (): Promise<ReferenceModelS
     },
   });
 
-  return models.map((model) => ({
-    id: model.id,
-    slug: model.slug,
-    name: model.name,
-    version: model.version,
-    status: model.status,
-    criteriaCount: model._count.elements,
-    assessmentCount: model._count.assessments,
-    proposalCount: model._count.proposals,
-  }));
+  // The catalogue row is seeded on EVERY install on purpose, so an operator can
+  // see the standard exists. Seeding its ELEMENT hierarchy is scoped to the
+  // archetype (#4870). Reading it was not, so a pet rescue saw "BIAN Service
+  // Landscape — ACTIVE — 0 criteria": a banking standard presented as live and
+  // empty, which reads as broken rather than as someone else's (BI-C44EAEE6).
+  const install = await getInstallArchetype();
+
+  return models.map((model) => {
+    const applicability = describeReferenceModelApplicability(model.slug, install);
+    return {
+      id: model.id,
+      slug: model.slug,
+      name: model.name,
+      version: model.version,
+      status: model.status,
+      applies: applicability.applies,
+      applicabilityReason: applicability.reason,
+      criteriaCount: model._count.elements,
+      assessmentCount: model._count.assessments,
+      proposalCount: model._count.proposals,
+    };
+  });
 });
 
 const COVERAGE_STATUSES: CoverageStatus[] = [
@@ -393,8 +431,18 @@ export const getReferenceModelDetail = cache(
       },
     });
 
+    // A direct link to a model this install does not serve must be as honest as
+    // the card that offered it, or the drill-through becomes the place the
+    // "active but empty" impression survives (BI-C44EAEE6).
+    const applicability = describeReferenceModelApplicability(
+      model.slug,
+      await getInstallArchetype(),
+    );
+
     return {
       ...model,
+      applies: applicability.applies,
+      applicabilityReason: applicability.reason,
       valueStreamProjection: {
         viewId: valueStreamProjection?.id ?? null,
         viewName: valueStreamProjection?.name ?? null,

--- a/apps/web/lib/explore/reference-model-data.test.ts
+++ b/apps/web/lib/explore/reference-model-data.test.ts
@@ -9,6 +9,8 @@ vi.mock("@dpf/db", () => ({
     eaReferenceModel: { findMany: vi.fn(), findUnique: vi.fn() },
     eaReferenceAssessment: { findMany: vi.fn() },
     eaView: { findFirst: vi.fn() },
+    storefrontConfig: { findFirst: vi.fn() },
+    storefrontArchetype: { findUnique: vi.fn() },
   },
 }));
 
@@ -23,10 +25,19 @@ const mockPrisma = prisma as unknown as {
   eaReferenceModel: { findMany: ReturnType<typeof vi.fn>; findUnique: ReturnType<typeof vi.fn> };
   eaReferenceAssessment: { findMany: ReturnType<typeof vi.fn> };
   eaView: { findFirst: ReturnType<typeof vi.fn> };
+  storefrontConfig: { findFirst: ReturnType<typeof vi.fn> };
+  storefrontArchetype: { findUnique: ReturnType<typeof vi.fn> };
 };
+
+/** Put the install on a declared archetype, the way setup leaves it. */
+function installIs(category: string | null, archetypeId: string | null): void {
+  mockPrisma.storefrontConfig.findFirst.mockResolvedValue({ archetypeId: "cuid-archetype" });
+  mockPrisma.storefrontArchetype.findUnique.mockResolvedValue({ category, archetypeId });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
+  installIs("nonprofits-and-community", "pet-rescue");
 });
 
 describe("getReferenceModelsSummary", () => {
@@ -50,8 +61,53 @@ describe("getReferenceModelsSummary", () => {
         name: "IT4IT",
         version: "3.0.1",
         criteriaCount: 417,
+        applies: true,
       }),
     ]);
+  });
+
+  // BI-C44EAEE6: the seed scopes an industry model's element hierarchy to the
+  // archetype, so on a pet rescue BIAN is correctly empty. The read used to pass
+  // that through as "active with 0 criteria", which reads as broken.
+  it("marks an industry model as not this install's, and says why", async () => {
+    mockPrisma.eaReferenceModel.findMany.mockResolvedValue([
+      {
+        id: "rm-2",
+        slug: "bian_service_landscape_v14_0_0",
+        name: "BIAN Service Landscape",
+        version: "14.0.0",
+        status: "active",
+        _count: { elements: 0, assessments: 0, proposals: 0 },
+      },
+    ]);
+
+    const [model] = await getReferenceModelsSummary();
+
+    expect(model?.applies).toBe(false);
+    expect(model?.applicabilityReason).toContain("banking-financial-services");
+    expect(model?.applicabilityReason).toContain("pet-rescue");
+    // The catalogue row is still returned: it is kept on every install so an
+    // operator can see the standard exists.
+    expect(model?.slug).toBe("bian_service_landscape_v14_0_0");
+  });
+
+  it("applies the same industry model on an install that IS a bank", async () => {
+    installIs("banking-financial-services", "community-bank");
+    mockPrisma.eaReferenceModel.findMany.mockResolvedValue([
+      {
+        id: "rm-2",
+        slug: "bian_service_landscape_v14_0_0",
+        name: "BIAN Service Landscape",
+        version: "14.0.0",
+        status: "active",
+        _count: { elements: 390, assessments: 4, proposals: 0 },
+      },
+    ]);
+
+    const [model] = await getReferenceModelsSummary();
+
+    expect(model?.applies).toBe(true);
+    expect(model?.criteriaCount).toBe(390);
   });
 });
 

--- a/apps/web/lib/explore/reference-model-types.ts
+++ b/apps/web/lib/explore/reference-model-types.ts
@@ -10,7 +10,18 @@ export type ReferenceModelSummary = {
   slug: string;
   name: string;
   version: string;
+  /** Seeded lifecycle status of the model itself, e.g. `active`. */
   status: string;
+  /**
+   * Whether this install's archetype is one the model serves.
+   *
+   * Separate from `status` on purpose: a model can be an active, maintained
+   * standard AND be none of this install's business. Conflating the two is what
+   * put "BIAN Service Landscape — ACTIVE — 0 criteria" on a pet rescue.
+   */
+  applies: boolean;
+  /** One operator-readable sentence for why, shown when it does not apply. */
+  applicabilityReason: string;
   criteriaCount: number;
   assessmentCount: number;
   proposalCount: number;
@@ -103,6 +114,10 @@ export type ReferenceModelDetail = {
   name: string;
   version: string;
   status: string;
+  /** Whether this install's archetype is one the model serves (BI-C44EAEE6). */
+  applies: boolean;
+  /** One operator-readable sentence for why, shown when it does not apply. */
+  applicabilityReason: string;
   authorityType: string;
   description: string | null;
   valueStreamProjection: {

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -652,7 +652,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - text"
     },
     "/ea": {
-      "defaultVisibleWords": 335,
+      "defaultVisibleWords": 339,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -685,7 +685,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - button\n  - link"
     },
     "/ea/models": {
-      "defaultVisibleWords": 126,
+      "defaultVisibleWords": 131,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -693,7 +693,7 @@
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text"
     },
     "/ea/value-streams": {
       "defaultVisibleWords": 128,

--- a/docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md
+++ b/docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md
@@ -1867,6 +1867,14 @@ telecommunications, GS1 in supply chains, or jurisdiction-specific law and profe
 Selection **MUST** be based on applicability, version, license, and actual implementation evidence.
 A category label alone is not proof that a standard applies to every leaf or WorkUnitDefinition.
 
+Applicability is enforced on both halves of the lifecycle, not one. `packages/db/src/reference-model-applicability.ts`
+holds the single rule naming which archetypes an industry model serves; the seed consults it before
+importing a model's element hierarchy, and every read path consults it before presenting the model.
+A profile catalogue entry is kept on every install so an operator can see the standard exists, so the
+read is what makes an inapplicable profile honest: it reports **not this archetype** with the reason
+rather than a lifecycle status beside empty counts. Scoping only the seed is insufficient and was the
+defect in BI-C44EAEE6, where an install outside banking still advertised the BIAN profile as active.
+
 ## 14. Conformance model
 
 ### 14.1 Profiles

--- a/docs/user-guide/architecture/index.md
+++ b/docs/user-guide/architecture/index.md
@@ -18,6 +18,14 @@ The EA Modeler is a canvas-based tool for building and maintaining your organiza
 - **Value Streams** — End-to-end sequences of activities that deliver value to a customer or stakeholder. Modelled in the business layer and traceable to the products and capabilities that enable them.
 - **Workroom Definitions** — Reusable collaboration patterns attached to value streams. Each definition names its portfolio, shape, participants, queues, human triggers, linked process view, and associated running instances.
 
+## Reference Models and your archetype
+
+Some reference models are universal and some belong to one industry. IT4IT describes IT management for any organisation that runs IT, so every install gets its full criteria set. An industry model such as the BIAN Service Landscape serves banking, and its criteria are imported only on an install whose archetype is a banking one.
+
+The catalogue entry is kept everywhere on purpose, so you can see that the standard exists and what it is for. On an install it does not serve, the model is listed as **not this archetype** with the reason, instead of showing a lifecycle status beside empty counts. Empty counts there are correct rather than incomplete: the criteria were never imported because the model is not your business.
+
+If you change the archetype your install declares, the next seed imports the criteria for any industry model that now applies.
+
 ## Workroom Definitions
 
 Open **Architecture > Workrooms** (`/ea/workrooms`) to review collaboration from the definition perspective. The page keeps all four portfolios visible, groups each Value Stream Team under its owning portfolio, and links the reusable shape to its process view and operational instances.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -58,6 +58,7 @@
     "./sovereignty-assessment": "./src/sovereignty-assessment.ts",
     "./cada-readiness": "./src/cada-readiness.ts",
     "./regulation-applicability": "./src/regulation-applicability.ts",
+    "./reference-model-applicability": "./src/reference-model-applicability.ts",
     "./seed-deliberation": "./src/seed-deliberation.ts",
     "./edge-node-types": "./src/edge-node-types.ts",
     "./wiki-taxonomy": "./src/wiki-taxonomy.ts",

--- a/packages/db/src/ea-reference-model-applicability.test.ts
+++ b/packages/db/src/ea-reference-model-applicability.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { referenceModelAppliesToInstall } from "./seed-ea-reference-models.js";
+import {
+  describeReferenceModelApplicability,
+  referenceModelAppliesToInstall,
+} from "./reference-model-applicability.js";
 
 // BI-DDB48B04 follow-on. The eaReferenceModels seed used to import the BIAN
 // Service Landscape and then ASSERT a non-zero element count for it on every
@@ -92,5 +95,68 @@ describe("referenceModelAppliesToInstall", () => {
         ARCHETYPES,
       ),
     ).toBe(false);
+  });
+});
+
+// BI-C44EAEE6. The read path needs the REASON, not just the boolean: a card that
+// says only "not applicable" invites the question this answers.
+describe("describeReferenceModelApplicability", () => {
+  const banking = { bian_service_landscape_v14_0_0: ["banking-financial-services"] };
+
+  it("names the install's own archetype when an industry model is not its business", () => {
+    const result = describeReferenceModelApplicability(
+      "bian_service_landscape_v14_0_0",
+      { category: "nonprofits-and-community", archetypeId: "pet-rescue" },
+      banking,
+    );
+    expect(result.applies).toBe(false);
+    expect(result.reason).toContain("banking-financial-services");
+    expect(result.reason).toContain("pet-rescue");
+  });
+
+  it("says so plainly when setup has not chosen an archetype yet", () => {
+    const result = describeReferenceModelApplicability(
+      "bian_service_landscape_v14_0_0",
+      { category: null, archetypeId: null },
+      banking,
+    );
+    expect(result.applies).toBe(false);
+    expect(result.reason).toContain("not chosen an archetype");
+  });
+
+  it("applies on the category as well as the specific archetype id", () => {
+    for (const install of [
+      { category: "banking-financial-services", archetypeId: "community-bank" },
+      { category: null, archetypeId: "banking-financial-services" },
+    ]) {
+      expect(
+        describeReferenceModelApplicability("bian_service_landscape_v14_0_0", install, banking)
+          .applies,
+      ).toBe(true);
+    }
+  });
+
+  it("treats a universal model as everyone's, with a reason that says why", () => {
+    const result = describeReferenceModelApplicability(
+      "it4it_v3_0_1",
+      { category: "nonprofits-and-community", archetypeId: "pet-rescue" },
+      banking,
+    );
+    expect(result.applies).toBe(true);
+    expect(result.reason).toContain("every install");
+  });
+
+  it("agrees with the boolean rule the seed uses, for every combination", () => {
+    for (const slug of ["bian_service_landscape_v14_0_0", "it4it_v3_0_1"]) {
+      for (const install of [
+        { category: "banking-financial-services", archetypeId: "community-bank" },
+        { category: "nonprofits-and-community", archetypeId: "pet-rescue" },
+        { category: null, archetypeId: null },
+      ]) {
+        expect(describeReferenceModelApplicability(slug, install, banking).applies).toBe(
+          referenceModelAppliesToInstall(slug, install, banking),
+        );
+      }
+    }
   });
 });

--- a/packages/db/src/reference-model-applicability.ts
+++ b/packages/db/src/reference-model-applicability.ts
@@ -1,0 +1,93 @@
+// Whether an industry reference model belongs to this install (BI-C44EAEE6).
+//
+// This rule has TWO consumers and they must not drift:
+//
+//   1. The seed (`seed-ea-reference-models.ts`) uses it to decide whether to
+//      import a model's element hierarchy at all.
+//   2. The read path (`apps/web/lib/explore/ea-data.ts`) uses it to decide how
+//      to present a model the catalogue deliberately keeps everywhere.
+//
+// Splitting the rule out is the whole point. Seeding was scoped in #4870 and the
+// read was not, so a pet rescue's Enterprise Architecture page advertised "BIAN
+// Service Landscape — ACTIVE — 0 criteria". The catalogue row is kept on every
+// install on purpose, so an operator can see the standard exists; what was
+// missing is the other half of that bargain, which is scoping it at consumption.
+// One exported rule, imported by both sides, is what stops the halves diverging
+// again.
+//
+// Deliberately free of Prisma and of any clock: resolving WHICH archetype an
+// install is belongs to the caller, because the seed reads it with its own
+// client and the web app reads it with its own.
+
+/**
+ * Which archetypes an industry-specific reference model serves.
+ *
+ * Entries may be archetype CATEGORY slugs (`banking-financial-services`) or
+ * specific archetype ids (`credit-union`), matching either — the same contract
+ * `RegulationApplicability.archetypes` already uses, so an operator reads one
+ * rule for "is this vertical content mine?", not two.
+ *
+ * An empty/absent list means universal: IT4IT describes IT management for any
+ * organisation that runs IT, which is every install.
+ */
+export const REFERENCE_MODEL_ARCHETYPES: Readonly<Record<string, readonly string[]>> = {
+  bian_service_landscape_v14_0_0: ["banking-financial-services"],
+};
+
+/** The install's declared archetype, as category slug + specific archetype id. */
+export interface InstallArchetype {
+  category: string | null;
+  archetypeId: string | null;
+}
+
+/**
+ * Does this install need the element hierarchy for `modelSlug`?
+ *
+ * Universal models (no declared archetypes) always apply. An industry model
+ * applies only when the install's category or archetype id is in its list.
+ */
+export function referenceModelAppliesToInstall(
+  modelSlug: string,
+  install: InstallArchetype,
+  archetypesBySlug: Readonly<Record<string, readonly string[]>> = REFERENCE_MODEL_ARCHETYPES,
+): boolean {
+  const archetypes = archetypesBySlug[modelSlug];
+  if (!archetypes || archetypes.length === 0) return true;
+  return archetypes.some(
+    (a) => a === install.category || a === install.archetypeId,
+  );
+}
+
+/**
+ * Why a model is or is not this install's, in one operator-readable sentence.
+ *
+ * The read path needs the reason, not just the boolean: a card that says only
+ * "not applicable" invites the question this answers. Mirrors the shape
+ * `regulationApplies` already returns for regulations.
+ */
+export function describeReferenceModelApplicability(
+  modelSlug: string,
+  install: InstallArchetype,
+  archetypesBySlug: Readonly<Record<string, readonly string[]>> = REFERENCE_MODEL_ARCHETYPES,
+): { applies: boolean; reason: string } {
+  const archetypes = archetypesBySlug[modelSlug];
+  if (!archetypes || archetypes.length === 0) {
+    return { applies: true, reason: "Applies to every install." };
+  }
+  if (referenceModelAppliesToInstall(modelSlug, install, archetypesBySlug)) {
+    return {
+      applies: true,
+      reason: `Applies because this install is ${install.archetypeId ?? install.category}.`,
+    };
+  }
+  // Naming the install's own archetype matters more than naming the model's:
+  // the operator knows what they run, and the question they are answering is
+  // "why is a banking standard on my screen".
+  const declared = install.archetypeId ?? install.category;
+  return {
+    applies: false,
+    reason: declared
+      ? `Serves ${archetypes.join(", ")}, and this install is ${declared}.`
+      : `Serves ${archetypes.join(", ")}, and this install has not chosen an archetype yet.`,
+  };
+}

--- a/packages/db/src/seed-ea-reference-models.ts
+++ b/packages/db/src/seed-ea-reference-models.ts
@@ -7,6 +7,21 @@ import {
   slugifyReferenceModelName,
 } from "./reference-model-import.js";
 import { readWorkbook, requireSheetData, sheetDataToObjects } from "./excel-sheet-reader.js";
+import {
+  referenceModelAppliesToInstall,
+  type InstallArchetype,
+} from "./reference-model-applicability";
+
+// Re-exported so the seed stays the one place callers already know to look for
+// this rule; the rule itself now lives in one module the read path shares
+// (BI-C44EAEE6).
+export {
+  REFERENCE_MODEL_ARCHETYPES,
+  describeReferenceModelApplicability,
+  referenceModelAppliesToInstall,
+  type InstallArchetype,
+} from "./reference-model-applicability";
+
 import type {
   FunctionalCriteriaRow,
   ParticipationMatrixRow,
@@ -169,27 +184,6 @@ const BIAN_SD_TO_CAPABILITY_KEY: Readonly<Record<string, string>> = {
 };
 
 /**
- * Which archetypes an industry-specific reference model serves.
- *
- * Entries may be archetype CATEGORY slugs (`banking-financial-services`) or
- * specific archetype ids (`credit-union`), matching either — the same contract
- * `RegulationApplicability.archetypes` already uses, so an operator reads one
- * rule for "is this vertical content mine?", not two.
- *
- * An empty/absent list means universal: IT4IT describes IT management for any
- * organisation that runs IT, which is every install.
- */
-const REFERENCE_MODEL_ARCHETYPES: Readonly<Record<string, readonly string[]>> = {
-  bian_service_landscape_v14_0_0: ["banking-financial-services"],
-};
-
-/** The install's declared archetype, as category slug + specific archetype id. */
-interface InstallArchetype {
-  category: string | null;
-  archetypeId: string | null;
-}
-
-/**
  * Read the install's setup-chosen archetype. `StorefrontConfig.archetypeId` is a
  * cuid FK, not a slug, so the join to StorefrontArchetype is required to reach
  * the category/id slugs the applicability lists are written in.
@@ -213,24 +207,6 @@ async function resolveInstallArchetype(): Promise<InstallArchetype> {
     category: archetype?.category ?? null,
     archetypeId: archetype?.archetypeId ?? null,
   };
-}
-
-/**
- * Does this install need the element hierarchy for `modelSlug`?
- *
- * Universal models (no declared archetypes) always apply. An industry model
- * applies only when the install's category or archetype id is in its list.
- */
-export function referenceModelAppliesToInstall(
-  modelSlug: string,
-  install: InstallArchetype,
-  archetypesBySlug: Readonly<Record<string, readonly string[]>> = REFERENCE_MODEL_ARCHETYPES,
-): boolean {
-  const archetypes = archetypesBySlug[modelSlug];
-  if (!archetypes || archetypes.length === 0) return true;
-  return archetypes.some(
-    (a) => a === install.category || a === install.archetypeId,
-  );
 }
 
 async function seedBianReferenceModel(modelId: string): Promise<void> {


### PR DESCRIPTION
## What the founder saw

The Enterprise Architecture overview of an install running a pet rescue, offering:

> ACTIVE · BIAN Service Landscape · 14.0.0 · 0 criteria · 0 assessments · 0 proposals

A banking standard presented as live and empty reads as broken rather than as someone else's.

## Why

Two mechanisms keep archetype-specific content off an install, and only one was applied.

- **Seeding was scoped.** `referenceModelAppliesToInstall` gates the BIAN element hierarchy on the install's archetype, shipped in #4870. It works: 0 BIAN elements here against 688 for IT4IT. The zero counts are correct.
- **Reading was never scoped.** `getReferenceModelsSummary` was a bare `findMany` over every model with no archetype predicate, and the cards printed the seeded lifecycle status verbatim. Both models carry `status: active` from the seed.

So the seed fix made the noise more visible rather than less. Before it, the card showed a populated banking hierarchy; after it, an empty one still labelled ACTIVE.

The intent was documented and then half-finished. The comment beside the seed says to keep a catalogue entry and scope it at consumption, mirroring `seed-banking-compliance.ts`. The regulations honour that: each row declares an applicability spec and `regulationApplies` evaluates it, which is why Bank Secrecy Act sits in this database and never reaches a screen. The reference-model read never implemented its half.

## Change

- The applicability rule moves out of the seed into `packages/db/src/reference-model-applicability.ts`, so the seed and the read share one rule instead of drifting. The seed re-exports it; its behaviour is unchanged and its existing tests still pass unmodified.
- `describeReferenceModelApplicability` returns the reason as well as the verdict, mirroring what `regulationApplies` already gives the compliance read path.
- `getReferenceModelsSummary` and `getReferenceModelDetail` resolve the install archetype and mark each model. The catalogue row is still returned, because it is seeded everywhere on purpose so an operator can see the standard exists.
- All three surfaces are fixed, not only the one in the screenshot: the EA overview cards, the `/ea/models` directory, and the model detail page. Each shows **not this archetype** with the reason in place of a lifecycle status beside empty counts.

## Also in this branch

One unrelated commit, because it blocked the gate. `workroom-stall.test.ts` built its App Router root with `new URL(...).pathname`, which returns `/D:/...` on Windows, so `readdirSync` failed and the walk reported every route as missing. It was red on every Windows host while green in CI, and it reproduces on a pristine `origin/main` checkout. `fileURLToPath` is the platform-correct conversion. The route it checks is correct and unchanged.

## Verification

- 608 tests across the EA surface in both packages, including a case asserting the same model **does** apply on a banking install, and one asserting the catalogue row is still listed rather than hidden.
- `pnpm run pregate:preflight`: OK, 65 guards clean.
- `pnpm run pregate`: PASS for HEAD 99b534c312df.

## Design grounding

Existing specs and plans reviewed: the four-portfolio standard §13.5, which already required a profile to be selected on applicability rather than a category label; `docs/user-guide/architecture/index.md`; and the #4870 seed-scoping change. Current code substrate reviewed: `apps/web/lib/explore/ea-data.ts`, the two EA card components, `packages/db/src/seed-ea-reference-models.ts`, and `packages/db/src/regulation-applicability.ts` as the precedent. Source of truth: the single applicability rule now in `packages/db/src/reference-model-applicability.ts`, shared by seed and read. Decision: no new surface and no new concept, one shared rule plus honest presentation on the three existing surfaces.

Both docs are updated. The user guide explains universal versus industry models and what an operator sees. The four-portfolio standard now records that applicability is enforced on both halves of the lifecycle, because enforcing it on one is what produced this defect.

Seed-Fit-Decision: global-default

Convergence-Impact-Decision: auto-converges — the catalogue row is seeded content already present on every install and this changes how it is read, so the portal image carries it on the next self-upgrade with no data migration, no reseed and no operator action.

Docs-Impact-Decision: both linked user-guide pages are updated in this PR.

Closes BI-C44EAEE6. The general rule this exposed is filed as BI-B507DBD1: ask the archetype-scope question when functionality is built, and make the answer name the mechanism that enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
