### PR TITLE
fix(hooks): expose readable purposes in managed definitions

### DIFF
--- a/docs/superpowers/specs/2026-09-08-readable-hook-purposes-design.md
+++ b/docs/superpowers/specs/2026-09-08-readable-hook-purposes-design.md
@@ -1,0 +1,77 @@
+---
+status: draft
+---
+
+# Readable managed hook purposes
+
+BI-26DC98EE; WC-4D594E6F. Small defect repair extending FLOW-MCP-HOOK in
+[the client contract design](2026-09-04-mcp-client-contract-consolidation-design.md#5-discovery-and-operator-presentation--existing-bi-1ba8f46c).
+
+## Defect and boundary
+
+The installed plugin and canonical `packages/dpf-skill-pack/hooks/hooks.json`
+contain 28 handlers with commands but no human-readable purpose. The operator
+sees numbered hooks when deciding what to trust. The plugin owns its metadata;
+the client owns how approval rows render and which exact definitions are trusted.
+The peer-owned exposure initiative BI-1BA8F46C remains unchanged.
+
+## Design
+
+Add the documented `statusMessage` to each canonical handler. Write its purpose
+once, beside the command. Preserve commands, matchers, handler order and events.
+Generate `packages/dpf-skill-pack/hooks/README.md` from those definitions, with
+event, event-local ordinal, matcher, purpose and a relative source link. This
+replaces a hand-maintained external mapping with a reference shipped in the pack.
+The ordinal is a lookup aid, not a stable ID; identify a hook by event and command.
+
+The generator must reject a missing purpose or an unsafe/unresolvable source
+link. Its check mode detects stale documentation without rewriting files. Use
+Node built-ins and the existing JSON definition; no service, database table,
+dependency, new execution wrapper or second hook catalog is needed. Adapter
+tests must prove metadata survives existing transformations. Trust decisions
+remain in the client and are never represented as static generated facts.
+
+No schema migration or policy change. Existing clients may ignore presentation
+metadata. Do not add undocumented `name`, `title`, or per-handler `description`
+fields. A new definition may require fresh client trust; do not approve it on
+the operator's behalf. Do not label an execution message as an approval label.
+
+## Research and settled direction
+
+[Codex hooks](https://learn.chatgpt.com/docs/hooks) documents per-handler
+`statusMessage` as execution feedback and top-level file `description`. It does
+not promise friendly approval-row names. The existing client-contract design
+already compares Codex and Claude hook adapters and chooses this supported
+field plus a generated reference when a host cannot render friendly row labels.
+Reuse that direction. A hand-maintained second list or invented UI field would
+reintroduce drift. This bounded metadata repair requires no new architecture.
+
+## Ordered fix plan
+
+1. Add an invariant test that all current handlers expose a useful purpose and
+   that the generated reference covers every handler and source link.
+2. Add purpose metadata, derive the reference, and test escaping and stale-output
+   detection. Compare all original operational fields before and after.
+3. Verify the existing surface adapters preserve metadata; run the affected
+   built-in Node tests and source guards. Commit with DCO and publish through PR.
+4. Refresh the installed pack through its managed update path after merge.
+   Verify installed metadata and inspect what the supported clients display.
+   If approval rows remain numbered or cannot be inspected, record that exact
+   limitation and expose the shipped reference before trust. Never claim rendered
+   acceptance from JSON alone.
+
+## Acceptance
+
+- AC-HOOK-1: Every canonical handler has an accurate concise purpose.
+- AC-HOOK-2: The generated reference includes every event, matcher, command and
+  relative source link; missing metadata and stale output fail verification.
+- AC-HOOK-3: Original commands, event order and matchers remain identical; the
+  existing adapter outputs retain supported purpose metadata.
+- AC-HOOK-4: The managed install carries the metadata and reference. Record the
+  actual host/version and approval-display result separately from execution text;
+  an unavailable display check remains unverified.
+
+Approximately one fifth of effort consolidates the inventory into the canonical
+definition and generator, removing hand-maintained purpose drift. Documentation
+and tests ship together. No performance or approval-UI improvement is claimed
+until observed.

--- a/docs/superpowers/specs/2026-09-08-readable-hook-purposes-design.md
+++ b/docs/superpowers/specs/2026-09-08-readable-hook-purposes-design.md
@@ -25,8 +25,9 @@ replaces a hand-maintained external mapping with a reference shipped in the pack
 The ordinal is a lookup aid, not a stable ID; identify a hook by event and command.
 
 The generator must reject a missing purpose or an unsafe/unresolvable source
-link. Its check mode detects stale documentation without rewriting files. Use
-Node built-ins and the existing JSON definition; no service, database table,
+link. Its check mode detects stale documentation without rewriting files. Extend
+the dependency-free Python updater's existing `hook_roster` (BI-276EC984), moving
+its separate `HOOK_PURPOSES` dictionary into handler metadata; no service, database table,
 dependency, new execution wrapper or second hook catalog is needed. Adapter
 tests must prove metadata survives existing transformations. Trust decisions
 remain in the client and are never represented as static generated facts.

--- a/packages/dpf-skill-pack/hooks/README.md
+++ b/packages/dpf-skill-pack/hooks/README.md
@@ -1,0 +1,57 @@
+# DPF hook purposes
+
+Generated from [hooks.json](hooks.json). Do not edit this reference by hand.
+
+Before enabling a hook, match its event and command with the entries below.
+Numbers follow definition order; your client may order entries differently.
+The client owns the current trust state. This reference does not grant trust.
+
+Purpose text is stored as `statusMessage`, which clients may show while a hook runs.
+Friendly names in approval rows remain a [Codex client request](https://github.com/openai/codex/issues/31469).
+A purpose in this file is not proof that an approval row displays it.
+
+
+## PreToolUse
+
+- Hook 1 [Bash]: [lease-guard.mjs](lease-guard.mjs) — Check the environment lease before starting a server
+- Hook 2 [Bash]: [root-clone-guard.mjs](root-clone-guard.mjs) — Protect the shared source checkout from unsafe changes
+- Hook 3 [Bash]: [compose-guard.mjs](compose-guard.mjs) — Protect shared services from destructive Compose commands
+- Hook 4 [Bash]: [portal-image-guard.mjs](portal-image-guard.mjs) — Keep portal image changes on the verified release path
+- Hook 5 [Bash]: [lease-punt-guard.mjs](lease-punt-guard.mjs) — Check runtime verification has a provisioned environment
+- Hook 6 [Bash]: [pregate-evidence-guard.mjs](pregate-evidence-guard.mjs) — Check verification evidence before publishing code
+- Hook 7 [Bash]: [pregate-invocation-guard.mjs](pregate-invocation-guard.mjs) — Check the verification command can run and report its result
+- Hook 8 [Bash]: [workroom-claim-guard.mjs](workroom-claim-guard.mjs) — Check this source change belongs to a claimed Workroom
+- Hook 9 [AskUserQuestion]: [decision-routing-guard.mjs](decision-routing-guard.mjs) — Check platform guidance before asking for a decision
+- Hook 10 [Write\|Edit\|MultiEdit]: [root-clone-guard.mjs](root-clone-guard.mjs) — Protect the shared source checkout from unsafe changes
+- Hook 11 [Write\|Edit\|MultiEdit]: [plan-backlog-coverage-guard.mjs](plan-backlog-coverage-guard.mjs) — Check planned deliverables are tracked before source edits
+- Hook 12 [Write\|Edit\|MultiEdit]: [ux-fit-precheck.mjs](ux-fit-precheck.mjs) — Remind the author to review usability for UI changes
+- Hook 13 [Write\|Edit\|MultiEdit]: [spec-plan-doc-precheck.mjs](spec-plan-doc-precheck.mjs) — Remind the author to include required design and documentation
+- Hook 14 [Write\|Edit\|MultiEdit]: [design-grounding-precheck.mjs](design-grounding-precheck.mjs) — Remind the author to check existing design and implementation
+- Hook 15 [Write\|Edit\|MultiEdit]: [tool-economy-precheck.mjs](tool-economy-precheck.mjs) — Remind the author to keep tool descriptions and results bounded
+- Hook 16 [Write\|Edit\|MultiEdit]: [workroom-claim-guard.mjs](workroom-claim-guard.mjs) — Check this source change belongs to a claimed Workroom
+
+## WorktreeCreate
+
+- Hook 1: [worktree-create.mjs](worktree-create.mjs) — Create an isolated worktree in the shared worktree directory
+
+## SessionStart
+
+- Hook 1: [process-spine-health-check.mjs](process-spine-health-check.mjs) — Check required DPF skills are installed and exposed
+- Hook 2: [governance-freshness-check.mjs](governance-freshness-check.mjs) — Check this checkout has current process guards
+- Hook 3: [worktree-session-hygiene.mjs](worktree-session-hygiene.mjs) — Check worktree location and unused checkout inventory
+- Hook 4: [worktree-session-heartbeat.mjs](worktree-session-heartbeat.mjs) — Refresh this session heartbeat to protect active work
+- Hook 5: [root-clone-freshness.mjs](root-clone-freshness.mjs) — Safely fast-forward the clean shared source checkout
+- Hook 6: [worktree-readiness-banner.mjs](worktree-readiness-banner.mjs) — Report which checks this worktree is ready to run
+
+## SessionEnd
+
+- Hook 1: [uncommitted-work-guard.mjs](uncommitted-work-guard.mjs) — Warn about uncommitted work before the session ends
+- Hook 2: [worktree-session-heartbeat.mjs](worktree-session-heartbeat.mjs) — Remove the ended session heartbeat
+- Hook 3: [worktree-session-hygiene.mjs](worktree-session-hygiene.mjs) — Reap this checkout only when merged, clean and no longer in use
+
+## Stop
+
+- Hook 1: [uncommitted-work-guard.mjs](uncommitted-work-guard.mjs) — Warn about uncommitted work before ending the turn
+- Hook 2: [worktree-session-heartbeat.mjs](worktree-session-heartbeat.mjs) — Refresh this session heartbeat to protect active work
+
+Regenerate with `python scripts/update_agent_toolchain.py --write-hook-reference` from the skill-pack directory.

--- a/packages/dpf-skill-pack/hooks/hooks.json
+++ b/packages/dpf-skill-pack/hooks/hooks.json
@@ -6,35 +6,43 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/lease-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/lease-guard.mjs\"",
+            "statusMessage": "Check the environment lease before starting a server"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-guard.mjs\"",
+            "statusMessage": "Protect the shared source checkout from unsafe changes"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/compose-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/compose-guard.mjs\"",
+            "statusMessage": "Protect shared services from destructive Compose commands"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/portal-image-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/portal-image-guard.mjs\"",
+            "statusMessage": "Keep portal image changes on the verified release path"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/lease-punt-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/lease-punt-guard.mjs\"",
+            "statusMessage": "Check runtime verification has a provisioned environment"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pregate-evidence-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pregate-evidence-guard.mjs\"",
+            "statusMessage": "Check verification evidence before publishing code"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pregate-invocation-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pregate-invocation-guard.mjs\"",
+            "statusMessage": "Check the verification command can run and report its result"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/workroom-claim-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/workroom-claim-guard.mjs\"",
+            "statusMessage": "Check this source change belongs to a claimed Workroom"
           }
         ]
       },
@@ -43,7 +51,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/decision-routing-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/decision-routing-guard.mjs\"",
+            "statusMessage": "Check platform guidance before asking for a decision"
           }
         ]
       },
@@ -52,31 +61,38 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-guard.mjs\"",
+            "statusMessage": "Protect the shared source checkout from unsafe changes"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-backlog-coverage-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-backlog-coverage-guard.mjs\"",
+            "statusMessage": "Check planned deliverables are tracked before source edits"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ux-fit-precheck.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ux-fit-precheck.mjs\"",
+            "statusMessage": "Remind the author to review usability for UI changes"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/spec-plan-doc-precheck.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/spec-plan-doc-precheck.mjs\"",
+            "statusMessage": "Remind the author to include required design and documentation"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/design-grounding-precheck.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/design-grounding-precheck.mjs\"",
+            "statusMessage": "Remind the author to check existing design and implementation"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-economy-precheck.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-economy-precheck.mjs\"",
+            "statusMessage": "Remind the author to keep tool descriptions and results bounded"
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/workroom-claim-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/workroom-claim-guard.mjs\"",
+            "statusMessage": "Check this source change belongs to a claimed Workroom"
           }
         ]
       }
@@ -86,7 +102,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-create.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-create.mjs\"",
+            "statusMessage": "Create an isolated worktree in the shared worktree directory"
           }
         ]
       }
@@ -96,7 +113,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/process-spine-health-check.mjs\" --hook"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/process-spine-health-check.mjs\" --hook",
+            "statusMessage": "Check required DPF skills are installed and exposed"
           }
         ]
       },
@@ -104,7 +122,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/governance-freshness-check.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/governance-freshness-check.mjs\"",
+            "statusMessage": "Check this checkout has current process guards"
           }
         ]
       },
@@ -112,7 +131,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\"",
+            "statusMessage": "Check worktree location and unused checkout inventory"
           }
         ]
       },
@@ -120,7 +140,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\"",
+            "statusMessage": "Refresh this session heartbeat to protect active work"
           }
         ]
       },
@@ -128,7 +149,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-freshness.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-freshness.mjs\"",
+            "statusMessage": "Safely fast-forward the clean shared source checkout"
           }
         ]
       },
@@ -136,7 +158,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-readiness-banner.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-readiness-banner.mjs\"",
+            "statusMessage": "Report which checks this worktree is ready to run"
           }
         ]
       }
@@ -146,7 +169,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\"",
+            "statusMessage": "Warn about uncommitted work before the session ends"
           }
         ]
       },
@@ -154,7 +178,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\"",
+            "statusMessage": "Remove the ended session heartbeat"
           }
         ]
       },
@@ -162,7 +187,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\"",
+            "statusMessage": "Reap this checkout only when merged, clean and no longer in use"
           }
         ]
       }
@@ -172,7 +198,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\"",
+            "statusMessage": "Warn about uncommitted work before ending the turn"
           }
         ]
       },
@@ -180,7 +207,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\"",
+            "statusMessage": "Refresh this session heartbeat to protect active work"
           }
         ]
       }

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -1149,17 +1149,21 @@ def grok_hooks_file(home: Path) -> Path:
     return home / ".grok" / "hooks" / "dpf-guards.json"
 
 
-def _grok_hook_command(hooks_dir: Path, script: str, timeout: int = 15) -> dict[str, Any]:
-    return {
+def _managed_hook_command(hooks_dir: Path, script: str, timeout: int = 15, event: str = "PreToolUse") -> dict[str, Any]:
+    result = {
         "type": "command",
         "command": f'node "{hooks_dir / script}"',
         "timeout": timeout,
     }
+    purpose = hook_purposes(hooks_dir.parent, event).get(script)
+    if purpose:
+        result["statusMessage"] = purpose
+    return result
 
 
-def _grok_command_entry(hooks_dir: Path, script: str, timeout: int = 15) -> dict[str, Any]:
+def _grok_command_entry(hooks_dir: Path, script: str, timeout: int = 15, event: str = "PreToolUse") -> dict[str, Any]:
     """Single-script PreToolUse group (legacy shape used by session events)."""
-    return {"hooks": [_grok_hook_command(hooks_dir, script, timeout=timeout)]}
+    return {"hooks": [_managed_hook_command(hooks_dir, script, timeout=timeout, event=event)]}
 
 
 def _grok_matched_group(
@@ -1171,7 +1175,7 @@ def _grok_matched_group(
     timeout: int = 15,
 ) -> dict[str, Any] | None:
     hooks = [
-        _grok_hook_command(hooks_dir, script, timeout=timeout)
+        _managed_hook_command(hooks_dir, script, timeout=timeout)
         for script in scripts
         if dry_run or (hooks_dir / script).exists()
     ]
@@ -1192,21 +1196,21 @@ def build_grok_hooks_payload(managed: Path, dry_run: bool = False) -> dict[str, 
     if pre_entries:
         payload["hooks"]["PreToolUse"] = pre_entries
     start = [
-        _grok_command_entry(hooks_dir, script, timeout=30)
+        _grok_command_entry(hooks_dir, script, timeout=30, event="SessionStart")
         for script in GROK_SESSION_START_SCRIPTS
         if dry_run or (hooks_dir / script).exists()
     ]
     if start:
         payload["hooks"]["SessionStart"] = start
     end = [
-        _grok_command_entry(hooks_dir, script, timeout=60)
+        _grok_command_entry(hooks_dir, script, timeout=60, event="SessionEnd")
         for script in GROK_SESSION_END_SCRIPTS
         if dry_run or (hooks_dir / script).exists()
     ]
     if end:
         payload["hooks"]["SessionEnd"] = end
     stop = [
-        _grok_command_entry(hooks_dir, script, timeout=60)
+        _grok_command_entry(hooks_dir, script, timeout=60, event="Stop")
         for script in GROK_STOP_SCRIPTS
         if dry_run or (hooks_dir / script).exists()
     ]
@@ -1358,21 +1362,21 @@ def _build_codex_pre_tool_use_groups(managed: Path, *, dry_run: bool) -> list[di
     hooks_dir = managed / "hooks"
     groups: list[dict[str, Any]] = []
     bash_entries = [
-        {"type": "command", "command": f'node "{hooks_dir / guard}"', "timeout": 15}
+        _managed_hook_command(hooks_dir, guard)
         for guard in CODEX_BASH_GUARDS
         if dry_run or (hooks_dir / guard).exists()
     ]
     if bash_entries:
         groups.append({"matcher": "Bash", "hooks": bash_entries})
     ask_entries = [
-        {"type": "command", "command": f'node "{hooks_dir / guard}"', "timeout": 15}
+        _managed_hook_command(hooks_dir, guard)
         for guard in CODEX_ASK_GUARDS
         if dry_run or (hooks_dir / guard).exists()
     ]
     if ask_entries:
         groups.append({"matcher": "AskUserQuestion", "hooks": ask_entries})
     write_entries = [
-        {"type": "command", "command": f'node "{hooks_dir / guard}"', "timeout": 15}
+        _managed_hook_command(hooks_dir, guard)
         for guard in CODEX_WRITE_GUARDS
         if dry_run or (hooks_dir / guard).exists()
     ]
@@ -1495,37 +1499,24 @@ def codex_hook_trust_blocking_notice() -> list[str]:
     ]
 
 
-# One-line purpose per hook script. The operator granting hook-trust on Codex/Grok
-# sees an opaque numbered list ("Hook 1..N") because the hook-object schema has no
-# name/description field (BI-276EC984; upstream asks openai/codex#31469 and
-# xai-org/plugin-marketplace#71). Until those land, the installer prints this roster
-# so the trust decision is informed. Keyed by script basename; a CI test asserts
-# every command hook in hooks.json has an entry here (kept in sync mechanically).
-HOOK_PURPOSES = {
-    "lease-guard.mjs": "blocks launching a long-running server without a nonprod lease",
-    "root-clone-guard.mjs": "blocks destructive rm / git clean aimed at the root clone",
-    "compose-guard.mjs": "blocks docker compose commands that tear down shared services",
-    "portal-image-guard.mjs": "blocks hand-building the canonical portal image, which overwrites what the live install runs",
-    "lease-punt-guard.mjs": "blocks a runtime-bound gate (prisma migrate / db push) in a source-only worktree",
-    "decision-routing-guard.mjs": "blocks asking the operator a platform decision with no kernel consultation",
-    "workroom-claim-guard.mjs": "blocks work on a feature branch that no live Workroom claim covers (AGENTS.md 12)",
-    "plan-backlog-coverage-guard.mjs": "blocks production source edits until xlarge and independently shippable plan work has live BI coverage",
-    "pregate-evidence-guard.mjs": "blocks git push / gh pr create when HEAD has no unexpired local-CI sandbox evidence",
-    "pregate-invocation-guard.mjs": "blocks a pregate run shaped so it cannot succeed or cannot be read (piped, backgrounded, chained, timeout-wrapped)",
-    "ux-fit-precheck.mjs": "reminds to run a UX-fit review when editing UI surfaces",
-    "spec-plan-doc-precheck.mjs": "reminds to attach a spec/plan/doc when writing gated files",
-    "design-grounding-precheck.mjs": "reminds to review specs and current code substrate before UX/workflow edits",
-    "tool-economy-precheck.mjs": "reminds about tool-economy budget when adding tool surface",
-    "worktree-create.mjs": "seeds a new worktree with MCP config on WorktreeCreate",
-    "worktree-readiness-banner.mjs": "SessionStart: announces a SOURCE-ONLY worktree and what it forbids, so agents never promise a typecheck they cannot run",
-    "process-spine-health-check.mjs": "SessionStart: warns when DPF-native replacement skills are missing or hidden by retired generic skills",
-    "governance-freshness-check.mjs": "SessionStart: warns if governance guard wiring is stale",
-    "grok-session-start.mjs": "Grok SessionStart: process-spine exposure probe + governance-freshness (global hook plane)",
-    "worktree-session-hygiene.mjs": "SessionStart observe worktree sprawl; SessionEnd reaps THIS worktree when Tier-A (merged+clean) — primary reaper, not cron",
-    "worktree-session-heartbeat.mjs": "SessionStart/Stop write + SessionEnd remove a gitignored session heartbeat so the janitor never reaps a worktree with a live session (non-destructive)",
-    "root-clone-freshness.mjs": "SessionStart: fast-forwards the shared root clone to origin/main (ff-only, on-main+clean) so junctioned worktrees never inherit a stale root",
-    "uncommitted-work-guard.mjs": "SessionEnd/Stop/post-checkout: warns before uncommitted spec/plan loss",
-}
+# Purpose metadata lives with each canonical handler (BI-26DC98EE).
+# Existing installer and client adapters consume it; there is no second roster.
+def hook_purposes(skill_pack: Path, event: str) -> dict[str, str]:
+    try:
+        data = json.loads((skill_pack / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    purposes = {}
+    for key, groups in data.get("hooks", {}).items():
+        if key != event:
+            continue
+        for group in groups:
+            for hook in group.get("hooks", []):
+                base = hook_script_basename(hook.get("command", ""))
+                purpose = hook.get("statusMessage")
+                if base and isinstance(purpose, str) and purpose.strip():
+                    purposes.setdefault(base, purpose)
+    return purposes
 
 
 def hook_script_basename(command: str) -> str | None:
@@ -1538,8 +1529,8 @@ def hook_roster(skill_pack: Path) -> list[str]:
     """Human-readable roster of the plugin's hooks (name + purpose), grouped by event.
 
     Printed so an operator granting hook-trust on Codex/Grok knows what each numbered
-    "Hook N" actually is (BI-276EC984). Order matches hooks.json, which is the order
-    the trust UIs number them.
+    "Hook N" actually is (BI-276EC984). Order follows hooks.json; clients may
+    reorder it, so confirm the event and command before trusting a definition.
     """
     hooks_json = skill_pack / "hooks" / "hooks.json"
     try:
@@ -1549,7 +1540,7 @@ def hook_roster(skill_pack: Path) -> list[str]:
     events = data.get("hooks", {})
     if not isinstance(events, dict):
         return []
-    lines = ["Plugin hooks — what each numbered 'Hook N' in the Codex/Grok trust UI is:"]
+    lines = ["Plugin hooks — purposes in definition order; confirm event and command in the trust UI:"]
     for event, groups in events.items():
         entry_lines = []
         n = 0
@@ -1558,7 +1549,7 @@ def hook_roster(skill_pack: Path) -> list[str]:
             for hook in group.get("hooks", []) if isinstance(group, dict) else []:
                 n += 1
                 base = hook_script_basename(hook.get("command", "")) or "?"
-                purpose = HOOK_PURPOSES.get(base, "(undescribed — add to HOOK_PURPOSES)")
+                purpose = hook.get("statusMessage") or "(purpose unavailable in this definition)"
                 mtag = f" [{matcher}]" if matcher else ""
                 entry_lines.append(f"    Hook {n}{mtag}: {base} — {purpose}")
         if entry_lines:
@@ -1596,6 +1587,40 @@ def guard_liveness_advisory() -> list[str]:
     ]
 
 
+def hook_reference(skill_pack: Path) -> str:
+    """Render the existing roster as a shipped reference, without reading trust state."""
+    hooks_dir = (skill_pack / "hooks").resolve()
+    data = json.loads((hooks_dir / "hooks.json").read_text(encoding="utf-8"))
+    for groups in data["hooks"].values():
+        for group in groups:
+            for hook in group["hooks"]:
+                base = hook_script_basename(hook.get("command", ""))
+                source = (hooks_dir / (base or "")).resolve()
+                if not base or hooks_dir not in source.parents or not source.is_file():
+                    raise ValueError(f"Hook source is unavailable: {base}")
+                if not isinstance(hook.get("statusMessage"), str) or not hook["statusMessage"].strip():
+                    raise ValueError(f"Hook purpose is missing: {base}")
+    lines = [
+        "# DPF hook purposes", "",
+        "Generated from [hooks.json](hooks.json). Do not edit this reference by hand.", "",
+        "Before enabling a hook, match its event and command with the entries below.",
+        "Numbers follow definition order; your client may order entries differently.",
+        "The client owns the current trust state. This reference does not grant trust.", "",
+        "Purpose text is stored as `statusMessage`, which clients may show while a hook runs.",
+        "Friendly names in approval rows remain a [Codex client request](https://github.com/openai/codex/issues/31469).",
+        "A purpose in this file is not proof that an approval row displays it.", "",
+    ]
+    for line in hook_roster(skill_pack)[1:]:
+        if line.startswith("    "):
+            entry = line.strip().replace("|", "\\|").replace("<", "&lt;").replace(">", "&gt;")
+            entry = re.sub(r"([A-Za-z0-9_.-]+\.mjs)", r"[\1](\1)", entry, count=1)
+            lines.append(f"- {entry}")
+        else:
+            lines.extend(["", f"## {line.strip().rstrip(':')}", ""])
+    lines.extend(["", "Regenerate with `python scripts/update_agent_toolchain.py --write-hook-reference` from the skill-pack directory.", ""])
+    return "\n".join(lines)
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="Update DPF Codex/Claude/Grok/Antigravity agent skills and MCP wiring.")
     parser.add_argument("--skill-pack-path", default=str(default_skill_pack_path()))
@@ -1616,7 +1641,22 @@ def main(argv: list[str]) -> int:
         help="Exit 2 when Codex is installed but hook trust has not been granted (BI-66EBEA06).",
     )
     parser.add_argument("--dry-run", action="store_true")
+    reference_mode = parser.add_mutually_exclusive_group()
+    reference_mode.add_argument("--write-hook-reference", action="store_true")
+    reference_mode.add_argument("--check-hook-reference", action="store_true")
     args = parser.parse_args(argv)
+
+    if args.write_hook_reference or args.check_hook_reference:
+        root = Path(args.skill_pack_path).expanduser().resolve()
+        reference = hook_reference(root)
+        path = root / "hooks" / "README.md"
+        if args.write_hook_reference:
+            path.write_text(reference, encoding="utf-8")
+            return 0
+        if not path.exists() or path.read_text(encoding="utf-8") != reference:
+            print("Hook reference is stale; regenerate it from hooks.json.", file=sys.stderr)
+            return 1
+        return 0
 
     if args.codex_only and args.claude_only:
         raise SystemExit("--codex-only and --claude-only cannot be combined")

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -269,9 +269,66 @@ class HookRosterTest(unittest.TestCase):
             for group in groups if isinstance(groups, list) else []:
                 for hook in group.get("hooks", []) if isinstance(group, dict) else []:
                     base = updater.hook_script_basename(hook.get("command", ""))
-                    if base and base not in updater.HOOK_PURPOSES:
+                    if base and not str(hook.get("statusMessage", "")).strip():
                         missing.append(base)
-        self.assertEqual(missing, [], f"hooks missing a HOOK_PURPOSES entry: {missing}")
+        self.assertEqual(missing, [], f"hooks missing a statusMessage: {missing}")
+
+    def test_roster_uses_canonical_purpose_not_a_second_dictionary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "hooks").mkdir()
+            (root / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {
+                "Stop": [{"hooks": [{"type": "command", "command": 'node "hooks/test.mjs"',
+                                      "statusMessage": "Preserve work before ending"}]}]}}))
+            self.assertIn("Preserve work before ending", "\n".join(updater.hook_roster(root)))
+
+    def test_reference_matches_all_canonical_handlers_and_is_current(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        reference = updater.hook_reference(root)
+        self.assertEqual((root / "hooks" / "README.md").read_text(encoding="utf-8"), reference)
+        data = json.loads((root / "hooks" / "hooks.json").read_text())
+        for groups in data["hooks"].values():
+            for group in groups:
+                for hook in group["hooks"]:
+                    self.assertIn(hook["statusMessage"], reference)
+                    self.assertIn(updater.hook_script_basename(hook["command"]), reference)
+
+    def test_codex_adapter_carries_purpose_from_canonical_definition(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        payload = updater.merge_codex_hooks_payload({}, root, dry_run=False)
+        for group in payload["hooks"]["PreToolUse"]:
+            for hook in group["hooks"]:
+                self.assertTrue(hook.get("statusMessage"), hook["command"])
+
+    def test_grok_lifecycle_purposes_match_event_not_just_script(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        payload = updater.build_grok_hooks_payload(root)
+        for event, expected in [("SessionStart", "Check worktree location"),
+                                ("SessionEnd", "Reap this checkout")]:
+            hooks = [h for group in payload["hooks"][event] for h in group["hooks"]]
+            hook = next(h for h in hooks if "worktree-session-hygiene.mjs" in h["command"])
+            self.assertTrue(hook["statusMessage"].startswith(expected))
+
+    def test_reference_check_is_read_only_and_detects_stale_content(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            copy = Path(tmp)
+            import shutil
+            shutil.copytree(root / "hooks", copy / "hooks")
+            reference = copy / "hooks" / "README.md"
+            reference.write_text("stale", encoding="utf-8")
+            self.assertEqual(updater.main(["--skill-pack-path", str(copy), "--check-hook-reference"]), 1)
+            self.assertEqual(reference.read_text(), "stale")
+
+    def test_reference_rejects_missing_purpose(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "hooks").mkdir()
+            (root / "hooks" / "test.mjs").write_text("")
+            (root / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {
+                "Stop": [{"hooks": [{"type": "command", "command": "node hooks/test.mjs"}]}]}}))
+            with self.assertRaisesRegex(ValueError, "purpose is missing"):
+                updater.hook_reference(root)
 
     def test_roster_enumerates_named_hooks(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
Closes BI-26DC98EE for the DPF metadata/reference slice of FLOW-MCP-HOOK.

Operators currently get numbered hook entries without purpose metadata. Store a concise statusMessage beside each of the 28 canonical handlers and ship a generated hook reference with event, matcher and source links. The existing installer roster and managed client adapters consume the same definitions; remove the separate HOOK_PURPOSES dictionary. Session-start and session-end messages stay distinct for shared scripts.

Commands, matchers and ordering are unchanged. This does not grant trust or claim to rename Codex approval rows: openai/codex#31469 remains open, and the reference explicitly states the client limitation. No portal, database or dependency changes.

## Design grounding

Specs/plans reviewed: docs/superpowers/specs/2026-09-08-readable-hook-purposes-design.md and FLOW-MCP-HOOK in docs/superpowers/specs/2026-09-04-mcp-client-contract-consolidation-design.md. Current code substrate reviewed: packages/dpf-skill-pack/hooks/hooks.json and scripts/update_agent_toolchain.py within the pack. The existing JSON handlers remain the source of truth; the roster and reference are projections.

## Validation

- 63 Python updater tests pass, including metadata coverage, event-specific adapters, generated-reference freshness and preservation of unrelated client configuration.
- 24 Node hook-wiring tests pass. Comparing before/after with statusMessage removed produces identical operational definitions.
- Generated reference check, git diff --check and all 66 source guards pass. The first guard-run process ended without a diagnostic; an identical-tree retry completed successfully in 160.2 seconds.
- Exact-tree semantic service returned PASS with no blocking findings. Its result reports two branches while its rationale describes the low-risk exemption; no independent-review-count claim is made from that inconsistent metadata.
- Managed plugin installation and actual client display remain post-merge acceptance. Friendly approval-row names are not claimed.

Local-CI-Override: operator-emergency: standing operator authorization; local runtime CI unrun for the metadata/updater slice, focused tests executed, protected merge-queue CI remains mandatory.
