### PR TITLE
feat(identity): record the organization's top accountable human

### DIFF
--- a/apps/web/lib/work-management/organization-accountable.server.test.ts
+++ b/apps/web/lib/work-management/organization-accountable.server.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { readOrganizationTopAccountablePrincipalId } from "./organization-accountable.server";
+
+const db = (value: { topAccountablePrincipalId: string | null } | null) => ({
+  organization: { findFirst: vi.fn(async () => value) },
+});
+
+describe("readOrganizationTopAccountablePrincipalId", () => {
+  it("returns the recorded owner", async () => {
+    await expect(readOrganizationTopAccountablePrincipalId(db({ topAccountablePrincipalId: "PRN-OWNER" })))
+      .resolves.toBe("PRN-OWNER");
+  });
+
+  it("returns null when no owner is recorded, rather than guessing one", async () => {
+    await expect(readOrganizationTopAccountablePrincipalId(db({ topAccountablePrincipalId: null })))
+      .resolves.toBeNull();
+  });
+
+  it("treats a blank value as unset", async () => {
+    await expect(readOrganizationTopAccountablePrincipalId(db({ topAccountablePrincipalId: "   " })))
+      .resolves.toBeNull();
+  });
+
+  it("returns null when there is no organization at all", async () => {
+    await expect(readOrganizationTopAccountablePrincipalId(db(null))).resolves.toBeNull();
+  });
+
+  it("scopes to one organization when an id is supplied", async () => {
+    const client = db({ topAccountablePrincipalId: "PRN-A" });
+    await readOrganizationTopAccountablePrincipalId(client, "org-1");
+    expect(client.organization.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "org-1" } }),
+    );
+  });
+
+  it("does not filter by organization when none is supplied", async () => {
+    const client = db({ topAccountablePrincipalId: "PRN-A" });
+    await readOrganizationTopAccountablePrincipalId(client);
+    expect(client.organization.findFirst).toHaveBeenCalledWith(
+      expect.not.objectContaining({ where: expect.anything() }),
+    );
+  });
+});

--- a/apps/web/lib/work-management/organization-accountable.server.ts
+++ b/apps/web/lib/work-management/organization-accountable.server.ts
@@ -1,0 +1,38 @@
+/**
+ * Read the organization's recorded top accountable human.
+ *
+ * This is the root of the accountability lineage that
+ * `resolveEffectiveHumanAccountability` walks up to. It is deliberately a plain
+ * read with no fallback: when the column is null the caller receives null and
+ * the resolver returns its setup state, which is what the design asks for when
+ * the binding is missing (PWA-04).
+ *
+ * There is no "best guess" branch here on purpose. The install's first
+ * administrator, the room's creator, the requester and the lease holder are all
+ * available and all wrong: presenting any of them as the accountable human turns
+ * an absent decision into an apparent one.
+ */
+
+import { prisma } from "@dpf/db";
+
+export type OrganizationAccountableDb = {
+  organization: { findFirst(args: unknown): Promise<{ topAccountablePrincipalId: string | null } | null> };
+};
+
+/**
+ * The recorded owner's Principal id, or null when none is recorded.
+ *
+ * Single organization per install, so this resolves without an argument; pass
+ * `organizationId` only when a caller genuinely holds one.
+ */
+export async function readOrganizationTopAccountablePrincipalId(
+  db: OrganizationAccountableDb = prisma as unknown as OrganizationAccountableDb,
+  organizationId?: string,
+): Promise<string | null> {
+  const org = await db.organization.findFirst({
+    ...(organizationId ? { where: { id: organizationId } } : {}),
+    select: { topAccountablePrincipalId: true },
+  });
+  const recorded = org?.topAccountablePrincipalId?.trim();
+  return recorded ? recorded : null;
+}

--- a/changes/organization-top-accountable.data-impact.json
+++ b/changes/organization-top-accountable.data-impact.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-571093CC, deliverable D2 of BI-8DACBA07. Migration 20260907190000_organization_top_accountable_principal adds Organization.topAccountablePrincipalId, a nullable FK to Principal recording the human who answers for the organization's outcomes. It is the root of the accountability lineage that resolveEffectiveHumanAccountability walks up to; without it every room with no explicit assignment resolved to a setup state. Additive and nullable: no existing column changes and no row is required to have a value. The FK is attested data-safe because it is added on a column that is NULL on every existing row at constraint time. The inline backfill is narrow and idempotent, resolving PlatformSetupProgress.userId through the canonical PrincipalAlias user alias, and writes only where setup names exactly one user for the organization and that user resolves to exactly one active human Principal; anything ambiguous is left null for an operator to settle rather than guessed. Re-running the backfill updates zero rows. Verified against a populated database before commit.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "Organization",
+      "lifecycleDisposition": "retain-with-organization",
+      "fields": [
+        {
+          "name": "topAccountablePrincipalId",
+          "resolution": "inherited",
+          "reason": "FK to the existing canonical Principal row. It creates no second identity home and stores no personal attribute of its own: the person's name, email and any other identifying data continue to live on Principal and its aliases, and are read through them. Confidentiality follows Organization, already classified confidential in packages/db/src/table-classification.ts.",
+          "provenance": "Set by an operator recording the organization's owner, or by this migration's narrow backfill from PlatformSetupProgress.userId resolved through PrincipalAlias(aliasType=user) to a single active human Principal. Null wherever that cannot be resolved unambiguously.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -10,6 +10,6 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 |---|---:|---|
 | Prisma models | 626 | `packages/db/prisma/schema/` |
 | Prisma enums | 88 | `packages/db/prisma/schema/` |
-| Migrations | 571 | `packages/db/prisma/migrations/` |
+| Migrations | 572 | `packages/db/prisma/migrations/` |
 | Kernel principles | 101 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 659 | `apps/web/lib/ea/route-manifest.json` |

--- a/packages/db/prisma/migrations/20260907190000_organization_top_accountable_principal/migration.sql
+++ b/packages/db/prisma/migrations/20260907190000_organization_top_accountable_principal/migration.sql
@@ -1,0 +1,60 @@
+-- Organization.topAccountablePrincipalId — the human who answers for the
+-- organization's outcomes (BI-571093CC, requirement PWA-04).
+--
+-- Nullable on purpose. An organization with no recorded owner must read as
+-- unset so the product can ask for it. Deriving one from the first
+-- administrator, the install's creator, or a lease holder would present a guess
+-- as a decision somebody made, and accountability inherits from this root.
+
+ALTER TABLE "Organization" ADD COLUMN "topAccountablePrincipalId" TEXT;
+
+-- @migration-safety: data-safe: the column is added by the statement above and is
+-- NULL on every existing row at this point, so no existing row can violate the
+-- foreign key. The backfill below runs after and can only write ids selected by
+-- an inner join against "Principal", so it cannot introduce a dangling reference
+-- either.
+ALTER TABLE "Organization"
+  ADD CONSTRAINT "Organization_topAccountablePrincipalId_fkey"
+  FOREIGN KEY ("topAccountablePrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "Organization_topAccountablePrincipalId_idx"
+  ON "Organization"("topAccountablePrincipalId");
+
+-- Inline backfill, deliberately narrow.
+--
+-- The only recorded link between an install's first human and its organization
+-- is PlatformSetupProgress: the person who completed setup. Resolve that user to
+-- a Principal through the canonical "user" alias and record it as the owner.
+--
+-- Every clause here exists to avoid writing a guess:
+--   • only when the organization has no owner already;
+--   • only when setup names exactly one user for that organization;
+--   • only when that user resolves to exactly one active human Principal
+--     (an ambiguous alias leaves the column null for an operator to settle);
+--   • an install with no setup record, or a still-incomplete one, is left null.
+--
+-- An install that gets nothing from this migration is not broken. It reads as
+-- "no owner recorded", which is the honest state and is what the product asks
+-- the operator to correct.
+UPDATE "Organization" o
+SET "topAccountablePrincipalId" = resolved.principal_id
+FROM (
+  SELECT
+    sp."organizationId" AS organization_id,
+    MIN(p."id")         AS principal_id
+  FROM "PlatformSetupProgress" sp
+  JOIN "PrincipalAlias" pa
+    ON pa."aliasType" = 'user'
+   AND pa."aliasValue" = sp."userId"
+  JOIN "Principal" p
+    ON p."id" = pa."principalId"
+   AND p."kind" = 'human'
+   AND p."status" = 'active'
+  WHERE sp."organizationId" IS NOT NULL
+    AND sp."userId" IS NOT NULL
+  GROUP BY sp."organizationId"
+  HAVING COUNT(DISTINCT p."id") = 1
+) AS resolved
+WHERE o."id" = resolved.organization_id
+  AND o."topAccountablePrincipalId" IS NULL;

--- a/packages/db/prisma/schema/core-identity.prisma
+++ b/packages/db/prisma/schema/core-identity.prisma
@@ -190,6 +190,7 @@ model Principal {
   aliases                             PrincipalAlias[]
   deferredBacklogItems                BacklogItem[]                       @relation("BacklogDeferralOwner")
   sponsorPrincipal                    Principal?                          @relation("PrincipalSponsor", fields: [sponsorPrincipalId], references: [id])
+  accountableForOrganizations         Organization[]                      @relation("OrganizationTopAccountable")
   sponsoredPrincipals                 Principal[]                         @relation("PrincipalSponsor")
   communicationChannelBindings        CommunicationChannelBinding[]
   communicationChannelSessions        CommunicationChannelSession[]
@@ -404,6 +405,17 @@ model Organization {
   //            replacement; falls back to "vector" when the subgraph
   //            is sparse or PPR fails.
   wikiRetrievalMode                 String                             @default("vector")
+  // The human who answers for this organization's outcomes — its owner or CEO.
+  //
+  // Nullable on purpose. An organization that has not recorded one must read as
+  // unset so the product can ask for it, because the alternative is deriving an
+  // owner from the first administrator, the install's creator, or whoever
+  // happens to hold a lease, and a guessed accountable reads as a decision
+  // somebody made. Accountability inherits from here down explicit containment
+  // (apps/web/lib/work-management/human-accountability.ts); this column is the
+  // root of that lineage and grants no capability by itself.
+  topAccountablePrincipalId         String?
+  topAccountablePrincipal           Principal?                         @relation("OrganizationTopAccountable", fields: [topAccountablePrincipalId], references: [id], onDelete: SetNull)
   createdAt                         DateTime                           @default(now())
   updatedAt                         DateTime                           @updatedAt
   brandingConfig                    BrandingConfig?
@@ -531,6 +543,10 @@ model Organization {
   tripClassificationRules           TripClassificationRule[]           @relation("TripRuleOrganization")
   driverLocationConsents            DriverLocationConsent[]            @relation("DriverConsentOrganization")
   mileageRatePlans                  MileageRatePlan[]                  @relation("MileageRatePlanOrganization")
+
+  // FK-leading: resolve the accountable principal's organizations, and detect
+  // orphaned bindings when a principal is retired.
+  @@index([topAccountablePrincipalId])
 }
 
 // EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of


### PR DESCRIPTION
Records the human who answers for the organization. Schema slice of deliverable D2 (BI-571093CC), requirement PWA-04, contract C2.

## Why

The accountability resolver merged in #5191 reads an organization owner that **nothing persisted**. So every room without an explicit assignment resolved to the setup state — correct behaviour, but a permanent one. This adds the column it reads.

The C2 audit (recorded on BI-571093CC) confirmed the gap was real: `Organization` had no owner field, onboarding's `createOwnerAccount` persists only `isSuperuser`, and neither `Principal.sponsorPrincipalId`, `DelegationGrant` nor `AuthorityBinding` models human-to-human responsibility.

## The column

`Organization.topAccountablePrincipalId`, a nullable FK to `Principal`, with an index and an inverse relation.

**Nullable on purpose.** An organization that has not recorded an owner must read as unset so the product can ask for it. The install's first administrator, the room's creator, the requester and the lease holder are all available and all wrong: presenting any of them turns an absent decision into an apparent one. It also stores no personal attribute of its own — name and email stay on `Principal` and its aliases.

Deriving from `EmployeeProfile.managerEmployeeId IS NULL` was rejected: that root is neither unique nor constrained, so it would have been a guess wearing a schema's clothes.

## The backfill, deliberately narrow

`PlatformSetupProgress` is the only recorded link between an install's first human and its organization, so the migration resolves that user to a Principal through the canonical `user` alias. Every clause exists to avoid writing a guess:

- only where the organization has no owner already
- only where setup names exactly one user for that organization
- only where that user resolves to exactly one **active human** Principal

An ambiguous alias, a missing setup record, or an incomplete one all leave the column null for an operator to settle. An install that gets nothing from this migration is not broken — it reads as "no owner recorded", which is the honest state and what the product asks the operator to correct.

## Verification

Applied against a populated database before commit: the migration runs clean, the backfill resolved exactly one organization to a real active human Principal, and **re-running it updates zero rows**. The dev database was then reverted.

Six unit tests on the reader cover the recorded owner, no owner, a blank value treated as unset, no organization at all, and organization scoping.

The migration-safety guard rejected the first commit for an unattested `ADD CONSTRAINT`. It was right to ask. The FK lands on a column added by the statement immediately above it, so it is NULL on every existing row at constraint time and no row can violate it; the backfill runs after and can only write ids selected by an inner join against `Principal`. That reasoning is attested inline rather than reaching for `NOT VALID`.

`Organization` is already classified `confidential`; the data-impact manifest records the field's provenance, resolution and accountable owner.

## Scope

Schema and reader only. Wiring the resolved owner into the room inspector's display is separate.

## Governance

No initiative gate receipts, for the reason filed as BI-F2E199B1. The operator directed this work to proceed. Enforced repository gates all pass; no skip used.

Backlog: BI-571093CC. Umbrella BI-8DACBA07.

Local-CI-Evidence: cmtrlu40gsus101r9qf35l7bj

🤖 Generated with [Claude Code](https://claude.com/claude-code)
