### PR TITLE
fix(ea): the Workrooms page leads with the rooms that exist, not a plan count nothing can create (BI-0EB855CC)

### DIFF
--- a/apps/web/app/(shell)/ea/workrooms/page.test.tsx
+++ b/apps/web/app/(shell)/ea/workrooms/page.test.tsx
@@ -6,6 +6,13 @@ import { measureUxBudget } from "@/lib/ux-budget/measure";
 vi.mock("@dpf/db", () => ({ prisma: {} }));
 vi.mock("next/navigation", () => ({ usePathname: () => "/ea/workrooms" }));
 vi.mock("@/lib/ea/workroom-architecture", () => ({
+  // The install this page was reported against: hundreds of rooms, no team
+  // plans, most rooms with no recorded placement (BI-0EB855CC).
+  loadRoomInventory: vi.fn(async () => ({
+    openTotal: 451,
+    unclassified: 367,
+    byRole: { foundational: 71, manufactureAndDeliver: 13, forEmployees: 0, productsAndServicesSold: 0 },
+  })),
   loadWorkroomCoordination: vi.fn(async () => ({ readAt: "2026-09-06T12:00:00.000Z", truncated: true, rooms: [
     { roomId: "WC-REVIEW", title: "Review change", status: "blocked", teamId: null, assignedActorRef: null, parentItemId: null, href: "/workspace/cases/work-capsule%3AWC-REVIEW?operation=unmapped" },
   ] })),
@@ -56,6 +63,25 @@ describe("WorkroomArchitecturePage", () => {
     expect(html).toContain("matches no canonical portfolio role");
   });
 
+  // The page used to lead with "No Workroom plans are set yet" and stat cards of
+  // zero while hundreds of rooms were open, so an owner read "we have no rooms".
+  // It must lead with what exists, report the unclassified rather than default
+  // them, and never instruct an action the product cannot perform.
+  it("leads with the rooms that exist, not a plan count nothing can create", async () => {
+    const html = renderToStaticMarkup(await WorkroomArchitecturePage());
+    expect(html).toContain("451 rooms are open.");
+    expect(html).toContain("367 of them have no portfolio recorded.");
+    expect(html).toContain("No team plans are configured on this install.");
+    expect(html).not.toContain("No Workroom plans are set yet");
+    expect(html).not.toContain("Set up a value stream team");
+  });
+  it("counts each portfolio by its real rooms and never defaults an unplaced room into one", async () => {
+    const html = renderToStaticMarkup(await WorkroomArchitecturePage());
+    expect(html).toContain("71 open rooms");
+    expect(html).toContain("13 open rooms");
+    expect(html).toContain("No open rooms in For Employees");
+    expect(html).toContain("Not configured on this install");
+  });
   it("labels a truncated architecture read as partial rather than a total", async () => {
     const html = renderToStaticMarkup(await WorkroomArchitecturePage());
     expect(html).toContain("Partial read");

--- a/apps/web/app/(shell)/ea/workrooms/page.tsx
+++ b/apps/web/app/(shell)/ea/workrooms/page.tsx
@@ -4,7 +4,7 @@ import { prisma } from "@dpf/db";
 import { EaTabNav } from "@/components/ea/EaTabNav";
 import { Surface } from "@/components/ui/Surface";
 import { EmptyState, StatCard, StatusBadge } from "@/components/ui/report-kit";
-import { loadWorkroomArchitecture, loadWorkroomCoordination } from "@/lib/ea/workroom-architecture";
+import { loadRoomInventory, loadWorkroomArchitecture, loadWorkroomCoordination } from "@/lib/ea/workroom-architecture";
 
 export const dynamic = "force-dynamic";
 
@@ -24,7 +24,11 @@ function HumanGateList({ triggers }: { triggers: Array<{ triggerPoint: string; r
 
 export default async function WorkroomArchitecturePage({ searchParams }: { searchParams?: Promise<{ operation?: string }> } = {}) {
   const operation = (await searchParams)?.operation;
-  const [architecture, coordination] = await Promise.all([loadWorkroomArchitecture(prisma), loadWorkroomCoordination(prisma, new Date(), { teamId: operation === "unmapped" ? null : operation })]);
+  const [architecture, coordination, inventory] = await Promise.all([
+    loadWorkroomArchitecture(prisma),
+    loadWorkroomCoordination(prisma, new Date(), { teamId: operation === "unmapped" ? null : operation }),
+    loadRoomInventory(prisma),
+  ]);
   const { bands, unplaced, truncated: architectureTruncated } = architecture;
   const definitions = bands.flatMap((band) => band.definitions);
   const instanceCount = definitions.reduce((total, definition) => total + definition.instanceCount, 0);
@@ -40,21 +44,33 @@ export default async function WorkroomArchitecturePage({ searchParams }: { searc
       <EaTabNav />
 
       <Surface data-dpf-lead className="my-6" rounded="xl">
+        {/* Lead with the rooms that EXIST. The plan count is a different
+            question, and it is zero on every install because nothing can create
+            a team plan — leading with it read as "you have no rooms" while
+            hundreds were running (BI-0EB855CC, decision DI-66AC55277576). */}
         <p className="text-sm font-medium text-[var(--dpf-text)]">
+          {inventory.openTotal === 0
+            ? "No rooms are open."
+            : `${inventory.openTotal} room${inventory.openTotal === 1 ? " is" : "s are"} open.`}
+        </p>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          {inventory.unclassified > 0
+            ? `${inventory.unclassified} of them ${inventory.unclassified === 1 ? "has" : "have"} no portfolio recorded. `
+            : ""}
           {definitions.length === 0
-            ? "No Workroom plans are set yet."
-            : `${definitions.length} Workroom plan${definitions.length === 1 ? "" : "s"} guide work in ${bands.filter((band) => band.definitions.length > 0).length} portfolios.`}
+            ? "No team plans are configured on this install."
+            : `${definitions.length} team plan${definitions.length === 1 ? "" : "s"} guide work here.`}
         </p>
 
-        <Link data-owner-first-next-action href={definitions.length > 0 ? `#portfolio-${bands.find((band) => band.definitions.length > 0)?.role ?? "foundational"}` : "/ea/value-streams"} className="mt-3 inline-block text-xs font-medium text-[var(--dpf-accent)] hover:underline">
-          {definitions.length > 0 ? "Review Workroom plans" : "Review value streams"}
+        <Link data-owner-first-next-action href="#coordination" className="mt-3 inline-block text-xs font-medium text-[var(--dpf-accent)] hover:underline">
+          Review open rooms
         </Link>
       </Surface>
 
       <div className="mb-6 grid gap-3 sm:grid-cols-3">
-        <StatCard label="Workroom plans" value={definitions.length} hint="Active value stream teams" />
-        <StatCard label="Linked rooms" value={instanceCount} href="#coordination" hint="Includes completed work" />
-        <StatCard label="Portfolios" value={`${bands.filter((band) => band.definitions.length > 0).length} / 4`} hint="All four stay in view" />
+        <StatCard label="Open rooms" value={inventory.openTotal} href="#coordination" hint="Open only" />
+        <StatCard label="No portfolio recorded" value={inventory.unclassified} hint="Never defaulted" />
+        <StatCard label="Team plans" value={definitions.length} hint={definitions.length === 0 ? "Not configured on this install" : "Active value stream teams"} />
       </div>
 
       {architectureTruncated ? (
@@ -104,10 +120,16 @@ export default async function WorkroomArchitecturePage({ searchParams }: { searc
                 <p className="text-dpf-caption uppercase tracking-[0.16em] text-[var(--dpf-muted)]">Portfolio</p>
                 <h2 id={`portfolio-${band.role}`} className="text-lg font-semibold text-[var(--dpf-text)]">{band.label}</h2>
               </div>
-              <StatusBadge intent={band.definitions.length > 0 ? "success" : "neutral"} label={`${band.definitions.length} definition${band.definitions.length === 1 ? "" : "s"}`} uppercase={false} />
+              <StatusBadge intent={inventory.byRole[band.role] > 0 ? "success" : "neutral"} label={`${inventory.byRole[band.role]} open room${inventory.byRole[band.role] === 1 ? "" : "s"}`} uppercase={false} />
             </div>
             {band.definitions.length === 0 ? (
-              <EmptyState size="sm" title={`No ${band.label} Workroom plans yet`} description="Set up a value stream team to show its room here." />
+              <EmptyState
+                size="sm"
+                title={inventory.byRole[band.role] > 0
+                  ? `${inventory.byRole[band.role]} open room${inventory.byRole[band.role] === 1 ? "" : "s"} here, none linked to a team plan`
+                  : `No open rooms in ${band.label}`}
+                description="Team plans are not configured here. Rooms are listed under Coordination."
+              />
             ) : (
               <div className="grid gap-4 xl:grid-cols-2">
                 {band.definitions.map((definition) => (

--- a/apps/web/lib/ea/workroom-architecture.test.ts
+++ b/apps/web/lib/ea/workroom-architecture.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { loadWorkroomArchitecture, loadWorkroomCoordination, resolvePortfolioPlacement } from "./workroom-architecture";
+import { loadRoomInventory, loadWorkroomArchitecture, loadWorkroomCoordination, resolvePortfolioPlacement } from "./workroom-architecture";
 
 describe("loadWorkroomArchitecture", () => {
   it("links actual rooms and reports missing architecture placement without guessing", async () => {
@@ -142,3 +142,45 @@ const TEAM_UNRESOLVED = {
         portfolioId: "p", portfolio: { slug: "mystery-stream", name: "Mystery" }, isActive: true,
         roles: [], hitlGates: [], queues: [], workItems: [{ _count: { capsules: 1 } }],
       };
+
+
+// The page led with a plan count that is zero on every install while hundreds of
+// rooms were running, so an owner read "we have no rooms" (BI-0EB855CC). The
+// inventory is the TOTAL, distinct from the bounded coordination sample, and it
+// reports unplaced rooms rather than folding them into a portfolio — the rule
+// PR #5189 set for teams, applied to rooms.
+describe("loadRoomInventory", () => {
+  it("counts open rooms by portfolio and reports the unclassified rather than defaulting them", async () => {
+    const db = { workroom: { groupBy: vi.fn().mockResolvedValue([
+      { portfolioRole: "foundational", _count: { _all: 71 } },
+      { portfolioRole: "manufactureAndDeliver", _count: { _all: 13 } },
+      { portfolioRole: null, _count: { _all: 367 } },
+    ]) } };
+
+    const inventory = await loadRoomInventory(db);
+
+    expect(inventory.openTotal).toBe(451);
+    expect(inventory.unclassified).toBe(367);
+    expect(inventory.byRole.foundational).toBe(71);
+    expect(inventory.byRole.manufactureAndDeliver).toBe(13);
+    // A portfolio with no rooms reads zero, not absent.
+    expect(inventory.byRole.forEmployees).toBe(0);
+  });
+
+  it("excludes completed and archived rooms, so the count matches what is open", async () => {
+    const db = { workroom: { groupBy: vi.fn().mockResolvedValue([]) } };
+    await loadRoomInventory(db);
+    expect(db.workroom.groupBy).toHaveBeenCalledWith(expect.objectContaining({
+      where: { archivedAt: null, status: { notIn: ["complete", "abandoned", "archived"] } },
+    }));
+  });
+
+  it("does not fold an unrecognised portfolio value into a real portfolio", async () => {
+    const db = { workroom: { groupBy: vi.fn().mockResolvedValue([
+      { portfolioRole: "somethingElse", _count: { _all: 5 } },
+    ]) } };
+    const inventory = await loadRoomInventory(db);
+    expect(inventory.unclassified).toBe(5);
+    expect(inventory.byRole.foundational).toBe(0);
+  });
+});

--- a/apps/web/lib/ea/workroom-architecture.ts
+++ b/apps/web/lib/ea/workroom-architecture.ts
@@ -153,6 +153,44 @@ export type WorkroomArchitectureProjection = {
 
 const ARCHITECTURE_PAGE_SIZE = 200;
 
+/** A COUNT of the rooms that actually exist, by portfolio placement.
+ *
+ *  The coordination list is a bounded sample (201 rows) and must never be read
+ *  as a total. This is the total, and it reports rooms with no recorded
+ *  placement as `unclassified` rather than folding them into a portfolio —
+ *  the same rule PR #5189 established for teams: a reader must be able to tell
+ *  a room genuinely in a portfolio from one nobody has classified (BI-0EB855CC).
+ */
+export async function loadRoomInventory(
+  db: { workroom: { groupBy(args: unknown): Promise<Array<{ portfolioRole: string | null; _count: { _all: number } }>> } },
+): Promise<{
+  openTotal: number;
+  unclassified: number;
+  byRole: Record<WorkCapsulePortfolioRole, number>;
+}> {
+  const rows = await db.workroom.groupBy({
+    by: ["portfolioRole"],
+    where: { archivedAt: null, status: { notIn: TERMINAL_CAPSULE_STATUSES } },
+    _count: { _all: true },
+  });
+
+  const byRole = Object.fromEntries(
+    WORK_CAPSULE_PORTFOLIO_ROLES.map((role) => [role, 0]),
+  ) as Record<WorkCapsulePortfolioRole, number>;
+  let unclassified = 0;
+  let openTotal = 0;
+
+  for (const row of rows) {
+    const count = row._count?._all ?? 0;
+    openTotal += count;
+    const role = row.portfolioRole as WorkCapsulePortfolioRole | null;
+    if (role && role in byRole) byRole[role] += count;
+    else unclassified += count;
+  }
+
+  return { openTotal, unclassified, byRole };
+}
+
 export async function loadWorkroomArchitecture(db: ArchitectureDb): Promise<WorkroomArchitectureProjection> {
   const teams = await db.valueStreamTeam.findMany({
     where: { isActive: true },

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -718,15 +718,15 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text"
     },
     "/ea/workrooms": {
-      "defaultVisibleWords": 222,
-      "leadBandWords": 9,
+      "defaultVisibleWords": 237,
+      "leadBandWords": 22,
       "primaryActions": 1,
       "visibleFields": 0,
       "maxChoicesPerControl": 0,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - group\n    - button\n    - paragraph\n      - text\n    - list\n      - listitem\n        - link\n        - paragraph\n          - text\n        - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - text"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - group\n    - button\n    - paragraph\n      - text\n    - list\n      - listitem\n        - link\n        - paragraph\n          - text\n        - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - text"
     },
     "/employee": {
       "defaultVisibleWords": 306,

--- a/docs/user-guide/architecture/index.md
+++ b/docs/user-guide/architecture/index.md
@@ -28,11 +28,11 @@ If you change the archetype your install declares, the next seed imports the cri
 
 ## Workroom Definitions
 
-Open **Architecture > Workrooms** (`/ea/workrooms`) to review collaboration from the definition perspective. The page keeps all four portfolios visible, groups each Value Stream Team under its owning portfolio, and links the reusable shape to its process view and operational instances.
+Open **Architecture > Workrooms** (`/ea/workrooms`) to see the rooms that are actually running and how they sit across the four portfolios. The page leads with a true count of open rooms — completed and archived rooms are excluded — and says plainly how many have no portfolio recorded. Those are reported as unclassified, never quietly filed under a portfolio nobody assigned. Where team plans exist, each is grouped under its owning portfolio with its shape, participants, queues, triggers and process view.
 
 A team is placed in a portfolio from what the platform actually records: an explicit portfolio role on the team wins, and its portfolio slug or name are used only as weaker fallbacks. When none of those decides the question, the team is listed under **Not placed in a portfolio** with the reason, instead of being shown inside a portfolio nobody assigned it to. Those teams are counted separately, so a portfolio's total only ever counts teams that genuinely belong to it. Correct a placement by setting the team's portfolio role or linking it to the right portfolio.
 
-The page reads a bounded page of teams rather than the whole estate. When more exist than it shows, it says **Partial read**, so the counts above are never mistaken for an estate-wide total. Define or refine the underlying Value Stream Team when participants, queues, or approval triggers need to change; use **Operations > Workrooms** to inspect activity created from those definitions.
+The room count is a real total. The plan list and the Coordination list are each a bounded read; when more exist than are shown the page says so (**Partial read**, **More rooms exist**), so a bounded list is never mistaken for the whole estate. If no team plans are configured on your install, the page says exactly that rather than implying you forgot to set one up — there is currently no in-product way to create one, so an install with none is normal.
 
 ## What You Can Do
 
@@ -59,10 +59,9 @@ Use the AI Workforce area for everyday coworker discovery and work assignment.
 
 ## Following a Concern Across Views
 
-On **Workrooms**, expand **Coordination** to open an actual room. A plan's linked
-room count includes completed work; the coordination list shows open rooms from
-a bounded database read and reports when more exist. Missing value-stream links
-are shown explicitly. Select a plan's room link to narrow the operation first.
+On **Workrooms**, expand **Coordination** to open an actual room. It shows open rooms from a bounded database read and
+reports when more exist. A room with no team plan behind it says so explicitly.
+Select a plan's room link to narrow the list to that operation first.
 
 Inside the room, select a process step to inspect its reason, next action, owner
 and evidence. **Operation** returns to the same architecture selection. Intended

--- a/docs/ux-fit/2026-09-08-ea-workrooms-lead-with-rooms.ux-fit.json
+++ b/docs/ux-fit/2026-09-08-ea-workrooms-lead-with-rooms.ux-fit.json
@@ -1,0 +1,17 @@
+{
+  "version": "1",
+  "decidedOption": "lead-with-real-rooms",
+  "decisionInteractionId": "DI-66AC55277576",
+  "scope": {
+    "files": ["apps/web/app/(shell)/ea/workrooms/page.tsx"]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "lead-with-real-rooms",
+      "fix-copy-only",
+      "build-plan-creation",
+      "hide-the-tab"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -973,7 +973,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 57
+    "textMass": 63
   },
   "apps/web/app/(shell)/employee/page.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Operator on `/ea/workrooms`: **"confusing and unusable."** The page showed, at once:

```
No Workroom plans are set yet.
WORKROOM PLANS 0    LINKED ROOMS 0    PORTFOLIOS 0 / 4
▸ Coordination · 200+ open
```

"Linked rooms 0" directly above "200+ open". An owner reads *we have no rooms*. They have 463.

## Two layers

**1. Two questions presented as one answer.** The stat cards count `ValueStreamTeam` definitions; the Coordination section counts actual rooms. Nothing on the page says these differ.

**2. The plan concept has no creation path anywhere in the product.**

```
ValueStreamTeam rows (active):   0
Active rooms:                  463
WorkItems with a teamId:         0
```

Every `create`/`upsert` reference to `valueStreamTeam` outside the generated Prisma client is absent — no seed, no server action, no UI. So the stats are zero on every install, and the empty state instructed *"Set up a value stream team to show its room here"* — an action the product cannot perform. The user guide gave the same impossible instruction in prose. That is why it was unusable, not merely confusing.

## What changed

- **Leads with what exists.** "451 rooms are open" replaces "No Workroom plans are set yet."
- **`loadRoomInventory`** counts open rooms by portfolio as a **true total** — distinct from the 201-row Coordination sample, which must never be read as one.
- **Unclassified rooms are reported, never defaulted** into a portfolio — the rule #5189 set for teams, applied to rooms. 367 of 463 have no recorded placement; the page says so.
- Stat cards: *Open rooms / No portfolio recorded / Team plans*, with "Not configured on this install" as the honest hint rather than an implied user error.
- No empty state asks for the impossible. Coordination stays collapsed on arrival: a first pass opened it by default and the **UX route sweep caught the cost** (222 → 249 words on arrival, landmark shape changed) — the lead surface and stat cards already carry the decision, so the list does not need to.
- User guide corrected.

## Decision

`DI-66AC55277576` (stakes elevated, ui): **lead-with-real-rooms 10.32** over fix-copy-only 5.94, build-plan-creation 3.94, hide-the-tab 3.50. Margin 4.38, high confidence, zero flipping principles.

**Deliberately not built:** plan creation — a net-new capability the operator did not ask for. Whether `ValueStreamTeam` should exist at all, or be retired in favour of the room's own portfolio placement, is a separate design question flagged on the BI.

## UX route sweep — one route re-frozen

The sweep blocked on `/ea/workrooms`: words on arrival 222 → 237 and a shape flag. Both are the deliberate change, so the route was re-frozen through the sanctioned path (`workflow_dispatch` run `34262138748`, artifact spliced for **this route only**, 213 routes measured, 0 dropped).

- **+15 words** is the honest lead — two true sentences where one false one stood.
- **The shape flag is a projection artefact.** The three stat cards projected as `paragraph, link›paragraph, paragraph` because the `#coordination` link sat on the *middle* card. It now sits on the first card, so the two plain cards became adjacent and the sweep collapsed them. Same node kinds, one fewer after dedupe. Reordering cards to dodge the dedupe would tune the page for the gate rather than the reader.

A first pass also opened Coordination by default; the sweep measured that at 249 words and it was reverted before the freeze.

## Verification

- `vitest app/(shell)/ea/workrooms lib/ea` — **336/336**, incl. 3 new loader tests, 2 new page-honesty tests, and the existing high-school reading-grade cap
- `tsc --noEmit` — clean
- Prose-lint baseline raised by exactly the 6 UI words it costs to say two true things where one false one stood
- Local-CI gate passed on gated sha `1947de68bbf4`, production build compiled

**Verified signed-in** on the Contributor preview against the live DB (sha `1947de68bbf4`, operator signed in, evidence `cmtt2ipqy59v901mwjhu94dy7`): lead reads *318 rooms are open / 260 of them have no portfolio recorded / No team plans are configured on this install*; stat cards 318 · 260 · 0; portfolios 35 + 13 + 7 + 3 = 58 placed + 260 unclassified = 318, reconciling to the total. Coordination expands, every link carries the canonical address, and "Adopter health" opens its room.

Refs: BI-0EB855CC · DI-66AC55277576 · EP-00B120A1

Local-CI-Evidence: cmtt0ddg02ykn01mworydnwm4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

