### PR TITLE
fix(work-activity): make the portfolio tree's disclosure, counts and statements truthful at scale (BI-8DACBA07)

### DIFF
--- a/apps/web/app/(shell)/ops/workrooms/page.test.tsx
+++ b/apps/web/app/(shell)/ops/workrooms/page.test.tsx
@@ -49,7 +49,10 @@ describe("Work activity page", () => {
 
   it("shows a recorded blocker as a concrete statement, not a count", async () => {
     const html = renderToStaticMarkup(await WorkroomsPage());
-    expect(html).toContain("Blocked: waiting on reviewer");
+    // The room is named alongside its blocker: measured at scale, rooms
+    // sharing one generic liveness reason rendered as identical lines.
+    expect(html).toContain("blocked: waiting on reviewer");
+    expect(html).toMatch(/[^<>]+ · blocked: waiting on reviewer/);
   });
 
   it("opens each room in one click from its activity line", async () => {

--- a/apps/web/app/(shell)/ops/workrooms/page.tsx
+++ b/apps/web/app/(shell)/ops/workrooms/page.tsx
@@ -15,8 +15,14 @@ import {
 
 export const dynamic = "force-dynamic";
 
+/** Rooms read for one render of this page. */
+const WORKROOM_READ_LIMIT = 200;
+
 export default async function WorkroomsPage() {
-  const inventory = await loadCapsuleLivenessInventory(prisma, { where: {}, take: 200 });
+  const inventory = await loadCapsuleLivenessInventory(prisma, { where: {}, take: WORKROOM_READ_LIMIT });
+  // A full page means the read stopped at its limit, so branch counts describe
+  // the rooms read rather than the rooms that exist. The tree is told, and says so.
+  const roomReadBounded = inventory.capsulesAll.length >= WORKROOM_READ_LIMIT;
   const workrooms = inventory.capsulesAll.map((room) => ({
     ...room,
     updatedAt: room.updatedAt instanceof Date ? room.updatedAt.toISOString() : String(room.updatedAt),
@@ -73,7 +79,11 @@ export default async function WorkroomsPage() {
       </Surface>
       <Surface className="mt-6" rounded="xl">
         <h2 className="text-base font-semibold text-[var(--dpf-text)]">Activity by portfolio</h2>
-        <PortfolioActivityTree rows={activityRows} partial={activity.partial} />
+          <PortfolioActivityTree
+          rows={activityRows}
+          partial={activity.partial}
+          roomReadBounded={roomReadBounded}
+        />
       </Surface>
 
       <div className="mt-6">

--- a/apps/web/components/ops/workrooms/PortfolioActivityTree.test.tsx
+++ b/apps/web/components/ops/workrooms/PortfolioActivityTree.test.tsx
@@ -45,7 +45,7 @@ describe("PortfolioActivityTree", () => {
     const html = renderToStaticMarkup(
       <PortfolioActivityTree rows={withLabels(page.rows)} partial={page.partial} />,
     );
-    expect(html).toContain("Blocked: Waiting for release review");
+    expect(html).toContain("blocked: Waiting for release review");
     expect(html).toContain("Checking invoice matching");
     // The count is present, but as a supplement beside the statements.
     expect(html).toContain("3 rooms");
@@ -95,7 +95,7 @@ describe("PortfolioActivityTree", () => {
     );
     expect(html).toContain('aria-current="true"');
     expect(html).toContain('aria-expanded="false"');
-    const order = ["Blocked: Waiting for release review", "Checking invoice matching"];
+    const order = ["blocked: Waiting for release review", "Checking invoice matching"];
     expect(html.indexOf(order[0]!)).toBeLessThan(html.indexOf(order[1]!));
   });
 
@@ -142,5 +142,83 @@ describe("PortfolioActivityTree", () => {
       expect(typeof value, `prop "${key}" must be serializable`).not.toBe("function");
     }
     expect(() => JSON.stringify(props)).not.toThrow();
+  });
+});
+
+describe("expansion actually discloses (BI-8DACBA07 scale verification)", () => {
+  // Caught by rendering /ops/workrooms against 1,001 rooms: the chevron flipped
+  // `aria-expanded` and its own glyph while the list below it never changed.
+  // A disclosure control that discloses nothing is the defect this pins.
+  const page = projectPortfolioActivityPage({
+    rooms: Array.from({ length: 40 }, (_, i) =>
+      room({ roomId: `r-${String(i).padStart(3, "0")}`, branchId: "finance" }),
+    ),
+    now: NOW,
+  });
+  const branch = page.rows[0]!;
+
+  it("carries more rooms to disclose than the collapsed summary shows", () => {
+    expect(branch.representative.length).toBe(3);
+    expect(branch.disclosed.length).toBeGreaterThan(branch.representative.length);
+  });
+
+  it("bounds an expanded branch instead of emptying every room into the page", () => {
+    expect(branch.disclosed.length).toBe(25);
+    expect(branch.disclosedTruncated).toBe(true);
+    expect(branch.undisclosedCount).toBe(15);
+    expect(branch.disclosed.length + branch.undisclosedCount).toBe(branch.roomCount);
+  });
+
+  it("opens on the representative rooms it was already summarising", () => {
+    // Opening a branch must not reshuffle what the operator was just reading.
+    expect(branch.disclosed.slice(0, 3).map((a) => a.roomId)).toEqual(
+      branch.representative.map((a) => a.roomId),
+    );
+  });
+
+  it("renders the collapsed summary, not the disclosed set, before any click", () => {
+    const html = renderToStaticMarkup(
+      <PortfolioActivityTree rows={withLabels(page.rows)} partial={page.partial} />,
+    );
+    const links = html.match(/\/workspace\/cases\//g) ?? [];
+    expect(links.length).toBe(3);
+    expect(html).toContain('aria-expanded="false"');
+  });
+});
+
+describe("statements and counts stay truthful at scale (BI-8DACBA07)", () => {
+  it("names the room in a blocker line so identical blockers stay distinguishable", () => {
+    // At 1,001 rooms several rooms shared one generic liveness reason and
+    // rendered as three identical "Blocked: ..." lines.
+    const page = projectPortfolioActivityPage({
+      rooms: [
+        room({ roomId: "r-a", title: "Payroll run", blocker: "Synced 12m ago." }),
+        room({ roomId: "r-b", title: "Invoice sync", blocker: "Synced 12m ago." }),
+      ],
+      now: NOW,
+    });
+    const statements = page.rows[0]!.representative.map((a) => a.statement);
+    expect(new Set(statements).size).toBe(statements.length);
+    expect(statements.some((s) => s.includes("Payroll run"))).toBe(true);
+    expect(statements.some((s) => s.includes("Invoice sync"))).toBe(true);
+  });
+
+  it("marks counts as read-scoped when the room read was bounded", () => {
+    const page = projectPortfolioActivityPage({
+      rooms: [room({ roomId: "r-1" }), room({ roomId: "r-2" })],
+      now: NOW,
+    });
+    const bounded = renderToStaticMarkup(
+      <PortfolioActivityTree rows={withLabels(page.rows)} partial={false} roomReadBounded />,
+    );
+    expect(bounded).toContain("2 rooms read");
+    expect(bounded).toContain("not every Workroom in");
+
+    const complete = renderToStaticMarkup(
+      <PortfolioActivityTree rows={withLabels(page.rows)} partial={false} />,
+    );
+    expect(complete).toContain("2 rooms");
+    expect(complete).not.toContain("2 rooms read");
+    expect(complete).not.toContain("not every Workroom in");
   });
 });

--- a/apps/web/components/ops/workrooms/PortfolioActivityTree.tsx
+++ b/apps/web/components/ops/workrooms/PortfolioActivityTree.tsx
@@ -26,6 +26,10 @@ export type BranchRowView = BranchRow & { label: string };
  * Three interaction rules the design is explicit about, and each is easy to get
  * wrong:
  *
+ * Expansion discloses. Opening a branch replaces its three-line summary with
+ * the rooms it carries, bounded by the projection so a thousand-room portfolio
+ * stays readable and says what it is not showing.
+ *
  * Expansion and selection are independent. The chevron discloses a branch's
  * rooms; it does not change what the inspector is showing. Selecting an activity
  * does not collapse or reorder anything. Conflating them makes an operator lose
@@ -101,11 +105,19 @@ function ActivityLine({
 export function PortfolioActivityTree({
   rows,
   partial,
+  roomReadBounded = false,
   selectedRoomId = null,
 }: {
   rows: readonly BranchRowView[];
   /** True when more branches exist than this page carries. */
   partial: boolean;
+  /**
+   * True when the underlying room read hit its limit, so a branch count is a
+   * count of the rooms read — not of the rooms the portfolio holds. Measured at
+   * 1,001 rooms against a 200-room read, "51 rooms" read as a portfolio total
+   * and was off by a factor of five. A count that cannot be the whole says so.
+   */
+  roomReadBounded?: boolean;
   selectedRoomId?: string | null;
 }) {
   // Expansion is view state and deliberately separate from selection.
@@ -145,12 +157,20 @@ export function PortfolioActivityTree({
                 {/* A count supplements the statements below; it never replaces them. */}
                 <span className="text-xs text-[var(--dpf-muted)]">
                   {row.roomCount} room{row.roomCount === 1 ? "" : "s"}
+                  {roomReadBounded ? " read" : ""}
                   {row.attentionCount > 0 ? ` · ${row.attentionCount} need attention` : ""}
                 </span>
               </div>
 
+              {/*
+                Collapsed, a branch shows its representative activities. Open,
+                it shows the rooms it discloses. The chevron must actually
+                change what is on the page — a control that only rewrites its
+                own glyph and `aria-expanded` claims a disclosure it never
+                performs, and an operator learns to distrust it.
+              */}
               <ul className="ml-11 mt-1">
-                {row.representative.map((activity) => (
+                {(isOpen ? row.disclosed : row.representative).map((activity) => (
                   <ActivityLine
                     key={activity.roomId}
                     activity={activity}
@@ -158,11 +178,23 @@ export function PortfolioActivityTree({
                   />
                 ))}
               </ul>
+              {isOpen && row.disclosedTruncated ? (
+                <p className="ml-11 mt-1 text-xs text-[var(--dpf-muted)]">
+                  {row.undisclosedCount} more room{row.undisclosedCount === 1 ? "" : "s"} in this
+                  portfolio are not listed here.
+                </p>
+              ) : null}
 
             </li>
           );
         })}
       </ul>
+      {roomReadBounded ? (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          Counts cover the most recently updated Workrooms this page read, not every Workroom in
+          the portfolio.
+        </p>
+      ) : null}
       {partial ? (
         <p className="mt-3 text-xs text-[var(--dpf-muted)]">Partial read: more branches exist.</p>
       ) : null}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2501,7 +2501,10 @@
         "a-known-tension-accepted-deliberately",
         "what-is-deliberately-not-renamed-yet",
         "what-a-human-reads-is-renamed-and-now-guarded",
-        "related"
+        "related",
+        "a-disclosure-control-discloses",
+        "a-count-says-what-it-counted",
+        "a-statement-names-its-room"
       ]
     },
     "docs/business-types/_readability-report.md": {

--- a/apps/web/lib/work-management/portfolio-activity-projection.test.ts
+++ b/apps/web/lib/work-management/portfolio-activity-projection.test.ts
@@ -86,8 +86,8 @@ describe("selectRepresentativeActivities", () => {
       room({ roomId: "run", evidenceAt: ago(1_000), latestAction: "Checking invoice matching" }),
       room({ roomId: "stuck", blocker: "Waiting for release review" }),
     ], NOW, 2);
-    expect(picked[0]!.statement).toBe("Blocked: Waiting for release review");
-    expect(picked[1]!.statement).toBe("Checking invoice matching");
+    expect(picked[0]!.statement).toBe("Room stuck · blocked: Waiting for release review");
+    expect(picked[1]!.statement).toBe("Room run · Checking invoice matching");
     for (const p of picked) expect(p.statement).not.toMatch(/^\d+$/);
   });
 

--- a/apps/web/lib/work-management/portfolio-activity-projection.ts
+++ b/apps/web/lib/work-management/portfolio-activity-projection.ts
@@ -153,8 +153,14 @@ export type RepresentativeActivity = {
 };
 
 function statementFor(room: RoomActivityInput, signal: ActivitySignal): string {
-  if (room.blocker) return `Blocked: ${room.blocker}`;
-  if (room.latestAction) return room.latestAction;
+  // Every statement names its room. Measured at 1,001 rooms, blockers and
+  // actions are frequently identical across rooms — several rooms blocked on
+  // the same generic liveness reason rendered as three indistinguishable
+  // "Blocked: ..." lines, so the operator could not tell which room each line
+  // was about or that they were different rooms at all. The room is the thing
+  // being acted on; it belongs in the sentence.
+  if (room.blocker) return `${room.title} · blocked: ${room.blocker}`;
+  if (room.latestAction) return `${room.title} · ${room.latestAction}`;
   // No concrete action recorded — say that, rather than manufacturing one.
   return `${room.title} · ${signal.label.toLocaleLowerCase("en-US")}`;
 }
@@ -190,6 +196,15 @@ export function selectRepresentativeActivities(
   }));
 }
 
+/**
+ * How many rooms one expanded branch discloses at most.
+ *
+ * Expansion has to stay bounded independently of how many rooms exist: the
+ * whole point of the tree is that a portfolio with a thousand rooms is still
+ * readable. Beyond this, the branch says how many it is not showing.
+ */
+export const DEFAULT_DISCLOSURE_LIMIT = 25;
+
 export type BranchRow = {
   branchId: string;
   portfolioRole: WorkCapsulePortfolioRole | null;
@@ -198,6 +213,17 @@ export type BranchRow = {
   /** Rooms needing attention: blocked or waiting on a person. */
   attentionCount: number;
   representative: RepresentativeActivity[];
+  /**
+   * The rooms a branch discloses when it is expanded, in the same order the
+   * summary uses. Bounded: a portfolio holding a thousand rooms must not empty
+   * all of them into the document the moment someone opens the chevron, so this
+   * carries at most `disclosureLimit` and reports the remainder instead.
+   */
+  disclosed: RepresentativeActivity[];
+  /** True when the branch holds more rooms than `disclosed` carries. */
+  disclosedTruncated: boolean;
+  /** Rooms in this branch beyond the disclosed bound. Never negative. */
+  undisclosedCount: number;
 };
 
 export type PortfolioActivityPage = {
@@ -227,11 +253,14 @@ export function projectPortfolioActivityPage(input: {
   pageSize?: number;
   /** Max representative activities per collapsed branch. */
   representativeLimit?: number;
+  /** Max rooms an expanded branch discloses before it reports a remainder. */
+  disclosureLimit?: number;
   /** Resume after this branch id. */
   cursor?: string | null;
 }): PortfolioActivityPage {
   const pageSize = Math.max(1, input.pageSize ?? 50);
   const representativeLimit = input.representativeLimit ?? 3;
+  const disclosureLimit = input.disclosureLimit ?? DEFAULT_DISCLOSURE_LIMIT;
 
   const seen = new Set<string>();
   const byBranch = new Map<string, RoomActivityInput[]>();
@@ -256,12 +285,17 @@ export function projectPortfolioActivityPage(input: {
       const state = deriveActivitySignal(room, input.now).state;
       return state === "blocked" || state === "waiting-on-person";
     }).length;
+    const disclosed = selectRepresentativeActivities(rooms, input.now, disclosureLimit);
+
     return {
       branchId,
       portfolioRole: rooms[0]!.portfolioRole,
       roomCount: rooms.length,
       attentionCount,
       representative: selectRepresentativeActivities(rooms, input.now, representativeLimit),
+      disclosed,
+      disclosedTruncated: rooms.length > disclosed.length,
+      undisclosedCount: Math.max(0, rooms.length - disclosed.length),
     };
   });
 

--- a/docs/architecture/workroom-vocabulary-boundary.md
+++ b/docs/architecture/workroom-vocabulary-boundary.md
@@ -329,3 +329,32 @@ old word free to come back, which is exactly how this one survived.
 - [Claim a workroom before you work](../founder-kernel/wiki/principles/claim-a-workroom-before-you-work.md)
 - [Workroom participation and channel continuity](work-room-participation-and-channel-continuity.md)
 - Plan: `docs/superpowers/plans/2026-08-15-workroom-canonical-rename.md`
+
+## A disclosure control discloses
+
+Expanding a branch of the portfolio activity tree replaces its summary with the
+rooms it carries. This is stated because the first implementation did not do it:
+the chevron flipped `aria-expanded`, swapped its own glyph, and left the list
+below unchanged, so the control announced a disclosure it never performed. A
+control that changes only its own appearance is worse than no control, because
+an operator reads the absence of new rows as "this branch has nothing more".
+
+Disclosure is bounded. A portfolio holding a thousand rooms discloses the first
+`DEFAULT_DISCLOSURE_LIMIT` of them in the order it was already summarising, then
+says how many it is not listing. Opening a branch never empties a portfolio into
+the page, and never reshuffles the rows the operator was reading.
+
+## A count says what it counted
+
+A branch count describes the rooms the page read, not the rooms that exist. The
+page reads a bounded number of Workrooms; when that read hits its limit the tree
+renders "N rooms read" and states the bound. Measured against 1,001 rooms and a
+200-room read, an unqualified "51 rooms" understated the portfolio five-fold
+while looking exactly like a total.
+
+## A statement names its room
+
+Every activity line carries its room's title alongside the action or blocker.
+Blockers are frequently generic and shared: at scale, several rooms blocked on
+one liveness reason rendered as identical lines with no way to tell which room
+each described, or that they were different rooms at all.

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -14,6 +14,12 @@ Operations is the delivery backlog for the platform. It tracks the work items, e
 
 Open **Operations > Workrooms** (`/ops/workrooms`) for one operational inventory across business work, coworker activity, and development. **Live now** requires current execution evidence such as a valid lease, an open pull request, or recent activity. **History and cleanup** retains terminal, expired, stalled, and cleanup-eligible records without counting them as active. Select a Workroom to open its canonical activity case; open **Architecture > Workrooms** when you need the reusable definition instead of the instance history.
 
+**Activity by portfolio** groups the same Workrooms under the four portfolios and summarises each one with a few concrete activities rather than a bare count. Every line names its Workroom and says what is happening to it, so two Workrooms blocked for the same reason stay distinguishable. Select any line to open that Workroom's activity case in one step.
+
+Use the arrow beside a portfolio to expand it. Expanding lists the Workrooms in that portfolio, up to twenty-five at a time, and tells you how many it is not listing. Expanding one portfolio does not collapse the others and does not change what you already have open.
+
+Counts describe the Workrooms the page read, not everything in the portfolio. When the page reads its limit, each count reads "N rooms read" and a note below the tree says so. To see beyond that, narrow the inventory below or open the portfolio itself.
+
 ## Key Concepts
 
 - **Backlog Items** — Individual units of work with a status, priority, epic, and owner. Items move through triaging, open, in-progress, done, deferred, or retired.

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -6893,7 +6893,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 9
+    "textMass": 25
   },
   "apps/web/components/ops/workrooms/WorkroomInventory.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Rendering `/ops/workrooms` against **1,001 Workrooms and 100 agent executors** — the scale verification BI-8DACBA07 required — surfaced three defects that are invisible at fixture scale and misleading at real scale. All three are fixed here.

### 1. The disclosure control disclosed nothing

`PortfolioActivityTree` computed `isOpen`, drove `aria-expanded` and the chevron glyph from it, then rendered `row.representative` unconditionally. No code path ever showed a branch's rooms.

Measured: tree words identical at 138 before expanding, after expanding one branch, and after expanding all four. A control that changes only its own appearance is worse than no control, because the absence of new rows reads as "this branch has nothing more".

Expansion now discloses the branch's rooms, bounded at `DEFAULT_DISCLOSURE_LIMIT = 25` so a thousand-room portfolio stays readable, and states the remainder it is not listing.

### 2. A branch count read as a portfolio total

The page reads 200 rooms. `Workforce 51 rooms` described that read, not the 250-room portfolio — understating it five-fold while looking exactly like a total. When the read hits its limit the tree now renders `51 rooms read` and says so below.

### 3. Blocked rows were indistinguishable

Several rooms shared one generic liveness reason and rendered as three identical `Blocked: Synced 15m ago.` lines, with no way to tell which room each described. Every statement now names its room.

## Verification

Canonical nonproduction runtime, provisioned exactly as the UX Route Budget Sweep workflow provisions its own: isolated ephemeral Postgres, `prisma migrate deploy`, full seed, `ux:sweep-fixture`, production build, portal on `127.0.0.1:3100`, authenticated through `e2e/auth-only.ts`. No live database and no shared runtime were touched.

Measured after the fix, at 1,001 rooms:

| Measure | Result |
| --- | --- |
| Page load | 1.1s |
| Tree collapsed | 207 words |
| One branch expanded | 437 words |
| All four expanded | 1,211 words, 100 room links |
| Expand click to painted | 319ms |

Each expanded branch reports its remainder. Expanding one branch leaves siblings collapsed and selection unchanged.

**Route budget:** at standard fixture scale `/ops/workrooms` is clean against its frozen baseline. The earlier 223 → 1,179 word reading was taken with 1,000 extra fixture rooms present and is not a valid ratchet comparison, since the committed baseline was frozen against the standard fixture.

**Residual, not fixed:** the pre-existing `WorkroomInventory` table below the tree contributes ~844 words at a 200-room read and does not progressively disclose. It is bounded by the page's read rather than growing without limit, and sits outside the components this delivery owns.

36 unit tests pass across the projection, tree and page suites, including six new regressions pinning each defect.

Design-Grounding-Decision: extends the accepted portfolio work activity design (docs/superpowers/specs/2026-09-07-portfolio-work-activity-design.md, OBJ-ACTIVITY and OBJ-SCALE) in its own components rather than adding a parallel surface; no routing or contract change.

Convergence-Impact-Decision: auto-converges — scripts/ is copied wholesale into the promoter image by Dockerfile.promoter, so the retightened prose-lint baseline ships with the next image and needs no operator action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Local-CI-Evidence: cmtrs9s6y0kn601p84vvwvj7m
