### PR TITLE
fix: govern exact-bound receipt authority (BI-B19AF1F3)

### DIFF
--- a/apps/web/lib/govern/authority/coworker-authority-decision.ts
+++ b/apps/web/lib/govern/authority/coworker-authority-decision.ts
@@ -1,8 +1,10 @@
 import { createHash } from "node:crypto";
 
 import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
+import type { ToolConsequence } from "@/lib/mcp-tools";
 
 import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
+import type { InitiativeReviewBinding } from "@/lib/mcp-task-review-contract";
 
 import {
   canAccessAuthoritySubject,
@@ -73,6 +75,9 @@ export type CoworkerAuthorityInput = {
     routeContext: string | null;
     allowedRouteContexts?: readonly string[];
     approvalPolicy: CoworkerApprovalPolicy;
+    /** False when an explicit operator policy forbids policy projection. */
+    policyProjectionAllowed?: boolean;
+    consequence?: ToolConsequence | null;
     requiresDelegationChain?: boolean;
   };
   subject?: CoworkerAuthoritySubject | null;
@@ -97,6 +102,8 @@ export type CoworkerAuthorityInput = {
   task?: {
     taskRunId: string;
     parentTaskRunId?: string | null;
+    /** Immutable server-validated review scope; never sourced from tool args. */
+    initiativeReviewBinding?: InitiativeReviewBinding;
   } | null;
   rawParams: Record<string, unknown>;
   approval?: {

--- a/apps/web/lib/govern/authority/coworker-tool-authority-gate.ts
+++ b/apps/web/lib/govern/authority/coworker-tool-authority-gate.ts
@@ -53,7 +53,7 @@ export type PolicyAuthorityProjectionAttempt = (input: {
   authorityDecisionId: string;
   envelopeId: string;
   expiresAt: Date;
-} | { outcome: "not-authorized" }
+} | { outcome: "not-authorized"; explanation?: string }
   | {
       outcome: "denied";
       reasonCode: "policy-declined" | "policy-authorization-invalid";
@@ -330,6 +330,11 @@ export async function enforceCoworkerToolAuthority(
         reasonCode: projected.reasonCode,
         explanation: projected.explanation,
         nextAction: "request-authority",
+      };
+    } else if (projected.explanation) {
+      decision = {
+        ...decision,
+        explanation: projected.explanation,
       };
     }
   }

--- a/apps/web/lib/govern/authority/policy-action-judgment.test.ts
+++ b/apps/web/lib/govern/authority/policy-action-judgment.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { buildCoworkerApprovalBinding, type CoworkerAuthorityInput } from "./coworker-authority-decision";
 import {
   buildPolicyActionJudgmentRequest,
+  routinePolicyActionEligibility,
   producePolicyActionJudgment,
 } from "./policy-action-judgment";
 
@@ -53,6 +54,87 @@ function authorityInput(): CoworkerAuthorityInput {
 }
 
 describe("policy action judgment", () => {
+  const workroomRef = {
+    kind: "workroom-head" as const,
+    workroomId: "WC-48A3D214",
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    branchName: "fix/wwmd-exact-bound-receipts",
+    headSha: "f5681171c826a328c6795dfbdac8868efc2e4506",
+  };
+  const artifactRef = {
+    kind: "repo-blob-at-commit" as const,
+    repositoryFullName: workroomRef.repositoryFullName,
+    commitSha: workroomRef.headSha,
+    path: "docs/superpowers/specs/wwmd-exact-bound-receipts.md",
+    providerBlobId: "blob-1",
+  };
+
+  function routine(overrides: Record<string, unknown> = {}) {
+    const input = authorityInput();
+    input.task = {
+      taskRunId: "TR-EXACT",
+      initiativeReviewBinding: {
+        writerToolName: "record_initiative_evidence",
+        itemId: "BI-2014236E",
+        gate: "research",
+        workroomRef: { ...workroomRef },
+        artifactRef: { ...artifactRef },
+      },
+    };
+    input.rawParams = {
+      decision: "pass",
+      reason: "The named-ref reproduction and evidence pass.",
+      findings: [],
+      resolvedFindingRefs: [],
+      ...overrides,
+    };
+    return input;
+  }
+
+  it("admits only an exact-bound finding-free platform receipt pass", () => {
+    expect(routinePolicyActionEligibility(routine())).toEqual({ eligible: true });
+  });
+
+  it.each([
+    ["finding-bearing pass", { findings: [{ issue: "Unresolved", severity: "important" }] }, "findings-present"],
+    ["failed review", { decision: "fail" }, "non-pass-decision"],
+    ["not-applicable review", { decision: "not-applicable" }, "non-pass-decision"],
+  ])("escalates a %s", (_name, rawPatch, reason) => {
+    expect(routinePolicyActionEligibility(routine(rawPatch))).toEqual({ eligible: false, reason });
+  });
+
+  it("escalates missing and mismatched immutable Workroom bindings", () => {
+    const missing = routine();
+    delete missing.task?.initiativeReviewBinding?.workroomRef;
+    expect(routinePolicyActionEligibility(missing)).toEqual({ eligible: false, reason: "workroom-binding-required" });
+
+    const mismatch = routine();
+    mismatch.task!.initiativeReviewBinding!.artifactRef.commitSha = "different-head";
+    expect(routinePolicyActionEligibility(mismatch)).toEqual({ eligible: false, reason: "workroom-binding-mismatch" });
+  });
+
+  it("escalates cross-scope, customer-business, external, and non-immediate actions", () => {
+    const customerBusiness = routine();
+    customerBusiness.organizationId = "org-customer";
+    expect(routinePolicyActionEligibility(customerBusiness)).toEqual({ eligible: false, reason: "platform-scope-required" });
+
+    const external = routine();
+    external.integration = { required: true, state: "connected" };
+    expect(routinePolicyActionEligibility(external)).toEqual({ eligible: false, reason: "internal-action-required" });
+
+    const proposed = routine();
+    proposed.action.executionMode = "proposal";
+    expect(routinePolicyActionEligibility(proposed)).toEqual({ eligible: false, reason: "immediate-action-required" });
+
+    const destructive = routine();
+    destructive.action.consequence = "irreversible";
+    expect(routinePolicyActionEligibility(destructive)).toEqual({ eligible: false, reason: "consequential-action-requires-human" });
+
+    const always = routine();
+    always.action.policyProjectionAllowed = false;
+    expect(routinePolicyActionEligibility(always)).toEqual({ eligible: false, reason: "operator-policy-requires-approval" });
+  });
+
   it("builds a server-owned exact WWMD question without trusting caller policy fields", () => {
     const input = authorityInput();
     const approvalBinding = buildCoworkerApprovalBinding(input);
@@ -99,7 +181,7 @@ describe("policy action judgment", () => {
   });
 
   it("invokes the governed scorer once and passes the internal binding only to its ledger adapter", async () => {
-    const input = authorityInput();
+    const input = routine();
     const approvalBinding = buildCoworkerApprovalBinding(input);
     const runPrincipleDecision = vi.fn().mockResolvedValue({ success: true });
 

--- a/apps/web/lib/govern/authority/policy-action-judgment.ts
+++ b/apps/web/lib/govern/authority/policy-action-judgment.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import type { ToolPackHandler } from "@/lib/mcp/tool-pack";
 import type { KernelConsultPolicyProjection } from "@/lib/decision/kernel-consult-ledger";
+import { INITIATIVE_READINESS_LANES } from "@/lib/tak/initiative-readiness-tool-grants";
 import type { PolicyAuthorityProjectionAttempt } from "./coworker-tool-authority-gate";
 
 type JudgmentInput = Parameters<PolicyAuthorityProjectionAttempt>[0];
@@ -16,6 +17,98 @@ export type PolicyActionJudgmentRequest = {
   context: Parameters<ToolPackHandler>[2];
   policyRecord: KernelConsultPolicyProjection;
 };
+
+export type RoutinePolicyActionIneligibility =
+  | "platform-scope-required"
+  | "backlog-subject-required"
+  | "immutable-review-binding-required"
+  | "review-binding-mismatch"
+  | "workroom-binding-required"
+  | "workroom-binding-mismatch"
+  | "gate-not-authorized"
+  | "internal-action-required"
+  | "immediate-action-required"
+  | "side-effect-required"
+  | "consequential-action-requires-human"
+  | "operator-policy-requires-approval"
+  | "non-pass-decision"
+  | "findings-present";
+
+export type RoutinePolicyActionEligibility =
+  | { eligible: true }
+  | { eligible: false; reason: RoutinePolicyActionIneligibility };
+
+/**
+ * Admit only a finding-free platform receipt whose writer, backlog item,
+ * canonical blob and Workroom head are all fixed by server-validated TaskRun
+ * metadata. This is deliberately narrower than generic coworker authority.
+ */
+export function routinePolicyActionEligibility(
+  input: JudgmentInput["authorityInput"],
+): RoutinePolicyActionEligibility {
+  if (input.organizationId !== "platform") {
+    return { eligible: false, reason: "platform-scope-required" };
+  }
+  if (input.subject?.kind !== "backlog-item") {
+    return { eligible: false, reason: "backlog-subject-required" };
+  }
+  const binding = input.task?.initiativeReviewBinding;
+  if (!binding) {
+    return { eligible: false, reason: "immutable-review-binding-required" };
+  }
+  if (
+    binding.writerToolName !== input.action.toolName
+    || binding.itemId !== input.subject.id
+  ) {
+    return { eligible: false, reason: "review-binding-mismatch" };
+  }
+  const workroom = binding.workroomRef;
+  if (!workroom) {
+    return { eligible: false, reason: "workroom-binding-required" };
+  }
+  if (
+    binding.artifactRef.repositoryFullName !== workroom.repositoryFullName
+    || binding.artifactRef.commitSha !== workroom.headSha
+  ) {
+    return { eligible: false, reason: "workroom-binding-mismatch" };
+  }
+  const lane = INITIATIVE_READINESS_LANES[input.action.toolName];
+  if (!lane || !lane.gates.some((gate) => gate === binding.gate)) {
+    return { eligible: false, reason: "gate-not-authorized" };
+  }
+  if (
+    input.integration.required
+    || input.dataPolicy.sensitivity !== "internal"
+  ) {
+    return { eligible: false, reason: "internal-action-required" };
+  }
+  if (input.action.executionMode !== "immediate") {
+    return { eligible: false, reason: "immediate-action-required" };
+  }
+  if (!input.action.sideEffect) {
+    return { eligible: false, reason: "side-effect-required" };
+  }
+  if (input.action.consequence) {
+    return { eligible: false, reason: "consequential-action-requires-human" };
+  }
+  if (input.action.policyProjectionAllowed === false) {
+    return { eligible: false, reason: "operator-policy-requires-approval" };
+  }
+  if (input.rawParams.decision !== "pass") {
+    return { eligible: false, reason: "non-pass-decision" };
+  }
+  const findings = input.rawParams.findings;
+  const resolved = input.rawParams.resolvedFindingRefs;
+  if (
+    !Array.isArray(findings)
+    || !Array.isArray(resolved)
+    || findings.length > 0
+    || resolved.length > 0
+  ) {
+    return { eligible: false, reason: "findings-present" };
+  }
+  return { eligible: true };
+}
 
 /**
  * Build the one action-specific WWMD question from verified server context.
@@ -134,6 +227,10 @@ export async function producePolicyActionJudgment(
   input: JudgmentInput,
   overrides: { runPrincipleDecision?: PrincipleRunner } = {},
 ): Promise<void> {
+  const eligibility = routinePolicyActionEligibility(input.authorityInput);
+  if (!eligibility.eligible) {
+    throw new Error(`routine policy action is ineligible: ${eligibility.reason}`);
+  }
   const request = buildPolicyActionJudgmentRequest(input);
   const runPrincipleDecision = overrides.runPrincipleDecision
     ?? (await import("@/lib/mcp/packs/principle-decide-pack")).runPrincipleDecision;

--- a/apps/web/lib/govern/authority/policy-authority-projector.test.ts
+++ b/apps/web/lib/govern/authority/policy-authority-projector.test.ts
@@ -128,6 +128,7 @@ describe("projectPolicyAuthority", () => {
     if (result.outcome === "allow") {
       expect(result.expiresAt.getTime()).toBeGreaterThan(now.getTime());
       expect(result.auditEvidenceDigest).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.contributionLedger).toEqual([{ principleId: "P-1", contribution: 4.2 }]);
     }
   });
 
@@ -273,6 +274,9 @@ describe("persistPolicyAuthorityProjection", () => {
         decision: "allow",
         organizationId: "org-1",
         policyVersion: "PV-7",
+        rationale: expect.objectContaining({
+          contributionLedger: [{ principleId: "P-1", contribution: 4.2 }],
+        }),
       }),
     }));
     expect(envelopeCreate).toHaveBeenCalledWith(expect.objectContaining({
@@ -280,6 +284,11 @@ describe("persistPolicyAuthorityProjection", () => {
         status: "approved",
         authorityDecisionId: result.authorityDecisionId,
         approvalBindingFingerprint: expect.any(String),
+        argsJson: expect.objectContaining({
+          policyAuthority: expect.objectContaining({
+            contributionLedger: [{ principleId: "P-1", contribution: 4.2 }],
+          }),
+        }),
       }),
     }));
   });

--- a/apps/web/lib/govern/authority/policy-authority-projector.ts
+++ b/apps/web/lib/govern/authority/policy-authority-projector.ts
@@ -111,6 +111,7 @@ export type PolicyAuthorityProjection =
       artifactFingerprint: string;
       approvalBindingFingerprint: string;
       auditEvidenceDigest: string;
+      contributionLedger: unknown[];
       issuedAt: Date;
       expiresAt: Date;
       maxUses: 1;
@@ -345,6 +346,7 @@ export function projectPolicyAuthority(
     artifactFingerprint: binding.artifactFingerprint,
     approvalBindingFingerprint,
     auditEvidenceDigest,
+    contributionLedger: judgment.contributionLedger,
     issuedAt: now,
     expiresAt,
     maxUses: 1,
@@ -428,6 +430,7 @@ export async function persistPolicyAuthorityProjection(input: {
           artifactFingerprint: input.projection.artifactFingerprint,
           approvalBindingFingerprint: input.projection.approvalBindingFingerprint,
           auditEvidenceDigest: input.projection.auditEvidenceDigest,
+          contributionLedger: input.projection.contributionLedger,
           issuedAt: input.projection.issuedAt.toISOString(),
           expiresAt: input.projection.expiresAt.toISOString(),
           maxUses: input.projection.maxUses,
@@ -451,6 +454,7 @@ export async function persistPolicyAuthorityProjection(input: {
             interactionId: input.projection.interactionId,
             profileVersionId: input.projection.profileVersionId,
             auditEvidenceDigest: input.projection.auditEvidenceDigest,
+            contributionLedger: input.projection.contributionLedger,
             maxUses: input.projection.maxUses,
           },
         },

--- a/apps/web/lib/govern/authority/resolve-coworker-tool-authority.test.ts
+++ b/apps/web/lib/govern/authority/resolve-coworker-tool-authority.test.ts
@@ -4,6 +4,7 @@ import {
   deriveAllowedRouteContexts,
   deriveCoworkerApprovalPolicy,
   deriveCoworkerAuthoritySubject,
+  resolveBoundInitiativeReviewBinding,
   resolveBoundInitiativeReviewItem,
   resolveInitiativeAuthorityContext,
 } from "./resolve-coworker-tool-authority";
@@ -156,6 +157,8 @@ describe("resolveBoundInitiativeReviewItem", () => {
   it("accepts only the exact writer and exact persisted item/tool scope", () => {
     expect(resolveBoundInitiativeReviewItem(task, "record_initiative_evidence"))
       .toBe("BI-47ACE2C7");
+    expect(resolveBoundInitiativeReviewBinding(task, "record_initiative_evidence"))
+      .toMatchObject({ itemId: "BI-47ACE2C7", artifactRef });
   });
 
   // Observed 2026-09-06. summon_coworker persists the initiativeReviewBinding key
@@ -249,28 +252,33 @@ describe("deriveCoworkerApprovalPolicy", () => {
     expect(deriveCoworkerApprovalPolicy(input)).toBe(expected);
   });
 
-  it("does not add a second human approval to an exact server-bound initiative review", () => {
+  it("routes an exact server-bound initiative review through action-specific policy authority", () => {
     expect(deriveCoworkerApprovalPolicy({
       hitlTierDefault: 2,
       hitlPolicy: "side-effects",
       serverBoundInitiativeReview: true,
-    })).toBe("none");
+    })).toBe("side-effects");
+    expect(deriveCoworkerApprovalPolicy({
+      hitlTierDefault: 3,
+      hitlPolicy: "none",
+      serverBoundInitiativeReview: true,
+    })).toBe("side-effects");
   });
 
-  it("does not ask the business owner to approve an exact bound research receipt", () => {
+  it("does not let a tier-1 reviewer identity bypass the action-specific authority seam", () => {
     expect(deriveCoworkerApprovalPolicy({
       hitlTierDefault: 1,
       hitlPolicy: "side-effects",
       serverBoundInitiativeReview: true,
-    })).toBe("none");
+    })).toBe("all");
   });
 
-  it("treats the exact server-bound review as the approval even for a tier-1 reviewer", () => {
+  it("keeps a bound review subject to the reviewer's configured side-effect policy", () => {
     expect(deriveCoworkerApprovalPolicy({
       hitlTierDefault: 1,
       hitlPolicy: "side-effects",
       serverBoundInitiativeReview: true,
-    })).toBe("none");
+    })).toBe("all");
   });
 
   it("keeps ordinary side effects behind the coworker's configured approval policy", () => {

--- a/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
+++ b/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
@@ -9,6 +9,7 @@ import type { GovernedExecuteContext } from "@/lib/mcp-governed-execute";
 import { getGrantedCapabilities } from "@/lib/permissions";
 import {
   parseInitiativeReviewBinding,
+  type InitiativeReviewBinding,
   validateInitiativeReviewAuthorityScope,
 } from "@/lib/mcp-task-review-contract";
 
@@ -101,10 +102,10 @@ function objectRecord(value: unknown): Record<string, unknown> | null {
 /** Return the server-bound initiative only for a fully validated external MCP
  * review. Once binding metadata is present, every mismatch fails closed rather
  * than falling back to model-visible writer arguments. */
-export function resolveBoundInitiativeReviewItem(
+export function resolveBoundInitiativeReviewBinding(
   task: InitiativeReviewTask | null,
   executingToolName: string,
-): string | null {
+): InitiativeReviewBinding | null {
   if (!task) return null;
   const metadata = objectRecord(task.a2aMetadata);
   // `== null` catches BOTH an absent key and a persisted JSON null. It used to
@@ -149,7 +150,14 @@ export function resolveBoundInitiativeReviewItem(
       : `tool:${binding.writerToolName}`;
     throw new Error(`The external TaskRun is missing exact authority scope ${required}.`);
   }
-  return binding.itemId;
+  return binding;
+}
+
+export function resolveBoundInitiativeReviewItem(
+  task: InitiativeReviewTask | null,
+  executingToolName: string,
+): string | null {
+  return resolveBoundInitiativeReviewBinding(task, executingToolName)?.itemId ?? null;
 }
 
 /** Resolve initiative subject and organization from the canonical item. Caller
@@ -198,17 +206,14 @@ export function deriveCoworkerApprovalPolicy(input: {
   serverBoundInitiativeReview?: boolean;
 }): CoworkerApprovalPolicy {
   const policy = input.hitlPolicy?.trim().toLowerCase() ?? "";
-  // A server-issued initiative-review TaskRun is already constrained to one
-  // immutable artifact, one backlog item, one exact writer, and an eligible
-  // reviewer principal. Requiring the delegating employee to approve that
-  // writer again turns the technical review into a human proxy gate and makes
-  // the single-human installation path impossible to complete. Independence,
-  // when required by the lane, remains enforced by the receipt repository.
-  // `always` is an explicit operator policy and still wins. A numeric tier is
-  // only the coworker's generic default, so it must not re-wrap this already
-  // authorized initiative-review boundary in a second human approval.
+  // Immutable binding constrains the action but does not authorize it. Bound
+  // side effects always enter the action-specific policy seam, where routine
+  // platform receipts may receive exact WWMD authority and every exception
+  // falls back to the ordinary human decision envelope.
   if (policy === "always") return "all";
-  if (input.serverBoundInitiativeReview) return "none";
+  if (input.serverBoundInitiativeReview && input.hitlTierDefault >= 3) {
+    return "side-effects";
+  }
   if (input.hitlTierDefault <= 1) return "all";
   if (
     input.hitlTierDefault === 2
@@ -291,10 +296,11 @@ export const resolveCoworkerToolAuthorityInput: CoworkerAuthorityInputResolver =
             },
           })
         : null;
-    const trustedBoundItemId = resolveBoundInitiativeReviewItem(
+    const initiativeReviewBinding = resolveBoundInitiativeReviewBinding(
       task,
       execution.toolName,
     );
+    const trustedBoundItemId = initiativeReviewBinding?.itemId ?? null;
     const [agent, delegation, initiativeAuthority] = await Promise.all([
       agentPromise,
       delegationPromise,
@@ -355,6 +361,9 @@ export const resolveCoworkerToolAuthorityInput: CoworkerAuthorityInputResolver =
         routeContext: execution.context?.routeContext ?? null,
         allowedRouteContexts: deriveAllowedRouteContexts(tool.screenSurface),
         approvalPolicy,
+        policyProjectionAllowed:
+          agent.governanceProfile?.hitlPolicy.trim().toLowerCase() !== "always",
+        consequence: tool.consequence ?? null,
         requiresDelegationChain: Boolean(execution.context?.delegationChainId),
       },
       subject: initiativeAuthority.subject,
@@ -382,7 +391,13 @@ export const resolveCoworkerToolAuthorityInput: CoworkerAuthorityInputResolver =
         decisionVersionsCurrent: true,
         decisionVersionIds,
       },
-      task,
+      task: task
+        ? {
+            taskRunId: task.taskRunId,
+            parentTaskRunId: task.parentTaskRunId,
+            ...(initiativeReviewBinding ? { initiativeReviewBinding } : {}),
+          }
+        : null,
       rawParams: execution.rawParams,
       approval: null,
     };

--- a/apps/web/lib/govern/authority/resolve-policy-action-authority.test.ts
+++ b/apps/web/lib/govern/authority/resolve-policy-action-authority.test.ts
@@ -8,7 +8,7 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
     const now = new Date("2026-08-23T12:00:00.000Z");
     const authorityInput: CoworkerAuthorityInput = {
       now,
-      organizationId: "org-canonical",
+      organizationId: "platform",
       authContext: {
         principalId: "principal-mark",
         principalAliases: [],
@@ -45,8 +45,29 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
         decisionVersionsCurrent: true,
         decisionVersionIds: ["PV-7"],
       },
-      task: null,
-      rawParams: { itemId: "BI-F0715C9C", commitSha: "abc123" },
+      task: {
+        taskRunId: "TR-BOUND",
+        initiativeReviewBinding: {
+          writerToolName: "record_initiative_design_review",
+          itemId: "BI-F0715C9C",
+          gate: "spec-approval",
+          workroomRef: {
+            kind: "workroom-head",
+            workroomId: "WC-BOUND",
+            repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+            branchName: "fix/wwmd-exact-bound-receipts",
+            headSha: "abc123",
+          },
+          artifactRef: {
+            kind: "repo-blob-at-commit",
+            repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+            commitSha: "abc123",
+            path: "docs/superpowers/specs/exact-bound.md",
+            providerBlobId: "blob-abc123",
+          },
+        },
+      },
+      rawParams: { decision: "pass", findings: [], resolvedFindingRefs: [] },
       approval: null,
     };
     const approvalBinding = buildCoworkerApprovalBinding(authorityInput);
@@ -84,7 +105,7 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
         policyActionBinding: {
           actionKey: "record_initiative_design_review",
           subject: { kind: "backlog-item", id: "BI-F0715C9C" },
-          organizationId: "org-canonical",
+          organizationId: "platform",
           professionId: null,
           routeContext: "/tool/record_initiative_design_review",
           artifactFingerprint: approvalBinding.inputFingerprint,
@@ -115,7 +136,7 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
         userContext: { platformRole: "admin", isSuperuser: false },
         context: {
           agentId: "AGT-WS-DEV",
-          organizationId: "org-canonical",
+          organizationId: "platform",
           routeContext: "/tool/record_initiative_design_review",
         },
         source: "agentic-loop",
@@ -130,9 +151,14 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
     }));
     expect(authorizationCreate).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
-        organizationId: "org-canonical",
+        organizationId: null,
         policyVersion: "PV-7",
-        rationale: expect.objectContaining({ interactionId: "DI-BOUND-YES" }),
+        rationale: expect.objectContaining({
+          interactionId: "DI-BOUND-YES",
+          contributionLedger: [{ principleId: "P-1", contribution: 3.1 }],
+          artifactFingerprint: approvalBinding.inputFingerprint,
+          approvalBindingFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+        }),
       }),
     }));
 
@@ -152,7 +178,7 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
         userContext: { platformRole: "admin", isSuperuser: false },
         context: {
           agentId: "AGT-WS-DEV",
-          organizationId: "org-canonical",
+          organizationId: "platform",
           routeContext: "/tool/record_initiative_design_review",
         },
         source: "agentic-loop",
@@ -162,8 +188,8 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
     }, db as never);
 
     expect(declined).toMatchObject({
-      outcome: "denied",
-      reasonCode: "policy-declined",
+      outcome: "not-authorized",
+      explanation: expect.stringContaining("explicitly declined"),
     });
     expect(authorizationCreate).toHaveBeenCalledTimes(1);
 
@@ -182,7 +208,7 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
         userContext: { platformRole: "admin", isSuperuser: false },
         context: {
           agentId: "AGT-WS-DEV",
-          organizationId: "org-canonical",
+          organizationId: "platform",
           routeContext: "/tool/record_initiative_design_review",
         },
         source: "agentic-loop",
@@ -192,8 +218,8 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
     }, db as never);
 
     expect(dualControl).toMatchObject({
-      outcome: "resolution-required",
-      reasonCode: "dual-control-required",
+      outcome: "not-authorized",
+      explanation: expect.stringContaining("distinct human approver"),
     });
     expect(authorizationCreate).toHaveBeenCalledTimes(1);
 
@@ -214,7 +240,7 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
         userContext: { platformRole: "admin", isSuperuser: false },
         context: {
           agentId: "AGT-WS-DEV",
-          organizationId: "org-canonical",
+          organizationId: "platform",
           routeContext: "/tool/record_initiative_design_review",
         },
         source: "agentic-loop",
@@ -223,7 +249,10 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
       approvalBinding,
     }, db as never);
 
-    expect(uncertain).toEqual({ outcome: "not-authorized" });
+    expect(uncertain).toMatchObject({
+      outcome: "not-authorized",
+      explanation: expect.stringContaining("missing a current, explicit"),
+    });
     expect(authorizationCreate).toHaveBeenCalledTimes(1);
   });
 
@@ -249,8 +278,29 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
       subject: { kind: "backlog-item" as const, id: "BI-2014236E" },
       delegation: null, integration: { required: false, state: "not-required" as const },
       dataPolicy: { sensitivity: "internal" as const, maskingRequired: false, maskingSatisfied: true, decisionVersionsCurrent: true, decisionVersionIds: ["PV-7"] },
-      task: null,
-      rawParams: { itemId: "BI-2014236E" }, approval: null,
+      task: {
+        taskRunId: "TR-EXACT",
+        initiativeReviewBinding: {
+          writerToolName: "record_initiative_evidence",
+          itemId: "BI-2014236E",
+          gate: "research",
+          workroomRef: {
+            kind: "workroom-head",
+            workroomId: "WC-48A3D214",
+            repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+            branchName: "fix/wwmd-exact-bound-receipts",
+            headSha: "abc123",
+          },
+          artifactRef: {
+            kind: "repo-blob-at-commit",
+            repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+            commitSha: "abc123",
+            path: "docs/superpowers/specs/exact-bound.md",
+            providerBlobId: "blob-abc123",
+          },
+        },
+      },
+      rawParams: { decision: "pass", findings: [], resolvedFindingRefs: [] }, approval: null,
     };
     const approvalBinding = buildCoworkerApprovalBinding(authorityInput);
     const exactRow = {
@@ -306,7 +356,7 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
       { execution, authorityInput, approvalBinding }, db as never, { produceJudgment },
     );
     expect(produceJudgment).toHaveBeenCalledOnce();
-    expect(declined).toMatchObject({ outcome: "denied", reasonCode: "policy-declined" });
+    expect(declined).toMatchObject({ outcome: "not-authorized", explanation: expect.stringContaining("explicitly declined") });
 
     produceJudgment.mockClear();
     findMany.mockReset().mockResolvedValueOnce([]).mockResolvedValueOnce([{
@@ -323,6 +373,6 @@ describe("resolveAndPersistPolicyActionAuthority", () => {
       { execution, authorityInput, approvalBinding }, db as never, { produceJudgment },
     );
     expect(produceJudgment).toHaveBeenCalledOnce();
-    expect(mismatched).toEqual({ outcome: "not-authorized" });
+    expect(mismatched).toMatchObject({ outcome: "not-authorized", explanation: expect.stringContaining("WWMD did not produce") });
   });
 });

--- a/apps/web/lib/govern/authority/resolve-policy-action-authority.ts
+++ b/apps/web/lib/govern/authority/resolve-policy-action-authority.ts
@@ -139,6 +139,14 @@ export async function resolveAndPersistPolicyActionAuthority(
 ): ReturnType<PolicyAuthorityProjectionAttempt> {
     const { execution, authorityInput, approvalBinding } = input;
     if (!PROJECTABLE_ACTIONS.has(execution.toolName)) return { outcome: "not-authorized" };
+    const { routinePolicyActionEligibility } = await import("./policy-action-judgment");
+    const eligibility = routinePolicyActionEligibility(authorityInput);
+    if (!eligibility.eligible) {
+      return {
+        outcome: "not-authorized",
+        explanation: `Human decision required: ${eligibility.reason}.`,
+      };
+    }
     const actingHumanUserId = authorityInput.authContext.actingHumanUserId;
     const actingAgentId = authorityInput.authContext.actingAgentId;
     if (!actingHumanUserId || !actingAgentId || !authorityInput.subject) return { outcome: "not-authorized" };
@@ -268,22 +276,15 @@ export async function resolveAndPersistPolicyActionAuthority(
       });
       if (projection.outcome === "deny") {
         return {
-          outcome: "denied",
-          reasonCode: projection.reasonCode === "policy-declined"
-            ? "policy-declined"
-            : "policy-authorization-invalid",
-          explanation: projection.explanation,
+          outcome: "not-authorized",
+          explanation: `Human decision required: ${projection.explanation}`,
         };
       }
       if (projection.outcome === "resolve") {
-        if (projection.reasonCode === "dual-control-required") {
-          return {
-            outcome: "resolution-required",
-            reasonCode: "dual-control-required",
-            explanation: projection.explanation,
-          };
-        }
-        return { outcome: "not-authorized" };
+        return {
+          outcome: "not-authorized",
+          explanation: `Human decision required: ${projection.explanation}`,
+        };
       }
       const persisted = await persistPolicyAuthorityProjection({
         db,
@@ -298,7 +299,12 @@ export async function resolveAndPersistPolicyActionAuthority(
         expiresAt: projection.expiresAt,
       };
     }
-    if (producedJudgment) return { outcome: "not-authorized" };
+    if (producedJudgment) {
+      return {
+        outcome: "not-authorized",
+        explanation: "Human decision required: WWMD did not produce an exact, high-confidence, autonomy-eligible authorization.",
+      };
+    }
     producedJudgment = true;
     try {
       const produceJudgment = overrides.produceJudgment
@@ -310,7 +316,10 @@ export async function resolveAndPersistPolicyActionAuthority(
         "[policy-action-authority] WWMD judgment unavailable:",
         error instanceof Error ? error.message : String(error),
       );
-      return { outcome: "not-authorized" };
+      return {
+        outcome: "not-authorized",
+        explanation: "Human decision required: the exact WWMD judgment is unavailable.",
+      };
     }
     }
 }

--- a/apps/web/lib/mcp-governed-execute-authority.cases.ts
+++ b/apps/web/lib/mcp-governed-execute-authority.cases.ts
@@ -230,6 +230,44 @@ export function registerCoworkerAuthorityCases(
     });
   });
 
+  it("puts the unresolved WWMD residue on the human decision card", async () => {
+    const pending = harness.authorityInput({
+      action: {
+        ...harness.authorityInput().action,
+        toolName: "create_backlog_item",
+        requiredCapability: "manage_backlog",
+        sideEffect: true,
+        approvalPolicy: "side-effects",
+      },
+    });
+    harness.applyOverrides({
+      resolveCoworkerAuthorityInput: async () => pending,
+      policyAuthorityProjectionAttempt: async () => ({
+        outcome: "not-authorized" as const,
+        explanation: "Human decision required: commandment conflict.",
+      }),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "bounded exception" },
+      userId: "user-1",
+      userContext: harness.normalUser,
+      context: { agentId: "AGT-100", taskRunId: "TASK-EXCEPTION" },
+      source: "agentic-loop",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "approval_required",
+      message: expect.stringContaining("Human decision required: commandment conflict."),
+    });
+    expect(harness.approvalEnvelopeCreate()).toHaveBeenCalledWith(expect.objectContaining({
+      explanation: "Human decision required: commandment conflict.",
+    }));
+    expect(harness.executeMock()).not.toHaveBeenCalled();
+  });
+
   it("consumes a server-projected exact-call policy authorization before execution", async () => {
     const pending = harness.authorityInput({
       organizationId: "org-canonical",

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -677,6 +677,13 @@ describe("recovery packets are executable by the real consumer", () => {
         parseInitiativeReviewBinding(route.requestCoworker.initiativeReviewBinding),
         `parseInitiativeReviewBinding rejected the packet for ${route.toolName}`,
       ).not.toBeNull();
+      expect(route.requestCoworker.initiativeReviewBinding.workroomRef).toEqual({
+        kind: "workroom-head",
+        workroomId: dispatchContext.workroomId,
+        repositoryFullName: dispatchContext.repositoryFullName,
+        branchName: dispatchContext.branchName,
+        headSha: dispatchContext.headSha,
+      });
     }
   });
 

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -524,16 +524,16 @@ function requestCoworkerPacket(args: {
     itemId: args.decision.subject.id,
     gate: args.gate,
     expectedCurrentBaselineId: args.expectedCurrentBaselineId,
+    workroomRef: {
+      kind: "workroom-head" as const,
+      workroomId: args.dispatch.workroomId,
+      repositoryFullName: args.dispatch.repositoryFullName,
+      branchName: args.dispatch.branchName,
+      headSha: args.dispatch.headSha,
+    },
     ...(args.gate === "objective-mapping" && args.eligibleEvidenceActivityIds
       ? {
         eligibleEvidenceActivityIds: args.eligibleEvidenceActivityIds,
-        workroomRef: {
-          kind: "workroom-head" as const,
-          workroomId: args.dispatch.workroomId,
-          repositoryFullName: args.dispatch.repositoryFullName,
-          branchName: args.dispatch.branchName,
-          headSha: args.dispatch.headSha,
-        },
       }
       : {}),
     artifactRef: {

--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -330,6 +330,13 @@ describe("claimGovernedBacklogWorkspace", () => {
                 itemId: "BI-ENTRY",
                 gate: "design-spec",
                 expectedCurrentBaselineId: null,
+                workroomRef: {
+                  kind: "workroom-head",
+                  workroomId: "WC-ENTRY",
+                  repositoryFullName: input.repositoryFullName,
+                  branchName: input.headBranch,
+                  headSha: "1111111111111111111111111111111111111111",
+                },
                 artifactRef: {
                   kind: "repo-blob-at-commit",
                   repositoryFullName: input.repositoryFullName,

--- a/docs/superpowers/specs/2026-09-08-wwmd-exact-bound-platform-receipt-authority-design.md
+++ b/docs/superpowers/specs/2026-09-08-wwmd-exact-bound-platform-receipt-authority-design.md
@@ -1,0 +1,107 @@
+---
+status: active
+---
+
+# WWMD Exact-Bound Platform Receipt Authority
+
+**Backlog item:** BI-B19AF1F3
+
+**Workroom:** WC-60566397
+
+**Profile:** fix
+
+**Decision:** DI-3F125C09C368 (`wwmd-exception-routing`)
+
+## Problem and reproduced defect
+
+The receipt writer is already constrained to an external MCP TaskRun, an exact writer, one backlog item, an immutable repository blob, and an eligible reviewer. At named pre-fix ref `d67c4d5dd469e73e0947102dfbabd8c7c10f578b`, `deriveCoworkerApprovalPolicy` turns Build Specialist's tier-1 identity into `approvalPolicy = all`. At delivered ref `f5681171c826a328c6795dfbdac8868efc2e4506`, a binding-specific shortcut instead returns `none`. The first behavior asks the founder to rubber-stamp routine evidence; the second skips the action-specific WWMD projector entirely. Neither makes the Workroom outcome and exact action evidence the authority boundary.
+
+The live reproduction is BI-B3584737, TaskRun `TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-133C509AF2C9`, and envelope `cmti2racd18zq01lht28321dp`: an immutable, finding-free research pass expired awaiting a human click. Source inspection ruled out receipt-schema validation and reviewer-independence validation: those gates run after authority and remain intact. It also ruled out the WWMD projector itself as absent; the projector exists, but the binding shortcut prevents the request from reaching it.
+
+## Options considered
+
+1. **Human every time.** Keep coworker-global approval as the final authority. Rejected because a routine exact-bound pass adds no unresolved judgment for the human and blocks unattended governed delivery.
+2. **WWMD exception routing.** Project a current, high-confidence WWMD yes into one exact call; route every non-routine or uncertain case to a concise human decision card. Chosen by DI-3F125C09C368 with high confidence, no commandment conflict, and `autonomyEligible=true`.
+3. **Never-human research.** Treat immutable binding or reviewer identity as authorization. Rejected because binding constrains what may be attempted but does not decide whether it should be written.
+
+## Research and benchmarking
+
+- [Open Policy Agent decision logs](https://www.openpolicyagent.org/docs/management-decision-logs) attach a decision ID, evaluated input, result, and policy/bundle revision for audit and offline reconstruction. DPF adopts the decision-ID and exact-input traceability shape, using its existing `DecisionInteraction`, `AuthorizationDecisionLog`, and envelope records rather than adding OPA.
+- [Cedar](https://github.com/cedar-policy/cedar-docs/blob/main/docs/index.md) separates application operations from an authorization decision engine. DPF adopts that policy-decision/policy-enforcement separation at the universal governed-execute seam; it rejects a parallel Cedar policy language because WWMD and the existing projector already own platform judgment.
+- [OpenFGA contextual tuples](https://openfga.dev/docs/interacting/contextual-tuples) demonstrate request-scoped authorization context that is checked under the same model as durable relations. DPF adopts the request-scoped principle for immutable TaskRun and Workroom bindings, but rejects a new relationship store because Workroom, TaskRun, grant, and receipt records are already canonical.
+
+## Design grounding
+
+- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-31-taskrun-async-push-delivery-design.md` owns TaskRun transport; it does not define this receipt-authority policy.
+- Current code substrate reviewed: `apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts`, `apps/web/lib/govern/authority/resolve-policy-action-authority.ts`, `apps/web/lib/govern/authority/policy-authority-projector.ts`, and `apps/web/lib/tak/initiative-readiness-tool-grants.ts`.
+- Source of truth: `INITIATIVE_READINESS_LANES` owns writer/gate pairings; TaskRun metadata owns immutable review binding; Workroom owns branch/head identity; the WWMD ledger and authority projector own platform judgment and its exact-call projection.
+- Decision: extend those existing homes. Do not add a parallel policy store, binding registry, or receipt writer.
+
+## Design
+
+### One authority seam
+
+Immutable initiative-review binding no longer returns an approval policy of `none`. A bound side effect enters the existing `evaluateCoworkerAuthority` approval branch. The existing policy-action resolver may satisfy that branch only for the routine class below. An explicit operator `always` policy remains human-only.
+
+The validated `InitiativeReviewBinding` is preserved ephemerally on the server-resolved authority input. No model-visible parameter becomes authority, and no new persistent authority store is introduced.
+
+### Routine admission predicate
+
+All conditions are conjunctive:
+
+- canonical organization scope is the platform sentinel and the subject is the binding's backlog item;
+- TaskRun metadata was validated as an external MCP review and binds this exact writer;
+- binding includes a Workroom ID, repository, branch, and head SHA;
+- immutable artifact repository and commit equal the Workroom repository and head;
+- writer and gate are paired by `INITIATIVE_READINESS_LANES`, the existing single registry;
+- tool is an immediate, ordinary internal side effect with no outward, irreversible, authority-changing, or external-integration consequence;
+- receipt decision is `pass`, `findings` is empty, and `resolvedFindingRefs` is empty;
+- explicit operator policy permits policy projection.
+
+The resolver then asks WWMD one action-specific question bound to the existing approval fingerprint. Only a sealed, current, high-confidence, usable, stable, autonomy-eligible `proceed` without commandment conflict projects. The resulting existing envelope is single-use. Existing persistence records the WWMD interaction, policy version, contribution/audit digest, exact action fingerprint, and approval-binding fingerprint.
+
+### Human residue
+
+If routine admission fails, WWMD is unavailable or uncertain, WWMD declines/conflicts, provenance or binding fails, risk exceeds the floor, or dual control applies, the resolver does not auto-authorize. It returns a short residue explanation to the existing approval-envelope path, which creates the human decision card. This reuses the platform's current card and resume mechanics rather than inventing a second escalation surface.
+
+Receipt schema, immutable read evidence, independent-review enforcement, baseline minting, objective mapping, token scope, grant intersection, and database repository validation remain unchanged. There is no direct database writer or validation exception.
+
+### Recovery packet binding
+
+Every immutable initiative-review recovery packet carries its server-issued Workroom reference, not only objective mapping. This lets the authority seam prove Workroom/head exactness for research, specification, plan, and specialist-review receipts. A retained artifact from an older commit remains reviewable, but is intentionally human-routed rather than auto-authorized because it is not the current Workroom head.
+
+## Ordered implementation
+
+1. Preserve the validated immutable review binding in server-owned authority context.
+2. Route bound side effects through the existing approval/policy seam while honoring explicit operator policy.
+3. Add the pure routine-admission predicate using the existing readiness-lane registry and declared tool consequence.
+4. Project only eligible exact calls and send every rejected/resolution residue to the existing human card.
+5. Add Workroom refs to all immutable recovery packets.
+6. Verify unit behavior, production type/build behavior, canonical runtime execution, independent receipts, objective reconciliation, and completion evidence.
+
+## Objectives and acceptance
+
+- **OBJ-WWMD-EXACT-AUTH:** Routine exact-bound platform receipts complete without a human click under an eligible WWMD decision.
+  - **AC-WWMD-ROUTINE-PASS:** The BI-B3584737 receipt shape records and cites DI-3F125C09C368 or a fresh equivalent.
+  - **AC-WWMD-AUDIT-BINDING:** Each automatic authorization persists the WWMD decision and exact binding fingerprints.
+- **OBJ-WWMD-EXCEPTION-RESIDUE:** Non-routine or uncertain actions remain under human control.
+  - **AC-WWMD-HUMAN-CARD:** Finding-bearing pass, fail/not-applicable, low confidence, unusable/unstable signal, commandment conflict, binding mismatch, cross-scope, destructive/outbound, customer-business, specialist-policy, and explicit-human-policy cases create a concise decision card stating the residue.
+- **OBJ-WWMD-SINGLE-SOURCE:** Existing validation and authority stores remain canonical.
+  - **AC-WWMD-NO-BYPASS:** No direct database bypass, parallel policy store, or weakened immutable receipt validation exists.
+
+## Verification matrix
+
+- Approval policy: tier 1/2/3 bound reviewers reach action-specific authority; unbound behavior and explicit `always` remain unchanged.
+- Admission: routine pass; finding-bearing pass; fail; absent/mismatched writer, item, artifact, Workroom, or gate; customer organization; external integration; proposal; non-side-effect; declared outward/irreversible/authority consequence; explicit human policy.
+- Projection: exact high-confidence pass; low confidence; unusable/unstable/weak coverage; commandment conflict; policy decline; stale provenance; action fingerprint mismatch; risk/delegation/dual-control; single-use replay.
+- Escalation: unresolved residue is present on the existing human decision envelope.
+- Packet seam: every emitted immutable binding parses and carries the exact Workroom ref; writer and reader tool scope remains closed.
+- Live acceptance: an independent reviewer reads the current blob and records a passing routine receipt without a human click; ToolExecution and authority evidence cite the WWMD interaction and fingerprints.
+
+## Data, scale, rollback, and documentation
+
+No schema or migration is required. The hot path adds no unbounded collection: it performs constant-time checks over one parsed binding, then uses the existing bounded recent-decision lookup (25 candidates) and existing transactional projection. Broader role-derived coworker authority remains owned by EP-31815F97.
+
+Rollback is a source revert of this scoped change. Existing human approval remains the fail-safe because every ineligible or unavailable projection returns to the envelope path. No data backfill is needed; already-recorded policy decisions and envelopes remain valid under their original fingerprints and expiry rules.
+
+This design is the user/coworker-facing documentation impact for the authority behavior. The asynchronous TaskRun transport remains documented separately in `docs/superpowers/specs/2026-08-31-taskrun-async-push-delivery-design.md`; this document does not duplicate that transport design.


### PR DESCRIPTION
## Outcome

Routine, finding-free platform readiness receipts now enter the action-specific WWMD authority seam. A current, exact, autonomy-eligible WWMD yes produces one single-use authorization; every exception returns to the existing human decision card with the unresolved residue.

## What changed

- Preserves the server-validated TaskRun review binding in authority context and binds it to the Workroom repository/head.
- Removes immutable binding as an approval bypass; tier 1/2/3 reviewers all reach the policy seam, while an explicit operator `always` policy remains human-only.
- Admits only immediate, ordinary internal platform receipt passes with no findings. Customer-business, missing/mismatched binding, finding/fail/not-applicable, external, consequential, uncertain, conflicting, or dual-control cases escalate.
- Persists the WWMD interaction, contribution ledger, artifact fingerprint, approval-binding fingerprint, and audit digest on the existing authority/envelope trail.
- Adds Workroom identity to every immutable initiative-review recovery packet.
- Adds the dedicated BI-B19AF1F3 design and acceptance baseline source.

## Verification

- 221 affected and blast-radius tests passed across 15 files.
- Web TypeScript typecheck passed.
- Documentation index, links, diagrams, and prose lint passed.
- Governed merged-code local-CI full test/build gate passed for this commit.
- UX: not applicable; this changes server-side authority and existing card data, not UI rendering.
- Migration: not applicable; existing authority, envelope, TaskRun, Workroom, and receipt stores are reused.
- Independent semantic review: auto-pass under the current shadow policy; no issues.

Linked backlog item: BI-B19AF1F3

Local-CI-Evidence: cmtszzp6h2ke601mw39sa0s9w (fix/wwmd-exact-bound-receipts@a44a6cb1ad3d18e4c98b6059c406708c735647bd)
