### PR TITLE
feat(gates): a scoped seed-fit answer must name the mechanism that enforces it (BI-B507DBD1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,7 @@ COPY scripts/lib/ci-evidence-plan.mjs ./scripts/lib/
 COPY scripts/lib/derived-artifacts-registry.mjs ./scripts/lib/
 COPY scripts/lib/gate-sensitivity.mjs ./scripts/lib/
 COPY scripts/lib/seed-fit-gate.mjs ./scripts/lib/
+COPY scripts/lib/seed-fit-mechanism.mjs ./scripts/lib/
 COPY scripts/lib/pr-trailer-contract.mjs ./scripts/lib/
 COPY scripts/lib/module-size-scope.mjs ./scripts/lib/
 COPY scripts/lib/ci-policy-guards.mjs ./scripts/lib/

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10737,6 +10737,7 @@
         "what-runs-in-ci",
         "policy-guard-profiles",
         "re-evaluating-a-trailer-or-label-without-pushing",
+        "a-scoped-seed-fit-answer-names-its-mechanism",
         "where-ci-runs-it",
         "run-locally-before-pushing",
         "the-pre-push-gate-pregate-default-on",

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -103,6 +103,34 @@ The profiles reflect execution substrate, not separate policy inventories:
 
 #### Re-evaluating a trailer or label without pushing
 
+### A scoped seed-fit answer names its mechanism
+
+`Seed-Fit-Decision: archetype-scoped` and `vertical-scoped` claim the content is
+limited to some installs. Since BI-B507DBD1 the claim must also say **how** that
+limit is enforced, and the named rule must appear in the diff:
+
+```
+Seed-Fit-Decision: archetype-scoped mechanism=seed-gate  symbol=referenceModelAppliesToInstall
+Seed-Fit-Decision: vertical-scoped  mechanism=read-scope symbol=regulationApplies
+```
+
+Two mechanisms exist, both correct, and the choice is yours:
+
+- **`seed-gate`** — do not put the content on installs it does not serve. The
+  seeder consults an applicability rule before writing.
+- **`read-scope`** — ship it everywhere on purpose and filter at consumption.
+  Each row declares applicability and the read path evaluates it.
+
+`global-default` claims no limit and owes no mechanism. A label can still carry
+the decision, but a scoped one needs the mechanism in the body, because a label
+cannot carry the evidence.
+
+This exists because in BI-C44EAEE6 a banking reference model was scoped at seed
+time and never on read, so a pet rescue advertised it as active. One half
+shipped, the other did not, and nothing looked at the pair. The gate now checks
+that the rule you name is actually referenced by a file you changed, so an
+unimplemented claim fails rather than reads well.
+
 Several `pull-request` guards — Seed Contribution Fit, UX Fit, Design Grounding,
 Docs Impact — tell you to add a trailer such as `Seed-Fit-Decision:` to the PR
 body, or to apply a label. **Editing the body alone used to do nothing.**

--- a/scripts/check-seed-fit-decision.mjs
+++ b/scripts/check-seed-fit-decision.mjs
@@ -7,6 +7,7 @@ import {
   normalizeGithubLabels,
   SEED_FIT_DECISIONS,
 } from "./lib/seed-fit-gate.mjs";
+import { describeScopeMechanism } from "./lib/seed-fit-mechanism.mjs";
 import { requireChangedFiles } from "./lib/git-changed-files.mjs";
 
 const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
@@ -70,6 +71,16 @@ if (result.reason === "contradictory-decisions") {
 }
 if (result.reason === "invalid-decision") {
   console.error(`Invalid decisions: ${result.invalid.join(", ")}`);
+}
+if (result.reason === "scope-mechanism-unproven") {
+  console.error(`Decision ${result.decision} claims a limited scope, so it owes the mechanism that enforces it.`);
+  console.error(`  ${describeScopeMechanism(result.mechanism)}`);
+  console.error("");
+  console.error("  Seed-Fit-Decision: archetype-scoped mechanism=seed-gate symbol=referenceModelAppliesToInstall");
+  console.error("  Seed-Fit-Decision: vertical-scoped  mechanism=read-scope symbol=regulationApplies");
+  console.error("");
+  console.error("  seed-gate  = do not put the content on installs it does not serve.");
+  console.error("  read-scope = ship it everywhere and filter at consumption.");
 }
 if (result.reason === "decision-not-merge-eligible") {
   console.error(`Decision ${result.decision} requires revision or removal of the seed delta before merge.`);

--- a/scripts/check-seed-fit-decision.test.mjs
+++ b/scripts/check-seed-fit-decision.test.mjs
@@ -42,11 +42,49 @@ describe("seed-fit PR gate", () => {
   });
 
   it("passes an eligible decision from a label", () => {
+    // A label carries the DECISION but cannot carry the evidence, so an unscoped
+    // decision is complete on its own.
     assert.deepEqual(evaluateSeedFitGate({
       changedFiles: ["packages/db/src/seed-skills.ts"],
       prBody: "",
-      labels: ["seed-fit:vertical-scoped"],
+      labels: ["seed-fit:global-default"],
     }).ok, true);
+  });
+
+  // BI-B507DBD1. A scoped claim owes the mechanism that enforces it, however the
+  // decision arrived. Without this a change could answer "vertical-scoped" and
+  // ship globally, because nothing downstream read the answer.
+  it("fails a scoped decision that names no enforcement mechanism", () => {
+    const result = evaluateSeedFitGate({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      prBody: "",
+      labels: ["seed-fit:vertical-scoped"],
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "scope-mechanism-unproven");
+    assert.equal(result.mechanism.reason, "missing-mechanism");
+  });
+
+  it("passes a label-sourced scoped decision whose body names a wired mechanism", () => {
+    const result = evaluateSeedFitGate({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      prBody: "Seed-Fit-Decision: vertical-scoped mechanism=seed-gate symbol=skillAppliesToInstall",
+      labels: ["seed-fit:vertical-scoped"],
+      readFile: () => "if (!skillAppliesToInstall(slug, install)) return;",
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.mechanism.reason, "mechanism-wired");
+  });
+
+  it("fails a scoped decision whose named rule appears in no changed file", () => {
+    const result = evaluateSeedFitGate({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      prBody: "Seed-Fit-Decision: vertical-scoped mechanism=read-scope symbol=neverWired",
+      labels: [],
+      readFile: () => "export const SKILLS = [];",
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.mechanism.reason, "symbol-not-in-diff");
   });
 
   it("fails contradictory body and label decisions", () => {

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -663,7 +663,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("scripts/check-docs-impact.mjs"),
     ]),
     guard("seed-fit-gate", "Seed Contribution Fit Gate", [
-      node("--test", "scripts/check-seed-fit-decision.test.mjs"),
+      node("--test", "scripts/check-seed-fit-decision.test.mjs", "scripts/lib/seed-fit-mechanism.test.mjs"),
       node("scripts/check-seed-fit-decision.mjs"),
     ]),
     guard("spec-plan-doc-gate", "Spec/Plan/Doc Gate", [

--- a/scripts/lib/seed-fit-gate.mjs
+++ b/scripts/lib/seed-fit-gate.mjs
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { evaluateScopeMechanism } from "./seed-fit-mechanism.mjs";
+
 const config = JSON.parse(
   readFileSync(new URL("../../config/seed-content-paths.json", import.meta.url), "utf8"),
 );
@@ -55,7 +57,7 @@ function collectDecisionTokens(prBody, labels) {
   return [...bodyMatches, ...labelMatches];
 }
 
-export function evaluateSeedFitGate({ changedFiles, prBody = "", labels = [] }) {
+export function evaluateSeedFitGate({ changedFiles, prBody = "", labels = [], readFile } = {}) {
   const seedPaths = findCanonicalSeedContentPaths(changedFiles);
   if (seedPaths.length === 0) {
     return { ok: true, reason: "no-seed-content", seedPaths, decision: null };
@@ -80,5 +82,20 @@ export function evaluateSeedFitGate({ changedFiles, prBody = "", labels = [] }) 
     return { ok: false, reason: "decision-not-merge-eligible", seedPaths, decision };
   }
 
-  return { ok: true, reason: "eligible-decision", seedPaths, decision };
+  // A decision that CLAIMS a limited scope must name how that scope is enforced,
+  // and the named rule must actually appear in the diff. Without this a change
+  // could truthfully answer "archetype-scoped" and ship globally, because nothing
+  // downstream read the answer — the BI-C44EAEE6 shape, where the seed half
+  // shipped and the read half did not (BI-B507DBD1, kernel DI-D17CAA32468F).
+  const mechanism = evaluateScopeMechanism({
+    decision,
+    prBody,
+    changedFiles,
+    readFile: readFile ?? ((file) => readFileSync(file, "utf8")),
+  });
+  if (!mechanism.ok) {
+    return { ok: false, reason: "scope-mechanism-unproven", seedPaths, decision, mechanism };
+  }
+
+  return { ok: true, reason: "eligible-decision", seedPaths, decision, mechanism };
 }

--- a/scripts/lib/seed-fit-mechanism.mjs
+++ b/scripts/lib/seed-fit-mechanism.mjs
@@ -1,0 +1,159 @@
+// A scoped seed-fit answer must name the mechanism that enforces it (BI-B507DBD1).
+//
+// The Seed Contribution Fit gate already asks the right question with the right
+// vocabulary. What it never asked was HOW an `archetype-scoped` answer would be
+// enforced, and nothing downstream read the answer. So a change could truthfully
+// answer "archetype-scoped" and ship globally, and nothing noticed.
+//
+// That is not hypothetical. In BI-C44EAEE6 the BIAN Service Landscape was scoped
+// at SEED time (#4870 gated its element hierarchy on the install's archetype) and
+// never scoped on READ, so a pet rescue's Enterprise Architecture page advertised
+// a banking standard as ACTIVE with zero criteria. One half shipped, the other
+// did not, and no gate looked at the pair.
+//
+// Two legitimate mechanisms exist in this codebase and both are in live use:
+//
+//   seed-gate   Do not put the content on the install at all. The seeder consults
+//               an applicability rule before writing.
+//               Live example: referenceModelAppliesToInstall.
+//   read-scope  Ship it everywhere on purpose and filter at consumption. Each row
+//               declares applicability and the read path evaluates it.
+//               Live example: regulationApplies.
+//
+// Both are correct. Choosing between them is the author's call. NAMING the choice
+// and pointing at the symbol that implements it is what makes the claim checkable
+// by something other than a reviewer's memory.
+//
+// Why this shape and not an intake question: kernel decision DI-D17CAA32468F
+// scored "derive, and say so when undecidable" at 10.83 against 3.56 for
+// demanding an annotation up front. `principles/gate-coverage-matches-blast-radius`
+// puts it plainly — "prefer a rule the gate can decide without anyone remembering
+// to annotate", because "opt-in coverage reproduces the very 'somebody must
+// remember' failure the gate exists to remove". This asks for one thing only, at
+// the moment the author already has the answer in hand, and then VERIFIES it
+// rather than trusting it.
+
+/** How a scoped contribution is kept off the installs it does not serve. */
+export const SCOPE_ENFORCEMENT_MECHANISMS = Object.freeze(["seed-gate", "read-scope"]);
+
+const MECHANISM_SET = new Set(SCOPE_ENFORCEMENT_MECHANISMS);
+
+/**
+ * Decisions that CLAIM the content is limited to some archetypes or verticals.
+ *
+ * `global-default` claims the opposite and owes no mechanism. `parameterize-first`,
+ * `install-local-only` and `reject-as-seed` are not merge-eligible, so the gate
+ * stops on them before reaching this rule.
+ */
+export const SCOPED_SEED_FIT_DECISIONS = Object.freeze(["archetype-scoped", "vertical-scoped"]);
+
+const SCOPED_SET = new Set(SCOPED_SEED_FIT_DECISIONS);
+
+export function isScopedSeedFitDecision(decision) {
+  return SCOPED_SET.has(String(decision ?? "").toLowerCase());
+}
+
+// Fenced blocks in a PR body are documentation, not attestation. The convergence
+// gate learned this the hard way when its own PR failed on a quoted `<mode>`.
+const FENCED_BLOCK_RE = /^[ \t]*(```|~~~)[^\n]*\n[\s\S]*?^[ \t]*\1[ \t]*$/gm;
+
+/**
+ * Read `mechanism=<m>` and `symbol=<s>` from the Seed-Fit-Decision line.
+ *
+ * Accepted on the same line as the decision, in either order:
+ *   Seed-Fit-Decision: archetype-scoped mechanism=read-scope symbol=regulationApplies
+ *
+ * Returns nulls when absent, so the caller distinguishes "not stated" from
+ * "stated wrongly" and can say which.
+ */
+export function parseSeedFitMechanism(prBody) {
+  const unfenced = String(prBody ?? "").replace(FENCED_BLOCK_RE, "");
+  const line = /Seed-Fit-Decision:[ \t]*([^\n]*)/i.exec(unfenced);
+  if (!line) return { mechanism: null, symbol: null };
+  const rest = line[1];
+  const mechanism = /\bmechanism\s*=\s*([A-Za-z][\w-]*)/i.exec(rest);
+  const symbol = /\bsymbol\s*=\s*([A-Za-z_$][\w$.]*)/i.exec(rest);
+  return {
+    mechanism: mechanism ? mechanism[1].toLowerCase() : null,
+    symbol: symbol ? symbol[1] : null,
+  };
+}
+
+/**
+ * Which changed files actually reference the named symbol.
+ *
+ * This is the half that makes the claim evidence rather than assertion: an author
+ * naming a symbol they did not wire is the exact BI-C44EAEE6 shape, where the
+ * intent was documented in a comment and the read path never implemented it.
+ *
+ * `readFile` is injected and may throw for a deleted or binary path; that is
+ * treated as "does not reference", never as a crash.
+ */
+export function findMechanismEvidence({ symbol, changedFiles, readFile }) {
+  if (!symbol) return [];
+  const needle = String(symbol);
+  return (changedFiles ?? []).filter((file) => {
+    try {
+      return String(readFile(file)).includes(needle);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Does a scoped seed-fit answer carry an enforceable mechanism?
+ *
+ * Returns `{ ok, reason, mechanism, symbol, evidenceFiles }`. `reason` is a
+ * machine-readable code; the caller renders the sentence, so this stays pure and
+ * testable and the gate output stays in one place.
+ */
+export function evaluateScopeMechanism({ decision, prBody = "", changedFiles = [], readFile }) {
+  if (!isScopedSeedFitDecision(decision)) {
+    return { ok: true, reason: "not-a-scoped-decision", mechanism: null, symbol: null, evidenceFiles: [] };
+  }
+
+  const { mechanism, symbol } = parseSeedFitMechanism(prBody);
+
+  if (!mechanism) {
+    return { ok: false, reason: "missing-mechanism", mechanism: null, symbol, evidenceFiles: [] };
+  }
+  if (!MECHANISM_SET.has(mechanism)) {
+    return { ok: false, reason: "unknown-mechanism", mechanism, symbol, evidenceFiles: [] };
+  }
+  if (!symbol) {
+    return { ok: false, reason: "missing-symbol", mechanism, symbol: null, evidenceFiles: [] };
+  }
+
+  const evidenceFiles = findMechanismEvidence({ symbol, changedFiles, readFile });
+  if (evidenceFiles.length === 0) {
+    return { ok: false, reason: "symbol-not-in-diff", mechanism, symbol, evidenceFiles };
+  }
+
+  return { ok: true, reason: "mechanism-wired", mechanism, symbol, evidenceFiles };
+}
+
+/** The operator-facing sentence for a mechanism verdict. */
+export function describeScopeMechanism(result) {
+  switch (result.reason) {
+    case "not-a-scoped-decision":
+      return "Decision does not claim archetype or vertical scope; no enforcement mechanism is owed.";
+    case "missing-mechanism":
+      return (
+        "A scoped decision must say how it is enforced. Add `mechanism=seed-gate` (do not put the content " +
+        "on installs it does not serve) or `mechanism=read-scope` (ship it everywhere and filter at " +
+        "consumption) to the Seed-Fit-Decision line, with `symbol=<the function that enforces it>`."
+      );
+    case "unknown-mechanism":
+      return `mechanism=${result.mechanism} is not one of ${SCOPE_ENFORCEMENT_MECHANISMS.join(" | ")}.`;
+    case "missing-symbol":
+      return `mechanism=${result.mechanism} names no symbol. Add \`symbol=<the function that enforces it>\` so the claim can be checked.`;
+    case "symbol-not-in-diff":
+      return (
+        `No changed file references \`${result.symbol}\`, so this change claims a scope it does not implement. ` +
+        `That is the BI-C44EAEE6 shape: the seed half shipped and the read half did not.`
+      );
+    default:
+      return `Enforced by ${result.mechanism} via ${result.symbol} (${result.evidenceFiles.length} file(s)).`;
+  }
+}

--- a/scripts/lib/seed-fit-mechanism.test.mjs
+++ b/scripts/lib/seed-fit-mechanism.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SCOPE_ENFORCEMENT_MECHANISMS,
+  describeScopeMechanism,
+  evaluateScopeMechanism,
+  findMechanismEvidence,
+  isScopedSeedFitDecision,
+  parseSeedFitMechanism,
+} from "./seed-fit-mechanism.mjs";
+
+const reader = (files) => (file) => {
+  if (!(file in files)) throw new Error(`no such file ${file}`);
+  return files[file];
+};
+
+test("only archetype/vertical answers claim a scope, so only they owe a mechanism", () => {
+  for (const scoped of ["archetype-scoped", "vertical-scoped", "ARCHETYPE-SCOPED"]) {
+    assert.equal(isScopedSeedFitDecision(scoped), true, scoped);
+  }
+  for (const unscoped of ["global-default", "parameterize-first", "install-local-only", "reject-as-seed", null, undefined]) {
+    assert.equal(isScopedSeedFitDecision(unscoped), false, String(unscoped));
+  }
+});
+
+test("a global-default answer is not asked for a mechanism", () => {
+  const result = evaluateScopeMechanism({ decision: "global-default", prBody: "Seed-Fit-Decision: global-default" });
+  assert.equal(result.ok, true);
+  assert.equal(result.reason, "not-a-scoped-decision");
+});
+
+test("reads mechanism and symbol in either order on the decision line", () => {
+  assert.deepEqual(
+    parseSeedFitMechanism("Seed-Fit-Decision: archetype-scoped mechanism=read-scope symbol=regulationApplies"),
+    { mechanism: "read-scope", symbol: "regulationApplies" },
+  );
+  assert.deepEqual(
+    parseSeedFitMechanism("Seed-Fit-Decision: archetype-scoped symbol=referenceModelAppliesToInstall mechanism=seed-gate"),
+    { mechanism: "seed-gate", symbol: "referenceModelAppliesToInstall" },
+  );
+});
+
+test("a quoted example in a fenced block is documentation, not an attestation", () => {
+  const body = [
+    "Here is how to answer:",
+    "```",
+    "Seed-Fit-Decision: archetype-scoped mechanism=seed-gate symbol=someRule",
+    "```",
+    "",
+    "Seed-Fit-Decision: archetype-scoped mechanism=read-scope symbol=realRule",
+  ].join("\n");
+  assert.deepEqual(parseSeedFitMechanism(body), { mechanism: "read-scope", symbol: "realRule" });
+});
+
+test("a scoped answer with no mechanism is refused, and says what to add", () => {
+  const result = evaluateScopeMechanism({
+    decision: "archetype-scoped",
+    prBody: "Seed-Fit-Decision: archetype-scoped",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "missing-mechanism");
+  assert.match(describeScopeMechanism(result), /mechanism=seed-gate/);
+  assert.match(describeScopeMechanism(result), /mechanism=read-scope/);
+});
+
+test("an unknown mechanism is refused and the vocabulary is named", () => {
+  const result = evaluateScopeMechanism({
+    decision: "archetype-scoped",
+    prBody: "Seed-Fit-Decision: archetype-scoped mechanism=vibes symbol=x",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "unknown-mechanism");
+  for (const mechanism of SCOPE_ENFORCEMENT_MECHANISMS) {
+    assert.match(describeScopeMechanism(result), new RegExp(mechanism));
+  }
+});
+
+test("a mechanism with no symbol is refused: an unnameable rule cannot be checked", () => {
+  const result = evaluateScopeMechanism({
+    decision: "archetype-scoped",
+    prBody: "Seed-Fit-Decision: archetype-scoped mechanism=seed-gate",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "missing-symbol");
+});
+
+// The defect this whole rule exists for: BI-C44EAEE6, where the seed half shipped
+// and the read half did not, and the claim looked fine in prose.
+test("a named symbol that no changed file references is refused", () => {
+  const result = evaluateScopeMechanism({
+    decision: "archetype-scoped",
+    prBody: "Seed-Fit-Decision: archetype-scoped mechanism=read-scope symbol=describeReferenceModelApplicability",
+    changedFiles: ["apps/web/lib/explore/ea-data.ts"],
+    readFile: reader({ "apps/web/lib/explore/ea-data.ts": "const models = await prisma.eaReferenceModel.findMany();" }),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "symbol-not-in-diff");
+  assert.match(describeScopeMechanism(result), /BI-C44EAEE6/);
+});
+
+test("a named symbol the diff actually wires passes, and reports where", () => {
+  const result = evaluateScopeMechanism({
+    decision: "archetype-scoped",
+    prBody: "Seed-Fit-Decision: archetype-scoped mechanism=read-scope symbol=describeReferenceModelApplicability",
+    changedFiles: ["apps/web/lib/explore/ea-data.ts", "docs/user-guide/architecture/index.md"],
+    readFile: reader({
+      "apps/web/lib/explore/ea-data.ts": "const applicability = describeReferenceModelApplicability(model.slug, install);",
+      "docs/user-guide/architecture/index.md": "Some models are universal.",
+    }),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.reason, "mechanism-wired");
+  assert.deepEqual(result.evidenceFiles, ["apps/web/lib/explore/ea-data.ts"]);
+});
+
+test("an unreadable path is not evidence, and does not crash the gate", () => {
+  const files = findMechanismEvidence({
+    symbol: "regulationApplies",
+    changedFiles: ["deleted.ts", "kept.ts"],
+    readFile: reader({ "kept.ts": "regulationApplies(spec, profile)" }),
+  });
+  assert.deepEqual(files, ["kept.ts"]);
+});
+
+test("both live mechanisms in the codebase are accepted vocabulary", () => {
+  // seed-gate is referenceModelAppliesToInstall; read-scope is regulationApplies.
+  for (const [mechanism, symbol] of [["seed-gate", "referenceModelAppliesToInstall"], ["read-scope", "regulationApplies"]]) {
+    const result = evaluateScopeMechanism({
+      decision: "vertical-scoped",
+      prBody: `Seed-Fit-Decision: vertical-scoped mechanism=${mechanism} symbol=${symbol}`,
+      changedFiles: ["x.ts"],
+      readFile: reader({ "x.ts": `import { ${symbol} } from "./rule";` }),
+    });
+    assert.equal(result.ok, true, mechanism);
+  }
+});


### PR DESCRIPTION
The Seed Contribution Fit gate already asked the right question with the right vocabulary. What it never asked was **how** an `archetype-scoped` answer would be enforced, and nothing downstream read the answer. So a change could truthfully answer "archetype-scoped" and ship globally.

That is not hypothetical. In BI-C44EAEE6 the BIAN Service Landscape was scoped at seed time by #4870 and never scoped on read, so an install running a pet rescue advertised a banking standard as ACTIVE with zero criteria. One half shipped, the other did not, and no gate looked at the pair.

## The rule

A scoped decision now states its mechanism and the symbol implementing it:

```
Seed-Fit-Decision: archetype-scoped mechanism=seed-gate  symbol=referenceModelAppliesToInstall
Seed-Fit-Decision: vertical-scoped  mechanism=read-scope symbol=regulationApplies
```

Both mechanisms already exist in this codebase and both are correct. `seed-gate` keeps the content off installs it does not serve. `read-scope` ships it everywhere on purpose and filters at consumption. Choosing between them is the author's call; naming the choice is what makes it checkable by something other than a reviewer's memory.

The gate then verifies the named symbol is actually referenced by a changed file. Naming a rule you did not wire now fails rather than reads well. **That check is the one that would have caught BI-C44EAEE6.**

`global-default` claims no limit and owes nothing, so the common case is untouched. A label still carries a decision, but a scoped one needs its mechanism in the body, because a label cannot carry the evidence. The existing label test is updated to say that deliberately rather than being weakened.

## Why this shape, and why not another gate

The founder asked what the trade-off is between governance assurance and adding gates unnecessarily, and referred it to the kernel rather than answering it. `principle_decide` scored three options against 35 principles and recorded DI-D17CAA32468F:

| Option | Composite |
|---|---|
| Derive scope, say so when undecidable | **10.83** |
| Refuse a build-triaged item without a scope | 3.56 |
| Accept and report as debt | 3.32 |

Margin 7.26, high confidence, autonomy eligible with no blockers. Refusing at intake is penalised directly by the commandment *Do the work; don't task the operator with what an agent can do*, and by *Never ask the user to run commands*.

`principles/gate-coverage-matches-blast-radius` gives the governing rule: "prefer a rule the gate can decide without anyone remembering to annotate", because "opt-in coverage reproduces the very 'somebody must remember' failure the gate exists to remove". So this **adds no new gate**. The existing one now covers what its name always implied. It asks for one thing, at the moment the author already has the answer in hand, and then verifies it instead of trusting it.

## Verification

- 11 tests on the pure mechanism module: the vocabulary, both orders of `mechanism=`/`symbol=`, the missing and unknown cases, an unreadable path not counting as evidence, and a fenced code block being documentation rather than attestation.
- 11 tests on the gate, including the symbol-not-wired case and a label-sourced scoped decision passing when the body names a wired mechanism.
- `pnpm run pregate:preflight`: OK, 66 guards clean.
- `pnpm run pregate`: PASS.

Docs: `docs/testing/pre-pr-gate.md` explains both mechanisms, when each is right, and why the rule exists.

Delivers the second and most consequential item of BI-B507DBD1. Widening the gate's trigger beyond canonical seed paths, by reusing the Convergence-Impact install-reachability classifier, is the remaining slice and stays open on that item.

Seed-Fit-Decision: global-default

Convergence-Impact-Decision: not-reachable — confined to CI guard scripts under scripts/ and their tests, plus docs. None of it is copied into the portal image or executed on an install, so no existing install has anything to converge to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
