### PR TITLE
fix(work-management): a room's declared shape decides its projection, and a failed cycle costs the cycle not the room (BI-97B24FB5)

### DIFF
--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -64,6 +64,7 @@ const room: WorkroomView = {
     sourceRefs: [{ kind: "source", id: "BK-1", sourceType: "booking" }],
   },
   currentCycle: null,
+  cycleProjectionError: null,
   completedCycles: [],
   participants: [
     {

--- a/apps/web/components/workspace/workroom/WorkroomCycles.test.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomCycles.test.tsx
@@ -71,6 +71,7 @@ function room(): WorkroomView {
       closureRuleSummary: null, gaps: [], sourceRefs: [],
     },
     currentCycle: cycle,
+    cycleProjectionError: null,
     completedCycles: [{ ...cycle, cycleKey: "2026-W31", carrierId: "WI-CYCLE-31", status: "closed", outcomePacket: packet }],
     participants: [], activity: [],
     work: { nextAction: "Continue work", attentionRequired: false, attentionReason: null, blockingActorKind: null, activeCapsuleRefs: [], activeTaskRunSummary: null, terminal: false, sourceRefs: [] },
@@ -108,13 +109,28 @@ describe("WorkroomCycles", () => {
     expect(html.indexOf("Current cycle")).toBeLessThan(html.indexOf("Completed cycles"));
   });
 
+  // A cycle that could not be projected is UNKNOWN, not idle. Reporting
+  // "healthy and idle" here would state a fact nobody established, on a room
+  // that is in trouble (BI-97B24FB5).
+  it("distinguishes a cycle that could not be projected from a healthy idle room", () => {
+    const value = room();
+    value.currentCycle = null;
+    value.cycleProjectionError = "finite_room_has_cycle";
+    const html = renderToStaticMarkup(<WorkroomCycles room={value} />);
+
+    expect(html).toContain("Cycle unavailable");
+    expect(html).not.toContain("Healthy and idle");
+    // The rest of the room survives: the section degrades, the page does not.
+    expect(html).toContain("Completed cycles");
+  });
+
   it("shows healthy-idle guidance for a standing room without a current cycle", () => {
     const value = room();
     value.currentCycle = null;
     const html = renderToStaticMarkup(<WorkroomCycles room={value} />);
 
     expect(html).toContain("Ready for the next cycle");
-    expect(html).toContain("healthy and idle");
+    expect(html).toContain("Healthy and idle");
   });
 
   it("does not add cycle chrome to finite rooms", () => {

--- a/apps/web/components/workspace/workroom/WorkroomCycles.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomCycles.tsx
@@ -136,8 +136,23 @@ function CompletedCycles({ cycles }: { cycles: readonly WorkroomCycleView[] }) {
   );
 }
 
+// A cycle that could not be projected is UNKNOWN, not idle: claiming the room is
+// healthy would report a state nobody established, on a room in trouble
+// (BI-97B24FB5).
+const IDLE_COPY = {
+  healthy: {
+    title: "Ready for the next cycle",
+    description: "Healthy and idle. Open a cycle when the next trigger arrives.",
+  },
+  unavailable: {
+    title: "Cycle unavailable",
+    description: "The rest of this room is accurate. Your platform team can see why.",
+  },
+} as const;
+
 export function WorkroomCycles({ room }: { room: WorkroomView }) {
   if (room.mode !== "standing") return null;
+  const idle = room.cycleProjectionError ? IDLE_COPY.unavailable : IDLE_COPY.healthy;
 
   return (
     <div className="space-y-3">
@@ -148,8 +163,8 @@ export function WorkroomCycles({ room }: { room: WorkroomView }) {
           <EmptyState
             size="sm"
             bordered={false}
-            title="Ready for the next cycle"
-            description="This standing room is healthy and idle. Open a bounded cycle when the next trigger arrives."
+            title={idle.title}
+            description={idle.description}
             icon={<RefreshCw className="size-6" />}
           />
         </section>

--- a/apps/web/lib/attention/sources/workroom-stall.ts
+++ b/apps/web/lib/attention/sources/workroom-stall.ts
@@ -12,6 +12,7 @@ import type { prisma } from "@dpf/db";
 import { encodeWorkCaseKey } from "@/lib/work-management/case-key";
 import { resolveRoomOwner, type RoomOwner } from "@/lib/work-management/room-owner-ladder";
 import { STANDING_SHAPES } from "@/lib/work-management/standing-operations-shapes";
+import { readDeclaredWorkShapeKey } from "@/lib/work-management/work-shapes";
 
 import type { AttentionItem, AttentionPortfolio } from "../types";
 
@@ -146,23 +147,12 @@ export function projectRoomStall(row: RoomStallRow): AttentionItem | null {
   };
 }
 
-/** The room's declared work shape key, e.g. "dependency-advisory-watch@1.0.0".
- *  scopeClaims is an untyped JSON array written by several writers; read it
- *  defensively rather than assuming a shape. */
-function readWorkShapeKey(scopeClaims: unknown): string | null {
-  if (!Array.isArray(scopeClaims)) return null;
-  for (const claim of scopeClaims) {
-    const ref = asRecord(claim)?.workShape;
-    if (typeof ref === "string" && ref.length > 0) return ref.split("@")[0] ?? null;
-  }
-  return null;
-}
 
 /** What the ladder resolves for a room, from its shape. Explicit appointments are
  *  not consulted here: a room that HAS an explicit coordinator is not refusing on
  *  missing_explicit_coordinator, so it never reaches this projection unowned. */
 function resolveLadderOwner(scopeClaims: unknown): RoomOwner | null {
-  const key = readWorkShapeKey(scopeClaims);
+  const key = readDeclaredWorkShapeKey(scopeClaims);
   const shape = key ? STANDING_SHAPES[key] : undefined;
   if (!shape) return null;
   return resolveRoomOwner({

--- a/apps/web/lib/work-management/room-cycle-projection.ts
+++ b/apps/web/lib/work-management/room-cycle-projection.ts
@@ -1,0 +1,50 @@
+import {
+  WorkroomCycleError,
+  selectCompletedWorkroomCycles,
+  selectCurrentWorkroomCycle,
+} from "./room-cycle";
+import type { WorkroomCycleCarrierCandidate } from "./room-cycle";
+import type { WorkroomCycleView } from "./room-types";
+import { readDeclaredWorkShapeKey } from "./work-shapes";
+
+/** Project a room's cycles, degrading to an explained gap rather than throwing.
+ *
+ *  Two rules live here together because they are the same lesson (BI-97B24FB5):
+ *
+ *  1. The room's DECLARED work shape can widen a finite source to standing. A
+ *     standing room always holds an active carrier, so a source-only reading
+ *     refuses the very rooms that are working correctly.
+ *
+ *  2. A cycle that cannot be projected costs the CYCLE, never the ROOM. The
+ *     throw used to escape the server component, so a mis-projected cycle blanked
+ *     the whole page and the operator lost the outcome, the owner and the
+ *     activity too. Fail closed on the section, open on the page.
+ */
+export function projectRoomCycles(input: {
+  sourceKey: string;
+  sourceId: string;
+  candidates: readonly WorkroomCycleCarrierCandidate[];
+  scopeClaims: unknown;
+  registered: boolean;
+}): {
+  currentCycle: WorkroomCycleView | null;
+  completedCycles: WorkroomCycleView[];
+  cycleProjectionError: string | null;
+} {
+  if (!input.registered) return { currentCycle: null, completedCycles: [], cycleProjectionError: null };
+
+  const options = { declaredShapeKey: readDeclaredWorkShapeKey(input.scopeClaims) };
+  try {
+    return {
+      currentCycle: selectCurrentWorkroomCycle(input.sourceKey, input.candidates, options),
+      completedCycles: selectCompletedWorkroomCycles(input.sourceKey, input.candidates, options),
+      cycleProjectionError: null,
+    };
+  } catch (error) {
+    if (!(error instanceof WorkroomCycleError)) throw error;
+    console.error(
+      `[work-case] cycle projection failed for ${input.sourceKey}:${input.sourceId} — ${error.reason}: ${error.message}`,
+    );
+    return { currentCycle: null, completedCycles: [], cycleProjectionError: error.reason };
+  }
+}

--- a/apps/web/lib/work-management/room-cycle.test.ts
+++ b/apps/web/lib/work-management/room-cycle.test.ts
@@ -191,3 +191,65 @@ describe("standing Work Room cycles", () => {
     expect(new Set(first.map((command) => command.idempotencyKey)).size).toBe(2);
   });
 });
+
+// A standing room must project its cycle, not crash (BI-97B24FB5).
+//
+// Every room sourced `work-capsule` was registered FINITE_ROOM_PROJECTION, so a
+// standing operational room — which by definition always holds an active
+// carrier — threw finite_room_has_cycle. The throw was uncaught in the server
+// component, so the operator got "Something went wrong" instead of the room:
+// on the live install WC-D40E9C3C (Inquiry response) and WC-0A92C30D (Adopter
+// health) had each refused 41 consecutive wakes and neither could be opened.
+//
+// The classification fact was already on the room. Both declare a work shape in
+// scopeClaims (adopter-health-watch@1.0.0), and every standing shape declares a
+// `cadence` trigger while every finite delivery shape triggers on `claim`. So
+// the source entry supplies the DEFAULT and the room's declared shape overrides
+// it — kernel decision DI-5F69035EC6B9.
+//
+// The override is deliberately one-way: a declared standing shape can widen a
+// finite source to standing, never the reverse. An unknown or absent shape keeps
+// today's finite behaviour, so no existing room changes meaning.
+describe("a room's declared shape decides its projection", () => {
+  it("projects a cycle for a standing shape on a finite source, instead of throwing", () => {
+    const cycle = selectCurrentWorkroomCycle("work-capsule", [candidate()], {
+      declaredShapeKey: "adopter-health-watch",
+    });
+    expect(cycle).not.toBeNull();
+    expect(cycle?.carrierId).toBe(candidate().carrierId);
+  });
+
+  it("still refuses a cycle on a finite source with no declared shape", () => {
+    expect(() => selectCurrentWorkroomCycle("work-capsule", [candidate()]))
+      .toThrowError(/finite and cannot project a recurring cycle/);
+  });
+
+  it("still refuses a cycle when the declared shape is a finite delivery shape", () => {
+    expect(() =>
+      selectCurrentWorkroomCycle("work-capsule", [candidate()], {
+        declaredShapeKey: "delivery-small",
+      }),
+    ).toThrowError(/finite and cannot project a recurring cycle/);
+  });
+
+  it("surfaces completed cycles for a standing shape, which a finite source hides", () => {
+    const packet = buildWorkroomOutcomePacket({
+      sourceKey: "work-capsule",
+      outcomeState: "achieved",
+      summary: "Adopter health swept.",
+      facts: [
+        { category: "receipts", sourceRef: receiptRef, provenance: "canonical" },
+        { category: "evidence", sourceRef: verificationRef, provenance: "canonical" },
+      ],
+      accountablePrincipalRef: "prn-finance-owner",
+      completedAt: "2026-08-01T16:00:00.000Z",
+    });
+    const closed = candidate({ status: "closed", carrierId: "WI-DONE", outcomePacket: packet });
+    expect(selectCompletedWorkroomCycles("work-capsule", [closed])).toHaveLength(0);
+    expect(
+      selectCompletedWorkroomCycles("work-capsule", [closed], {
+        declaredShapeKey: "adopter-health-watch",
+      }),
+    ).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/work-management/room-cycle.ts
+++ b/apps/web/lib/work-management/room-cycle.ts
@@ -9,7 +9,8 @@ import {
   type WorkCasePolicyInput,
 } from "./policy-envelope";
 import { dedupeRoomSourceRefs, roomText } from "./room-projection-utils";
-import { getWorkCaseSourceEntry } from "./source-registry";
+import { getWorkCaseSourceEntry, STANDING_ROOM_PROJECTION } from "./source-registry";
+import { isStandingWorkShape } from "./work-shapes";
 import type { WorkroomCycleView, WorkroomOutcomePacket } from "./room-types";
 import {
   evaluateWorkroomLifecycleConformance,
@@ -101,16 +102,53 @@ export function buildWorkroomCycle(candidate: WorkroomCycleCarrierCandidate): Wo
   };
 }
 
-export function selectCurrentWorkroomCycle(
-  sourceKey: string,
-  candidates: readonly WorkroomCycleCarrierCandidate[],
-): WorkroomCycleView | null {
+/** How a room may override the projection its source registers.
+ *
+ *  A room declares its work shape on its scope claims; the source entry only
+ *  supplies the default. A declared STANDING shape widens a finite source to
+ *  standing, because a room that recurs by declaration cannot be finite in fact
+ *  (BI-97B24FB5, kernel decision DI-5F69035EC6B9).
+ *
+ *  The widening is one-way on purpose. A declared shape never narrows a standing
+ *  source to finite, and an absent or unknown shape leaves the source's own
+ *  policy untouched — so no already-correct room changes meaning.
+ */
+export type WorkroomProjectionOptions = { declaredShapeKey?: string | null };
+
+function resolveRoomProjection(sourceKey: string, options?: WorkroomProjectionOptions) {
   const source = getWorkCaseSourceEntry(sourceKey);
   if (!source) {
     throw new WorkroomCycleError("unknown_source", `Work Room source '${sourceKey}' is not registered.`);
   }
+  const declared = options?.declaredShapeKey;
+  const widens = source.roomProjection.mode === "finite" && !!declared && isStandingWorkShape(declared);
+  return { source, projection: widens ? STANDING_ROOM_PROJECTION : source.roomProjection };
+}
+
+/** The projection mode a room actually runs at, after its declared shape is
+ *  considered. Every surface that renders a room must ask this, not the source
+ *  entry alone, or the room's mode and its cycle disagree (BI-97B24FB5). */
+export function resolveRoomProjectionMode(
+  sourceKey: string,
+  declaredShapeKey?: string | null,
+): "finite" | "standing" {
+  const source = getWorkCaseSourceEntry(sourceKey);
+  if (!source) return "finite";
+  return source.roomProjection.mode === "finite"
+      && !!declaredShapeKey
+      && isStandingWorkShape(declaredShapeKey)
+    ? "standing"
+    : source.roomProjection.mode;
+}
+
+export function selectCurrentWorkroomCycle(
+  sourceKey: string,
+  candidates: readonly WorkroomCycleCarrierCandidate[],
+  options?: WorkroomProjectionOptions,
+): WorkroomCycleView | null {
+  const { source, projection } = resolveRoomProjection(sourceKey, options);
   const active = candidates.filter((candidate) => candidate.status === "open" || candidate.status === "verifying");
-  if (source.roomProjection.mode === "finite") {
+  if (projection.mode === "finite") {
     if (active.length > 0) {
       throw new WorkroomCycleError("finite_room_has_cycle", `${source.displayLabel} is finite and cannot project a recurring cycle.`);
     }
@@ -122,7 +160,7 @@ export function selectCurrentWorkroomCycle(
   }
   if (active.length === 0) return null;
 
-  const precedence = source.roomProjection.cycleCarrierPrecedence;
+  const precedence = projection.cycleCarrierPrecedence;
   const selected = [...active].sort((left, right) => {
     const rank = precedence.indexOf(left.carrierKind) - precedence.indexOf(right.carrierKind);
     return rank || left.carrierId.localeCompare(right.carrierId);
@@ -136,13 +174,11 @@ export function selectCurrentWorkroomCycle(
 export function selectCompletedWorkroomCycles(
   sourceKey: string,
   candidates: readonly WorkroomCycleCarrierCandidate[],
+  options?: WorkroomProjectionOptions,
 ): WorkroomCycleView[] {
-  const source = getWorkCaseSourceEntry(sourceKey);
-  if (!source) {
-    throw new WorkroomCycleError("unknown_source", `Work Room source '${sourceKey}' is not registered.`);
-  }
+  const { projection } = resolveRoomProjection(sourceKey, options);
 
-  const precedence = source.roomProjection.cycleCarrierPrecedence;
+  const precedence = projection.cycleCarrierPrecedence;
   const completed = candidates.filter(
     (candidate) => candidate.status === "closed" || candidate.status === "carried-over",
   );

--- a/apps/web/lib/work-management/room-read-model.ts
+++ b/apps/web/lib/work-management/room-read-model.ts
@@ -20,8 +20,13 @@ import {
   resolveWorkroomPosture,
   type WorkroomPostureContext,
 } from "./room-posture";
+import { resolveRoomProjectionMode } from "./room-cycle";
 import { readWorkroomPostureClaim } from "./workroom-posture-claim";
-import { getWorkShape, readWorkShapeDefinitionContract } from "./work-shapes";
+import {
+  getWorkShape,
+  readDeclaredWorkShapeKey,
+  readWorkShapeDefinitionContract,
+} from "./work-shapes";
 import { readWorkShapeClaim, resolveWorkShapeClaim } from "./workroom-shape-claim";
 import {
   evaluateWorkroomShapeConformance,
@@ -52,6 +57,9 @@ export interface BuildWorkroomViewInput {
   detail: WorkCaseDetail;
   boundary?: Partial<WorkroomBoundaryInput>;
   currentCycle?: WorkroomCycleView | null;
+  /** Set when the cycle could not be projected. The room still renders; the
+   *  cycle section says so rather than the page dying (BI-97B24FB5). */
+  cycleProjectionError?: string | null;
   completedCycles?: readonly WorkroomCycleView[];
   participants?: readonly WorkroomParticipantView[];
   activities?: readonly WorkroomActivityInput[];
@@ -184,7 +192,13 @@ export function buildWorkroomView(
     context,
     contextProvided: Boolean(input.context),
   });
-  const mode = source?.roomProjection.mode ?? "finite";
+  // The room's own declared shape decides its mode, not the source entry alone
+  // — otherwise a standing room renders as finite while its cycle projects
+  // standing, and the two halves of the same room disagree (BI-97B24FB5).
+  const declaredShapeKey = readDeclaredWorkShapeKey(input.scopeClaims);
+  const mode = source
+    ? resolveRoomProjectionMode(caseRefForDetail(input.detail).sourceType, declaredShapeKey)
+    : "finite";
   const health = sourceHealth(input, source);
   const standingIdle = mode === "standing" && !input.currentCycle;
   const posture = resolveWorkroomPosture(
@@ -289,6 +303,7 @@ export function buildWorkroomView(
     },
     boundary,
     currentCycle,
+    cycleProjectionError: input.cycleProjectionError ?? null,
     completedCycles: [...(input.completedCycles ?? [])],
     participants,
     activity: normalizeWorkroomActivities(input.activities ?? []),

--- a/apps/web/lib/work-management/room-types.ts
+++ b/apps/web/lib/work-management/room-types.ts
@@ -229,6 +229,9 @@ export interface WorkroomView {
   outcome: WorkroomOutcomeView;
   boundary: WorkroomBoundaryView;
   currentCycle: WorkroomCycleView | null;
+  /** Why the cycle could not be projected, when it could not. Distinguishes a
+   *  room that is genuinely idle from one whose cycle failed (BI-97B24FB5). */
+  cycleProjectionError: string | null;
   completedCycles: WorkroomCycleView[];
   participants: WorkroomParticipantView[];
   activity: WorkroomActivityView[];

--- a/apps/web/lib/work-management/source-registry.ts
+++ b/apps/web/lib/work-management/source-registry.ts
@@ -136,7 +136,7 @@ const APPROVAL_ROOM_PROJECTION = {
   },
 } as const satisfies WorkCaseRoomProjectionPolicy;
 
-const STANDING_ROOM_PROJECTION = {
+export const STANDING_ROOM_PROJECTION = {
   mode: "standing",
   cycleCarrierPrecedence: ["work-item", "work-capsule", "task-run"],
   outcomePacket: {

--- a/apps/web/lib/work-management/work-shapes.ts
+++ b/apps/web/lib/work-management/work-shapes.ts
@@ -229,6 +229,35 @@ export function getWorkShape(key: string): WorkShapeDefinition | null {
   return ALL_SHAPES[key] ?? null;
 }
 
+/** Does this shape describe work that RECURS rather than finishing?
+ *
+ *  Read from the shape's own declared triggers, not a hand-kept list: every
+ *  standing operations shape declares `cadence`, every finite delivery shape
+ *  declares `claim`. A new standing shape is therefore standing the day it is
+ *  declared, with nothing else to remember to update (BI-97B24FB5).
+ */
+/** The work-shape key a room declares on its scope claims, e.g. from
+ *  "adopter-health-watch@1.0.0" -> "adopter-health-watch".
+ *
+ *  scopeClaims is an untyped JSON array written by several writers, so read it
+ *  defensively. Shared rather than re-implemented per caller: the room's
+ *  declared shape now decides its projection, so every reader must agree on
+ *  what the room declared (BI-97B24FB5).
+ */
+export function readDeclaredWorkShapeKey(scopeClaims: unknown): string | null {
+  if (!Array.isArray(scopeClaims)) return null;
+  for (const claim of scopeClaims) {
+    if (!claim || typeof claim !== "object") continue;
+    const ref = (claim as Record<string, unknown>).workShape;
+    if (typeof ref === "string" && ref.length > 0) return ref.split("@")[0] ?? null;
+  }
+  return null;
+}
+
+export function isStandingWorkShape(key: string): boolean {
+  return getWorkShape(key)?.triggers.includes("cadence") ?? false;
+}
+
 /** Agent ids that a declared shape names as accountable for at least one stage. */
 export function agentsWithDeclaredShape(): string[] {
   const agents = new Set<string>();

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -19,10 +19,7 @@ import {
   projectWorkItemCycleCarriers,
   WORKROOM_OUTCOME_MESSAGE_TYPE,
 } from "./room-cycle-adapter";
-import {
-  selectCompletedWorkroomCycles,
-  selectCurrentWorkroomCycle,
-} from "./room-cycle";
+import { projectRoomCycles } from "./room-cycle-projection";
 import type { WorkroomStructure } from "./room-structure";
 import type { WorkroomPostureContext } from "./room-posture";
 import { readWorkroomShapeClaim } from "./workroom-shape-claim";
@@ -687,12 +684,13 @@ export async function loadWorkspaceWorkCaseDetail({
     openedAt: item.createdAt,
   });
   const sourceEntry = getWorkCaseSourceEntry(item.sourceType);
-  const currentCycle = sourceEntry
-    ? selectCurrentWorkroomCycle(item.sourceType, cycleCandidates)
-    : null;
-  const completedCycles = sourceEntry
-    ? selectCompletedWorkroomCycles(item.sourceType, cycleCandidates)
-    : [];
+  const { currentCycle, completedCycles, cycleProjectionError } = projectRoomCycles({
+    sourceKey: item.sourceType,
+    sourceId: decoded.sourceId,
+    candidates: cycleCandidates,
+    scopeClaims: capsules[0]?.scopeClaims,
+    registered: Boolean(sourceEntry),
+  });
   const storedPackets = projectStoredWorkroomOutcomePackets(messages);
   const structure = structureLoader
     ? await structureLoader({ sourceType: source.sourceType, sourceId: source.sourceId })
@@ -771,6 +769,7 @@ export async function loadWorkspaceWorkCaseDetail({
     ].sort((a, b) => new Date(b.occurredAt ?? 0).getTime() - new Date(a.occurredAt ?? 0).getTime()),
     currentCycle,
     completedCycles,
+    cycleProjectionError,
     outcomePacket: storedPackets[0] ?? null,
     receipts: [
       ...roomReceiptsFromMessages(item, messages),

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -89,6 +89,17 @@ shape; every merge, deploy, acceptance and authority-changing advance is a `gove
 and the author never holds the receipt writer. `small | medium | large | xlarge` are
 `BacklogEffortSize`; `break-fix` is the expedite lane on a small fix (post-hoc review, WIP 1).
 
+That `claim` vs `cadence` split is load-bearing, not decorative. A shape's own
+declared triggers decide whether the room it drives RECURS: every standing shape
+declares `cadence`, every finite delivery shape declares `claim`, and
+`isStandingWorkShape` reads that rather than a hand-kept list. The source-registry
+entry supplies a room's default projection mode; the room's declared shape
+overrides it, one way only — a declared standing shape widens a finite source to
+standing, never the reverse, and an absent or unknown shape leaves the source's
+policy untouched. A new standing shape is therefore standing the day it is
+declared, with nothing else to remember to update
+(BI-97B24FB5, kernel decision DI-5F69035EC6B9).
+
 A delivery room gets its shape at the claim (`claim_backlog_item_for_work`, BI-02470C7E, design §3.3): declared by the caller as `workShape`, or derived from the item's `effortSize` and work type when every classification rule in design §3.4 agrees (`derive-delivery-shape.ts`, recorded with `source: derived` and the signals used). An implementation claim with no derivable shape is refused with `work_shape_required` and the five-shape pick list; an unattended caller gets `attentionRequired` on the refusal; `delivery-xlarge` is refused for implementation because it only ever decomposes. The shape persists as the room's `workShape` scope claim, read back by `readWorkShapeClaim` / `resolveWorkShapeClaim` like any activity shape.
 
 **This claim is what makes a room wake.** The standing-Workroom drive

--- a/docs/superpowers/specs/2026-09-07-room-projection-derives-from-declared-shape-design.md
+++ b/docs/superpowers/specs/2026-09-07-room-projection-derives-from-declared-shape-design.md
@@ -1,0 +1,118 @@
+---
+status: active
+title: A room's projection mode derives from its declared work shape
+backlog_item: BI-97B24FB5
+decision_interaction: DI-5F69035EC6B9
+---
+
+# A room's projection mode derives from its declared work shape
+
+- **Date:** 2026-09-07
+- **Scope:** platform — Workroom cycle projection, work-case read model
+- **Backlog item:** `BI-97B24FB5`
+- **Profile:** fix
+- **Status:** Design — implemented in this branch.
+
+## Problem
+
+Every room sourced `work-capsule` was registered `FINITE_ROOM_PROJECTION`. A
+standing operational room always holds an active carrier, so `room-cycle.ts`
+threw `finite_room_has_cycle`. The throw escaped the server component, so the
+operator saw "Something went wrong" instead of the room.
+
+Observed on the live install: WC-D40E9C3C (Inquiry response) and WC-0A92C30D
+(Adopter health) had each refused 41 consecutive wakes on
+`executor_writeback_unavailable`, were surfaced in the owner's Needs-you inbox,
+and neither could be opened.
+
+The failure was reported by the operator as "none of the Open room links work",
+which turned out to be three independent defects stacked on one button
+(BI-6F2CC21B, BI-EBEB77E2, and this one).
+
+## Research & Benchmarking
+
+The relevant comparison is not an external library but how mature workflow
+engines classify recurrence, and all three of the usual approaches were
+considered against what the platform already holds:
+
+- **Temporal / Cadence (Uber)** separates a *workflow type* from its *schedule*:
+  recurrence is a property declared on the definition, not inferred by the
+  runtime or attached to the storage class. DPF's `WorkShapeDefinition` is the
+  direct analogue, and it already carries `triggers`.
+- **Airflow** binds recurrence to the DAG object via `schedule_interval`;
+  a DAG without one is a manual, finite run. Same shape of rule: the definition
+  declares recurrence, the executor reads it.
+- **Camunda/BPMN** distinguishes a timer start event from a message/none start
+  event — again a declared property of the process definition.
+
+All three put recurrence on the *definition of the work*, none on the *source
+or storage class of the instance*. DPF adopts that: the source-registry entry is
+a default, the declared shape is the authority. DPF rejects inferring recurrence
+from runtime behaviour (e.g. "it woke more than once"), which none of the three
+engines do either, because it makes the classification unstable and unexplainable.
+
+## Decision
+
+Kernel decision `DI-5F69035EC6B9` (stakes: high, `external_coding_agent`):
+
+| Option | Composite |
+| --- | --- |
+| **Derive projection mode from the room's declared shape** | **11.97** |
+| Add a distinct `standing-room` source entry and migrate rooms | 5.38 |
+| Flip `work-capsule` wholesale to `STANDING_ROOM_PROJECTION` | 0.83 |
+
+Margin 6.58, confidence high, verdict proceed, no commandment conflict, zero
+flipping principles under sensitivity analysis, 49 principles applied. Leading
+contributors: *Research and Use Standards*, *Classify ambiguous requests before
+acting*, *Ground New Work In Existing Platform*, *Single Source of Truth*,
+*Verify substrate before proposing new*.
+
+The decisive evidence was that the classifying fact is **already on the room**:
+`scopeClaims` on WC-0A92C30D carries `workShape: "adopter-health-watch@1.0.0"`,
+and `STANDING_OPERATIONS_SHAPE_KEYS` already declares twelve standing shapes.
+The two rejected options both invent substrate to hold a fact the platform
+already stores.
+
+The wholesale flip was rejected because it trades a visible crash for an
+invisible correctness bug: genuine finite build rooms would silently project
+recurring cycles they must never have.
+
+## Design
+
+1. **Standing-ness is read from the shape's own trigger.** Every standing shape
+   declares `cadence`; every finite delivery shape declares `claim`.
+   `isStandingWorkShape(key)` reads that rather than a hand-kept membership list,
+   so a new standing shape is standing the day it is declared.
+
+2. **The override is one-way.** A declared standing shape widens a finite source
+   to standing; a declared shape never narrows a standing source to finite, and
+   an absent or unknown shape leaves the source's policy untouched. No
+   already-correct room changes meaning.
+
+3. **One resolver, every reader.** `resolveRoomProjectionMode` is used by both
+   the cycle selection and `room-read-model`, which previously derived `mode`
+   from the source alone — so a room's rendered mode and its projected cycle can
+   no longer disagree.
+
+4. **A failed projection costs the cycle, not the room.** `projectRoomCycles`
+   catches `WorkroomCycleError` at the loader boundary, logs the reason, and
+   carries it on the view. The cycle section reports that the cycle could not be
+   worked out, rather than claiming the room is "healthy and idle" — a state
+   nobody established, on a room that is in trouble.
+
+## Consequence for BI-A2234157
+
+`BI-A2234157` ("Standing Workrooms for ongoing operational activity") is
+deferred to 2026-09-15 on the premise that standing rooms need new trigger and
+scope substrate. That premise is overtaken: the work-shape registry has landed
+since the deferral and already carries what is needed. The item is flagged for
+its owner to close as overtaken or re-scope — not closed here, since the
+deferral is owner-attributed.
+
+## Non-goals
+
+- Reclassifying the four `COWORKER_STANDING_SHAPES` that do not declare
+  `cadence`. They keep today's finite behaviour; the conservative fallback means
+  this is a no-op for them, and whether they are genuinely standing is a
+  separate question for their owner.
+- Changing any room's stored data. This is a read-path change only.

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -128,6 +128,12 @@ Completion produces an Outcome Packet from governed decisions, artifacts, action
 
 In a standing room, the **Current cycle** panel shows the objective, trigger, review point, measure of done, and stop conditions before the general activity stream. When no cycle is active, the room says that it is healthy and idle rather than implying that recurring work is complete.
 
+If a room's cycle cannot be worked out, the cycle section says so instead of
+reporting the room as idle — an idle room and a room whose cycle failed are not
+the same thing, and only one of them is fine to leave alone. Everything else on
+the page stays accurate and safe to act on; the reason is recorded for your
+platform team rather than shown to you.
+
 **Completed cycles** are ordered by completion time. Open a completed cycle to read its Outcome Packet, durable-record count, verification state, and unresolved work. Each unresolved item has an explicit disposition: carry it into the next cycle, open a separate case, defer it, or accept it. Retrying carry-over does not create duplicate work.
 
 ## Pace and Priority

--- a/docs/ux-fit/2026-09-07-workroom-cycle-unavailable.ux-fit.json
+++ b/docs/ux-fit/2026-09-07-workroom-cycle-unavailable.ux-fit.json
@@ -1,0 +1,17 @@
+{
+  "version": "1",
+  "decidedOption": "named-unavailable-state",
+  "decisionInteractionId": "DI-89ACB51383C3",
+  "scope": {
+    "files": ["apps/web/components/workspace/workroom/WorkroomCycles.tsx"]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "named-unavailable-state",
+      "reuse-healthy-idle-copy",
+      "hide-cycle-section",
+      "show-raw-reason-code"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -9397,7 +9397,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 39
+    "textMass": 49
   },
   "apps/web/components/workspace/workroom/WorkroomHeader.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
The operator reported that no **Open room** button on the Needs-you inbox worked. That was three stacked defects; this is the third and the one that made the two rooms in the report unopenable.

Every room sourced `work-capsule` was registered `FINITE_ROOM_PROJECTION`. A standing operational room always holds an active carrier, so it threw `finite_room_has_cycle` — and the throw escaped the server component, so the operator got "Something went wrong" instead of the room. On the live install WC-D40E9C3C (Inquiry response) and WC-0A92C30D (Adopter health) had each refused 41 consecutive wakes and neither could be opened.

## Two faults, both fixed

**1. Classification.** The classifying fact was already on the room. `scopeClaims` on WC-0A92C30D carries `workShape: "adopter-health-watch@1.0.0"`, and `STANDING_OPERATIONS_SHAPE_KEYS` already declares twelve standing shapes — including both rooms'. The source entry now supplies the **default**; the room's declared shape **overrides** it.

Standing-ness is read from the shape's own `cadence` trigger rather than a hand-kept list — every standing shape declares `cadence`, every finite delivery shape declares `claim` — so a new standing shape is standing the day it is declared.

The override is **one-way**: a declared standing shape widens a finite source to standing, never the reverse; an absent or unknown shape keeps today's behaviour. No already-correct room changes meaning.

`room-read-model` had the same defect at a second site, deriving `mode` from the source alone. It now resolves through the same helper, so a room's rendered mode and its projected cycle can no longer disagree.

**2. Containment.** A cycle that cannot be projected now costs the **cycle**, never the **room**. `WorkroomCycleError` is caught at the loader boundary, the reason is logged and carried on the view, and the cycle section reports it — instead of reusing the "healthy and idle" empty state, which would assert a state nobody established on a room that is in trouble.

## Decisions

- **`DI-5F69035EC6B9`** (stakes: high) — derive-from-declared-shape (**11.97**) over a new standing source entry (5.38) and a wholesale flip of `work-capsule` to standing (0.83). Margin 6.58, high confidence, no commandment conflict, zero flipping principles under sensitivity analysis. The wholesale flip was rejected because it trades a visible crash for an invisible correctness bug: finite build rooms would silently project recurring cycles they must never have.
- **`DI-89ACB51383C3`** — the degraded-state copy: `named-unavailable-state` (9.76) over reusing the idle copy (1.37), hiding the section (3.99), and showing the raw reason code to a non-technical owner (5.94).

Design record: `docs/superpowers/specs/2026-09-07-room-projection-derives-from-declared-shape-design.md`, including a Research & Benchmarking section — Temporal/Cadence, Airflow and BPMN all put recurrence on the *definition of the work*, never on the source or storage class of the instance. DPF adopts that.

## Also

- Removes a duplicated declared-shape reader (`workroom-stall.ts` had its own copy). The declared shape now decides projection, so every reader must agree on what the room declared.
- Extracts `projectRoomCycles` into its own module, keeping `workspace-case-loader.ts` under the 800-LOC ratchet rather than raising it.

## Consequence for BI-A2234157

**BI-A2234157** ("Standing Workrooms for ongoing operational activity") is deferred to 2026-09-15 on the premise that standing rooms need new trigger/scope substrate. That premise is **overtaken** — the work-shape registry landed since, and already carries what is needed. Flagged for its owner to close as overtaken or re-scope; not closed here, since the deferral is owner-attributed.

## Verification

- `vitest lib/work-management/room-cycle.test.ts` — 2 new tests fail before (`finite_room_has_cycle`; completed cycles hidden), 14/14 pass after
- `vitest lib/work-management + components/workspace + lib/attention` — **1028/1028 passed**
- `tsc --noEmit` — clean
- Module-size, substrate-complexity, UX primitive-adoption and prose-lint ratchets all addressed by trimming rather than by raising a budget, except the +10 UI words the new state genuinely costs, which is recorded in the baseline
- Local-CI gate passed on gated sha `ec38ce3ff371`, production build compiled successfully

**Not verified end-to-end:** the two rooms cannot be opened on Arcamanus PROD until this is deployed. That check belongs to the deploy, not this PR.

Refs: BI-97B24FB5 · DI-5F69035EC6B9 · DI-89ACB51383C3 · EP-WORK-CONVERGENCE

Local-CI-Evidence: cmtrrtufn06eo01p8dqj64mo9

🤖 Generated with [Claude Code](https://claude.com/claude-code)