### PR TITLE
fix(release): the STT digest watch hands off instead of stranding its branch (BI-8CEBDD09)

### DIFF
--- a/.github/workflows/stt-digest-watch.yml
+++ b/.github/workflows/stt-digest-watch.yml
@@ -20,6 +20,7 @@ permissions:
   contents: write # push the re-pin branch
   pull-requests: write # open the re-pin PR + arm auto-merge
   actions: write # dispatch ci.yml / release-gates.yml onto the branch
+  issues: write # raise the hand-off when PR creation is refused (BI-8CEBDD09)
 
 concurrency:
   group: stt-digest-watch
@@ -90,14 +91,77 @@ jobs:
             -m "Process-Spine-Decision: mechanical dependency re-pin, no doc surface changed."
           git push -f origin "$BRANCH"
 
-          gh pr create \
+          # BI-8CEBDD09: `gh pr create` is refused outright when the repository
+          # has "Allow GitHub Actions to create and approve pull requests" off:
+          #   GraphQL: GitHub Actions is not permitted to create or approve pull requests
+          # That is a repository SETTING, not a token scope — this workflow already
+          # asks for pull-requests: write. Under `bash -e` the refusal killed the
+          # step, so the dispatch and auto-merge below never ran and the pushed
+          # branch was stranded with nothing but a red log to find it by. The pin
+          # then rotted in place: every release failed E2E install verification at
+          # the digest-pinned manifest check, so no release verified and no install
+          # could receive ANY merged work (measured 2026-09-07: three merged fixes
+          # undeliverable). Never let PR creation abort the hand-off.
+          set +e
+          pr_error=$(gh pr create \
             --title "fix(release): re-pin hwdsl2/whisper-server to current registry digest (auto)" \
             --body "Automated re-pin by the **STT Digest Watch** (BI-A9EAEE2C). The registry owner re-pushed \`:latest\`, rotating the index digest; without this re-pin the Release Contract Guards + Release Image Manifest Guard go red on every PR (see BI-4439CDF1 / PR #2615 for the manual precedent). Verified inside the workflow before commit: contract tests + \`verify-compose-image-manifests.mjs --only digest-pinned\` against the live registry. Required CI is dispatched onto this branch by the watch (GITHUB_TOKEN-created PRs do not trigger checks); auto-merge is armed. If checks have not appeared, dispatch \`ci.yml\` on this branch or push an empty commit." \
-            --head "$BRANCH" --base main
+            --head "$BRANCH" --base main 2>&1)
+          pr_code=$?
+          set -e
+          echo "$pr_error"
 
           # PRs created with GITHUB_TOKEN never trigger pull_request workflows;
-          # dispatch the required check workflows onto the branch explicitly.
+          # dispatch the required check workflows onto the branch explicitly. This
+          # runs whether or not the PR exists yet, so a hand-opened PR finds its
+          # checks already running rather than waiting on a second dispatch.
           gh workflow run ci.yml --ref "$BRANCH" || echo "ci.yml dispatch failed; dispatch manually"
           gh workflow run release-gates.yml --ref "$BRANCH" || echo "release-gates dispatch failed; dispatch manually"
 
-          gh pr merge "$BRANCH" --auto || echo "auto-merge not armed; arm manually after checks pass"
+          if [ "$pr_code" = "0" ]; then
+            gh pr merge "$BRANCH" --auto || echo "auto-merge not armed; arm manually after checks pass"
+            exit 0
+          fi
+
+          # Refused. The re-pin is pushed and verified; what is missing is one
+          # click. Leave something a human will actually see: a job summary and,
+          # for the permission refusal specifically, an open issue carrying the
+          # exact link. One issue at a time — this watch runs daily.
+          compare_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/main...$BRANCH?expand=1"
+          {
+            echo "## STT digest re-pin needs one click"
+            echo ""
+            echo "The re-pin is committed, pushed and verified on \`$BRANCH\`, but opening the PR failed:"
+            echo ""
+            echo "> $pr_error"
+            echo ""
+            echo "Open it: $compare_url"
+            echo ""
+            echo "To close this loop permanently, enable Settings > Actions > General > Allow GitHub Actions to create and approve pull requests."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$pr_error" in
+            *"not permitted to create or approve pull requests"*)
+              title="STT digest re-pin is blocked: GitHub Actions may not open pull requests"
+              existing=$(gh issue list --state open --search "$title in:title" --json number -q '.[0].number // empty')
+              if [ -z "$existing" ]; then
+                body_file="${RUNNER_TEMP:-/tmp}/stt-repin-handoff.md"
+                {
+                  echo "The STT Digest Watch re-pinned hwdsl2/whisper-server on `$BRANCH` and verified it, but could not open the PR:"
+                  echo ""
+                  echo "> $pr_error"
+                  echo ""
+                  echo "**Open the PR:** $compare_url"
+                  echo ""
+                  echo "**Why this matters:** while the pin is stale, verify-compose-image-manifests.mjs --only digest-pinned fails, which fails E2E install verification on every release. No release verifies, so no install can receive any merged work."
+                  echo ""
+                  echo "**Permanent fix:** enable Settings > Actions > General > Allow GitHub Actions to create and approve pull requests, or give this workflow a token that may open PRs. Tracked as BI-8CEBDD09."
+                } > "$body_file"
+                gh issue create --title "$title" --body-file "$body_file" || echo "issue creation failed; the job summary still carries the hand-off"
+              else
+                echo "hand-off issue #$existing is already open"
+              fi
+              ;;
+          esac
+          # Still a real failure: the loop did not close on its own.
+          exit "$pr_code"

--- a/docs/superpowers/plans/2026-09-07-stt-watch-hands-off-when-it-cannot-open-a-pr-plan.md
+++ b/docs/superpowers/plans/2026-09-07-stt-watch-hands-off-when-it-cannot-open-a-pr-plan.md
@@ -1,0 +1,36 @@
+---
+status: active
+title: The STT digest watch hands off instead of stranding its branch — fix plan
+backlog_item: BI-8CEBDD09
+design: docs/superpowers/specs/2026-09-07-stt-watch-hands-off-when-it-cannot-open-a-pr-design.md
+---
+
+# The STT digest watch hands off instead of stranding its branch — fix plan
+
+- **Backlog item:** `BI-8CEBDD09` (fix profile, atomic)
+- **Design:** [`2026-09-07-stt-watch-hands-off-when-it-cannot-open-a-pr-design.md`](../specs/2026-09-07-stt-watch-hands-off-when-it-cannot-open-a-pr-design.md)
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-8CEBDD09`
+- Receipt: `blocked-by: the coverage receipt is minted against this plan blob once it is on the bound Workroom head; recorded on the next push`
+- Rationale: guarding the refusal without the hand-off leaves the branch just as
+  invisible; the hand-off without the guard never runs, because the refusal
+  aborts the step before reaching it. One step, one behaviour.
+- Dependencies: none
+
+| Key | Requirement refs | Contract refs | Flow refs | Verification refs |
+| --- | --- | --- | --- | --- |
+| stt-watch-handoff | OBJ-STT-HANDOFF-1 | issues: write, GITHUB_STEP_SUMMARY, bot/stt-digest-repin | capture gh pr create instead of letting it abort; dispatch the checks unconditionally; raise one guarded hand-off issue | AC-1, AC-2, AC-3, AC-4 |
+
+## Fix sequence (all complete)
+
+1. `.github/workflows/stt-digest-watch.yml`: add `issues: write`.
+2. Same file: capture `gh pr create` output and exit code under `set +e`; dispatch `ci.yml` and `release-gates.yml` unconditionally; arm auto-merge and exit 0 on success.
+3. Same file: on refusal write the job summary, and for the permission refusal open one hand-off issue guarded by an open-issue search; exit with the original code.
+4. `scripts/stt-digest-watch-workflow.test.mjs`: execute the step tail against a stub `gh` that returns the real refusal text, covering AC-1..AC-4.
+
+## Verification
+
+Red-then-green: the three new hand-off assertions fail against the `origin/main` workflow and all 10 pass with the fix. OBJ-STT-HANDOFF-1 is covered by AC-1, AC-2, AC-3, AC-4.

--- a/docs/superpowers/specs/2026-09-07-stt-watch-hands-off-when-it-cannot-open-a-pr-design.md
+++ b/docs/superpowers/specs/2026-09-07-stt-watch-hands-off-when-it-cannot-open-a-pr-design.md
@@ -1,0 +1,53 @@
+---
+status: active
+title: The STT digest watch hands off instead of stranding its branch when it may not open a PR
+backlog_item: BI-8CEBDD09
+---
+
+# The STT digest watch hands off instead of stranding its branch
+
+- **Date:** 2026-09-07
+- **Scope:** platform — release automation (`stt-digest-watch.yml`)
+- **Backlog item:** `BI-8CEBDD09`
+- **Profile:** fix
+- **Status:** Design — implemented in this branch.
+
+**OBJ-STT-HANDOFF-1:** When the digest watch cannot open its own pull request, the re-pin it has already committed, pushed and verified reaches a human as one actionable click with its checks already running, rather than being stranded behind a red log.
+
+## 1. Defect, on a named ref
+
+Measured on 2026-09-07. `hwdsl2/whisper-server` retired the index digest pinned at `docker-compose.yml:1002`, exactly the rot this watch exists to catch. It caught it: the 12:27 UTC run re-resolved the digest, ran the contract tests and the digest-pinned manifest guard, committed, and pushed `bot/stt-digest-repin`. Then:
+
+```
+pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
+```
+
+That is the repository setting *Allow GitHub Actions to create and approve pull requests*, not a token scope: the workflow already requests `pull-requests: write`. Under `bash -e` the refusal killed the step, so the three lines after it never ran, and the branch was left with no PR, no dispatched checks and no auto-merge. The only trace was a red scheduled run.
+
+The consequence is not local. `verify-compose-image-manifests.mjs --only digest-pinned` fails on the rotted pin, which fails **E2E install verification (release mode)** in `publish-image.yml`. `release-runs-reader` treats a red verify job as `verify-failed`, so **no release verifies**, so the self-upgrade path has no eligible target. Release `v2026.09.07-upgrade-schedule-visibility.1` at `4c804bc` failed it twice, and three merged fixes (BI-A57B6185, BI-05F8860A, BI-3CA18934) could not reach any install. The same step also failed on 2026-09-03 and 2026-08-27, so it had been latent for at least ten days and only became load-bearing when the digest actually rotted.
+
+Ruled out by reading rather than assuming: a token-scope gap (the workflow declares `pull-requests: write`), the `--apply` exit-3 convention (already handled, BI-BBD60CF8), and the re-resolve script itself (its unit tests passed in the failing run).
+
+## 2. Fix sequence
+
+1. Capture `gh pr create` instead of letting it abort: `set +e`, keep both its output and exit code.
+2. Dispatch `ci.yml` and `release-gates.yml` onto the branch unconditionally, so a hand-opened PR finds its checks already running.
+3. On success, arm auto-merge and exit 0, unchanged.
+4. On failure, write a job summary with the refusal text and the compare link. For the permission refusal specifically, open one hand-off issue carrying the same link, guarded by a search so a daily watch cannot pile them up. Grant `issues: write`.
+5. Exit non-zero regardless: the loop did not close on its own, and the run must stay red.
+
+The complete fix is the repository setting; this makes the failure survivable and visible without widening what automation may do.
+
+## 3. Acceptance criteria
+
+| Criterion | Objective | Statement |
+| --- | --- | --- |
+| AC-1 | OBJ-STT-HANDOFF-1 | A refused PR creation still dispatches ci.yml and release-gates.yml onto the pushed branch |
+| AC-2 | OBJ-STT-HANDOFF-1 | The refusal raises one hand-off issue and a job summary carrying the compare link and the setting to enable |
+| AC-3 | OBJ-STT-HANDOFF-1 | A second daily run does not open a second issue while one is already open |
+| AC-4 | OBJ-STT-HANDOFF-1 | The step still exits non-zero on refusal, and on the happy path it arms auto-merge, raises no issue and exits zero |
+
+## 4. Non-goals
+
+- Changing the repository or organisation setting: security-relevant, and the operator's call.
+- Weakening digest pinning so a rotted digest stops failing verification. The pin is the supply-chain control; the failure is correct, the invisibility is not.

--- a/scripts/stt-digest-watch-workflow.test.mjs
+++ b/scripts/stt-digest-watch-workflow.test.mjs
@@ -13,7 +13,9 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 const WORKFLOW_PATH = ".github/workflows/stt-digest-watch.yml";
@@ -79,6 +81,89 @@ describe("STT Digest Watch — apply step", () => {
     const { reached, status } = survivesExitCode(applyScript, 2);
     assert.equal(reached, false, "exit 2 (API/usage failure) must stop the step");
     assert.equal(status, 2, "the step should surface the script's own exit code");
+  });
+});
+
+/**
+ * BI-8CEBDD09. Run the tail of the apply step — everything from `gh pr create`
+ * on — with `gh` replaced by a stub, and report what the step did. The refusal
+ * text is the real one GitHub returns when "Allow GitHub Actions to create and
+ * approve pull requests" is off.
+ */
+function runPrHandoff({ prCreateFails, issueAlreadyOpen = false }) {
+  const tail = applyScript.slice(applyScript.indexOf("# BI-8CEBDD09"));
+  const dir = mkdtempSync(join(tmpdir(), "stt-watch-"));
+  const log = join(dir, "gh.log");
+  const refusal = "GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)";
+  // A stub `gh` that records every call and fails only `pr create`.
+  const stub = [
+    "#!/usr/bin/env bash",
+    `echo "$@" >> ${JSON.stringify(log)}`,
+    'if [ "$1" = "pr" ] && [ "$2" = "create" ]; then',
+    prCreateFails ? `  echo ${JSON.stringify(refusal)}; exit 1` : "  echo created; exit 0",
+    "fi",
+    'if [ "$1" = "issue" ] && [ "$2" = "list" ]; then',
+    issueAlreadyOpen ? "  echo 4242; exit 0" : "  exit 0",
+    "fi",
+    "exit 0",
+  ].join("\n");
+  const ghPath = join(dir, "gh");
+  writeFileSync(ghPath, stub, { mode: 0o755 });
+  const summary = join(dir, "summary.md");
+  const result = spawnSync("bash", ["-e", "-c", tail], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH}`,
+      BRANCH: "bot/stt-digest-repin",
+      GITHUB_STEP_SUMMARY: summary,
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_REPOSITORY: "o/r",
+      RUNNER_TEMP: dir,
+    },
+  });
+  const calls = existsSync(log) ? readFileSync(log, "utf8") : "";
+  return {
+    status: result.status,
+    calls,
+    summary: existsSync(summary) ? readFileSync(summary, "utf8") : "",
+    dispatchedCi: calls.includes("workflow run ci.yml"),
+    dispatchedGates: calls.includes("workflow run release-gates.yml"),
+    createdIssue: calls.includes("issue create"),
+    armedAutoMerge: calls.includes("pr merge"),
+  };
+}
+
+describe("STT Digest Watch — PR hand-off when Actions may not open PRs (BI-8CEBDD09)", () => {
+  it("still dispatches the required checks onto the pushed branch", () => {
+    // The refusal used to abort the step under `bash -e`, so the branch was
+    // pushed and then abandoned: no checks, no auto-merge, no PR.
+    const r = runPrHandoff({ prCreateFails: true });
+    assert.equal(r.dispatchedCi, true, "ci.yml was not dispatched after the refusal");
+    assert.equal(r.dispatchedGates, true, "release-gates.yml was not dispatched after the refusal");
+  });
+
+  it("raises one hand-off issue carrying the compare link", () => {
+    const r = runPrHandoff({ prCreateFails: true });
+    assert.equal(r.createdIssue, true, "no issue was raised, so the stranded branch is invisible");
+    assert.match(r.summary, /compare\/main\.\.\.bot\/stt-digest-repin/);
+    assert.match(r.summary, /Allow GitHub Actions to create and approve pull requests/);
+  });
+
+  it("does not pile up an issue per daily run", () => {
+    const r = runPrHandoff({ prCreateFails: true, issueAlreadyOpen: true });
+    assert.equal(r.createdIssue, false, "a second issue was opened while one was already waiting");
+  });
+
+  it("still reports failure, because the loop did not close on its own", () => {
+    assert.notEqual(runPrHandoff({ prCreateFails: true }).status, 0);
+  });
+
+  it("arms auto-merge and succeeds on the happy path", () => {
+    const r = runPrHandoff({ prCreateFails: false });
+    assert.equal(r.armedAutoMerge, true, "auto-merge was not armed after a successful PR creation");
+    assert.equal(r.createdIssue, false, "an issue was raised even though the PR opened");
+    assert.equal(r.status, 0);
   });
 });
 


### PR DESCRIPTION
## Summary

The watch caught exactly the rot it exists for. On 2026-09-07 at 12:27 UTC it re-resolved the `hwdsl2/whisper-server` digest, ran the contract tests and the digest-pinned manifest guard, committed and pushed `bot/stt-digest-repin`. Then:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

That is the repository setting *Allow GitHub Actions to create and approve pull requests*, **not** a token scope — the workflow already requests `pull-requests: write`. Under `bash -e` the refusal killed the step, so the check dispatch and auto-merge below it never ran, and the branch was left with nothing but a red scheduled run to find it by.

The blast radius is not local. A rotted pin fails `verify-compose-image-manifests.mjs --only digest-pinned`, which fails **E2E install verification (release mode)**, which marks the release verify-failed. No release verified, so the self-upgrade path had no eligible target and three merged fixes (BI-A57B6185, BI-05F8860A, BI-3CA18934) could not reach any install. The same step also failed on 09-03 and 08-27: latent for ten days, load-bearing the moment the digest actually rotted.

## What changes

- `gh pr create` is captured rather than allowed to abort.
- `ci.yml` and `release-gates.yml` are dispatched onto the pushed branch either way, so a hand-opened PR finds its checks already running.
- A permission refusal writes a job summary and opens **one** hand-off issue (guarded by an open-issue search, since the watch runs daily) carrying the compare link and the setting to enable.
- The step still exits non-zero. The loop did not close on its own and the run must stay red.

**The complete fix is the repository setting.** This makes the failure survivable and visible without widening what automation may do, which is not my call to make.

## Verification

- Red-then-green: the 3 new hand-off assertions fail against the `origin/main` workflow and all 10 pass with this change, executing the step tail against a stub `gh` that returns the real refusal text.
- Workflow YAML parses; pull-request policy profile 8/8; local-CI gate PASS on 6291c29.

Backlog: BI-8CEBDD09 · Workroom: WC-32D79F4D

🤖 Generated with [Claude Code](https://claude.com/claude-code)