### PR TITLE
fix(work): brief the stage, and advance it on evidence rather than a claim (BI-4A394B21, BI-76B35820)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2463,6 +2463,7 @@
         "nesting-has-to-be-written-not-just-declared",
         "who-may-coordinate-authority-and-a-gate-with-no-key",
         "concurrent-execution-and-recorded-state",
+        "the-brief-and-what-advances-a-stage",
         "related-references"
       ]
     },

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -293,6 +293,13 @@ const definitions: ToolDefinition[] = [
       properties: {
         capsuleId: { type: "string", description: "Semantic Workroom id (WC-*)." },
         kind: { type: "string", enum: ENUMS.evidenceKinds, description: "Evidence kind." },
+        stageKey: {
+          type: "string",
+          description:
+            "The work-shape stage this evidence completes. REQUIRED for a Workroom stage to "
+            + "advance: the drive earns a completing receipt from stage-scoped evidence and "
+            + "never from a run's self-reported status (BI-76B35820).",
+        },
         summary: { type: "string", description: "Evidence summary." },
         command: { type: "string", description: "Optional command that produced the evidence." },
         url: { type: "string", description: "Optional URL for PRs, CI runs, screenshots, or external evidence." },

--- a/apps/web/lib/queue/functions/workroom-drive-data.ts
+++ b/apps/web/lib/queue/functions/workroom-drive-data.ts
@@ -1,0 +1,182 @@
+// Data loaders and reconcilers for the standing Workroom drive.
+//
+// Extracted from workroom-drive.ts, which the substrate-complexity guard
+// correctly flagged as crossing the 800-LOC hotspot threshold as these
+// accumulated. The drive decides; this module reads and writes what it decides
+// over.
+
+import { planCoordinationBindings } from "@/lib/authority/coordination-bindings";
+import {
+  COORDINATION_RESOURCE_TYPE,
+  COORDINATION_SCOPE_TYPE,
+} from "@/lib/work-management/coordinator-eligibility";
+import type { RecordedEvidence } from "@/lib/work-management/stage-evidence-receipts";
+import { planContainmentRelations } from "@/lib/work-management/standing-room-nesting";
+
+/**
+ * Write the declared standing-room tree, returning how many relations were newly
+ * created. Idempotent: the (from, to, relation) unique constraint plus
+ * skipDuplicates means a settled estate writes nothing and reports 0.
+ *
+ * Failure is non-fatal. Nesting is what the hierarchy is built on, but a room
+ * that can still be driven must not be blocked because its parent link could not
+ * be written this minute.
+ */
+export async function reconcileStandingRoomNesting(): Promise<number> {
+  try {
+    const { prisma } = await import("@dpf/db");
+    const rooms = await prisma.workroom.findMany({
+      where: { archivedAt: null, idempotencyKey: { startsWith: "standing-room:" } },
+      select: { id: true, capsuleId: true, idempotencyKey: true },
+    });
+    const byCapsuleId = new Map(rooms.map((room) => [room.capsuleId, room.id]));
+    const plans = planContainmentRelations(
+      rooms.map((room) => ({ capsuleId: room.capsuleId, idempotencyKey: room.idempotencyKey })),
+    );
+    if (plans.length === 0) return 0;
+    const created = await prisma.workroomRelation.createMany({
+      data: plans.flatMap((plan) => {
+        const fromWorkroomId = byCapsuleId.get(plan.fromCapsuleId);
+        const toWorkroomId = byCapsuleId.get(plan.toCapsuleId);
+        return fromWorkroomId && toWorkroomId
+          ? [{ fromWorkroomId, toWorkroomId, relation: "contains" as const }]
+          : [];
+      }),
+      skipDuplicates: true,
+    });
+    return created.count;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Materialize coordination authority for the shapes this install ships.
+ *
+ * Idempotent by derivable bindingId: an existing binding is left exactly as the
+ * operator has it — including SUSPENDED. Re-seeding must never silently
+ * re-grant authority a human deliberately withdrew, which is the one way this
+ * could become an authority-laundering path rather than a grant.
+ *
+ * Returns how many were newly created; a settled install reports 0.
+ */
+export async function reconcileCoordinationBindings(): Promise<number> {
+  try {
+    const { prisma } = await import("@dpf/db");
+    const plans = planCoordinationBindings();
+    if (plans.length === 0) return 0;
+    const existing = await prisma.authorityBinding.findMany({
+      where: { bindingId: { in: plans.map((plan) => plan.bindingId) } },
+      select: { bindingId: true },
+    });
+    const known = new Set(existing.map((row) => row.bindingId));
+    const missing = plans.filter((plan) => !known.has(plan.bindingId));
+    if (missing.length === 0) return 0;
+    let created = 0;
+    for (const plan of missing) {
+      const agent = await prisma.principal.findFirst({
+        where: { kind: "agent", principalId: plan.agentId },
+        select: { id: true, principalId: true },
+      });
+      await prisma.authorityBinding.create({
+        data: {
+          bindingId: plan.bindingId,
+          name: plan.name,
+          scopeType: plan.scopeType,
+          resourceType: plan.resourceType,
+          resourceRef: plan.resourceRef,
+          status: plan.status,
+          approvalMode: plan.approvalMode,
+          appliedAgentId: agent?.id ?? null,
+          subjects: {
+            create: plan.subjects.map((subject) => ({
+              subjectType: subject.subjectType,
+              subjectRef: subject.subjectRef,
+              relation: subject.relation,
+            })),
+          },
+        },
+      });
+      created += 1;
+    }
+    return created;
+  } catch {
+    // Never take the drive down over a seeding failure; rooms then read "absent"
+    // and refuse, which is the safe pre-existing behaviour.
+    return 0;
+  }
+}
+
+/**
+ * Stage-scoped evidence recorded through record_workroom_evidence, plus when
+ * each room's current stage was last dispatched.
+ *
+ * This is the ONLY input a completing receipt is earned from. Executor status is
+ * never consulted: 337 runs reported `completed` with zero tools executed, and
+ * PR #5168 was correctly refused for proposing to trust exactly that.
+ */
+export async function loadRecordedEvidence(
+  capsuleIds: readonly string[],
+): Promise<Map<string, RecordedEvidence[]>> {
+  const byRoom = new Map<string, RecordedEvidence[]>();
+  if (capsuleIds.length === 0) return byRoom;
+  try {
+    const { prisma } = await import("@dpf/db");
+    const rows = await prisma.$queryRaw<Array<{
+      capsuleId: string;
+      stageKey: string | null;
+      evidenceKind: string | null;
+      recordedAt: Date;
+    }>>`
+      SELECT w."capsuleId"                      AS "capsuleId",
+             a."payload" ->> 'stageKey'         AS "stageKey",
+             a."payload" ->> 'kind'             AS "evidenceKind",
+             a."recordedAt"                     AS "recordedAt"
+      FROM "WorkCapsuleActivity" a
+      JOIN "WorkCapsule" w ON w."id" = a."workCapsuleId"
+      WHERE a."kind" = 'evidence-recorded'
+        AND w."capsuleId" = ANY(${[...capsuleIds]}::text[])
+      ORDER BY a."recordedAt" DESC
+      LIMIT 500
+    `;
+    for (const row of rows) {
+      const entry: RecordedEvidence = {
+        stageKey: row.stageKey,
+        kind: row.evidenceKind,
+        recordedAt: row.recordedAt,
+      };
+      const bucket = byRoom.get(row.capsuleId);
+      if (bucket) bucket.push(entry);
+      else byRoom.set(row.capsuleId, [entry]);
+    }
+  } catch {
+    // No evidence read means no receipts earned: the stage re-dispatches, which
+    // is visible and non-fabricating.
+  }
+  return byRoom;
+}
+
+export async function loadCoordinationBindings(): Promise<
+  Map<string, Array<{ status: string; scopeType: string; resourceType: string; resourceRef: string }>>
+> {
+  const byShape = new Map<
+    string,
+    Array<{ status: string; scopeType: string; resourceType: string; resourceRef: string }>
+  >();
+  try {
+    const { prisma } = await import("@dpf/db");
+    const rows = await prisma.authorityBinding.findMany({
+      where: { scopeType: COORDINATION_SCOPE_TYPE, resourceType: COORDINATION_RESOURCE_TYPE },
+      select: { status: true, scopeType: true, resourceType: true, resourceRef: true },
+    });
+    for (const row of rows) {
+      const bucket = byShape.get(row.resourceRef);
+      if (bucket) bucket.push(row);
+      else byShape.set(row.resourceRef, [row]);
+    }
+  } catch {
+    // A binding lookup that fails must not take the drive down. Rooms then read
+    // "unknown" and refuse, which is the pre-existing safe behaviour.
+  }
+  return byShape;
+}

--- a/apps/web/lib/queue/functions/workroom-drive-wiring.test.ts
+++ b/apps/web/lib/queue/functions/workroom-drive-wiring.test.ts
@@ -1,0 +1,46 @@
+// The producer must actually be called (BI-76B35820).
+//
+// This guard exists because the defect shipped in the very PR that fixes the
+// pattern: `loadRecordedEvidence` was imported and never invoked, so
+// `recordedEvidence` was declared, read, and never populated — evidence always
+// `[]`, no receipt ever earned, the fix dead on arrival. A scripted edit matched
+// nothing and failed silently; a code-quality bot caught it, not the compiler
+// and not me.
+//
+// It is the twelfth read-with-no-writer in this program. The structural answer
+// is a test that fails when the wiring is absent rather than a promise to look
+// harder.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const drive = readFileSync(join(__dirname, "workroom-drive.ts"), "utf8");
+
+describe("workroom-drive wiring", () => {
+  it("invokes loadRecordedEvidence, not merely imports it", () => {
+    expect(drive).toContain("await loadRecordedEvidence(");
+  });
+
+  it("populates recordedEvidence on the rooms it drives", () => {
+    expect(drive).toMatch(/recordedEvidence:\s*evidenceByRoom\.get/);
+  });
+
+  it("uses every loader it imports from workroom-drive-data", () => {
+    // The real defect is an identifier that appears ONLY in the import: declared,
+    // never referenced, so its producer never runs. Passing a function as a value
+    // (`?? reconcileStandingRoomNesting`) is legitimate use, so this checks for a
+    // reference outside the import rather than a call.
+    const statement = drive.match(/import\s*\{([^}]*)\}\s*from\s*"\.\/workroom-drive-data";/);
+    const imported = (statement?.[1] ?? "")
+      .split(",")
+      .map((name) => name.trim())
+      .filter((name) => name.length > 0 && !name.startsWith("type "));
+    expect(imported.length).toBeGreaterThan(0);
+    const body = drive.replace(statement?.[0] ?? "", "");
+    for (const name of imported) {
+      expect(body, `${name} is imported but never referenced`).toContain(name);
+    }
+  });
+});

--- a/apps/web/lib/queue/functions/workroom-drive.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.ts
@@ -16,8 +16,15 @@ import {
   jsiSchemePresent,
   resolveCoordinatorEligibility,
 } from "@/lib/work-management/coordinator-eligibility";
-import { planCoordinationBindings } from "@/lib/authority/coordination-bindings";
-import { planContainmentRelations } from "@/lib/work-management/standing-room-nesting";
+import { buildStageBrief, stageEvidenceKinds } from "@/lib/work-management/stage-briefing";
+
+import {
+  loadCoordinationBindings,
+  loadRecordedEvidence,
+  reconcileCoordinationBindings,
+  reconcileStandingRoomNesting,
+} from "./workroom-drive-data";
+import { earnEvidenceReceipts, type RecordedEvidence } from "@/lib/work-management/stage-evidence-receipts";
 
 import { gateAtEntry } from "../quiescence-gates";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
@@ -61,6 +68,13 @@ export type WorkroomDriveRoom = {
   participants: ProjectableWorkroomParticipantAssignment[];
   currentStageKey: string | null;
   receipts: { stageKey: string; kind: string }[];
+  /** The room's own objective, sent to the coworker in its stage brief. */
+  objective?: string | null;
+  /** Stage-scoped evidence recorded through record_workroom_evidence — the only
+   *  thing a completing receipt is earned from (BI-76B35820). */
+  recordedEvidence?: RecordedEvidence[];
+  /** When the current stage was most recently dispatched. */
+  stageDispatchedAt?: Date | null;
   budgetUsage: { kind: string; used: number }[];
   stopConditionHits: string[];
   reviewDue: boolean;
@@ -234,7 +248,24 @@ export async function applyDrivePlan(input: {
       agentId: plan.agentId,
       ownerUserId: room.ownerUserId,
       title: `Workroom ${room.capsuleId} / ${plan.stageKey}`,
-      prompt: `Execute Workroom ${room.capsuleId} stage ${plan.stageKey} for shape ${plan.shapeKey}@${plan.shapeVersion}. Stay inside the declared grants. Do not skip stages, widen authority, or invent occupants.`,
+      // The old prompt was the stage KEY plus three prohibitions, and 337 runs
+      // answered it with prose and zero tool calls (BI-4A394B21). The shape
+      // already carries the objective, the definition of done and the evidence
+      // to leave; send it.
+      prompt: buildStageBrief({
+        capsuleId: room.capsuleId,
+        roomObjective: room.objective ?? null,
+        shapeKey: plan.shapeKey ?? "",
+        shapeVersion: plan.shapeVersion ?? "",
+        shapeTitle: plan.definition?.title ?? null,
+        shapeDescription: plan.definition?.description ?? null,
+        stageKey: plan.stageKey ?? "",
+        stageTitle: plan.definition?.stages.find((stage) => stage.key === plan.stageKey)?.title ?? null,
+        doneWhen:
+          plan.definition?.stages.find((stage) => stage.key === plan.stageKey)?.advance.condition ?? null,
+        evidenceKinds: stageEvidenceKinds(plan.definition ?? null, plan.stageKey),
+        stopConditions: (plan.definition?.stopConditions ?? []).map((entry) => entry.condition),
+      }),
       now,
       lease: { roomId: room.id, expiresAt, holderPrincipalId: room.leaseHolderPrincipalId },
     });
@@ -316,7 +347,18 @@ export async function runWorkroomDriveJob(
         presencePrincipalRefs: [],
       }),
       currentStageKey: room.currentStageKey ?? stored.currentStageKey,
-      receipts: room.receipts.length > 0 ? room.receipts : stored.receipts,
+      // Earned from governed, stage-scoped evidence only — never from a run's
+      // self-reported completion (BI-76B35820).
+      receipts: earnEvidenceReceipts({
+        stageKey: room.currentStageKey ?? stored.currentStageKey,
+        declaredKinds: stageEvidenceKinds(
+          shape ? readWorkShapeDefinitionContract(shape) : null,
+          room.currentStageKey ?? stored.currentStageKey,
+        ),
+        evidence: room.recordedEvidence ?? [],
+        dispatchedAt: room.stageDispatchedAt ?? null,
+        existing: room.receipts.length > 0 ? room.receipts : stored.receipts,
+      }) as { stageKey: string; kind: string }[],
       budgetUsage: room.budgetUsage.length > 0 ? room.budgetUsage : stored.budgetUsage,
       stopConditionHits: room.stopConditionHits.length > 0 ? room.stopConditionHits : stored.stopConditionHits,
       reviewDue: room.reviewDue || stored.reviewDue,
@@ -402,131 +444,8 @@ export async function loadStandingRoomIds(db: {
   return rows.map((row) => row.id);
 }
 
-/**
- * Write the declared standing-room tree, returning how many relations were newly
- * created. Idempotent: the (from, to, relation) unique constraint plus
- * skipDuplicates means a settled estate writes nothing and reports 0.
- *
- * Failure is non-fatal. Nesting is what the hierarchy is built on, but a room
- * that can still be driven must not be blocked because its parent link could not
- * be written this minute.
- */
-export async function reconcileStandingRoomNesting(): Promise<number> {
-  try {
-    const { prisma } = await import("@dpf/db");
-    const rooms = await prisma.workroom.findMany({
-      where: { archivedAt: null, idempotencyKey: { startsWith: "standing-room:" } },
-      select: { id: true, capsuleId: true, idempotencyKey: true },
-    });
-    const byCapsuleId = new Map(rooms.map((room) => [room.capsuleId, room.id]));
-    const plans = planContainmentRelations(
-      rooms.map((room) => ({ capsuleId: room.capsuleId, idempotencyKey: room.idempotencyKey })),
-    );
-    if (plans.length === 0) return 0;
-    const created = await prisma.workroomRelation.createMany({
-      data: plans.flatMap((plan) => {
-        const fromWorkroomId = byCapsuleId.get(plan.fromCapsuleId);
-        const toWorkroomId = byCapsuleId.get(plan.toCapsuleId);
-        return fromWorkroomId && toWorkroomId
-          ? [{ fromWorkroomId, toWorkroomId, relation: "contains" as const }]
-          : [];
-      }),
-      skipDuplicates: true,
-    });
-    return created.count;
-  } catch {
-    return 0;
-  }
-}
 
-/**
- * Coordination bindings, keyed by the shape they grant coordination over.
- *
- * One query for the whole tick rather than one per room: the binding set is
- * small (a row per shape the install staffs) and the drive reads every standing
- * room on every pass.
- */
-/**
- * Materialize coordination authority for the shapes this install ships.
- *
- * Idempotent by derivable bindingId: an existing binding is left exactly as the
- * operator has it — including SUSPENDED. Re-seeding must never silently
- * re-grant authority a human deliberately withdrew, which is the one way this
- * could become an authority-laundering path rather than a grant.
- *
- * Returns how many were newly created; a settled install reports 0.
- */
-export async function reconcileCoordinationBindings(): Promise<number> {
-  try {
-    const { prisma } = await import("@dpf/db");
-    const plans = planCoordinationBindings();
-    if (plans.length === 0) return 0;
-    const existing = await prisma.authorityBinding.findMany({
-      where: { bindingId: { in: plans.map((plan) => plan.bindingId) } },
-      select: { bindingId: true },
-    });
-    const known = new Set(existing.map((row) => row.bindingId));
-    const missing = plans.filter((plan) => !known.has(plan.bindingId));
-    if (missing.length === 0) return 0;
-    let created = 0;
-    for (const plan of missing) {
-      const agent = await prisma.principal.findFirst({
-        where: { kind: "agent", principalId: plan.agentId },
-        select: { id: true, principalId: true },
-      });
-      await prisma.authorityBinding.create({
-        data: {
-          bindingId: plan.bindingId,
-          name: plan.name,
-          scopeType: plan.scopeType,
-          resourceType: plan.resourceType,
-          resourceRef: plan.resourceRef,
-          status: plan.status,
-          approvalMode: plan.approvalMode,
-          appliedAgentId: agent?.id ?? null,
-          subjects: {
-            create: plan.subjects.map((subject) => ({
-              subjectType: subject.subjectType,
-              subjectRef: subject.subjectRef,
-              relation: subject.relation,
-            })),
-          },
-        },
-      });
-      created += 1;
-    }
-    return created;
-  } catch {
-    // Never take the drive down over a seeding failure; rooms then read "absent"
-    // and refuse, which is the safe pre-existing behaviour.
-    return 0;
-  }
-}
 
-async function loadCoordinationBindings(): Promise<
-  Map<string, Array<{ status: string; scopeType: string; resourceType: string; resourceRef: string }>>
-> {
-  const byShape = new Map<
-    string,
-    Array<{ status: string; scopeType: string; resourceType: string; resourceRef: string }>
-  >();
-  try {
-    const { prisma } = await import("@dpf/db");
-    const rows = await prisma.authorityBinding.findMany({
-      where: { scopeType: COORDINATION_SCOPE_TYPE, resourceType: COORDINATION_RESOURCE_TYPE },
-      select: { status: true, scopeType: true, resourceType: true, resourceRef: true },
-    });
-    for (const row of rows) {
-      const bucket = byShape.get(row.resourceRef);
-      if (bucket) bucket.push(row);
-      else byShape.set(row.resourceRef, [row]);
-    }
-  } catch {
-    // A binding lookup that fails must not take the drive down. Rooms then read
-    // "unknown" and refuse, which is the pre-existing safe behaviour.
-  }
-  return byShape;
-}
 
 async function loadStandingRooms(
   coordinationBindings?: Map<

--- a/apps/web/lib/queue/functions/workroom-drive.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.ts
@@ -326,6 +326,13 @@ export async function runWorkroomDriveJob(
       jsiSchemePresent(prisma as unknown as Record<string, unknown>),
     ];
     rooms = await loadStandingRooms(bindings, schemePresent);
+    // Stage-scoped evidence is the ONLY thing a completing receipt is earned
+    // from, so a room that arrives without it can never advance.
+    const evidenceByRoom = await loadRecordedEvidence(rooms.map((room) => room.capsuleId));
+    rooms = rooms.map((room) => ({
+      ...room,
+      recordedEvidence: evidenceByRoom.get(room.capsuleId) ?? [],
+    }));
   }
   const effects = deps?.effects ?? createWorkroomDriveEffects();
   const plans: WorkroomDriveResult["plans"] = [];

--- a/apps/web/lib/work-capsules/evidence-input-parity.test.ts
+++ b/apps/web/lib/work-capsules/evidence-input-parity.test.ts
@@ -1,0 +1,33 @@
+// Structural guard: every field the evidence tool advertises must survive to
+// the persisted payload.
+//
+// This exists because the identical seam already shipped broken once: the
+// scope-claim handler advertised `workShape`, never read it, and returned
+// success while dropping the claim. `stageKey` carries more weight — a dropped
+// stageKey means evidence is recorded, the tool reports success, and the stage
+// silently never advances, which is the defect BI-76B35820 exists to remove.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const packSource = readFileSync(
+  join(__dirname, "..", "mcp", "packs", "work-capsules-pack.ts"),
+  "utf8",
+);
+const handlerSource = readFileSync(join(__dirname, "mcp-handlers.ts"), "utf8");
+
+describe("record_workroom_evidence schema/handler parity", () => {
+  it("advertises stageKey", () => {
+    const schema = packSource.slice(packSource.indexOf('name: "record_workroom_evidence"'));
+    expect(schema.slice(0, 1600)).toContain("stageKey");
+  });
+
+  it("reads stageKey in the handler rather than silently dropping it", () => {
+    const handler = handlerSource.slice(handlerSource.indexOf("export async function recordCapsuleEvidenceTool"));
+    const body = handler.slice(0, 2400);
+    expect(body).toContain('stringParam(params, "stageKey")');
+    expect(body).toContain("evidence.stageKey");
+  });
+});

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -652,6 +652,9 @@ export async function recordCapsuleEvidenceTool(
   const evidence: {
     kind: WorkCapsuleEvidenceKind;
     summary: string;
+    // The stage this evidence completes. Without it the drive cannot tell a
+    // stage outcome from a room-level note, and the stage never advances.
+    stageKey?: string;
     command?: string;
     url?: string;
     targetId?: string;
@@ -662,6 +665,8 @@ export async function recordCapsuleEvidenceTool(
     kind: rawKind,
     summary,
   };
+  const stageKey = stringParam(params, "stageKey");
+  if (stageKey) evidence.stageKey = stageKey;
   const command = stringParam(params, "command");
   const url = stringParam(params, "url");
   const targetId = stringParam(params, "targetId");

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -76,6 +76,9 @@ type CapsuleCreateInput = {
 type CapsuleEvidenceInput = {
   kind: WorkCapsuleEvidenceKind;
   summary: string;
+  /** The work-shape stage this evidence completes. The drive earns a completing
+   *  receipt from stage-scoped evidence only (BI-76B35820). */
+  stageKey?: string;
   command?: string;
   url?: string;
   targetId?: string;

--- a/apps/web/lib/work-management/drive-resolution.test.ts
+++ b/apps/web/lib/work-management/drive-resolution.test.ts
@@ -30,6 +30,8 @@ function participant(
 const definition: WorkShapeDefinitionContract = {
   key: "obligation-assurance-watch",
   version: "1.0.0",
+  title: "Test shape",
+  description: "A shape used in tests.",
   triggers: ["cadence"],
   stages: [
     {

--- a/apps/web/lib/work-management/drive-resolution.ts
+++ b/apps/web/lib/work-management/drive-resolution.ts
@@ -86,6 +86,9 @@ export type DrivePlan = {
   roomId: string;
   shapeKey: string | null;
   shapeVersion: string | null;
+  /** The shape being driven, so the dispatcher can brief the coworker from it
+   *  rather than sending a bare stage key (BI-4A394B21). */
+  definition: WorkShapeDefinitionContract | null;
   stageKey: string | null;
   accountablePrincipalRef: string | null;
   agentId: string | null;
@@ -121,6 +124,7 @@ function emptyPlan(
     reason,
     roomId: input.roomId,
     shapeKey: input.definition?.key ?? null,
+    definition: input.definition ?? null,
     shapeVersion: input.definition?.version ?? null,
     stageKey: null,
     accountablePrincipalRef: null,
@@ -289,6 +293,7 @@ export function resolveDrivePlan(input: DriveResolutionInput): DrivePlan {
       reason,
       roomId: input.roomId,
       shapeKey: input.definition.key,
+      definition: input.definition ?? null,
       shapeVersion: input.definition.version,
       stageKey: stage.key,
       accountablePrincipalRef: stage.accountablePrincipalRef,
@@ -338,6 +343,7 @@ export function resolveDrivePlan(input: DriveResolutionInput): DrivePlan {
       reason: EXECUTOR_WRITEBACK_UNAVAILABLE_REASON,
       roomId: input.roomId,
       shapeKey: input.definition.key,
+      definition: input.definition ?? null,
       shapeVersion: input.definition.version,
       stageKey: stage.key,
       accountablePrincipalRef: stage.accountablePrincipalRef,
@@ -358,6 +364,7 @@ export function resolveDrivePlan(input: DriveResolutionInput): DrivePlan {
     reason: "agent_stage",
     roomId: input.roomId,
     shapeKey: input.definition.key,
+    definition: input.definition ?? null,
     shapeVersion: input.definition.version,
     stageKey: stage.key,
     accountablePrincipalRef: stage.accountablePrincipalRef,

--- a/apps/web/lib/work-management/stage-briefing.test.ts
+++ b/apps/web/lib/work-management/stage-briefing.test.ts
@@ -1,0 +1,79 @@
+// What the coworker is actually asked to do (BI-4A394B21).
+
+import { describe, expect, it } from "vitest";
+
+import { STAGE_EVIDENCE_TOOL, buildStageBrief, type StageBriefInput } from "./stage-briefing";
+
+const input: StageBriefInput = {
+  capsuleId: "WC-A69BCABB",
+  roomObjective: "Sweep published advisories against the recorded dependency manifest.",
+  shapeKey: "dependency-advisory-watch",
+  shapeVersion: "1.0.0",
+  shapeTitle: "Dependency and advisory watch",
+  shapeDescription: "The security engineer sweeps advisories. It never applies a patch.",
+  stageKey: "sweep",
+  stageTitle: "Sweep advisories against the manifest",
+  doneWhen: "Every advisory source in scope has been read and correlated to the recorded manifest.",
+  evidenceKinds: ["assurance-run"],
+  stopConditions: ["The advisory source cannot be read."],
+};
+
+describe("buildStageBrief", () => {
+  it("states the definition of done, which the old prompt omitted entirely", () => {
+    // The old brief was the stage KEY and three prohibitions. 337 runs answered
+    // it with prose and zero tool calls.
+    expect(buildStageBrief(input)).toContain("read and correlated to the recorded manifest");
+  });
+
+  it("carries the room objective and the activity's own description", () => {
+    const brief = buildStageBrief(input);
+    expect(brief).toContain("Sweep published advisories");
+    expect(brief).toContain("It never applies a patch.");
+  });
+
+  it("names the stage in words, not just a key", () => {
+    expect(buildStageBrief(input)).toContain("Sweep advisories against the manifest");
+  });
+
+  it("tells the coworker to record evidence through the governed tool, with the stage", () => {
+    const brief = buildStageBrief(input);
+    expect(brief).toContain(STAGE_EVIDENCE_TOOL);
+    expect(brief).toContain('stageKey "sweep"');
+    expect(brief).toContain('"assurance-run"');
+  });
+
+  it("says plainly that claiming completion does not advance anything", () => {
+    // The behaviour the platform now enforces; saying so is cheaper than
+    // letting the coworker discover it by being re-dispatched.
+    const brief = buildStageBrief(input);
+    expect(brief).toContain("Saying the work is done does not advance it");
+  });
+
+  it("tells the coworker to report a blocker rather than fake success", () => {
+    expect(buildStageBrief(input)).toContain("Do not report success for work you did not do.");
+  });
+
+  it("carries stop conditions so the run ends instead of grinding", () => {
+    expect(buildStageBrief(input)).toContain("The advisory source cannot be read.");
+  });
+
+  it("keeps the original prohibitions", () => {
+    expect(buildStageBrief(input)).toContain("Do not skip stages, widen authority, or invent occupants.");
+  });
+
+  it("degrades cleanly when the shape declares little", () => {
+    const sparse = buildStageBrief({
+      ...input,
+      roomObjective: null,
+      shapeTitle: null,
+      shapeDescription: null,
+      stageTitle: null,
+      doneWhen: null,
+      evidenceKinds: [],
+      stopConditions: [],
+    });
+    expect(sparse).toContain("WC-A69BCABB");
+    expect(sparse).toContain(STAGE_EVIDENCE_TOOL);
+    expect(sparse).not.toContain("null");
+  });
+});

--- a/apps/web/lib/work-management/stage-briefing.ts
+++ b/apps/web/lib/work-management/stage-briefing.ts
@@ -1,0 +1,106 @@
+// What the coworker is actually asked to do (BI-4A394B21).
+//
+// 337 dispatched stage runs reported `completed` having executed ZERO tools and
+// produced no summary, across all twelve standing rooms. The runs were real —
+// quiescence was held by a live `coworker.reasoning-loop` for
+// `Workroom WC-C9320161 / assemble` — so dispatch reached a coworker and a model
+// ran. It simply had nothing to act on.
+//
+// This was the entire brief:
+//
+//   "Execute Workroom WC-A69BCABB stage sweep for shape
+//    dependency-advisory-watch@1.0.0. Stay inside the declared grants. Do not
+//    skip stages, widen authority, or invent occupants."
+//
+// An opaque stage key and three prohibitions. No objective, no definition of
+// done, no evidence to leave, no statement of what the stage is for. A model
+// given that will reasonably answer in prose that it did the thing — which is
+// exactly what 337 runs did.
+//
+// Meanwhile the shape already carries all of it: the stage's title, its
+// `advance.condition` (which IS the definition of done), the `evidence` kinds it
+// must leave behind, the shape's own description including its prohibitions, and
+// the room's objective. None of it was being sent.
+//
+// Pure string building; no IO.
+
+import type { WorkShapeDefinitionContract } from "./work-shapes";
+
+export type StageBriefInput = {
+  capsuleId: string;
+  /** The room's own objective — why this room exists at all. */
+  roomObjective: string | null;
+  shapeKey: string;
+  shapeVersion: string;
+  shapeTitle: string | null;
+  shapeDescription: string | null;
+  stageKey: string;
+  stageTitle: string | null;
+  /** The stage's advance condition — the definition of done, in the shape's words. */
+  doneWhen: string | null;
+  /** Evidence kinds this stage must leave behind (§8.11). */
+  evidenceKinds: readonly string[];
+  /** Stop conditions that end the run rather than continuing. */
+  stopConditions: readonly string[];
+};
+
+/** The tool a stage's outcome must be recorded through. A completing receipt is
+ *  earned from THIS governed write, never from the run's self-reported status —
+ *  a completed TaskRun is the executor's claim about itself, and 337 of them
+ *  were false (see BI-76B35820 and the refusal of PR #5168). */
+export const STAGE_EVIDENCE_TOOL = "record_workroom_evidence";
+
+function line(label: string, value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? `${label}: ${trimmed}` : null;
+}
+
+/**
+ * The brief a dispatched coworker receives for one stage.
+ *
+ * Everything here is read from the shape and the room. Nothing is invented, and
+ * nothing that the shape declares is withheld — the previous prompt withheld all
+ * of it.
+ */
+export function buildStageBrief(input: StageBriefInput): string {
+  const evidence = input.evidenceKinds.filter((kind) => kind.trim().length > 0);
+  const sections: Array<string | null> = [
+    `You are executing one stage of a standing Workroom activity.`,
+    ``,
+    line("Room", input.capsuleId),
+    line("Room objective", input.roomObjective),
+    line("Activity", input.shapeTitle ?? input.shapeKey),
+    line("How this activity works", input.shapeDescription),
+    ``,
+    line("Your stage", input.stageTitle ? `${input.stageTitle} (${input.stageKey})` : input.stageKey),
+    // The advance condition is the shape's own definition of done. Sending the
+    // stage key without it is what produced 337 no-op completions.
+    line("This stage is done when", input.doneWhen),
+    input.stopConditions.length > 0
+      ? `Stop instead of continuing if: ${input.stopConditions.join(" | ")}`
+      : null,
+    ``,
+    `Do the work with your tools. Read the real sources; do not answer from memory or assumption.`,
+    evidence.length > 0
+      ? `Before you finish, record what you did by calling ${STAGE_EVIDENCE_TOOL} with capsuleId "${input.capsuleId}", stageKey "${input.stageKey}", and kind ${evidence.map((kind) => `"${kind}"`).join(" or ")}.`
+      : `Before you finish, record what you did by calling ${STAGE_EVIDENCE_TOOL} with capsuleId "${input.capsuleId}" and stageKey "${input.stageKey}".`,
+    // Said plainly, because the platform now enforces it: the stage does not
+    // advance on a claim of completion.
+    `That recorded evidence is what advances this activity. Saying the work is done does not advance it, and a stage with no recorded evidence will simply be dispatched again.`,
+    `If you cannot do the work — a source is unreachable, a tool is missing, authority is insufficient — record that instead, with what blocked you. Do not report success for work you did not do.`,
+    ``,
+    `Stay inside the declared grants. Do not skip stages, widen authority, or invent occupants.`,
+  ];
+  return sections.filter((section) => section !== null).join("\n");
+}
+
+/** The stage's declared evidence kinds, or an empty list. */
+export function stageEvidenceKinds(
+  definition: WorkShapeDefinitionContract | null,
+  stageKey: string | null,
+): readonly string[] {
+  if (!definition || !stageKey) return [];
+  const stage = definition.stages.find((candidate) => candidate.key === stageKey);
+  const evidence = (stage as { evidence?: readonly string[] } | undefined)?.evidence;
+  return Array.isArray(evidence) ? evidence : [];
+}

--- a/apps/web/lib/work-management/stage-evidence-receipts.test.ts
+++ b/apps/web/lib/work-management/stage-evidence-receipts.test.ts
@@ -1,0 +1,100 @@
+// A stage advances on recorded evidence, never on a claim (BI-76B35820).
+//
+// PR #5168 proposed earning receipts from TaskRun.status === "completed".
+// Refused, and the live data is why: 337 such claims, every one with
+// executedToolCount 0 and a null summary. Earning receipts from them would have
+// converted 337 fabrications into stage advancement.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  STAGE_EVIDENCE_RECEIPT_KIND,
+  earnEvidenceReceipts,
+  stageHasCompletingEvidence,
+  type RecordedEvidence,
+} from "./stage-evidence-receipts";
+
+const at = (iso: string) => new Date(iso);
+const dispatchedAt = at("2026-09-07T10:00:00Z");
+const evidence = (over: Partial<RecordedEvidence> = {}): RecordedEvidence => ({
+  stageKey: "sweep",
+  kind: "assurance-run",
+  recordedAt: at("2026-09-07T10:05:00Z"),
+  ...over,
+});
+
+const base = { stageKey: "sweep", declaredKinds: ["assurance-run"], dispatchedAt };
+
+describe("stageHasCompletingEvidence", () => {
+  it("accepts governed evidence for this stage, of the declared kind, after dispatch", () => {
+    expect(stageHasCompletingEvidence({ ...base, evidence: [evidence()] })).toBe(true);
+  });
+
+  it("rejects evidence recorded against a different stage", () => {
+    expect(stageHasCompletingEvidence({ ...base, evidence: [evidence({ stageKey: "raise" })] })).toBe(false);
+  });
+
+  it("rejects room-level evidence that names no stage", () => {
+    // A note on the room is not a stage outcome. Accepting it would let any
+    // unrelated write advance the shape.
+    expect(stageHasCompletingEvidence({ ...base, evidence: [evidence({ stageKey: null })] })).toBe(false);
+  });
+
+  it("rejects an evidence kind the stage never declared", () => {
+    expect(stageHasCompletingEvidence({ ...base, evidence: [evidence({ kind: "note" })] })).toBe(false);
+  });
+
+  it("rejects evidence older than the dispatch — a previous attempt cannot satisfy this one", () => {
+    expect(
+      stageHasCompletingEvidence({
+        ...base,
+        evidence: [evidence({ recordedAt: at("2026-09-07T09:00:00Z") })],
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts any stage-scoped evidence when the stage declared no kinds", () => {
+    expect(
+      stageHasCompletingEvidence({
+        stageKey: "sweep",
+        declaredKinds: [],
+        dispatchedAt,
+        evidence: [evidence({ kind: "note" })],
+      }),
+    ).toBe(true);
+  });
+
+  it("finds nothing when no evidence was recorded at all — today's live state", () => {
+    // 337 completed runs, zero evidence rows from the standing rooms.
+    expect(stageHasCompletingEvidence({ ...base, evidence: [] })).toBe(false);
+  });
+
+  it("earns nothing without a current stage", () => {
+    expect(stageHasCompletingEvidence({ ...base, stageKey: null, evidence: [evidence()] })).toBe(false);
+  });
+});
+
+describe("earnEvidenceReceipts", () => {
+  it("records the receipt that lets the drive advance", () => {
+    expect(earnEvidenceReceipts({ ...base, evidence: [evidence()], existing: [] })).toEqual([
+      { stageKey: "sweep", kind: STAGE_EVIDENCE_RECEIPT_KIND },
+    ]);
+  });
+
+  it("is idempotent", () => {
+    const existing = [{ stageKey: "sweep", kind: STAGE_EVIDENCE_RECEIPT_KIND }];
+    expect(earnEvidenceReceipts({ ...base, evidence: [evidence(), evidence()], existing })).toBe(existing);
+  });
+
+  it("returns the same reference when nothing was earned, so no write is needed", () => {
+    const existing: Array<{ stageKey: string; kind: string }> = [];
+    expect(earnEvidenceReceipts({ ...base, evidence: [], existing })).toBe(existing);
+  });
+
+  it("never earns from a completion claim — there is no path from run status to a receipt", () => {
+    // The refused design, asserted as absent: this module's only input is
+    // recorded evidence. A "completed" run with no evidence earns nothing.
+    const existing: Array<{ stageKey: string; kind: string }> = [];
+    expect(earnEvidenceReceipts({ ...base, evidence: [], existing })).toBe(existing);
+  });
+});

--- a/apps/web/lib/work-management/stage-evidence-receipts.ts
+++ b/apps/web/lib/work-management/stage-evidence-receipts.ts
@@ -1,0 +1,85 @@
+// A stage advances on recorded evidence, not on a claim of completion
+// (BI-76B35820, after the refusal of PR #5168).
+//
+// #5168 proposed earning the completing receipt from `TaskRun.status ===
+// "completed"`. That was correctly refused: a completed TaskRun is the
+// executor's claim about ITSELF. On this install all 337 such claims were false
+// — `executedToolCount: 0`, `scheduledSummary: null` — so earning receipts from
+// them would have converted 337 fabrications into stage advancement and undone
+// the fail-closed pause added by #5166. A visible loop is strictly better than
+// silent false progress.
+//
+// The kernel already says this: governance approves evidence, not provenance;
+// structural verification is not functional verification.
+//
+// So the receipt is earned from a governed WRITE the worker had to make through
+// MCP — `record_workroom_evidence`, a sanctioned mutator requiring
+// `work_capsule_write` — carrying the stage it belongs to and an evidence kind
+// the stage declared. The drive still owns the advance; the worker cannot
+// advance itself, it can only leave evidence the drive then reads.
+//
+// Pure resolution over supplied rows.
+
+export type RecordedEvidence = {
+  /** Stage the evidence was recorded against. Evidence with no stage cannot
+   *  advance one — it is a note on the room, not a stage outcome. */
+  stageKey: string | null;
+  kind: string | null;
+  recordedAt: Date;
+};
+
+export type StageEvidenceInput = {
+  stageKey: string | null;
+  /** Kinds the stage declared it would leave behind. Empty means the stage
+   *  declared none, and any stage-scoped evidence counts. */
+  declaredKinds: readonly string[];
+  evidence: readonly RecordedEvidence[];
+  /** When the stage was most recently dispatched. Evidence older than the
+   *  dispatch belongs to a previous attempt and must not satisfy this one. */
+  dispatchedAt: Date | null;
+};
+
+/**
+ * Whether the current stage has evidence good enough to advance on.
+ *
+ * Deliberately strict, because the failure this replaces was permissive:
+ *
+ * - Evidence must name THIS stage. Room-level notes do not advance a stage.
+ * - It must be of a kind the stage declared, when the stage declared any.
+ * - It must post-date the dispatch, so a previous attempt's evidence cannot
+ *   satisfy a fresh one.
+ *
+ * Anything short of that returns false and the stage is dispatched again, which
+ * is the correct, visible, non-fabricating outcome.
+ */
+export function stageHasCompletingEvidence(input: StageEvidenceInput): boolean {
+  if (!input.stageKey) return false;
+  const declared = new Set(input.declaredKinds.filter((kind) => kind.trim().length > 0));
+  return input.evidence.some((row) => {
+    if (row.stageKey !== input.stageKey) return false;
+    if (declared.size > 0 && (row.kind === null || !declared.has(row.kind))) return false;
+    if (input.dispatchedAt && row.recordedAt < input.dispatchedAt) return false;
+    return true;
+  });
+}
+
+/** Receipt kind recorded when a stage's governed evidence is present. Distinct
+ *  from #5166's `blocked`, which records a dispatch that produced no writeback. */
+export const STAGE_EVIDENCE_RECEIPT_KIND = "stage-evidence-recorded";
+
+export type StageReceipt = { stageKey: string; kind: string };
+
+/**
+ * The room's receipts after reading its recorded evidence.
+ *
+ * Idempotent, and returns the SAME array reference when nothing was earned so a
+ * caller can cheaply skip the write.
+ */
+export function earnEvidenceReceipts(input: StageEvidenceInput & {
+  existing: readonly StageReceipt[];
+}): readonly StageReceipt[] {
+  if (!input.stageKey) return input.existing;
+  if (input.existing.some((receipt) => receipt.stageKey === input.stageKey)) return input.existing;
+  if (!stageHasCompletingEvidence(input)) return input.existing;
+  return [...input.existing, { stageKey: input.stageKey, kind: STAGE_EVIDENCE_RECEIPT_KIND }];
+}

--- a/apps/web/lib/work-management/work-shapes.ts
+++ b/apps/web/lib/work-management/work-shapes.ts
@@ -105,6 +105,10 @@ export type WorkShapeDefinitionContract = Pick<
   WorkShapeDefinition,
   | "key"
   | "version"
+  // The activity's own words. The dispatcher briefs the coworker from these;
+  // without them the brief is a bare stage key (BI-4A394B21).
+  | "title"
+  | "description"
   | "triggers"
   | "stages"
   | "stopConditions"
@@ -120,6 +124,8 @@ export function readWorkShapeDefinitionContract(
   return {
     key: shape.key,
     version: shape.version,
+    title: shape.title,
+    description: shape.description,
     triggers: shape.triggers,
     stages: shape.stages,
     stopConditions: shape.stopConditions,

--- a/apps/web/lib/work-management/workroom-shape-conformance.test.ts
+++ b/apps/web/lib/work-management/workroom-shape-conformance.test.ts
@@ -35,6 +35,8 @@ function participant(
 const definition: WorkShapeDefinitionContract = {
   key: "obligation-assurance-watch",
   version: "1.0.0",
+  title: "Test shape",
+  description: "A shape used in tests.",
   triggers: ["cadence"],
   stages: [
     { key: "scan", title: "Scan", accountablePrincipalRef: "agent:watcher", advance: { kind: "status-change", condition: "scanned" }, evidence: ["findings"] },

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -669,6 +669,49 @@ reservation from normal replay. Unknown waits, rejected writers, approvals and
 exhausted recovery stay outside this automatic path. This does not make the separate
 inline semantic-review operation restartable or resume an interrupted provider call.
 
+## The brief, and what advances a stage
+
+Once the twelve standing rooms began dispatching, they produced **337 completed
+task runs with `executedToolCount: 0`** and no summary. Every one. The runs were
+real — quiescence was held by a live `coworker.reasoning-loop` for
+`Workroom WC-C9320161 / assemble` — so dispatch reached a coworker and a model
+ran. It had nothing to act on.
+
+This was the entire brief a coworker received:
+
+    Execute Workroom WC-A69BCABB stage sweep for shape
+    dependency-advisory-watch@1.0.0. Stay inside the declared grants. Do not skip
+    stages, widen authority, or invent occupants.
+
+An opaque stage key and three prohibitions. Meanwhile the shape already carried
+the stage's title, its `advance.condition` — which IS the definition of done —
+the `evidence` kinds it must leave behind, the activity's description including
+its prohibitions ("It never applies a patch"), and the room's objective. None of
+it was sent. A model handed that will reasonably answer in prose that it did the
+work, which is what 337 runs did.
+
+**The dispatcher now briefs from the shape.** Objective, activity description,
+stage title, definition of done, stop conditions, the evidence to record, and an
+explicit statement that claiming completion advances nothing.
+
+**And a stage advances on recorded evidence, never on a claim.** A completed
+`TaskRun` is the executor's claim about ITSELF — provenance, not evidence. PR
+#5168 proposed earning the completing receipt from `TaskRun.status` and was
+correctly refused: it would have converted those 337 fabrications into stage
+advancement and undone the fail-closed pause from #5166. A visible loop is
+strictly better than silent false progress.
+
+The receipt is earned instead from a governed write the worker had to make
+through MCP — `record_workroom_evidence`, a sanctioned mutator requiring
+`work_capsule_write` — carrying the stage it belongs to. The drive still owns the
+advance; a worker cannot advance itself, only leave evidence the drive reads.
+Evidence must name the stage, be of a kind the stage declared, and post-date the
+dispatch; anything short of that re-dispatches.
+
+`record_workroom_evidence` therefore takes an optional `stageKey`, and a
+schema/handler parity guard protects it — the same seam already shipped broken
+once when `workShape` was advertised and silently dropped.
+
 ## Related references
 
 - [Workroom vocabulary boundary](workroom-vocabulary-boundary.md) — what the word means at each layer

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -45,7 +45,7 @@ apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp/packs/backlog-pack.dispatch.test.ts	874
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	855
 apps/web/lib/mcp/packs/sandbox-pack.ts	921
-apps/web/lib/navigation/portal-navigation-model.ts	996
+apps/web/lib/navigation/portal-navigation-model.ts	994
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1379
 apps/web/lib/routing/chat-adapter.test.ts	1073
@@ -61,7 +61,7 @@ apps/web/lib/tak/agentic-loop.test.ts	2485
 apps/web/lib/tak/agentic-loop.ts	2680
 apps/web/lib/tak/route-context-map.ts	1440
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1239
-apps/web/lib/work-capsules/work-capsule-store.ts	1033
+apps/web/lib/work-capsules/work-capsule-store.ts	1036
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace-home/command-center.ts	1118


### PR DESCRIPTION
Two defects, one causal chain: the dispatched coworker had nothing to act on, and nothing it produced could advance the shape. Fixing either alone leaves the estate stuck, so they ship together.

## 1. The coworker was asked to do nothing (`BI-4A394B21`)

**337 dispatched stage runs reported `completed` with `executedToolCount: 0`** and no summary — every run, across all twelve standing rooms, with **zero evidence rows** between them.

The runs were real: quiescence run `QR-2026-09-07-e2d3ski9` was held by a live `coworker.reasoning-loop` for `Workroom WC-C9320161 / assemble`. Dispatch reached a coworker and a model ran. It had nothing to act on. This was the entire brief:

```
Execute Workroom WC-A69BCABB stage sweep for shape dependency-advisory-watch@1.0.0.
Stay inside the declared grants. Do not skip stages, widen authority, or invent occupants.
```

An opaque stage key and three prohibitions. Meanwhile the shape carried all of this, and none of it was sent:

| Shape declares | Was sent |
|---|---|
| stage title — "Sweep advisories against the manifest" | ✗ |
| `advance.condition` — *"Every advisory source in scope has been read and correlated to the recorded manifest"* (**the definition of done**) | ✗ |
| `evidence: ["assurance-run"]` — what to leave behind | ✗ |
| activity description, incl. "It never applies a patch" | ✗ |
| room objective, stop conditions | ✗ |

A model handed that will reasonably answer in prose that it did the work. 337 runs did.

The dispatcher now briefs from the shape, and says plainly that claiming completion advances nothing and that a blocker must be reported rather than faked.

## 2. Nothing the coworker produced could advance the stage (`BI-76B35820`)

A completed `TaskRun` is the executor's claim about **itself**. PR #5168 proposed earning the completing receipt from it and was correctly refused: it would have converted those 337 fabrications into stage advancement and undone the fail-closed pause from #5166. A visible loop is strictly better than silent false progress.

The receipt is earned instead from a **governed write the worker had to make through MCP** — `record_workroom_evidence`, a sanctioned mutator requiring `work_capsule_write` — carrying the stage it belongs to. The drive still owns the advance: a worker cannot advance itself, only leave evidence the drive reads.

Evidence must **name the stage**, be **of a kind the stage declared**, and **post-date the dispatch**. Anything short of that re-dispatches, visibly. There is no code path from run status to a receipt, and a test asserts that absence.

`record_workroom_evidence` gains an optional `stageKey`, with a schema/handler parity guard — the same seam already shipped broken once when `workShape` was advertised and silently dropped.

## Verified against the live database

The evidence query returns existing rows correctly, with `stageKey` null on all pre-existing evidence — which therefore earns nothing. Room-level notes are not stage outcomes.

## Module size

The substrate guard flagged `workroom-drive.ts` crossing the 800-LOC hotspot threshold as these loaders accumulated. Extracted to `workroom-drive-data.ts` — the drive decides, that module reads and writes what it decides over. **843 → 676 lines, and the hotspot set went 64 → 63.**

## Verification

- 66 pregate preflight guards clean
- **1608 tests pass** (178 files) — 23 new
- `tsc --noEmit`: exit 0
- Live-database query verification

**The heavy local-CI build was NOT run and is NOT passed** — fenced on `host-capacity-lost:host-memory-low`. Recorded `operator-emergency` override; cloud merge queue is the adjudicating build per AGENTS.md §4.

`BI-4A394B21` · `BI-76B35820`

Local-CI-Override: operator-emergency: heavy build unrun (NOT passed) — local-CI fenced on host-capacity-lost:host-memory-low. Fast tier clean (66 preflight guards, 1608 tests, tsc --noEmit exit 0, live-database verification). Cloud merge queue is the adjudicating build per AGENTS.md 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
