### PR TITLE
doc(plan): record the coverage table and name the receipt blocker (BI-8DACBA07)

### DIFF
--- a/docs/superpowers/plans/2026-09-07-portfolio-work-activity.md
+++ b/docs/superpowers/plans/2026-09-07-portfolio-work-activity.md
@@ -14,6 +14,28 @@ Delivery shape: decomposed, xlarge. This PR publishes the accepted visual direct
 
 Requirements, contracts, flows and verification IDs below are sections in the canonical design. Existing items retain their broader scope and status. Dependencies are delivery keys, not copied workrooms.
 
+**Formal coverage receipt: blocked, and this table stands in its place.** A
+`record_plan_backlog_coverage` receipt was attempted against this plan at its
+immutable blob and was refused, correctly:
+
+> no initiative scope baseline exists for this initiative
+
+A scope baseline is minted only by a passing `spec-approval` receipt from an
+independent reviewer. On this install every reviewer dispatch is intercepted by
+the generic coworker approval envelope and expires unapproved, so no receipt of
+any kind can be written — the condition recorded as BI-F2E199B1. The refusal
+tool's own guidance for this state is to record the coverage table in the plan
+and state the blocking condition rather than cite a backlog id that goes stale,
+which is what this note does.
+
+The route the refusal offers — claiming this xlarge initiative with
+`workIntent: implementation` to obtain the reviewer packet — is deliberately not
+taken. The operator direction on this work is explicit: do not bypass that
+refusal and do not reclassify the initiative. Delivery has proceeded through
+appropriately shaped items instead, each with its own scoped PR, tests, gate
+evidence and recorded execution evidence. The table above is the coverage; what
+is missing is the receipt, not the mapping.
+
 | Key | Deliverable / live backlog | Depends on | Requirements | Contracts | Flows | Verification |
 | --- | --- | --- | --- | --- | --- | --- |
 | D1 | Portfolio placement derivation and reconciliation — BI-FB6389E0 (existing) | — | PWA-01 | C1 | F1 | V1 |


### PR DESCRIPTION
`record_plan_backlog_coverage` was attempted against this plan at its immutable blob and refused, correctly:

> BacklogItem BI-8DACBA07 has no initiative scope baseline, so plan coverage cannot be bound to a governed scope.

A scope baseline is minted only by a passing `spec-approval` receipt from an independent reviewer. On this install every reviewer dispatch is intercepted by the generic coworker approval envelope and expires unapproved — the condition recorded as BI-F2E199B1. The defect blocks its own repair, because repairing it would itself need a receipt.

## What this PR does

The refusal's own guidance for exactly this state is to record the coverage table in the plan and state the blocking condition, rather than cite a backlog id that goes stale when it closes. That is what this adds — a short note beside the existing D1–D5 coverage table naming the condition in words.

## What this PR deliberately does not do

The refusal offers a second route: claim the xlarge initiative with `workIntent: implementation` to obtain the reviewer packet. **Not taken.** The operator direction on this work is explicit — do not bypass that refusal and do not reclassify the initiative. Delivery has run through appropriately shaped items instead, each with its own scoped PR, tests, gate evidence and recorded execution evidence.

The mapping is complete. What is missing is the receipt, not the coverage — and saying so plainly is more useful than an unbacked claim that coverage is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
