### PR TITLE
fix(readiness): immutable reader serves a commit+path locator without a blob id; review packets carry the blob id (BI-331F527B)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/repository-artifact.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/repository-artifact.test.ts
@@ -90,13 +90,26 @@ describe("resolveRepositoryArtifact", () => {
         transportFactory: () => ({ fetch: isolatedFetch as unknown as typeof fetch, close }),
       } as never);
 
-      expect(result).toEqual({ ok: true, data: bytes });
+      expect(result).toEqual({ ok: true, data: bytes, blobId: locator.providerBlobId });
       expect(isolatedFetch).toHaveBeenCalledTimes(1);
       expect(frameworkFetch).not.toHaveBeenCalled();
       expect(close).toHaveBeenCalledTimes(1);
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("serves a commit+path locator without an expected blob id and reports the blob the provider returned", async () => {
+    const isolatedFetch = providerFetch();
+    const result = await readRepositoryProviderBlob({
+      repositoryFullName: locator.repositoryFullName,
+      commitSha: locator.commitSha,
+      path: locator.path,
+      expectedBlobId: null,
+      db: db() as never,
+      transportFactory: () => ({ fetch: isolatedFetch as unknown as typeof fetch, close: vi.fn().mockResolvedValue(undefined) }),
+    } as never);
+    expect(result).toEqual({ ok: true, data: bytes, blobId: locator.providerBlobId });
   });
 
   it("maps production transport construction failure to an immutable-source refusal", async () => {
@@ -167,7 +180,7 @@ describe("resolveRepositoryArtifact", () => {
       expectedBlobId: locator.providerBlobId,
       db: db() as never,
       fetchImpl: fetchImpl as typeof fetch,
-    })).resolves.toEqual({ ok: true, data: bytes });
+    })).resolves.toEqual({ ok: true, data: bytes, blobId: locator.providerBlobId });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
@@ -219,7 +232,7 @@ describe("resolveRepositoryArtifact", () => {
       expectedBlobId: locator.providerBlobId,
       db: db() as never,
       fetchImpl: transient as typeof fetch,
-    })).resolves.toEqual({ ok: true, data: bytes });
+    })).resolves.toEqual({ ok: true, data: bytes, blobId: locator.providerBlobId });
     expect(transient).toHaveBeenCalledTimes(2);
     expect(cancel).toHaveBeenCalledTimes(1);
   });
@@ -272,7 +285,7 @@ describe("resolveRepositoryArtifact", () => {
       fetchImpl: fetchImpl as typeof fetch,
     });
 
-    expect(result).toEqual({ ok: true, data: bytes });
+    expect(result).toEqual({ ok: true, data: bytes, blobId: locator.providerBlobId });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl).toHaveBeenCalledWith(
       expect.stringContaining(`/contents/docs/superpowers/plans/test.md?ref=${locator.commitSha}`),

--- a/apps/web/lib/backlog/initiative-readiness/repository-artifact.ts
+++ b/apps/web/lib/backlog/initiative-readiness/repository-artifact.ts
@@ -62,7 +62,7 @@ function encodePath(path: string): string | null {
 }
 
 type RepositoryProviderBlobResult =
-  | ActionSuccess<Uint8Array>
+  | (ActionSuccess<Uint8Array> & { /** The blob the provider actually served; equals expectedBlobId when one was given. */ blobId: string })
   | {
       ok: false;
       code:
@@ -158,7 +158,7 @@ async function fetchGithubJson(args: {
   return { ok: false, kind: "transport", attempts: MAX_PROVIDER_ATTEMPTS };
 }
 
-function decodeGithubContent(payload: unknown, expectedBlobId: string): RepositoryProviderBlobResult {
+function decodeGithubContent(payload: unknown, expectedBlobId: string | null): RepositoryProviderBlobResult {
   if (!payload || typeof payload !== "object") {
     return { ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE", error: "Repository provider returned unreadable artifact metadata." };
   }
@@ -166,15 +166,21 @@ function decodeGithubContent(payload: unknown, expectedBlobId: string): Reposito
   if (row.type !== "file" || row.encoding !== "base64" || typeof row.content !== "string") {
     return { ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE", error: "Repository provider returned unreadable artifact metadata." };
   }
-  if (row.sha !== expectedBlobId) {
+  if (typeof row.sha !== "string" || !/^[a-f0-9]{40}$/i.test(row.sha)) {
+    return { ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE", error: "Repository provider returned unreadable artifact metadata." };
+  }
+  // A commit + path locator is already immutable; the blob id is verification
+  // when the caller has one, not a precondition for serving the artifact.
+  if (expectedBlobId !== null && row.sha !== expectedBlobId) {
     return { ok: false, code: "IMMUTABLE_BLOB_MISMATCH", error: "Repository provider blob identity does not match the requested locator." };
   }
+  const blobId = row.sha;
   if (typeof row.size === "number" && row.size > MAX_REPOSITORY_ARTIFACT_BYTES) {
     return { ok: false, code: "IMMUTABLE_SOURCE_TOO_LARGE", error: "Repository artifact exceeds the 1 MiB immutable reader ceiling." };
   }
   const bytes = Buffer.from(row.content.replace(/\s/g, ""), "base64");
   return bytes.byteLength <= MAX_REPOSITORY_ARTIFACT_BYTES
-    ? ok(bytes)
+    ? { ...ok(bytes), blobId }
     : { ok: false, code: "IMMUTABLE_SOURCE_TOO_LARGE", error: "Repository artifact exceeds the 1 MiB immutable reader ceiling." };
 }
 
@@ -184,11 +190,15 @@ async function fetchRepositoryProviderBlob(args: {
   token: string | null;
   commitSha: string;
   path: string;
-  expectedBlobId: string;
+  expectedBlobId: string | null;
   fetchImpl: typeof fetch;
 }): Promise<RepositoryProviderBlobResult> {
   const encodedPath = encodePath(args.path);
-  if (!encodedPath || !/^[a-f0-9]{40}$/i.test(args.commitSha) || !/^[a-f0-9]{40}$/i.test(args.expectedBlobId)) {
+  if (
+    !encodedPath
+    || !/^[a-f0-9]{40}$/i.test(args.commitSha)
+    || (args.expectedBlobId !== null && !/^[a-f0-9]{40}$/i.test(args.expectedBlobId))
+  ) {
     return { ok: false, code: "IMMUTABLE_SOURCE_IDENTITY_INVALID", error: "Repository artifact locator is not a recognized immutable provider blob." };
   }
   const result = await fetchGithubJson({
@@ -218,7 +228,8 @@ export async function readRepositoryProviderBlob(args: {
   repositoryFullName: string;
   commitSha: string;
   path: string;
-  expectedBlobId: string;
+  /** Verification when known. A commit + path locator is served without it. */
+  expectedBlobId?: string | null;
   db?: Pick<RepositoryArtifactDb, "credentialEntry" | "platformDevConfig" | "scheduledJob">;
   fetchImpl?: typeof fetch;
   transportFactory?: () => GithubReadTransport;
@@ -253,7 +264,7 @@ export async function readRepositoryProviderBlob(args: {
       token,
       commitSha: args.commitSha,
       path: args.path,
-      expectedBlobId: args.expectedBlobId,
+      expectedBlobId: args.expectedBlobId ?? null,
       fetchImpl: args.fetchImpl ?? transport!.fetch,
     });
   } finally {

--- a/apps/web/lib/mcp/packs/version-history-pack.test.ts
+++ b/apps/web/lib/mcp/packs/version-history-pack.test.ts
@@ -291,6 +291,7 @@ describe("version-history pack — handler behavior (delegation preserved)", () 
     repositoryArtifact.readRepositoryProviderBlob.mockResolvedValue({
       ok: true,
       data: Buffer.from("remote immutable bytes\n", "utf8"),
+      blobId: "b".repeat(40),
     });
     const res = await versionHistoryPack.handlers.read_source_at_version({
       repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
@@ -318,7 +319,36 @@ describe("version-history pack — handler behavior (delegation preserved)", () 
     expect(gitUtils.gitShow).not.toHaveBeenCalled();
   });
 
-  it("fails closed instead of falling back without a complete immutable provider identity", async () => {
+  it("reads a provider blob by commit and path when no blob id is supplied, and returns the provider's blob id", async () => {
+    // A reviewer dispatched over native MCP sees the reader's ordinary schema and
+    // knows the commit and path but not the blob id (the bound schema that
+    // carries it never reaches a native tools/list). Commit + path is already
+    // immutable, so the provider serves it and names the blob it returned.
+    gitUtils.gitBlobId.mockResolvedValue({ error: "unknown revision" });
+    repositoryArtifact.readRepositoryProviderBlob.mockResolvedValue({
+      ok: true,
+      data: Buffer.from("remote immutable bytes\n", "utf8"),
+      blobId: "c".repeat(40),
+    });
+    const res = await versionHistoryPack.handlers.read_source_at_version({
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      path: "docs/spec.md",
+      version: "a".repeat(40),
+    }, "u1");
+
+    expect(res).toMatchObject({
+      success: true,
+      data: { blobId: "c".repeat(40), content: "remote immutable bytes\n", version: "a".repeat(40) },
+    });
+    expect(repositoryArtifact.readRepositoryProviderBlob).toHaveBeenCalledWith({
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      commitSha: "a".repeat(40),
+      path: "docs/spec.md",
+      expectedBlobId: null,
+    });
+  });
+
+  it("fails closed without falling back when the repository is not named, and says what is missing", async () => {
     gitUtils.gitBlobId.mockResolvedValue({ error: "unknown revision" });
     const res = await versionHistoryPack.handlers.read_source_at_version({
       path: "docs/spec.md",
@@ -327,7 +357,34 @@ describe("version-history pack — handler behavior (delegation preserved)", () 
     }, "u1");
 
     expect(res).toMatchObject({ success: false, error: "unknown revision" });
+    expect(res.message).toContain("repositoryFullName");
+    expect(res.message).not.toMatch(/not available|unavailable/i);
     expect(repositoryArtifact.readRepositoryProviderBlob).not.toHaveBeenCalled();
+  });
+
+  it("fails closed without falling back when the version is not a commit sha, and says what is missing", async () => {
+    gitUtils.gitBlobId.mockResolvedValue({ error: "unknown revision" });
+    const res = await versionHistoryPack.handlers.read_source_at_version({
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      path: "docs/spec.md",
+      version: "main",
+    }, "u1");
+
+    expect(res).toMatchObject({ success: false });
+    expect(res.message).toMatch(/40-character commit/);
+    expect(repositoryArtifact.readRepositoryProviderBlob).not.toHaveBeenCalled();
+  });
+
+  it("names the missing provider inputs instead of claiming git is unavailable when there is no local git", async () => {
+    gitUtils.isGitAvailable.mockResolvedValue(false);
+    const res = await versionHistoryPack.handlers.read_source_at_version({
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      path: "docs/spec.md",
+      version: "main",
+    }, "u1");
+    expect(res.success).toBe(false);
+    expect(res.message).toMatch(/40-character commit/);
+    expect(res.message).not.toMatch(/Git history is not available/);
   });
 
   it("read_source_at_version surfaces a git error", async () => {
@@ -342,7 +399,8 @@ describe("version-history pack — handler behavior (delegation preserved)", () 
     for (const t of ["read_source_at_version", "search_source_at_version", "list_source_directory", "compare_versions"]) {
       const res = await versionHistoryPack.handlers[t]({ path: "x", query: "x", from: "a" }, "u1");
       expect(res.success, t).toBe(false);
-      expect(res.message, t).toBe("Git not available.");
+      if (t === "read_source_at_version") expect(res.message, t).toContain("repositoryFullName");
+      else expect(res.message, t).toBe("Git not available.");
     }
   });
 

--- a/apps/web/lib/mcp/packs/version-history-pack.ts
+++ b/apps/web/lib/mcp/packs/version-history-pack.ts
@@ -285,10 +285,22 @@ async function readSourceAtVersionHandler(params: Record<string, unknown>): Prom
   const path = String(params.path ?? "");
   const repositoryFullName = typeof params.repositoryFullName === "string" ? params.repositoryFullName : null;
   const expectedBlobId = typeof params.expectedBlobId === "string" ? params.expectedBlobId : null;
+  // The provider fallback needs the canonical repository and an immutable
+  // commit. The blob id is verification when the caller has one (a bound review
+  // packet), not a precondition: a caller that knows only commit + path — a
+  // reviewer reached over native MCP, which never sees the bound schema — is
+  // still asking for an immutable artifact.
+  const isSha = (value: string) => /^[a-f0-9]{40}$/i.test(value);
   const providerBound = repositoryFullName !== null
-    && expectedBlobId !== null
-    && /^[a-f0-9]{40}$/i.test(ref)
-    && /^[a-f0-9]{40}$/i.test(expectedBlobId);
+    && isSha(ref)
+    && (expectedBlobId === null || isSha(expectedBlobId));
+  const providerInputsMissing = (): string => {
+    const missing: string[] = [];
+    if (repositoryFullName === null) missing.push("repositoryFullName (the canonical repository owner/name)");
+    if (!isSha(ref)) missing.push("version as the 40-character commit sha");
+    if (expectedBlobId !== null && !isSha(expectedBlobId)) missing.push("expectedBlobId as a 40-character blob sha, or omit it");
+    return `This deployment's git volume does not hold ${ref}:${path}. The repository provider serves any commit + path; pass ${missing.join(" and ")} to read it.`;
+  };
 
   let content: string | null = null;
   let blobId: string | null = null;
@@ -317,11 +329,7 @@ async function readSourceAtVersionHandler(params: Record<string, unknown>): Prom
 
   if (content === null || blobId === null) {
     if (!providerBound) {
-      return {
-        success: false,
-        error: localError,
-        message: localError === gitUnavailable ? "Git not available." : localError,
-      };
+      return { success: false, error: localError, message: providerInputsMissing() };
     }
     const { readRepositoryProviderBlob } = await import("@/lib/backlog/initiative-readiness/repository-artifact");
     const providerBlob = await readRepositoryProviderBlob({
@@ -331,12 +339,12 @@ async function readSourceAtVersionHandler(params: Record<string, unknown>): Prom
       expectedBlobId,
     });
     if (!providerBlob.ok) return { success: false, error: providerBlob.code, message: providerBlob.error };
+    blobId = providerBlob.blobId;
     try {
       content = new TextDecoder("utf-8", { fatal: true }).decode(providerBlob.data);
     } catch {
       return { success: false, error: "IMMUTABLE_SOURCE_NOT_UTF8", message: "Repository artifact is not valid UTF-8 source text." };
     }
-    blobId = expectedBlobId;
   }
   const page = pageSource({
     content,

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -97,6 +97,8 @@ describe("initiative readiness recovery routing", () => {
       path: planArtifact.path, providerBlobId: planArtifact.providerBlobId, commitSha: planArtifact.commitSha,
     });
     expect(plan.objective).toContain(planArtifact.path);
+    // A native-MCP reviewer never sees the bound schema, so the objective must carry the blob id itself.
+    expect(plan.objective).toContain(planArtifact.providerBlobId);
     expect(plan.requestKey).toMatch(/:plan:[a-f0-9]{64}$/);
     expect(recovery.reviewerRoutes.find((route) => route.gate === "spec-approval")?.requestCoworker.initiativeReviewBinding?.artifactRef.path).toBe(canonicalArtifact.path);
   });

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -502,7 +502,9 @@ function requestCoworkerPacket(args: {
     : "";
   const objective = `For ${args.decision.subject.id} in ${args.dispatch.workroomId} on ${args.dispatch.repositoryFullName}#${args.dispatch.branchName} at Workroom head ${args.dispatch.headSha}, ${reviewConstraint}address ${args.gate} using ${args.toolName}.${
     args.artifact
-      ? ` Read ${args.artifact.path} at ${reviewSha} with ${IMMUTABLE_READER_TOOL},`
+      // A reviewer reached over native MCP never sees the bound schema, so the
+      // objective itself carries every locator input the reader needs.
+      ? ` Read ${args.artifact.path} at ${reviewSha} with ${IMMUTABLE_READER_TOOL} (repositoryFullName ${args.dispatch.repositoryFullName}, version ${reviewSha}, expectedBlobId ${args.artifact.providerBlobId}),`
       : ""
   } record a governed receipt only when the gate passes.${mappingInstruction}`;
   const questionPacketSummary = `${args.gate} for ${args.decision.subject.id} at ${args.dispatch.headSha.slice(0, 12)}`;

--- a/docs/superpowers/specs/2026-09-07-immutable-reader-commit-path-locator-design.md
+++ b/docs/superpowers/specs/2026-09-07-immutable-reader-commit-path-locator-design.md
@@ -1,0 +1,82 @@
+---
+status: draft
+---
+
+# Immutable reader serves a commit + path locator
+
+**Backlog item:** `BI-331F527B`  
+**Workroom:** `WC-7EBCC298`  
+**Readiness profile:** `fix`  
+**Follow-up:** `BI-907D6878` (loop blindness to natively executed MCP calls)
+
+## Problem and evidence
+
+Initiative-readiness reviewer coworkers dispatched through the Claude CLI in
+native-MCP mode call `read_source_at_version` themselves against `/api/mcp/v1`.
+The bound input schema produced by `narrowInitiativeReviewTools` — which pins
+`expectedBlobId` to the packet's blob — is applied only to the loop-side tool
+list and never reaches the CLI's native `tools/list`. The packet objective named
+the commit and path but not the blob. So every reviewer called the reader with
+`repositoryFullName`, `version` (commit sha) and `path`, and without
+`expectedBlobId`.
+
+`readSourceAtVersionHandler` treated that locator as incomplete: its provider
+fallback required a blob id, so when the install's read-only git volume lacked
+the branch commit the reader answered "Git history is not available in this
+deployment". Each reviewer repeated that sentence as its blocker and ended
+`input-required / missing-terminal-writer`. Four gates on `BI-8CF5A51D` failed
+this way on 2026-09-07 (`ToolExecution` rows with
+`executionMode=internal-mcp-session`, `success=false`, threads
+`cmtqlqxbl0y4701riqztfgfu1`, `cmtqlqspe0y3m01ripvp3vny2`,
+`cmtqlq08n0y2b01ri2a3v37mz`).
+
+Reproduction on the named ref: `read_source_at_version(path, version=b74573ad…,
+repositoryFullName)` → "Git not available."; the same call plus
+`expectedBlobId=5a80cf56…` → success through the provider.
+
+## Research
+
+A commit sha + path is already an immutable locator: the provider's contents
+API at `?ref=<sha>` returns the blob and its sha. The blob id adds verification
+(fail closed on mismatch), not identity. Requiring it as a precondition only
+excluded the caller that cannot know it.
+
+Compared implementations: GitHub's contents API and `git show <sha>:<path>`
+both resolve by commit + path and report the blob; `git cat-file` by blob id is
+the verification form. DPF keeps both: serve by commit + path, verify by blob
+when supplied.
+
+## Decision
+
+1. `readRepositoryProviderBlob` takes an optional `expectedBlobId`; success
+   returns the provider's `blobId`; a supplied mismatching id still fails closed
+   with `IMMUTABLE_BLOB_MISMATCH`.
+2. `read_source_at_version` engages the provider fallback on
+   `repositoryFullName` + 40-hex commit; the page's `blobId` is the provider's
+   sha. When the locator is incomplete the message names the missing inputs
+   rather than asserting git is unavailable.
+3. The reviewer packet objective states `repositoryFullName`, `version` and
+   `expectedBlobId`, so a native-MCP reviewer can pass them and the bound
+   schema's guarantee is carried in prose where the schema cannot travel.
+
+Out of scope, filed as `BI-907D6878`: reconciling natively executed MCP calls
+into the loop's executed-tool records, and serving the bound schema on the
+internal session's `tools/list`.
+
+## Acceptance
+
+- AC-1: reader with repository + commit + path, no blob id → page served via
+  provider, `blobId` = provider sha.
+- AC-2: blob id supplied and mismatched → `immutable_blob_mismatch`.
+- AC-3: repository missing or version not a commit → message names the missing
+  input and never says git is unavailable.
+- AC-4: packet objective contains the `providerBlobId`.
+- AC-5: affected vitest suites pass; local-CI gate (typecheck, tests, build)
+  passes for the branch head.
+
+## Verification
+
+Red-to-green: seven assertions failed before the change and pass after
+(`version-history-pack.test.ts`, `repository-artifact.test.ts`,
+`initiative-readiness-tool-grants.test.ts`). Local-CI gate evidence
+`cmtqnwp6k09wt01rixk5haqz0` on `3fd82d15`.


### PR DESCRIPTION
## Problem

Initiative-readiness reviewers dispatched through the Claude CLI in native-MCP mode call `read_source_at_version` themselves. The bound schema that pins `expectedBlobId` never reaches a native `tools/list`, and the packet objective did not state the blob, so every reviewer called the reader with repository, commit and path but no blob id. The reader treated that as an incomplete locator and answered "Git history is not available in this deployment"; the reviewers repeated it as their blocker and no initiative gate could mint a receipt. Four gates on BI-8CF5A51D failed this way on 2026-09-07 (ToolExecution rows, `executionMode=internal-mcp-session`, `success=false`).

## Change

- `readRepositoryProviderBlob`: `expectedBlobId` is optional verification; success returns the provider's `blobId`; a supplied mismatching id still fails closed with `IMMUTABLE_BLOB_MISMATCH`.
- `read_source_at_version`: the provider fallback engages on `repositoryFullName` + 40-hex commit; the refusal message names the missing locator inputs instead of claiming git is unavailable.
- Reviewer packet objective states `repositoryFullName`, `version` and `expectedBlobId` so a native-MCP reviewer can pass them.
- Spec: `docs/superpowers/specs/2026-09-07-immutable-reader-commit-path-locator-design.md`.

Follow-up filed as BI-907D6878: the agentic loop cannot see natively executed MCP calls, so terminal-policy nudges and the writer check miss them.

## Verification

- Red→green: 7 new/adjusted assertions failed before the change and pass after (`version-history-pack.test.ts`, `repository-artifact.test.ts`, `initiative-readiness-tool-grants.test.ts`).
- 348 tests pass across the affected suites.
- Local-CI sandbox gate (typecheck, tests, production build) passed on `3fd82d15` (evidence `cmtqnwp6k09wt01rixk5haqz0`) and on `79d44e84` (evidence `cmtqo2sj00hpx01rij3epyfx7`).
- Migration: not applicable. UX: not applicable (MCP tool behaviour and generated packet text).

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-09-02-zero-configuration-organization-federation-design.md (immutable evidence readers as the review substrate)
  - docs/architecture/mcp-tool-authorization-runbook.md
- Current code substrate reviewed:
  - apps/web/lib/mcp/packs/version-history-pack.ts (readSourceAtVersionHandler)
  - apps/web/lib/backlog/initiative-readiness/repository-artifact.ts (readRepositoryProviderBlob)
  - apps/web/lib/tak/initiative-readiness-tool-grants.ts (requestCoworkerPacket)
  - apps/web/lib/mcp-task-review-contract.ts (narrowInitiativeReviewTools, loop-side only)
  - apps/web/lib/routing/cli-adapter.ts (native mcp__dpf__ calls filtered from parsed tool calls)
- Source of truth: ToolExecution audit rows for threads cmtqlqxbl0y4701riqztfgfu1, cmtqlqspe0y3m01ripvp3vny2, cmtqlq08n0y2b01ri2a3v37mz (2026-09-07).
- Decision: a commit + path locator is already immutable; the blob id is verification when known, not a precondition. One input becomes optional; no new tool, no schema or contract widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)