### PR TITLE
chore(guards): a room is reachable by construction — kernel principle and CI guard (BI-00727E59)

### DIFF
--- a/apps/web/components/ops/BacklogItemRow.tsx
+++ b/apps/web/components/ops/BacklogItemRow.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { AlertTriangle, ExternalLink, Play, RotateCcw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { encodeWorkCaseKey } from "@/lib/work-management/case-key";
 import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
 import { deleteBacklogItem, escalateBacklogItemUpstream } from "@/lib/actions/backlog";
 import { startBacklogBuild } from "@/lib/actions/backlog-build";
@@ -282,7 +283,7 @@ function ActiveWorkroomOwnership({
         {workrooms.map((room) => (
           <div key={room.capsuleId} className="flex min-w-0 flex-wrap items-center gap-2">
             <Link
-              href={`/workspace/cases/${room.capsuleId}`}
+              href={`/workspace/cases/${encodeWorkCaseKey({ sourceType: "work-capsule", sourceId: room.capsuleId })}`}
               className="font-dpf-medium text-[var(--dpf-accent)] hover:underline"
             >
               {room.title}

--- a/apps/web/components/ops/OpsClient.test.tsx
+++ b/apps/web/components/ops/OpsClient.test.tsx
@@ -205,7 +205,9 @@ describe("OpsClient", () => {
 
     expect(html).toContain("Workroom active");
     expect(html).toContain("Workroom ownership safety");
-    expect(html).toContain('href="/workspace/cases/WC-923105A2"');
+    // The canonical work-case address, not the capsule id alone: a key without
+    // its source-type prefix does not decode, so the link 404s (BI-00727E59).
+    expect(html).toContain('href="/workspace/cases/work-capsule%3AWC-923105A2"');
     expect(html).toContain("working");
     expect(html).toContain("Codex Desktop");
     expect(html).toContain("fix/bi-workroom-single-owner");

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1636,6 +1636,7 @@
       "docs/architecture/enforced-ci-gates.md"
     ],
     "scripts/check-guard-conformance-marks.mjs": [
+      "docs/founder-kernel/wiki/principles/a-room-is-reachable-by-construction.md",
       "docs/testing/pre-pr-gate.md"
     ],
     "scripts/check-guards.mjs": [
@@ -1698,6 +1699,10 @@
     ],
     "scripts/check-no-unattributable-deferral.mjs": [
       "docs/architecture/backlog-and-planning-runbook.md"
+    ],
+    "scripts/check-no-unreachable-room-links.mjs": [
+      "docs/founder-kernel/wiki/principles/a-room-is-reachable-by-construction.md",
+      "docs/testing/pre-pr-gate.md"
     ],
     "scripts/check-override-comments.mjs": [
       "docs/architecture/contributor-procedure-runbook.md"
@@ -2730,6 +2735,10 @@
       "apps/web/lib/queue/functions/wiki-lint.ts",
       "packages/db/src/wiki-taxonomy.ts"
     ],
+    "docs/founder-kernel/wiki/principles/a-room-is-reachable-by-construction.md": [
+      "scripts/check-guard-conformance-marks.mjs",
+      "scripts/check-no-unreachable-room-links.mjs"
+    ],
     "docs/founder-kernel/wiki/principles/consult-scopes-before-asking.md": [
       "packages/dpf-skill-pack/hooks/decision-routing-guard.mjs"
     ],
@@ -3101,6 +3110,7 @@
       "scripts/check-label-association.mjs",
       "scripts/check-live-blocker-references.mjs",
       "scripts/check-mobile-jest-pin.mjs",
+      "scripts/check-no-unreachable-room-links.mjs",
       "scripts/ci-change-scope.mjs",
       "scripts/ci-policy-guards.test.mjs",
       "scripts/gate-worktree.mjs",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 698,
+  "pageCount": 699,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -3400,6 +3400,17 @@
         "what39s-still-missing",
         "how-to-navigate",
         "status-of-this-index-page"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/a-room-is-reachable-by-construction.md": {
+      "publicHref": "/founder-kernel/wiki/principles/a-room-is-reachable-by-construction/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "the-rule",
+        "why",
+        "how-it-is-enforced"
       ]
     },
     "docs/founder-kernel/wiki/principles/all-changes-land-via-pr.md": {
@@ -10735,6 +10746,7 @@
         "live-blocker-references-guard",
         "agent-principal-convergence-guard",
         "label-association-guard-ratchet",
+        "room-addressing-guard",
         "what-this-gate-is-not"
       ]
     },

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -11,5 +11,5 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma models | 626 | `packages/db/prisma/schema/` |
 | Prisma enums | 88 | `packages/db/prisma/schema/` |
 | Migrations | 572 | `packages/db/prisma/migrations/` |
-| Kernel principles | 101 | `docs/founder-kernel/wiki/principles/` |
+| Kernel principles | 102 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 659 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/founder-kernel/wiki/principles/a-room-is-reachable-by-construction.md
+++ b/docs/founder-kernel/wiki/principles/a-room-is-reachable-by-construction.md
@@ -1,0 +1,77 @@
+---
+title: A Room Is Reachable by Construction
+pageKind: principle
+status: published
+abstract: A room that exists can be opened. Its address is composed by one helper, resolved from one anchor, and never offered as a link that cannot be honoured.
+principleTier: core
+principleDirection: Compose a room's address from the canonical helper and resolve it from the canonical anchor; never spell a room path out, and never emit a link the read model cannot honour.
+principleDimensionVector: {"long_term_maintainability": 0.9, "schema_grounding": 0.85, "legibility_of_consequence": 0.7, "reusability": 0.6, "evidence_density": 0.5, "blast_radius": -0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - universal-ring
+principleConsumerArchetype: universal
+principlePublic: true
+principlePublicRationale: Adopters building surfaces over DPF work need to know that room addressing is a platform guarantee they compose against, not a URL convention they reimplement.
+---
+
+## The rule
+
+A room that exists is reachable. Four parts, all enforceable:
+
+1. **A room is addressable by construction.** Exactly one helper composes a
+   room's URL from its identity. No surface builds a room path by string
+   interpolation.
+2. **A room is resolvable from its canonical anchor.** The read model resolves a
+   room through the foreign key that anchors it, never through a naming
+   convention that may or may not have been populated.
+3. **A room that exists is reachable.** No surface emits a link to a room the
+   read model cannot resolve. If it cannot be opened, it is not offered.
+4. **A room's activities are contextual to the room's design.** What a room shows
+   derives from its own shape and projection mode, not from a default the
+   renderer assumes. A room whose projection cannot be computed degrades inside
+   its own frame; it never denies the operator the rest of the room.
+
+## Why
+
+Founder direction, 2026-09-07, on finding that no "Open room" button on the
+owner's attention inbox worked: *"The room should be reachable by design; the
+activities in that room are contextual to the design of that room."*
+
+That single symptom was four independent defects, and every one was this rule
+missing:
+
+- the attention lens composed `/ea/workrooms/<id>`, a path with no dynamic
+  segment behind it, so every card 404'd (BI-6F2CC21B);
+- the case loader resolved rooms by a naming convention instead of the
+  `Workroom.workItemId` anchor, so 405 of 462 active rooms could not be opened
+  (BI-EBEB77E2);
+- the source registry classified standing rooms as finite, so their cycle threw
+  and the uncaught error destroyed the whole page (BI-97B24FB5);
+- a backlog row built `/workspace/cases/<capsuleId>` without its source-type
+  prefix, so every workroom link on it 404'd — found by the guard this principle
+  carries, in a surface nobody had looked at.
+
+Four surfaces, four different wrong answers to the same question, none caught by
+a test. Fixing four instances leaves the fifth to be written next month. The rule
+is what closes the class, and a guard is what keeps it closed.
+
+## How it is enforced
+
+`scripts/check-no-unreachable-room-links.mjs` fails a diff that spells out a
+work-case path instead of composing it, or that links to a route prefix which
+provably cannot accept a dynamic segment. Rule 1 has no baseline — a hand-built
+work-case path is always wrong. Rule 2 carries a baseline so the class cannot
+grow while pre-existing entries are judged individually.
+
+The guard reads live repository state, so its self-test is registered as a
+`conformanceTest(...)` — see
+[[all-changes-land-via-pr]] and `scripts/check-guard-conformance-marks.mjs` for
+why an unmarked repository-reading self-test is silently stripped.
+
+Related: [[single-source-of-truth]] (one home for the addressing rule),
+[[verify-substrate-before-proposing-new]] (the classifying fact was already on
+the room), [[make-silent-failures-observable]] (a room whose cycle fails says so
+rather than reporting itself healthy).

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -1047,6 +1047,35 @@ composite widget rather than one control (a radio-group heading), add a
 is the checked-in baseline itself; file a live BI before proposing a separate
 paydown campaign.
 
+### Room Addressing Guard
+
+`scripts/check-no-unreachable-room-links.mjs` fails a PR that makes a room
+unopenable. An operator reported that no **Open room** button on the attention
+inbox worked; it was four defects across four surfaces, each a different wrong
+answer to "how do I address a room", and none caught by a test.
+
+Two rules:
+
+- **Rule 1 — no hand-built work-case path.** `/workspace/cases/${x}` must come
+  from `encodeWorkCaseKey`. A key without its source-type prefix does not decode,
+  so the link 404s. No baseline: this is always wrong.
+- **Rule 2 — no provably-unreachable link.** An interpolated link whose route
+  prefix names an App Router directory with no dynamic child can never resolve.
+  Baselined (`scripts/room-addressing-baseline.json`, owned and expiring) so the
+  class cannot grow while each pre-existing entry is judged on its own.
+
+Only link contexts are considered. `revalidatePath`, `fetch` and cache keys take
+the same shape but cannot 404 at a person; folding them in would make the guard
+noisy enough to be ignored.
+
+```bash
+node scripts/check-no-unreachable-room-links.mjs            # check (what CI runs)
+node scripts/check-no-unreachable-room-links.mjs --update   # retighten after fixing a link
+```
+
+The reasoning lives in the kernel principle
+[A Room Is Reachable by Construction](../founder-kernel/wiki/principles/a-room-is-reachable-by-construction.md).
+
 ## What this gate is NOT
 
 - **Not an e2e gate.** The Playwright suite under `tests/e2e/` runs separately on

--- a/packages/dpf-skill-pack/skills/dpf-bring-work-under-formula/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-bring-work-under-formula/SKILL.md
@@ -49,9 +49,14 @@ Clear stale active links and release retryable claims. Abandoned work returns to
 
 Write the failing adapter/projection tests first, then run the focused suites and `node --test scripts/check-work-unit-conformance.test.mjs && node scripts/check-work-unit-conformance.mjs`. Finish through `dpf-pr-with-dco` and validate the case on the canonical runtime.
 
+## 7. Make the room reachable
+
+An addressable case is not the same as a reachable one. Compose the room's URL with `encodeWorkCaseKey`, never by spelling the path out; resolve it from the `Workroom.workItemId` anchor, not from a naming convention; and do not emit a link the read model cannot honour. Let a room whose projection fails degrade inside its own frame rather than taking the page down. `scripts/check-no-unreachable-room-links.mjs` enforces this; the reasoning is the kernel principle *A Room Is Reachable by Construction*.
+
 ## Hard rules
 
 - One unit of work has one addressable case and one canonical WorkItem anchor.
+- A room that exists can be opened: composed address, canonical anchor, no link the read model cannot honour.
 - `status-projection.ts` is the single company-facing projection authority.
 - A new carrier requires an adapter + registry entry, never a forked formula.
 - No terminal carrier may silently mark implementation done without evidence.

--- a/scripts/check-no-unreachable-room-links.mjs
+++ b/scripts/check-no-unreachable-room-links.mjs
@@ -59,7 +59,8 @@ function sourceFiles(root) {
 // Rule 2 carries a baseline, the way module-size and prose-lint do. The rule is
 // enforced from today forward; the entries below are pre-existing links whose
 // prefix cannot accept a dynamic segment, recorded so the class cannot GROW
-// while each one is judged on its own (BI-ROOM-ADDR-FOLLOWUP). Rule 1 has no
+// while each one is judged on its own. The baseline file carries its own owner
+// and expiry, which is what forces that judgement. Rule 1 has no
 // baseline: a hand-built work-case path is always wrong.
 const BASELINE_PATH = join(REPO, "scripts/room-addressing-baseline.json");
 const UPDATE = process.argv.includes("--update");

--- a/scripts/check-no-unreachable-room-links.mjs
+++ b/scripts/check-no-unreachable-room-links.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// scripts/check-no-unreachable-room-links.mjs — a room is reachable by construction
+// (BI-00727E59). See scripts/lib/room-addressing-detect.mjs for why.
+//
+// This guard reads LIVE REPOSITORY STATE, so its self-test must be carried as a
+// conformanceTest(...) command — see scripts/check-guard-conformance-marks.mjs.
+
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import process from "node:process";
+
+import {
+  findHandBuiltCaseKeys,
+  findUnreachablePaths,
+} from "./lib/room-addressing-detect.mjs";
+
+const REPO = process.cwd();
+const APP_ROOT = join(REPO, "apps/web/app");
+const SCAN_ROOTS = ["apps/web/lib", "apps/web/components", "apps/web/app"];
+const SKIP = /node_modules|\.next|\.test\.|\.spec\.|__fixtures__/;
+
+function buildRouteTree(root) {
+  const tree = {};
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    const children = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    tree[dir] = children;
+    for (const child of children) walk(join(dir, child));
+  };
+  walk(root);
+  return tree;
+}
+
+function sourceFiles(root) {
+  const out = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (SKIP.test(path)) continue;
+      if (entry.isDirectory()) walk(path);
+      else if (/\.tsx?$/.test(entry.name)) out.push(path);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+// Rule 2 carries a baseline, the way module-size and prose-lint do. The rule is
+// enforced from today forward; the entries below are pre-existing links whose
+// prefix cannot accept a dynamic segment, recorded so the class cannot GROW
+// while each one is judged on its own (BI-ROOM-ADDR-FOLLOWUP). Rule 1 has no
+// baseline: a hand-built work-case path is always wrong.
+const BASELINE_PATH = join(REPO, "scripts/room-addressing-baseline.json");
+const UPDATE = process.argv.includes("--update");
+const readBaseline = () => {
+  try {
+    return new Set(JSON.parse(readFileSync(BASELINE_PATH, "utf8")).unreachableLinks ?? []);
+  } catch {
+    return new Set();
+  }
+};
+
+const tree = buildRouteTree(APP_ROOT);
+const violations = [];
+
+for (const scanRoot of SCAN_ROOTS) {
+  for (const file of sourceFiles(join(REPO, scanRoot))) {
+    const source = readFileSync(file, "utf8");
+    if (!source.includes("${")) continue;
+    for (const hit of [
+      ...findHandBuiltCaseKeys(source),
+      ...findUnreachablePaths(source, tree, APP_ROOT),
+    ]) {
+      violations.push({ file: relative(REPO, file), ...hit });
+    }
+  }
+}
+
+const baseline = readBaseline();
+const keyOf = (v) => `${v.file}::${v.prefix}`;
+
+if (UPDATE) {
+  const keys = [...new Set(violations.filter((v) => v.kind === "unreachable-path").map(keyOf))].sort();
+  const previous = (() => {
+    try {
+      return JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+    } catch {
+      return {};
+    }
+  })();
+  const payload = {
+    version: 1,
+    owner: previous.owner ?? "platform-architecture",
+    expiry: previous.expiry ?? "2026-12-07",
+    note: "Room-addressing Rule 2 baseline (BI-00727E59). Shrink-only: each entry is a link whose route prefix cannot accept a dynamic segment, recorded so the class cannot grow while each is judged on its own. Regenerate with: node scripts/check-no-unreachable-room-links.mjs --update",
+    unreachableLinks: keys,
+  };
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(payload, null, 2)}\n`);
+  console.log(`Wrote room-addressing baseline: ${keys.length} recorded link(s).`);
+  process.exit(0);
+}
+
+const stale = [...baseline].filter(
+  (key) => !violations.some((v) => v.kind === "unreachable-path" && keyOf(v) === key),
+);
+const unbaselined = violations.filter(
+  (v) => v.kind === "hand-built-case-key" || !baseline.has(keyOf(v)),
+);
+
+if (stale.length > 0) {
+  console.error("Room addressing — baseline entries no longer present; retighten with --update:\n");
+  for (const key of stale) console.error(`  - ${key}`);
+  process.exit(1);
+}
+
+const remaining = unbaselined;
+if (remaining.length > 0) {
+  console.error("Room addressing — a room must be reachable by construction (BI-00727E59).\n");
+  for (const v of remaining) {
+    if (v.kind === "hand-built-case-key") {
+      console.error(`  ${v.file}:${v.line}`);
+      console.error(`    a work-case path is spelled out: \`${v.prefix}\${${v.expression}}\``);
+      console.error("    compose it with encodeWorkCaseKey() — one home for the room address.\n");
+    } else {
+      console.error(`  ${v.file}:${v.line}`);
+      console.error(`    \`${v.prefix}\${...}\` can never resolve: ${v.prefix} names a route`);
+      console.error("    directory with no dynamic segment, so every such URL 404s.\n");
+    }
+  }
+  console.error("This is the class behind BI-6F2CC21B, BI-EBEB77E2 and BI-97B24FB5: a room");
+  console.error("that exists but cannot be opened, shipped because nothing asserted the link.");
+  process.exit(1);
+}
+
+console.log(`Room addressing OK — no hand-built work-case paths, no provably-unreachable room links (${Object.keys(tree).length} route dirs scanned). guard passed`);

--- a/scripts/check-no-unreachable-room-links.test.mjs
+++ b/scripts/check-no-unreachable-room-links.test.mjs
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { discoverGuardFiles } from "./check-guards.mjs";
+import {
+  acceptsDynamicChild,
+  findHandBuiltCaseKeys,
+  findInterpolatedPaths,
+  findUnreachablePaths,
+  isLinkContext,
+  resolveRouteDirs,
+} from "./lib/room-addressing-detect.mjs";
+
+// A tiny App Router tree: /workspace/cases/[caseKey] exists behind a route
+// group; /ea/workrooms has no dynamic child, which is exactly the BI-6F2CC21B
+// shape.
+const ROOT = "/app";
+const TREE = {
+  "/app": ["(shell)"],
+  "/app/(shell)": ["workspace", "ea"],
+  "/app/(shell)/workspace": ["cases"],
+  "/app/(shell)/workspace/cases": ["[caseKey]"],
+  "/app/(shell)/workspace/cases/[caseKey]": [],
+  "/app/(shell)/ea": ["workrooms"],
+  "/app/(shell)/ea/workrooms": [],
+};
+
+test("a route group is transparent when resolving a path prefix", () => {
+  assert.deepEqual(resolveRouteDirs(TREE, ROOT, ["workspace", "cases"]), [
+    "/app/(shell)/workspace/cases",
+  ]);
+  assert.deepEqual(resolveRouteDirs(TREE, ROOT, ["nope"]), []);
+});
+
+test("a dynamic child is detected through a route group", () => {
+  assert.equal(acceptsDynamicChild(TREE, ["/app/(shell)/workspace/cases"]), true);
+  assert.equal(acceptsDynamicChild(TREE, ["/app/(shell)/ea/workrooms"]), false);
+});
+
+test("RED: the BI-6F2CC21B defect — a link to a route with no dynamic segment", () => {
+  const source = 'const a = { href: `/ea/workrooms/${row.capsuleId}` };';
+  const hits = findUnreachablePaths(source, TREE, ROOT);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].prefix, "/ea/workrooms/");
+});
+
+test("GREEN: a link to a route that does accept a dynamic segment passes", () => {
+  const source = 'const a = { href: `/workspace/cases/${key}` };';
+  assert.deepEqual(findUnreachablePaths(source, TREE, ROOT), []);
+});
+
+test("RED: the BacklogItemRow defect — a work-case path spelled out by hand", () => {
+  const source = 'href={`/workspace/cases/${room.capsuleId}`}';
+  const hits = findHandBuiltCaseKeys(source);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].kind, "hand-built-case-key");
+});
+
+test("GREEN: the canonical helper composes the address", () => {
+  const source =
+    'href={`/workspace/cases/${encodeWorkCaseKey({ sourceType: "work-capsule", sourceId: id })}`}';
+  assert.deepEqual(findHandBuiltCaseKeys(source), []);
+});
+
+test("a non-link path of the same shape is out of scope", () => {
+  // revalidatePath cannot 404 at a person; folding it in would make the guard
+  // noisy enough to be ignored.
+  const source = "revalidatePath(`/ea/workrooms/${buildId}`);";
+  assert.deepEqual(findUnreachablePaths(source, TREE, ROOT), []);
+  assert.equal(isLinkContext(source, source.indexOf("`")), false);
+});
+
+test("a whole computed path carries no route signal", () => {
+  assert.deepEqual(findInterpolatedPaths("const p = `/${slug}`;"), []);
+});
+
+test("mid-segment interpolation is not a path join", () => {
+  assert.deepEqual(findInterpolatedPaths("const p = `/cases-${id}`;"), []);
+});
+
+test("guard follows check-no convention and passes on the live tree", () => {
+  const source = readFileSync(new URL("./check-no-unreachable-room-links.mjs", import.meta.url), "utf8");
+  assert.match(source, /room-addressing-detect/);
+  const discovered = discoverGuardFiles(readdirSync(new URL(".", import.meta.url)));
+  assert.ok(discovered.guards.includes("check-no-unreachable-room-links.mjs"));
+  assert.ok(discovered.tests.has("check-no-unreachable-room-links.test.mjs"));
+  const execution = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL("./check-no-unreachable-room-links.mjs", import.meta.url))],
+    { encoding: "utf8", cwd: fileURLToPath(new URL("..", import.meta.url)) },
+  );
+  assert.equal(execution.status, 0, execution.stderr);
+  assert.match(execution.stdout, /guard passed/i);
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -56,6 +56,7 @@ const EXPECTED_LEGACY_JOBS = [
   "module-size-guard",
   "n-minus-one-caller-honesty",
   "new-dependency-gate",
+  "no-unreachable-room-links",
   "override-provenance-guard",
   "package-boundary-guard",
   "platform-composition-single-home",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -333,6 +333,15 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-n-minus-one-caller-honesty.test.mjs"),
       node("scripts/check-n-minus-one-caller-honesty.mjs"),
     ], { inputs: ["code"] }),
+    // BI-00727E59: an operator reported that no "Open room" button worked. It
+    // was three defects stacked on one button (BI-6F2CC21B, BI-EBEB77E2,
+    // BI-97B24FB5) and a fourth found by this guard — every one the same
+    // missing rule: nothing guaranteed a room was reachable, so each surface
+    // re-derived how to address one. This closes the class.
+    guard("no-unreachable-room-links", "Room Addressing Guard", [
+      node("scripts/check-no-unreachable-room-links.mjs"),
+      conformanceTest("scripts/check-no-unreachable-room-links.test.mjs"),
+    ], { inputs: ["code"] }),
     guard("module-size-guard", "Module Size Guard", [
       node("scripts/check-module-size.mjs"),
     ], { inputs: ["code"] }),

--- a/scripts/lib/room-addressing-detect.mjs
+++ b/scripts/lib/room-addressing-detect.mjs
@@ -1,0 +1,117 @@
+// scripts/lib/room-addressing-detect.mjs — pure detection for the room-addressing
+// guard (BI-00727E59). Kept separate from the guard so the guard's own self-test
+// can exercise red and green fixtures without touching the repository.
+//
+// WHY THIS EXISTS. An operator reported that no "Open room" button on the
+// Needs-you inbox worked. It was three defects stacked on one button, and all
+// three were the same missing rule wearing different clothes: nothing guarantees
+// a room is reachable, so each surface re-derived how to address one and each got
+// it wrong differently. The attention lens invented `/ea/workrooms/<id>`, a path
+// with no dynamic segment behind it, so every card 404'd — and no test failed,
+// because nothing asserted the link resolved.
+//
+// Two rules, both statically decidable:
+//
+//   1. ADDRESSABILITY — a work-case path is composed by the canonical helper,
+//      never spelled out. `/workspace/cases/${x}` where x does not come from
+//      encodeWorkCaseKey is a second home for the addressing rule.
+//
+//   2. REACHABILITY — an interpolated app path whose static prefix names a real
+//      App Router directory that has NO dynamic child cannot resolve, ever. That
+//      is the BI-6F2CC21B defect generalized: provably 404 at author time.
+
+/** A route group "(shell)" adds nesting without consuming a URL segment. */
+const isRouteGroup = (name) => name.startsWith("(") && name.endsWith(")");
+const isDynamic = (name) => name.startsWith("[") && name.endsWith("]");
+
+/**
+ * Walk an App Router tree description to the directory a static path prefix
+ * names. `tree` is a map of dirPath -> child directory names, so the caller
+ * supplies the filesystem and this stays pure.
+ * Returns the resolved directory paths (a prefix can resolve through more than
+ * one route group), or [] when the prefix names nothing.
+ */
+export function resolveRouteDirs(tree, root, segments) {
+  let frontier = [root];
+  for (const segment of segments) {
+    const next = [];
+    for (const dir of frontier) {
+      for (const child of tree[dir] ?? []) {
+        const childPath = `${dir}/${child}`;
+        if (isRouteGroup(child)) {
+          frontier.push(childPath); // transparent: re-examine at this same segment
+          continue;
+        }
+        if (child === segment) next.push(childPath);
+      }
+    }
+    if (next.length === 0) return [];
+    frontier = next;
+  }
+  return frontier;
+}
+
+/** Does any resolved directory accept a further dynamic segment? */
+export function acceptsDynamicChild(tree, dirs) {
+  return dirs.some((dir) =>
+    (tree[dir] ?? []).some(
+      (child) =>
+        isDynamic(child)
+        || (isRouteGroup(child) && acceptsDynamicChild(tree, [`${dir}/${child}`])),
+    ),
+  );
+}
+
+/** Interpolated absolute paths in a source file: `/a/b/${...}`. */
+export function findInterpolatedPaths(source) {
+  const found = [];
+  const pattern = /`(\/[A-Za-z0-9._~\-/]*?)\$\{([^`]*?)\}/g;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    const prefix = match[1];
+    if (!prefix.endsWith("/")) continue; // interpolation mid-segment, not a path join
+    const segments = prefix.split("/").filter(Boolean);
+    // `/${x}` is a computed whole path, not a route join — every route would
+    // "match" its empty prefix, so it carries no signal.
+    if (segments.length === 0) continue;
+    found.push({ prefix, expression: match[2], index: match.index, segments });
+  }
+  return found;
+}
+
+/** Is this interpolation used as a link a person can follow?
+ *
+ *  Only a LINK can 404 at a user. revalidatePath, fetch and cache keys take the
+ *  same shape and are out of scope: a wrong path there is a different defect
+ *  with a different fix, and folding them in would make the guard noisy enough
+ *  to be ignored. */
+export function isLinkContext(source, index) {
+  const window = source.slice(Math.max(0, index - 120), index);
+  return /\b(href|deepLink|linkTo|connectHref|actionHref|url)\s*[:=]\s*$|\b(href|deepLink|connectHref)\s*[:=]\s*$/i.test(
+    window.replace(/\s+$/, "") + "",
+  ) || /\b(href|deepLink|connectHref|linkTo|actionHref)\b[^;]{0,40}$/i.test(window);
+}
+
+export function lineOf(source, index) {
+  return source.slice(0, index).split("\n").length;
+}
+
+/** Rule 1: a work-case path must come from the canonical helper. */
+export function findHandBuiltCaseKeys(source) {
+  return findInterpolatedPaths(source)
+    .filter((hit) => hit.prefix === "/workspace/cases/")
+    .filter((hit) => !/encodeWorkCaseKey|caseKey|canonicalKey/.test(hit.expression))
+    .map((hit) => ({ kind: "hand-built-case-key", line: lineOf(source, hit.index), ...hit }));
+}
+
+/** Rule 2: an interpolated path whose prefix cannot accept a dynamic segment. */
+export function findUnreachablePaths(source, tree, root) {
+  return findInterpolatedPaths(source)
+    .filter((hit) => isLinkContext(source, hit.index))
+    .map((hit) => ({ hit, dirs: resolveRouteDirs(tree, root, hit.segments) }))
+    // A prefix that names no route directory at all is not this guard's business:
+    // it may be an API path, an external URL, or a non-route string.
+    .filter(({ dirs }) => dirs.length > 0)
+    .filter(({ tree: _t, dirs }) => !acceptsDynamicChild(tree, dirs))
+    .map(({ hit }) => ({ kind: "unreachable-path", line: lineOf(source, hit.index), ...hit }));
+}

--- a/scripts/room-addressing-baseline.json
+++ b/scripts/room-addressing-baseline.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "owner": "platform-architecture",
+  "expiry": "2026-12-07",
+  "note": "Room-addressing Rule 2 baseline (BI-00727E59). Shrink-only: each entry is a link whose route prefix cannot accept a dynamic segment, recorded so the class cannot grow while each is judged on its own. Regenerate with: node scripts/check-no-unreachable-room-links.mjs --update",
+  "unreachableLinks": [
+    "apps/web/app/(shell)/finance/my-expenses/MyExpensesTable.tsx::/finance/my-expenses/",
+    "apps/web/components/customer-marketing/PublishEmailButton.tsx::/platform/tools/integrations/",
+    "apps/web/components/customer-marketing/PublishLinkedInButton.tsx::/platform/tools/integrations/",
+    "apps/web/lib/decision/decision-origin.ts::/build/"
+  ]
+}


### PR DESCRIPTION
An operator reported that no **Open room** button on the Needs-you inbox worked. That was three defects stacked on one button ([#5193](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5193), [#5194](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5194), [#5202](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5202)) — and every one was the same missing rule: nothing guaranteed a room was reachable, so each surface re-derived how to address one and each got it wrong differently.

Fixing three instances leaves the fourth to be written next month. **This closes the class.**

## The guard found the fourth instance immediately

In a surface nobody had looked at: `apps/web/components/ops/BacklogItemRow.tsx` built `/workspace/cases/<capsuleId>` without its source-type prefix, so every workroom link on a backlog row 404'd. Fixed here — and its test had asserted the *broken* URL, so the test encoded the bug. That assertion is corrected too.

## What lands

- **Kernel principle** `a-room-is-reachable-by-construction` (core tier) — the four-part rule and the founder direction behind it. **No AGENTS.md line:** the always-on instruction plane is shrink-only (BI-0020D511) and §11 already makes `wiki_query` the retrieval path for kernel doctrine, so a pointer would spend always-on budget duplicating what the kernel serves.
- **`scripts/check-no-unreachable-room-links.mjs`**, extending the existing `check-no-*` guard substrate rather than standing up a parallel one:
  - **Rule 1** — a work-case path composed by hand instead of by `encodeWorkCaseKey`. *No baseline: always wrong.*
  - **Rule 2** — a link whose route prefix provably cannot accept a dynamic segment. Baselined the way module-size and prose-lint are (owned, expiring), so the class cannot grow while the 4 pre-existing entries are judged individually.
- Detection is pure (`scripts/lib/room-addressing-detect.mjs`) so the self-test runs red/green fixtures without touching the repo — including the BI-6F2CC21B and BacklogItemRow shapes as explicit RED cases.
- Registered with `conformanceTest(...)`, because the guard reads live repository state and an unmarked repository-reading self-test is silently stripped by the pregate preflight.
- Cross-referenced from the `dpf-bring-work-under-formula` skill. An addressable case is not the same as a reachable one.
- Documented in `docs/testing/pre-pr-gate.md`.

## Deliberately not enforced

`revalidatePath`, `fetch` and cache keys take the same shape but cannot 404 at a person. Folding them in took the guard from 6 findings to 31, mostly noise — and a noisy guard is an ignored guard. Scoping to link contexts is what makes it trustworthy.

## Follow-up this surfaces

The Rule 2 baseline records 4 pre-existing links, and at least one looks like a genuine live 404 (`/finance/my-expenses/${c.id}`, where the route has no `[id]` segment). The baseline is owned and expires 2026-12-07 so they get judged rather than forgotten. I have not filed a BI for these yet — happy to, or leave them to the expiry review.

## Verification

- `node --test scripts/check-no-unreachable-room-links.test.mjs` — **10/10**, RED fixtures for both defect shapes, GREEN for the canonical helper
- `node scripts/check-no-unreachable-room-links.mjs` — passes on the live tree (841 route dirs)
- `check-guard-conformance-marks` / `check-ci-policy-test-inventory` / `check-no-expired-baseline-budgets` — all OK
- `golden-decisions` — the new principle does not destabilise the canonical decision baseline (2 decisions still hold)
- `vitest components/ops` — 217/217 · `tsc --noEmit` — clean
- Local-CI gate passed on gated sha `88127deeacd2`, production build compiled successfully

Refs: BI-00727E59 · BI-6F2CC21B · BI-EBEB77E2 · BI-97B24FB5

Local-CI-Evidence: cmtrub9us0dkh01qsmi2ckkkc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default

The kernel principle and the skill note are universal platform doctrine, not archetype- or vertical-specific: every install has rooms, and a room that exists but cannot be opened is a defect on all of them. The rule carries no archetype vocabulary and no install-local paths, and the guard it points at runs in the shared CI profile for every contributor surface.

Local-CI-Evidence: cmtrub9us0dkh01qsmi2ckkkc
