### PR TITLE
refactor(nav): one name means one destination — end two duplicate nav labels (BI-2DBC4D2D)

### DIFF
--- a/apps/web/components/platform/identity/IdentityTabNav.test.tsx
+++ b/apps/web/components/platform/identity/IdentityTabNav.test.tsx
@@ -37,7 +37,7 @@ describe("IdentityTabNav", () => {
     expect(html).toContain(">Federation<");
     expect(html).toContain(">Applications<");
     expect(html).toContain(">Authorization<");
-    expect(html).toContain(">AI Coworkers<");
+    expect(html).toContain(">Coworker Identity<");
   });
 
   it("marks nested identity routes as active", () => {

--- a/apps/web/components/platform/identity/IdentityTabNav.tsx
+++ b/apps/web/components/platform/identity/IdentityTabNav.tsx
@@ -11,7 +11,7 @@ const TABS = [
   { label: "Federation", href: "/platform/identity/federation" },
   { label: "Applications", href: "/platform/identity/applications" },
   { label: "Authorization", href: "/platform/identity/authorization" },
-  { label: "AI Coworkers", href: "/platform/identity/agents" },
+  { label: "Coworker Identity", href: "/platform/identity/agents" },
 ];
 
 // Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -44,7 +44,7 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       { label: "Identity Federation (SSO)", href: "/platform/identity/federation" },
       { label: "Applications", href: "/platform/identity/applications" },
       { label: "Authorization", href: "/platform/identity/authorization" },
-      { label: "AI Coworkers", href: "/platform/identity/agents" },
+      { label: "Coworker Identity", href: "/platform/identity/agents" },
     ],
   },
   {
@@ -120,7 +120,7 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       { label: "Ledger", href: "/platform/audit/ledger" },
       { label: "Journal", href: "/platform/audit/journal" },
       { label: "Routes", href: "/platform/audit/routes" },
-      { label: "Operations", href: "/platform/audit/operations" },
+      { label: "Jobs", href: "/platform/audit/operations" },
       { label: "Authority", href: "/platform/audit/authority" },
       { label: "Metrics", href: "/platform/audit/metrics" },
     ],

--- a/apps/web/lib/navigation/portal-navigation-model.test.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.test.ts
@@ -164,3 +164,34 @@ describe("portal navigation model", () => {
     expect(activityish).toHaveLength(1);
   });
 });
+
+describe("one name means one destination", () => {
+  // An operator reported being unable to remember the difference between two
+  // areas. The cause was literal: two entries carried the byte-identical label
+  // "AI Coworkers" for different destinations (/workforce and
+  // /platform/identity/agents), so the portal offered the same words twice and
+  // neither name said which was which. A duplicate label is not a style
+  // preference — it makes the navigation unusable by name.
+  it("gives no two nav entries the same label", () => {
+    const byLabel = new Map<string, string[]>();
+    for (const route of PORTAL_NAV_ROUTES) {
+      const paths = byLabel.get(route.label) ?? [];
+      paths.push(route.path);
+      byLabel.set(route.label, paths);
+    }
+    const collisions = [...byLabel.entries()]
+      .filter(([, paths]) => new Set(paths).size > 1)
+      .map(([label, paths]) => `${label} -> ${[...new Set(paths)].sort().join(" , ")}`);
+    expect(collisions).toEqual([]);
+  });
+
+  it("keeps the coworker directory and the identity surface distinctly named", () => {
+    const label = (path: string) =>
+      PORTAL_NAV_ROUTES.find((route) => route.path === path)?.label;
+    const directory = label("/workforce");
+    const identity = label("/platform/identity/agents");
+    expect(directory).toBeTruthy();
+    expect(identity).toBeTruthy();
+    expect(identity).not.toBe(directory);
+  });
+});

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -619,7 +619,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   },
   {
     key: "platform-identity-agents",
-    label: "AI Coworkers",
+    label: "Coworker Identity",
     path: "/platform/identity/agents",
     parentPath: "/platform/identity",
     domain: "platform",
@@ -803,7 +803,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   },
   {
     key: "platform-audit-operations",
-    label: "Operations",
+    label: "Jobs",
     path: "/platform/audit/operations",
     parentPath: "/platform/audit",
     domain: "platform",

--- a/docs/ux-fit/2026-09-08-nav-label-collisions.ux-fit.json
+++ b/docs/ux-fit/2026-09-08-nav-label-collisions.ux-fit.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "decidedOption": "rename-in-place-no-budget-change",
+  "scope": {
+    "files": [
+      "apps/web/components/platform/identity/IdentityTabNav.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "held",
+    "measured": {
+      "/platform/identity/agents": {
+        "defaultVisibleWords": 3439,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 2
+      },
+      "/platform/audit/operations": {
+        "defaultVisibleWords": 122,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
> "I already can't remember the difference between ai workforce and ai coworkers."

The cause was literal, not a matter of taste: **two pairs of navigation entries carried byte-identical labels for different destinations**, so the portal offered the same words twice and neither name said which was which.

## The collisions

Across 62 nav entries:

| Label | Destination A | Destination B |
| --- | --- | --- |
| `AI Coworkers` | `/workforce` — the coworker directory | `/platform/identity/agents` — identity and access |
| `Operations` | `/workspace` — the operator's own area | `/platform/audit/operations` — long-running jobs |

`/platform/identity/agents` sits beside Directory, Federation, Applications and Authorization and manages a coworker's identity and access, so it is now **Coworker Identity**. `/platform/audit/operations` is headed "Long-running Operations" over an async operations table, so it is now **Jobs**.

Each replacement keeps its predecessor's word count — two words and one word. A rename is not licence to grow a page.

## The durable part is the test, not the renames

A duplicate label makes navigation unusable by name, and nothing prevented the next one. `one name means one destination` fails if any two entries ever share a label.

It earned its keep immediately: I went looking only for the `AI Coworkers` collision the operator named, and the test found `Operations` on its first run.

## Verification

The full web suite: **28,789 tests passing**. Typecheck clean.

Measured on a rendered portal against a seeded database — both affected routes hold their frozen baselines exactly, `ok: true` and `structureChanged: false`, confirming no text budget moved:

| Route | Words on arrival | Structure |
| --- | --- | --- |
| `/platform/identity/agents` | 3,439 (unchanged) | unchanged |
| `/platform/audit/operations` | 122 (unchanged) | unchanged |

The three routes the local sweep reports as regressed — `/build/work`, `/inventory`, `/platform/tools/discovery` — are untouched by this change and are local fixture drift; CI is authoritative.

## What this does not do

It does not consolidate the surfaces themselves. Three directories over the same population still exist, `/platform/ai/*` still holds 33 routes and `/coworker-decisions/*` another 13, and `/ea/agents` is still a bare redirect marking where an earlier consolidation stopped. That work stays on BI-2DBC4D2D, which carries the full 327-route map. This is the part that removes the confusion actually reported, at no blast radius.

Worth noting for that work: `/platform/identity/agents` renders **3,439 words on arrival** against a 450-word budget — the second-worst surface in the portal. Renaming it does not make it findable.

Design-Grounding-Decision: no-contract-change (renames two colliding navigation labels and pins label uniqueness with a test; no routing, capability or contract change, and each replacement keeps its predecessor's word count so no measured budget moves)

Local-CI-Evidence: cmtry4tlr4d7l01qssbnfndk5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
