### PR TITLE
fix(ci): tolerate merge-order drift of repo-wide counts in the merge queue only (BI-DEFB9677)

### DIFF
--- a/scripts/derived-artifacts-gate.mjs
+++ b/scripts/derived-artifacts-gate.mjs
@@ -104,9 +104,35 @@ export function evaluatePushExemption(diffFiles, registry = DERIVED_ARTIFACTS, r
   return { exempt: true, reason: affected.length > 0 ? "docs diff, all affected artifacts fresh" : "docs-only diff, no registered artifact touched" };
 }
 
-/** Run every registry entry's check; returns [{ entry, ok }]. */
-export function evaluateCheckAll(registry = DERIVED_ARTIFACTS, runCheck = () => true) {
-  return registry.map((entry) => ({ entry, ok: runCheck(entry) }));
+/**
+ * True when running inside GitHub's merge queue — the `merge_group` event, or
+ * the synthetic `gh-readonly-queue/<base>/pr-<n>-<sha>` ref it checks out.
+ * Nothing local ever sets either, so pre-commit and pregate stay strict.
+ */
+export function isMergeQueueContext(env = process.env) {
+  if (env.GITHUB_EVENT_NAME === "merge_group") return true;
+  return typeof env.GITHUB_REF === "string" && env.GITHUB_REF.startsWith("refs/heads/gh-readonly-queue/");
+}
+
+/**
+ * Run every registry entry's check; returns [{ entry, ok, tolerated }].
+ *
+ * `tolerated` is true only for an entry flagged `mergeQueueRaceTolerant` that
+ * is stale while `mergeQueue` is set. Such an artifact is derived from
+ * repo-wide state (e.g. the migration count), so two PRs that each touch a
+ * source produce a merged tree neither of them could have generated: the
+ * second one into the queue is always stale, through no author error, and
+ * cannot push a fix into the queue. PR-head CI (`pull_request`) still runs
+ * this check strictly against the author's own base, so an author who forgot
+ * to regenerate is still caught; only merge-order drift is tolerated, and the
+ * next PR touching a source regenerates it (pre-commit) and heals main.
+ */
+export function evaluateCheckAll(registry = DERIVED_ARTIFACTS, runCheck = () => true, { mergeQueue = false } = {}) {
+  return registry.map((entry) => {
+    const ok = runCheck(entry);
+    const tolerated = !ok && mergeQueue === true && entry.mergeQueueRaceTolerant === true;
+    return { entry, ok, tolerated };
+  });
 }
 
 // ── IO-touching implementations used by the CLI ────────────────────────────
@@ -232,14 +258,23 @@ function cmdPushExempt(baseRef) {
 }
 
 function cmdCheckAll() {
-  const results = evaluateCheckAll(DERIVED_ARTIFACTS, runCheckLive);
+  const mergeQueue = isMergeQueueContext();
+  const results = evaluateCheckAll(DERIVED_ARTIFACTS, runCheckLive, { mergeQueue });
   let failed = false;
-  for (const { entry, ok } of results) {
-    console.log(`[derived-artifacts] ${entry.id}: ${ok ? "fresh" : "STALE"}`);
-    if (!ok) {
-      console.log(`[derived-artifacts]   run: ${entry.generate.join(" ")}`);
-      failed = true;
+  for (const { entry, ok, tolerated } of results) {
+    if (ok) {
+      console.log(`[derived-artifacts] ${entry.id}: fresh`);
+      continue;
     }
+    if (tolerated) {
+      console.log(
+        `[derived-artifacts] ${entry.id}: STALE — tolerated in the merge queue (repo-wide count drifted under a concurrent merge; PR-head CI enforced freshness against the author's base, and the next source-touching PR regenerates it)`,
+      );
+      continue;
+    }
+    console.log(`[derived-artifacts] ${entry.id}: STALE`);
+    console.log(`[derived-artifacts]   run: ${entry.generate.join(" ")}`);
+    failed = true;
   }
   return failed ? 1 : 0;
 }

--- a/scripts/derived-artifacts-gate.test.mjs
+++ b/scripts/derived-artifacts-gate.test.mjs
@@ -10,6 +10,7 @@ import {
   planRegenerate,
   evaluatePushExemption,
   evaluateCheckAll,
+  isMergeQueueContext,
   resolveDerivedArtifactInvocation,
 } from "./derived-artifacts-gate.mjs";
 
@@ -28,6 +29,15 @@ const DIAGRAMS = {
   generate: ["node", "scripts/render-doc-diagrams.mjs"],
   check: ["node", "scripts/render-doc-diagrams.mjs", "--check"],
   requiresBinary: "mmdc",
+};
+
+const COUNTS = {
+  id: "architecture-counts",
+  sourceGlobs: ["packages/db/prisma/migrations/**"],
+  artifactPaths: ["docs/architecture/architecture-counts.generated.md"],
+  generate: ["node", "scripts/gen-architecture-counts.mjs"],
+  check: ["node", "scripts/gen-architecture-counts.mjs", "--check"],
+  mergeQueueRaceTolerant: true,
 };
 
 const SBOM = {
@@ -164,4 +174,57 @@ test("evaluateCheckAll reports every entry's check result", () => {
       ["sbom-baseline", false],
     ],
   );
+});
+
+// ── merge-queue race tolerance ───────────────────────────────────────────────
+//
+// PR #5175 was ejected from the merge queue six times over twelve hours with
+// zero code failures: it added a migration, so did main, and the generated
+// migration COUNT in the merged tree matched neither. The author cannot fix
+// that from the queue. Tolerance is narrow on purpose: the flagged entry only,
+// the queue only, and never a substitute for the PR-head check.
+
+test("a race-tolerant entry that is stale in the MERGE QUEUE is tolerated, not failed", () => {
+  const results = evaluateCheckAll([COUNTS], () => false, { mergeQueue: true });
+  assert.deepEqual(results.map((r) => [r.entry.id, r.ok, r.tolerated]), [
+    ["architecture-counts", false, true],
+  ]);
+});
+
+test("the same stale entry on a PR head (not the queue) still FAILS — author error stays caught", () => {
+  const results = evaluateCheckAll([COUNTS], () => false, { mergeQueue: false });
+  assert.deepEqual(results.map((r) => [r.entry.id, r.ok, r.tolerated]), [
+    ["architecture-counts", false, false],
+  ]);
+});
+
+test("an entry WITHOUT the flag is never tolerated, even in the merge queue", () => {
+  const results = evaluateCheckAll([DOC_INDEX, COUNTS], () => false, { mergeQueue: true });
+  assert.deepEqual(results.map((r) => [r.entry.id, r.tolerated]), [
+    ["doc-index", false],
+    ["architecture-counts", true],
+  ]);
+});
+
+test("a fresh race-tolerant entry is simply fresh — tolerance never fires on ok", () => {
+  const [result] = evaluateCheckAll([COUNTS], () => true, { mergeQueue: true });
+  assert.equal(result.ok, true);
+  assert.equal(result.tolerated, false);
+});
+
+test("evaluateCheckAll default (no options) is the strict pre-existing behaviour", () => {
+  const [result] = evaluateCheckAll([COUNTS], () => false);
+  assert.equal(result.ok, false);
+  assert.equal(result.tolerated, false);
+});
+
+test("isMergeQueueContext recognises the merge_group event and the readonly-queue ref, nothing else", () => {
+  assert.equal(isMergeQueueContext({ GITHUB_EVENT_NAME: "merge_group" }), true);
+  assert.equal(
+    isMergeQueueContext({ GITHUB_EVENT_NAME: "push", GITHUB_REF: "refs/heads/gh-readonly-queue/main/pr-5175-9afc62cf" }),
+    true,
+  );
+  assert.equal(isMergeQueueContext({ GITHUB_EVENT_NAME: "pull_request", GITHUB_REF: "refs/pull/5175/merge" }), false);
+  assert.equal(isMergeQueueContext({ GITHUB_EVENT_NAME: "push", GITHUB_REF: "refs/heads/main" }), false);
+  assert.equal(isMergeQueueContext({}), false);
 });

--- a/scripts/gen-architecture-counts.mjs
+++ b/scripts/gen-architecture-counts.mjs
@@ -14,7 +14,10 @@
 // derived from the artifacts that actually decide each number. Registered in
 // scripts/lib/derived-artifacts-registry.mjs, so pre-commit regenerates it when
 // a source changes and CI (`derived-artifacts-gate.mjs check-all`) fails on
-// staleness. Living docs LINK the include instead of retyping the numbers.
+// staleness — except inside the merge queue, where a repo-wide count can drift
+// under a concurrent merge that the author could not have seen (the entry is
+// `mergeQueueRaceTolerant`). Living docs LINK the include instead of retyping
+// the numbers.
 //
 // Deliberately timestamp-free: the content changes only when a count changes,
 // so `--check` is a byte comparison and re-runs are idempotent.

--- a/scripts/lib/derived-artifacts-registry.mjs
+++ b/scripts/lib/derived-artifacts-registry.mjs
@@ -127,6 +127,15 @@ export const DERIVED_ARTIFACTS = [
     artifactPaths: ["docs/architecture/architecture-counts.generated.md"],
     generate: ["node", "scripts/gen-architecture-counts.mjs"],
     check: ["node", "scripts/gen-architecture-counts.mjs", "--check"],
+    // Derived from REPO-WIDE counts (migrations above all). Two PRs that each
+    // add a migration produce a merged tree neither could have generated, so
+    // whichever enters the merge queue second is stale through no fault of
+    // its author — and cannot push a regeneration into the queue. PR #5175
+    // was ejected six times over twelve hours this way with zero code
+    // failures. PR-head CI still checks this strictly against the author's
+    // own base; only merge-order drift is tolerated, in the queue only, and
+    // the next source-touching PR regenerates it via pre-commit.
+    mergeQueueRaceTolerant: true,
   },
   // ─── Route-derived registry chain (BI-34D69270) ────────────────────────────
   //


### PR DESCRIPTION
Closes the merge-queue race that ejected #5175 six times over twelve hours with zero code failures. Filed as BI-DEFB9677.

## What was happening

`docs/architecture/architecture-counts.generated.md` is generated from repo-wide counts, including the number of migrations. A PR that adds a migration regenerates it against its own base; every migration that then lands on `main` invalidates it in the **merged** tree — a tree neither PR could have generated — and nothing can push a regeneration into a `gh-readonly-queue/` ref. `pr:health` said READY the whole time, because the staleness never existed on the PR head.

## What this does

Tolerates that drift under three conditions at once, and no fewer:

- the entry is flagged `mergeQueueRaceTolerant` (only `architecture-counts`);
- the run is inside the merge queue — `merge_group` event or a `gh-readonly-queue/` ref. Nothing local ever sets either, so pre-commit and pregate stay strict;
- the check is otherwise a failure. A fresh entry is simply fresh.

The PR-head `pull_request` run still fails a stale artifact against the author's own base, so **an author who forgot to regenerate is still caught**. Only merge-order drift is tolerated, and the next source-touching PR regenerates the file via pre-commit and heals `main`, so drift is bounded by concurrent merges and self-correcting.

## Rejected

- A bot commit onto `main` that regenerates — all changes land via PR (§3).
- Dropping the volatile counts — the artifact exists because hand-typed numbers lie (BI-79BCE3F2).

## Proof

With the migration count deliberately corrupted, then restored:

| context | result |
|---|---|
| strict (local / PR head) | `STALE`, exit 1 |
| `GITHUB_EVENT_NAME=merge_group` | tolerated, exit 0 |
| `GITHUB_REF=refs/heads/gh-readonly-queue/…` alone | tolerated, exit 0 |

35 gate/registry tests pass, 6 new (tolerated in queue; still fails on PR head; unflagged entry never tolerated; fresh entry never "tolerated"; default options unchanged; context detector positives and negatives). Guard loop: 39 passed. Full local CI gate passed on the amended head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
