### PR TITLE
docs: publish portal UX criteria and ongoing PR review contract

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1732,6 +1732,7 @@
       "docs/architecture/mcp-tool-surface-ergonomics-audit.md"
     ],
     "scripts/check-ux-fit-decision.mjs": [
+      "docs/architecture/portal-ux-evaluation-framework.md",
       "docs/architecture/theme-aware-styling-runbook.md",
       "docs/design/golden-triangle-design.md"
     ],
@@ -2625,6 +2626,9 @@
       "scripts/platform-substrate-baseline.json",
       "scripts/platform-substrate-manifest.json",
       "scripts/platform-substrate-runtime-baseline.json"
+    ],
+    "docs/architecture/portal-ux-evaluation-framework.md": [
+      "scripts/check-ux-fit-decision.mjs"
     ],
     "docs/architecture/section-navigation.md": [
       "apps/web/components/shell/SectionNav.tsx",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 699,
+  "pageCount": 701,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -2093,6 +2093,8 @@
         "4-workroom-centered-disclosure",
         "archetype-sentinels-without-ia-forks",
         "5-standing-ux-design-and-fit-gate",
+        "every-pr-review-and-convergence-of-existing-ux",
+        "september-8-delivery-reconciliation",
         "6-architecture-decision-and-research",
         "consolidation-and-dependency-review"
       ]

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2079,6 +2079,22 @@
         "what-success-means"
       ]
     },
+    "docs/architecture/portal-ux-evaluation-framework.md": {
+      "publicHref": "/architecture/portal-ux-evaluation-framework/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "portal-page-and-flow-evaluation-framework",
+        "1-evaluate-a-job-not-a-screenshot",
+        "2-rubric-and-decision-rules",
+        "3-measurement-protocol",
+        "4-workroom-centered-disclosure",
+        "archetype-sentinels-without-ia-forks",
+        "5-standing-ux-design-and-fit-gate",
+        "6-architecture-decision-and-research"
+      ]
+    },
     "docs/architecture/principle-decide-mcda-identity.md": {
       "publicHref": "/architecture/principle-decide-mcda-identity/",
       "portalHref": null,
@@ -10707,6 +10723,20 @@
       "publishedPortal": false,
       "anchors": [
         "populated-performance-live-acceptance"
+      ]
+    },
+    "docs/testing/portal-ux-scorecard-template.md": {
+      "publicHref": "/testing/portal-ux-scorecard-template/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "portal-page-flow-scorecard-template",
+        "identity-and-purpose",
+        "measures",
+        "rubric",
+        "task-and-state-evidence",
+        "disposition-and-refactoring"
       ]
     },
     "docs/testing/pr-health.md": {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2088,11 +2088,13 @@
         "portal-page-and-flow-evaluation-framework",
         "1-evaluate-a-job-not-a-screenshot",
         "2-rubric-and-decision-rules",
+        "inspect-inside-every-item",
         "3-measurement-protocol",
         "4-workroom-centered-disclosure",
         "archetype-sentinels-without-ia-forks",
         "5-standing-ux-design-and-fit-gate",
-        "6-architecture-decision-and-research"
+        "6-architecture-decision-and-research",
+        "consolidation-and-dependency-review"
       ]
     },
     "docs/architecture/principle-decide-mcda-identity.md": {
@@ -10736,7 +10738,8 @@
         "measures",
         "rubric",
         "task-and-state-evidence",
-        "disposition-and-refactoring"
+        "disposition-and-refactoring",
+        "item-detail-and-dependency-inventory"
       ]
     },
     "docs/testing/pr-health.md": {

--- a/docs/architecture/portal-ux-evaluation-framework.md
+++ b/docs/architecture/portal-ux-evaluation-framework.md
@@ -217,6 +217,93 @@ explicit review evidence. This documentation revision does **not** implement new
 automatic enforcement. Any later automation extends those existing contracts
 under a scoped BI; it must fail visibly when it cannot measure.
 
+### Every-PR review and convergence of existing UX
+
+Every PR receives a UX-impact disposition against this framework, including
+backend, schema, dependency, prompt and workflow changes that can alter what a
+person sees or can accomplish. A concrete source-backed no-impact reason takes
+the lightweight path; it does not require booting a portal for an unrelated
+documentation change. Unknown impact requires investigation, not an automatic
+N/A. The same criteria govern new designs and refactoring of existing surfaces.
+
+For affected UX, map the change to the ten criteria above and link the relevant
+scorecard evidence. Identify affected routes, shared-component consumers, personas,
+archetypes, default item details and external dependency handoffs. Use the existing
+navigation model and source graph to select coverage, with source/graph/served
+versions recorded; a graph is not evidence of rendered task success. Render
+representative primary and adverse states, expand coverage when a shared failure
+is found, and retain the existing broad route-sweep checks where applicable.
+
+The PR review distinguishes three outcomes:
+
+- New or worsened violations: correct them before acceptance. Missing required
+  evidence remains unmeasured or inconclusive, never a pass.
+- Existing debt touched by the change: record before/after harm and retire the
+  relevant duplication or unnecessary detail within the bounded slice. If it
+  cannot fit safely, link its existing BI, accountable owner and review trigger.
+- Unrelated existing debt: retain its evidence and backlog linkage without
+  misattributing it to this PR or expanding every PR into a portal rewrite.
+
+An unchanged baseline is not proof of good design. Refactoring slices declare
+which criteria they will improve and prove the improvement while preserving task
+outcomes and permissions. Do not silently rebaseline regressions. Track the
+80% refactoring / at most 20% justified net-new allocation across the program;
+individual PRs remain cohesive and need not artificially mix both work types.
+
+The author supplies impact and evidence; the PR reviewer records the criterion
+verdict and remaining debt. Re-evaluate affected evidence after material changes
+to the reviewed diff, and reconcile delivered results to the served version.
+Emit one maintained review result per PR rather than repeated audit commentary.
+Broader release review samples untouched families to detect drift beyond changed
+routes. Navigation changes update the canonical source and existing projection
+pipeline, not a separately maintained audit graph.
+
+This is the required ongoing review contract. Automated all-PR classification,
+evidence validation and review publication must extend the existing PR/UX gates
+under governed implementation coverage. They are not activated by this document
+and must operate independently of a particular desktop task or AI client.
+
+### September 8 delivery reconciliation
+
+Recent merged work already delivers parts of this direction. The following is
+PR/source evidence reviewed on 2026-09-08, not a new live-install verification.
+
+| Merged change | Criteria advanced | Remaining acceptance work |
+| --- | --- | --- |
+| [#5207](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5207), distinct navigation labels with a uniqueness test | Navigation, cognitive load | Renaming did not consolidate the three directories. The PR reports 3,439 arrival words on coworker identity; unchanged is not acceptable design merely because the ratchet passes. |
+| [#5208](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5208), one Work rail entry and corrected Delivery cross-link | Canonical home, time to action | Verify affected personas and return paths on the served version. The PR measured the shared rail cost and limited baseline changes to attributed effects. |
+| [#5198](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5198) and [#5203](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5203), portfolio activity and repaired disclosure at scale | Disclosure, state truth, workroom relevance | The latter PR reports a residual inventory table contributing about 844 words at a 200-room read. Review whether tree and table serve distinct tasks; consolidate redundant default content. |
+| [#5212](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5212), architecture Workrooms leads with actual rooms | Outcome orientation, state quality, model leakage | Preserve the distinction between actual work and team definitions. Do not add plan-creation capability merely to fill a zero card. |
+| [#5204](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5204), canonical room addressing and CI guard | Navigation, meaningful task completion | Reuse this guard; its documented baseline retains four legacy link candidates requiring individual verification. |
+
+The existing UX-fit script detects new routes, controls and visible copy in TSX
+diffs and validates changed manifests against route budgets. That is useful
+enforcement, but it does not establish the full every-PR impact assessment above:
+indirect read-model, permission, prompt, workflow and dependency changes can alter
+UX without matching those additions. Its option-decision evidence also does not
+prove task completion. Extend this contract and its shared sensitivity logic;
+do not create another scanner or claim that a PR-description assertion is proof.
+
+Delivery sequence:
+
+1. Publish this framework and scorecard as documentation, reconciled with the
+   merged work above. Keep historical observations and their versions intact.
+2. Under governed implementation coverage, extend existing impact/manifest and
+   review machinery to require every-PR classification, affected-criterion
+   evidence, and explicit regression versus legacy-debt disposition. Exercise
+   positive and negative fixtures, including a backend-only UX change, unrelated
+   docs, shared-component consumers, and stale/missing evidence.
+3. Apply the extended review to a bounded consolidation slice: the Work page's
+   tree/inventory overlap is the first candidate; coworker directory duplication
+   follows its existing BI-2DBC4D2D scope. Re-measure current served behavior before
+   choosing the final slice, then prove reduced default detail with preserved
+   room discovery, selection, direct links and permissions at ordinary and large
+   data volumes.
+
+Completion means the documentation is merged, the review executes on PRs with
+traceable evidence, and a refactoring PR demonstrates criterion improvement.
+This reconciliation does not claim those outstanding outcomes are delivered.
+
 ## 6. Architecture decision and research
 
 The subsequent operator-directed 80/20 allocation is authoritative for this

--- a/docs/architecture/portal-ux-evaluation-framework.md
+++ b/docs/architecture/portal-ux-evaluation-framework.md
@@ -1,0 +1,215 @@
+# Portal page and flow evaluation framework
+
+Revision: 2026-09-06. Documentation delivery: `BI-D09EE31E`, Workroom
+`WC-302E3E59`. This is the evaluation method for the
+[portal UX spine](../superpowers/plans/2026-05-26-portal-ux-simplification-spine.md).
+It extends the [usability standards](../platform-usability-standards.md), not the
+runtime schema. Use the [scorecard](../testing/portal-ux-scorecard-template.md)
+for each route, persona, state and task combination.
+
+## 1. Evaluate a job, not a screenshot
+
+Write the contract first: **When [trigger], [persona] needs to [job], so that
+[observable outcome].** Name the start location, permission, prerequisites,
+work object and completion oracle. A heading, saved record, sent prompt or
+completed animation is not proof of the real-world outcome.
+
+The page must lead to an action, decision or justified confidence. An
+informational page is valid when it answers a named question with current
+evidence; do not invent a primary button to satisfy a count. A returned view
+should preserve location, filters and selection and make relevant changes
+recognizable without relying on memory or color alone.
+
+Separate four evidence classes in every finding:
+
+- **Observed:** rendered behavior on a named served SHA, fixture and date.
+- **Source-verified:** contract or implementation at a named source SHA; no claim
+  that it was served or usable.
+- **Estimated:** predicted effort or time, with assumptions and range.
+- **Proposed:** redesign hypothesis with acceptance evidence still to collect.
+
+The September audit's 367 pages, 205 budgeted routes, 3,048 words on Platform AI
+overview and three axe violations on Documents are historical observations from
+that packet. They are audit leads, not fresh measurements. Reproduce them before
+claiming current defects. An unavailable evaluator produces **unmeasured**, not
+zero failures.
+
+## 2. Rubric and decision rules
+
+Score each applicable dimension separately: **0** = observed failure of the
+anchor; **1** = works only with assistance, avoidable traversal or partial
+coverage; **2** = anchor passes for the primary task and adverse state; **3** =
+2 plus a returning-user and contrasting archetype/role pass. **U** = unmeasured;
+**N/A** requires a written reason. Store evidence for every score. Scores are
+ordinal review summaries, not scientific measurements; do not average them into
+a platform quality percentage.
+
+| Dimension | Pass anchor (score 2) | Failure evidence to collect |
+| --- | --- | --- |
+| Outcome orientation | First viewport names the work/object and next action or decision; the task reaches its completion oracle without coaching | Misidentified purpose, decorative metrics, record creation mistaken for outcome |
+| Persona and archetype fit | Real permission and one relevant archetype fixture expose the right job first; no remembered schema relationships are needed | Wrong first action, administrator-only dependency, vocabulary the participant cannot explain |
+| Progressive disclosure | Orientation and primary action remain visible; secondary information has a named, accessible disclosure trigger; deeper evidence is reachable | Hidden primary verb, default expanded diagnostics, disclosure that loses context |
+| Time and distance to action | Recorded path meets the task's predeclared interaction/time target; action is near its motivating object | Detours, scrolling to unrelated footer actions, excessive pointer or keyboard travel |
+| Cognitive load | Existing shell budget passes or documented legacy debt improves; competing first-view choices do not increase; participant recognizes location and change | Choice count, misclicks, repeated rereading, unfamiliar status labels |
+| Data model leakage | Normal work has no unjustified raw IDs, enums, schema/provider/phase labels or null strings; authorized diagnostics remain available | Exact visible text, location, persona, business need or absence of one |
+| Workroom relevance | Page explicitly chooses summary, linked room or no room; work in motion/blocked/decision states follow canonical work identity and evidence | Duplicate tasks, all stored rooms called live, recursive tree dumping, invented room status |
+| AI context and trust | Context binds to the work object/room; launch preview identifies scope and next step; required confirmation precedes effect; receipt or safe failure follows | Prompt/tool/provider leakage, incidental navigation starting work, false success, missing receipt |
+| Navigation | Canonical home, local state and contextual command each serve distinct intents; destination and return path preserve object context | Duplicate nav layers, feature in global rail, label/destination mismatch, shellless dead end |
+| Empty/loading/failure/permission | Each applicable state has one valid next step or honest explanation; loading is distinguishable from empty; failure retains recoverable work | Zero dashboard, infinite spinner, lost input, dead CTA, unauthorized action or data |
+
+**Release blockers override scores:** unauthorized data/action; hidden prompts or
+secret/raw tool payload exposure; consequential AI effect without required
+confirmation; false success or contradictory authoritative state; unreachable
+primary task; keyboard trap or overlap that prevents the task. Any applicable
+unmeasured blocker leaves the verdict **inconclusive**. A confirmed accessibility
+failure must be repaired or explicitly carried as scoped pre-existing debt under
+the repository's gate rules; a high rubric score cannot waive it.
+
+Use the existing fit verdicts: `fits`, `fits-with-guardrails`, `defer`, `reject`.
+`fits-with-guardrails` is design acceptance after named edits, not a runtime pass.
+The target is score 2 or better on all applicable dimensions, with no unmeasured
+acceptance scenario. Score 3 is evidence of broader robustness, not a prerequisite
+for every small PR. Report the score vector, blocker list and evidence coverage.
+
+## 3. Measurement protocol
+
+Freeze the start route, persona permissions, archetype/configuration, data volume,
+locale, theme, viewport, zoom, input method, source SHA and served SHA. Capture
+arrival after content has settled with disclosures at their actual default;
+capture loading separately. A timeout or partial load is a state finding, never
+a low word-count win. Record responsive drawer state and whether a dialog is open.
+
+Use 1440x900 and 390x844 CSS pixels at 100% as the initial comparison pair;
+also check 320 CSS-pixel reflow, 200% zoom, keyboard focus and relevant screen
+reader announcements. These viewport choices are DPF sampling conventions, not
+universal usability thresholds. Use the same fixture and geometry before/after.
+
+| Measure | Reproducible definition | Acceptance use |
+| --- | --- | --- |
+| First-viewport purpose clarity | After five seconds of the settled viewport, ask the participant to identify the job/object, what needs attention and the next step; record correct answers out of 3 and the actual words | Provisional pilot target 3/3 without coaching; expert inspection is marked estimated, not user-tested |
+| Default visible words | Run canonical `auditUxBudget` measurement with collapsed disclosure excluded; retain its measurement scope and tool version. Separately count viewport-only words; never compare that subset with a full-default baseline | Use `budgets.ts` and committed route baseline; do not duplicate thresholds here |
+| Visible choices | Count enabled links, buttons, selectable options and disclosure triggers actually visible in the viewport, partitioned into shell and task content; repeated links count as separate affordances. Record disabled controls separately | Compare like-for-like; justify increases by the task. This is distinct from canonical `maxChoicesPerControl` |
+| Primary action distance | Record above-fold yes/no, scroll pixels from arrival, click/tap count, route changes, and focus stops from main content. Pointer travel is the sum of straight-line distances between successive target centers in CSS pixels, with the starting point recorded | First useful action/decision visible on action homes; minimize unnecessary travel while retaining required review and confirmation |
+| Navigation layers | Count simultaneously visible sets of navigation choices: rail, section nav, local tabs. Record breadcrumbs as orientation and filters as data selection separately; note duplicated intent regardless of count | No duplicate intent; normally global + section and at most one necessary local layer, with any additional layer justified |
+| Internal leakage | Count occurrences and distinct values of raw IDs/enums/schema/provider/phase/null labels. Record exact example and classification: useful business reference, authorized diagnostic, unnecessary leakage | Zero unnecessary leakage in normal-work defaults; an order number needed to find an order is not a defect |
+| Time to action/outcome | Observe seconds from settled arrival to first useful action, and separately to completion oracle. Record wall-clock load/provider wait separately. For estimates, list read/decision/interaction/wait assumptions and a range | Compare observed medians and ranges at the same task; never call estimated savings realized savings |
+| Workroom relevance | Classify no room / summary / linked active room / detail; record parent-child path, unresolved decisions, evidence freshness, and return behavior | Show the depth needed for this job; opening a room is success only for a find/open task |
+| AI trust | Trace trigger -> preview/context -> confirmation -> work state -> result/receipt; test provider failure and retry | Navigation never starts AI work; match current confirmation contract; retries do not duplicate the promised effect |
+| State quality | Test populated, fresh, loading, failure, permission-limited and not-applicable where relevant; record next step and resulting destination | No dead actions; no silent stale/partial data; absence and failure remain distinct |
+| Mobile/accessibility | Record overlap/overflow, keyboard completion, focus after disclosure/dialog, names/labels, status announcements, contrast/theme and axe findings | Manual checks plus automation; zero axe findings alone does not establish accessibility |
+
+For a pilot, use three representative participants per primary persona where
+available, include a returning-user attempt, and retain individual results.
+This is formative testing, not a statistically representative study. Alternate
+before/after order to limit learning effects. Freeze task targets before testing;
+do not lower them to fit a favored layout. When participants are unavailable,
+complete deterministic checks and mark human comprehension/time evidence pending.
+
+## 4. Workroom-centered disclosure
+
+Keep the canonical work object and room identity. Reuse
+`apps/web/components/workspace/workroom/`, the case route, workroom liveness
+classifier and purpose contracts. No parallel work hierarchy, generic chat home,
+or client-side re-derivation of authoritative status is introduced by this method.
+
+| Depth | What the user sees | Transition and boundary |
+| --- | --- | --- |
+| Workspace or domain home | What needs me now, blocked commitments, work in motion, next decision and meaningful recent change | Relevant summary links to the existing work object/room; no full transcript or tree |
+| Parent workroom | Outcome, accountable participants, current state/freshness, human decision, next step, concise child exceptions | Show child rooms only when they explain a dependency, exception or requested detail; summarize routine activity |
+| Child workroom | Its bounded contribution, blocker, owner/coworker, expected next step and recent receipt | Keep parent context and return path; do not duplicate the parent's task or approval |
+| Evidence detail | Source, timestamp, result and decision rationale | Authorized operator can expand diagnostics; normal users see meaningful receipts rather than prompts/provider errors |
+
+Do not recursively open every child. Aggregate by canonical identity, preserve
+partial/stale states, and explain which child blocks the parent. A parent must not
+claim complete while a required child outcome is pending. Permissions are enforced
+at the server/read boundary before counts, summaries or evidence reach the client;
+collapsing unauthorized detail is not access control.
+
+AI states should answer human questions: working on what, waiting for whom,
+what can I do, and what changed. Do not relabel uncertain state as healthy.
+Use a safe explanation plus retry/escalation on failure; put technical detail
+behind authorized diagnostics. Preview includes the room/object, intended action,
+affected scope, expected next step and consequence. Keep explicit confirmation
+for coworker launches under the existing fit contract, and always for consequential
+effects; this framework does not weaken that requirement. Receipt links to the
+same work and states success, partial result or failure honestly.
+
+### Archetype sentinels without IA forks
+
+Use existing workspace-home profiles/registry to change priority, terminology and
+default filters, while canonical routes, permissions and work identity stay shared.
+These are proposed acceptance tasks, not assertions that every workflow is built.
+
+| Persona / sentinel | Job and first content | Detail deferred |
+| --- | --- | --- |
+| Rescue director (current install archetype) | Identify an intake/foster commitment needing a decision, open its work and see the next accountable step | Funding/provider/capability configuration unrelated to that decision |
+| Dispatcher in a service archetype | Find an unscheduled job, inspect capacity, assign through the owning workflow and receive a receipt | Full process graph and historical orchestration |
+| Worker or volunteer | Open assigned work, understand next action and record completion within actual permission | Organization-wide management and AI governance |
+| Platform operator | Explain blocked coworker work or a count discrepancy and reach source evidence | Raw diagnostics until the operator asks for them |
+| External customer/applicant | Submit a request or inspect their own status and understand what happens next | Internal management, other customers, workroom internals |
+
+If a sentinel lacks an implemented completion path, record the missing capability
+and use an existing supported task for the UX baseline; do not mock success or
+silently expand a layout slice into a new workflow implementation.
+
+## 5. Standing UX design-and-fit gate
+
+Apply before accepting routes, tabs, cards, dashboards, launchers, settings fields
+or page primitives. Use `dpf-ux-fit-review`; this is its evidence method, not a
+competing skill. The navigation principles live in the spine.
+
+1. **Design entry:** attach a purpose contract, primary task, canonical home,
+   permission/archetype fixture, navigation intent, state matrix, source truth,
+   AI boundary and baseline scorecard. Reject a second home without a distinct
+   user job. Compare an existing filtered view, contextual action and disclosure
+   before proposing a new route or primitive.
+2. **Design fit:** identify reused primitives and duplication to retire. Use WWMD
+   for open platform-direction choices. Record `fits`, `fits-with-guardrails`,
+   `defer` or `reject`, reviewer, required edits and evidence. An unresolved data
+   seam or missing task outcome defers implementation of that surface.
+3. **Implementation entry:** one BI, governed branch and PR-sized scope; current
+   initiative readiness and immutable coverage receipts remain mandatory where
+   applicable. Reserve about 20% of effort for in-scope refactoring, with exact
+   duplicate helpers, status maps or launcher patterns named after inspection.
+4. **Before merge:** existing source gates and UX-fit manifest plus measured
+   before/after scorecard, browser task, failure/permission check, mobile and
+   manual accessibility evidence. A valid `propose-n-pick` manifest records a
+   design choice; it is not evidence that the served task passed.
+5. **After delivery:** record served SHA and completion oracle in the Workroom.
+   Reconcile accepted outcomes and failures before closing the implementation BI.
+
+Today, `lib/ux-budget/`, route-purpose contracts and
+`scripts/check-ux-fit-decision.mjs` provide code-backed checks for their defined
+axes. Human comprehension, whole-flow completion and manual accessibility remain
+explicit review evidence. This documentation revision does **not** implement new
+automatic enforcement. Any later automation extends those existing contracts
+under a scoped BI; it must fail visibly when it cannot measure.
+
+## 6. Architecture decision and research
+
+WWMD `DI-BED2443DAD54` selected `extend-purpose-contracts`, composite 8.422,
+margin 4.687, high confidence, usable and autonomy-eligible, no blockers or
+commandment conflict. Alternatives were a dedicated UX service and a manual-only
+checklist. Largest positive contributions: Research and Use Standards (+0.783),
+Ground New Work In Existing Platform (+0.697), Architecture Over Shortcuts
+(+0.667). These are MCDA contributions from estimated design attributes, not
+usability measurements. Preserve the existing single-source architecture.
+
+Source inspection at `4dcd2bc75ed6bd6ee4fcf05d96abb0ca7ed89fc3` found existing
+page-purpose intent/findability/state/task protocols, route budget ratchets,
+workroom inventory/definition contracts, workspace-home profiles and report-kit
+disclosure/empty-state primitives. Extend these; do not copy thresholds or add an
+independent route inventory. The July holistic UX design is historical context;
+its claims about then-missing tokens and gates are not current source truth.
+
+Research checked 2026-09-06:
+
+| Primary source | Adopt for this framework | Limit |
+| --- | --- | --- |
+| [GOV.UK Design System patterns](https://design-system.service.gov.uk/patterns/) | Reuse task patterns such as completing tasks, checking answers and confirmation pages | Do not impose a linear form flow on every operational workspace |
+| [Carbon notification guidance](https://carbondesignsystem.com/components/notification/usage/) | Match notification placement and disruption to context and urgency | Do not turn every background coworker event into an interrupting alert |
+| [WCAG 2.2 quick reference](https://www.w3.org/WAI/WCAG22/quickref/) | Check keyboard, reflow, visible/unobscured focus, labels, status messages and target size | Automated counts do not prove conformance; 2.5.8 addresses target size/spacing with exceptions, not a blanket font-size rule |
+
+These open design-system comparisons inform pattern choices; they do not justify
+adding dependencies. DPF's five-second clarity probe, sampling sizes and travel
+measures are provisional evaluation conventions to calibrate, not WCAG rules.

--- a/docs/architecture/portal-ux-evaluation-framework.md
+++ b/docs/architecture/portal-ux-evaluation-framework.md
@@ -7,6 +7,12 @@ It extends the [usability standards](../platform-usability-standards.md), not th
 runtime schema. Use the [scorecard](../testing/portal-ux-scorecard-template.md)
 for each route, persona, state and task combination.
 
+Operator direction, clarified 2026-09-06: allocate **80% to refactoring and
+consolidation, 20% to net-new capability**. This supersedes the earlier 20%
+refactoring allowance. The primary work is to collapse the existing spread of
+surfaces, repeated representations and unnecessary dependency burden. The
+net-new allocation is a ceiling for justified gaps, not a quota to fill.
+
 ## 1. Evaluate a job, not a screenshot
 
 Write the contract first: **When [trigger], [persona] needs to [job], so that
@@ -36,6 +42,30 @@ zero failures.
 
 ## 2. Rubric and decision rules
 
+### Inspect inside every item
+
+Audit the contents of cards, table rows, badges, menus, drawers, forms and
+workroom entries as well as the page around them. A compact card can still expose
+its implementation: provider/model selection, capability/grant matrices, process
+phases, retry state, storage relationships, provenance fields and configuration
+switches. Translating these into friendlier words does not establish that the
+user needs them. For every field or control ask: **Does this persona need this
+information now to act, decide or trust the outcome?**
+
+Classify each item detail as **keep visible**, **summarize**, **disclose on demand**,
+**operator-only**, **merge with canonical representation**, or **remove from this
+surface**. Name its consumer and purpose. A removal from presentation does not
+delete canonical data or required audit evidence. Essential consequences,
+permissions, meaningful uncertainty and next steps stay visible. Useful business
+references remain available; unauthorized content never reaches the client.
+
+For example, a worker's work item may need its job, due time, blocker and next
+action. Its provider, model, orchestration phase, tool grants and retry counters
+belong in authorized diagnostics when there is a real diagnostic job. This is a
+design example, not a claim that those fields were observed on a particular page.
+An accordion full of duplicated internals is only a concealment change; separately
+prove that redundant components, projections and dependency paths were converged.
+
 Score each applicable dimension separately: **0** = observed failure of the
 anchor; **1** = works only with assistance, avoidable traversal or partial
 coverage; **2** = anchor passes for the primary task and adverse state; **3** =
@@ -51,7 +81,7 @@ a platform quality percentage.
 | Progressive disclosure | Orientation and primary action remain visible; secondary information has a named, accessible disclosure trigger; deeper evidence is reachable | Hidden primary verb, default expanded diagnostics, disclosure that loses context |
 | Time and distance to action | Recorded path meets the task's predeclared interaction/time target; action is near its motivating object | Detours, scrolling to unrelated footer actions, excessive pointer or keyboard travel |
 | Cognitive load | Existing shell budget passes or documented legacy debt improves; competing first-view choices do not increase; participant recognizes location and change | Choice count, misclicks, repeated rereading, unfamiliar status labels |
-| Data model leakage | Normal work has no unjustified raw IDs, enums, schema/provider/phase labels or null strings; authorized diagnostics remain available | Exact visible text, location, persona, business need or absence of one |
+| Data model leakage | Each item exposes only details needed for the persona's action, decision or trust; unnecessary internal fields and controls are removed, summarized or properly disclosed, even when their labels sound human | Item/field inventory and disposition; raw IDs, enums, schema/provider/phase labels, null strings, unnecessary metadata and configuration |
 | Workroom relevance | Page explicitly chooses summary, linked room or no room; work in motion/blocked/decision states follow canonical work identity and evidence | Duplicate tasks, all stored rooms called live, recursive tree dumping, invented room status |
 | AI context and trust | Context binds to the work object/room; launch preview identifies scope and next step; required confirmation precedes effect; receipt or safe failure follows | Prompt/tool/provider leakage, incidental navigation starting work, false success, missing receipt |
 | Navigation | Canonical home, local state and contextual command each serve distinct intents; destination and return path preserve object context | Duplicate nav layers, feature in global rail, label/destination mismatch, shellless dead end |
@@ -91,7 +121,8 @@ universal usability thresholds. Use the same fixture and geometry before/after.
 | Visible choices | Count enabled links, buttons, selectable options and disclosure triggers actually visible in the viewport, partitioned into shell and task content; repeated links count as separate affordances. Record disabled controls separately | Compare like-for-like; justify increases by the task. This is distinct from canonical `maxChoicesPerControl` |
 | Primary action distance | Record above-fold yes/no, scroll pixels from arrival, click/tap count, route changes, and focus stops from main content. Pointer travel is the sum of straight-line distances between successive target centers in CSS pixels, with the starting point recorded | First useful action/decision visible on action homes; minimize unnecessary travel while retaining required review and confirmation |
 | Navigation layers | Count simultaneously visible sets of navigation choices: rail, section nav, local tabs. Record breadcrumbs as orientation and filters as data selection separately; note duplicated intent regardless of count | No duplicate intent; normally global + section and at most one necessary local layer, with any additional layer justified |
-| Internal leakage | Count occurrences and distinct values of raw IDs/enums/schema/provider/phase/null labels. Record exact example and classification: useful business reference, authorized diagnostic, unnecessary leakage | Zero unnecessary leakage in normal-work defaults; an order number needed to find an order is not a defect |
+| Internal leakage | Inventory fields and controls within every sampled item; count unnecessary details, affected items and total items inspected, plus raw ID/enum occurrences. Record their visible/disclosed/operator-only scope and disposition | Zero unnecessary internal detail in normal-work defaults; human wording does not excuse irrelevant content |
+| Redundancy and dependencies | Count duplicate representations/components and external tools, services, packages or manual handoffs required for the named job. Record before/after consumers, canonical replacement and retained dependency rationale | Prove retired duplication and reduced setup/failure burden without losing the task; a hidden card or transitive package-count reduction alone is not a consolidation outcome |
 | Time to action/outcome | Observe seconds from settled arrival to first useful action, and separately to completion oracle. Record wall-clock load/provider wait separately. For estimates, list read/decision/interaction/wait assumptions and a range | Compare observed medians and ranges at the same task; never call estimated savings realized savings |
 | Workroom relevance | Classify no room / summary / linked active room / detail; record parent-child path, unresolved decisions, evidence freshness, and return behavior | Show the depth needed for this job; opening a room is success only for a find/open task |
 | AI trust | Trace trigger -> preview/context -> confirmation -> work state -> result/receipt; test provider failure and retry | Navigation never starts AI work; match current confirmation contract; retries do not duplicate the promised effect |
@@ -169,8 +200,9 @@ competing skill. The navigation principles live in the spine.
    seam or missing task outcome defers implementation of that surface.
 3. **Implementation entry:** one BI, governed branch and PR-sized scope; current
    initiative readiness and immutable coverage receipts remain mandatory where
-   applicable. Reserve about 20% of effort for in-scope refactoring, with exact
-   duplicate helpers, status maps or launcher patterns named after inspection.
+   applicable. Allocate 80% of effort to refactoring/consolidation and at most
+   20% to justified net-new capability. Name what is merged, retired or removed,
+   including unnecessary per-item detail and external dependency paths.
 4. **Before merge:** existing source gates and UX-fit manifest plus measured
    before/after scorecard, browser task, failure/permission check, mobile and
    manual accessibility evidence. A valid `propose-n-pick` manifest records a
@@ -186,6 +218,33 @@ automatic enforcement. Any later automation extends those existing contracts
 under a scoped BI; it must fail visibly when it cannot measure.
 
 ## 6. Architecture decision and research
+
+The subsequent operator-directed 80/20 allocation is authoritative for this
+revision; the WWMD result below establishes contract reuse, not the effort ratio.
+
+### Consolidation and dependency review
+
+Start each slice with an inventory of competing route homes, cards, components,
+read projections, helpers and external dependencies serving the same user job.
+Choose the existing canonical implementation, migrate its consumers and retire
+redundancy. Track planned and actual effort by refactoring versus net new, not
+by lines of code: replacement code can be refactoring when it preserves the job
+and removes a competing implementation. A new drawer is not itself consolidation.
+
+For each external dependency record the job it enables, callers/data flows,
+setup and credentials the user must manage, operational failure modes, and the
+existing platform capability that could absorb its role. Decide retain,
+consolidate, replace or retire with evidence. Preserve integrations that provide
+necessary external data or execution. Do not rebuild a mature external service
+merely to lower the dependency count. Implementation requires consumer mapping,
+compatibility/data migration where applicable, failure-path checks and rollback;
+this planning revision does not disconnect services or uninstall packages.
+
+Net-new work must demonstrate that reuse, consolidation or refactoring cannot
+deliver the accepted outcome. Prefer a smaller addition that closes that gap;
+record what existing surface or dependency it replaces, or why no replacement
+is possible. Measure success as fewer concepts, duplicate representations,
+unnecessary item details and dependency failure points while preserving outcomes.
 
 WWMD `DI-BED2443DAD54` selected `extend-purpose-contracts`, composite 8.422,
 margin 4.687, high confidence, usable and autonomy-eligible, no blockers or

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -2,6 +2,13 @@
 
 Living reference for all UI development. All developers and AI agents must follow these standards when creating or reviewing UI code.
 
+For outcome-based route audits and redesign acceptance, use the
+[portal page and flow evaluation framework](architecture/portal-ux-evaluation-framework.md)
+and its [scorecard](testing/portal-ux-scorecard-template.md). It connects the
+existing page-purpose contracts and UX budgets below to persona tasks, workroom
+disclosure, navigation fit and evidence. Counts alone do not establish that a
+user can complete the job.
+
 ## Color System
 
 Every UI component uses CSS custom properties for all color roles. These properties are set by the branding system via `buildBrandingStyleTag()` and fall back to defaults in `globals.css`.

--- a/docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md
+++ b/docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md
@@ -138,6 +138,14 @@ ten dimensions. Fewer words, links or cards are useful only when the user can
 still recognize the work, reach its action and trust the result. Do not start a
 layout from the database entities or require every page to become a dashboard.
 
+The operator's revised allocation is **80% refactoring and consolidation, 20%
+net new**. Collapse existing redundancy before adding surfaces. Inspect the guts
+of each item: a card, row or drawer must not expose fields, statuses, controls or
+dependency details merely because they exist internally. The framework's
+item-detail inventory and dependency review define what to keep, summarize,
+disclose, restrict, merge or remove. This includes unnecessary details with
+perfectly readable labels, not only raw IDs and technical jargon.
+
 1. Audience before system map. A founder/operator, dispatcher, clinic scheduler, retail worker, contributor, and customer should not all see the same first screen.
 2. The primary shell is a memory aid, not a database menu. Navigation should group by user intent and work object.
 3. Every number, status pill, and readiness cell must either drill into the objects that produced it or render as non-clickable explanatory status.
@@ -411,6 +419,11 @@ Verification:
 - Prefer small PR-sized slices.
 - Use MCP/backlog state before filing new work.
 - For any incoming UI plan, run the §4.1 fit gate and capture the result in the plan or a linked audit before implementation starts.
-- Keep refactoring inside each slice rather than accumulating cleanup debt. Spend roughly 20% of implementation effort removing mixed concepts, duplicated patterns, or leaky abstractions discovered by that slice.
+- Allocate 80% of implementation effort to refactoring/consolidation and at most
+  20% to justified net-new capability. Retire duplicate surfaces, components,
+  projections and unnecessary external dependency paths; remove unnecessary
+  internal detail from individual items. Record actual removals and migrated
+  consumers, not only reduced visible counts. New work must prove an existing
+  capability cannot be reused or refactored to deliver the outcome.
 - Do not route this through Build Studio until Build Studio can produce reliable UX verification evidence.
 - No slice is done with screenshots alone. Each UI slice needs a persona task outcome and a failure-mode check.

--- a/docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md
+++ b/docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md
@@ -15,6 +15,15 @@ status: active
 
 ## Review Packet For Circulation
 
+The September follow-up (`BI-D09EE31E`, `WC-302E3E59`) establishes the
+[objective evaluation framework](../../architecture/portal-ux-evaluation-framework.md)
+and [page/flow scorecard](../../testing/portal-ux-scorecard-template.md).
+Use those as the single measurement method. The September audit remains a dated
+evidence packet; the [execution plan](2026-09-06-portal-ux-simplification-execution-plan.md)
+owns current priority and sampling. Numbered slices below identify scope, not
+mandatory execution order. WWMD `DI-BED2443DAD54` selects extension of existing
+purpose/budget contracts rather than a second UX registry or scoring service.
+
 Use this document as the single review packet for the cross-functional audit pass. Reviewers should comment on factual accuracy, user/persona fit, sequencing, and missing risk. They should not bikeshed visual style in the abstract; every comment should name the route, persona, user harm, and evidence needed.
 
 ### Review goals
@@ -124,6 +133,11 @@ The latest manual UX audit (`2026-05-20-portal-ux-audit.md`) plus follow-on loca
 
 ## 3. Design Principles For This Refactor
 
+Judge the user's route from trigger to accepted outcome using the framework's
+ten dimensions. Fewer words, links or cards are useful only when the user can
+still recognize the work, reach its action and trust the result. Do not start a
+layout from the database entities or require every page to become a dashboard.
+
 1. Audience before system map. A founder/operator, dispatcher, clinic scheduler, retail worker, contributor, and customer should not all see the same first screen.
 2. The primary shell is a memory aid, not a database menu. Navigation should group by user intent and work object.
 3. Every number, status pill, and readiness cell must either drill into the objects that produced it or render as non-clickable explanatory status.
@@ -134,6 +148,45 @@ The latest manual UX audit (`2026-05-20-portal-ux-audit.md`) plus follow-on loca
 8. Refactoring is part of each slice. Reserve time to remove mixed concepts or duplicated patterns rather than only layering new UI over old structure.
 9. Trust is a first-view requirement. If a link, coworker response, KPI, or status cannot explain what happened and what the user can do next, it does not belong in the primary decision surface.
 10. Feature fit comes before feature surface area. Every new UI plan must name its owning area, route family, persona, navigation layer, component reuse path, empty state, and evidence before implementation starts.
+
+### 3.1 Navigation design principles
+
+1. **Give each job one canonical home.** Record the user's intent for every rail
+   entry, section link, tab, filter and contextual command. Secondary shortcuts
+   land at that same home with object/filter context; they do not create parallel
+   screens or duplicate work state.
+2. **Assign each navigation layer a different job.** AppRail chooses a durable
+   area; section navigation chooses sibling work families; local tabs choose
+   meaningful views of one object; filters select data; contextual commands act
+   on that data. Remove layers expressing the same choice. A primary action is
+   not a navigation category.
+3. **Make route families understandable without remembering URLs.** Heading,
+   rail/section label and breadcrumb describe the same work. Prefer literal
+   outcome/work-object language; resolve People/Employee and internal
+   Portal/Storefront contradictions through the existing nav model. Renaming a
+   label does not itself justify moving the route.
+4. **Keep feature work local.** Customer marketing belongs in Business > Customer.
+   A new feature does not earn a global AppRail item, Workspace card or generic
+   coworker launcher merely by existing. Search or a contextual shortcut can
+   improve discovery without another navigation tier.
+5. **Workrooms carry work context across areas.** Link from an exception or work
+   object to its canonical room. Parent summaries reveal relevant children and
+   evidence on demand; preserve a clear path back, selection and scroll state.
+   Operational rooms, architecture definitions and operator diagnostics are
+   distinct intents, not three competing homes for doing the same job.
+6. **Separate internal management from external service.** `/storefront` is
+   internal management; `/portal` and `/s/[slug]` are customer-facing experiences.
+   Customer navigation must not expose internal management or other customers'
+   work. Authorization shapes both destinations and visible summaries.
+7. **Adapt priority without forking IA.** Existing archetype workspace profiles
+   may change first content, terminology and default filters; reuse route and
+   work identity. Worker/volunteer starts must not inherit an administrator's
+   setup or platform operations menu as their default task surface.
+8. **Make discovery and recovery testable.** Audit first-click destination,
+   direct-link entry, browser back, parent return, permission denial and missing
+   route recovery. Navigation must never send a prompt or silently start work.
+   Keep actions adjacent to the context that motivates them and reachable by
+   keyboard and touch.
 
 ## 4. Persona Acceptance Gates
 
@@ -150,6 +203,11 @@ Every slice must name the user it is improving before it changes IA. The same co
 ### 4.1 UX Feature Fit Gate
 
 Use this gate before accepting any UI-impacting feature plan, including route additions, tab additions, dashboard bands, metric tiles, coworker launchers, and workflow entry points.
+
+Complete the [framework's standing gate](../../architecture/portal-ux-evaluation-framework.md#5-standing-ux-design-and-fit-gate)
+and attach its scorecard. This table is the spine's intake summary; the framework
+owns measurement definitions, blocker rules and evidence requirements. A design
+fit verdict is not a runtime task pass.
 
 | Gate | Required answer |
 | ---- | --------------- |
@@ -248,7 +306,9 @@ Verification:
 
 Scope:
 
-- Reduce the first viewport to command strip, core signals, readiness, and work in motion.
+- Compose the first viewport from the persona's priority outcome, next decision
+  and relevant work in motion. A command strip, signals or readiness band is
+  included only when it helps that job; these are not mandatory dashboard bands.
 - Move lower-frequency launch tiles below the first decision surface or behind a clearer grouped launcher.
 - Replace any repeated generic explanation with a compact help/info affordance.
 - Add a persona-first acceptance script for founder/operator and one configured worker persona. The first viewport must answer "what needs my attention now?" before it offers a site map.
@@ -256,7 +316,9 @@ Scope:
 Verification:
 
 - Browser screenshots at desktop and narrow widths.
-- Link-count reduction from the current `/workspace` baseline.
+- Comparable before/after scorecard showing task completion and reduced avoidable
+  choice/traversal cost; the May full-page link count is historical context, not
+  a current first-viewport baseline.
 - Evidence that the primary action and priority exception are visible without scrolling on desktop and mobile.
 - No overlapping text, no horizontal overflow, and no navigation layer duplicates between AppRail, section tabs, and local launchers.
 

--- a/docs/superpowers/plans/2026-09-06-portal-ux-simplification-execution-plan.md
+++ b/docs/superpowers/plans/2026-09-06-portal-ux-simplification-execution-plan.md
@@ -2,7 +2,125 @@
 status: active
 ---
 
-# Portal UX Simplification Closeout Execution Plan
+# Portal UX Simplification Execution Plan
+
+September outcome-framework revision: `BI-D09EE31E`, `WC-302E3E59`, branch
+`doc/portal-ux-outcome-framework`. The closeout packet below merged in PR #5120
+at `8d1057e0208fe55caf63c01738ad0961d5ea4d3f` on 2026-09-06. Its backlog
+closeout remains separately owned; source merge is not served verification.
+
+Use the [evaluation framework](../../architecture/portal-ux-evaluation-framework.md)
+and [scorecard](../../testing/portal-ux-scorecard-template.md) for every slice.
+They define the rubric, measurement protocol, workroom disclosure and standing
+feature-fit gate. WWMD `DI-BED2443DAD54` ratifies reuse of existing page-purpose
+and UX-budget contracts; this revision introduces no new runtime scoring system.
+
+## Revised priority and PR boundaries
+
+Phase numbers below remain stable scope identifiers. Execute by the priority
+table, not numerical phase order. Live MCP on 2026-09-06 confirms the six visible
+implementation BIs remain open; this is a recommended queue, not a claim that
+their research/readiness gates have passed. Recheck ownership before claiming.
+
+| Priority | Existing BI / slice | Accepted finding and smallest outcome | Dependency and evidence |
+| --- | --- | --- | --- |
+| P0 evidence | `BI-5A1A3C13`, phase 1 | Reconcile merged delegate source with served runtime | Sanctioned readiness/upgrade only; record CAN-TEST or exact blocker. Do not block documentation on this operational stream |
+| P0 trust | `BI-36A2CF08`, phase 3 | Workspace transcript hides setup/prompt/provider internals and gives one recoverable failure state, tied to the relevant work | Reproduce current defect, then greeting + work request + unavailable provider/retry; verify launch preview/confirmation and receipt on existing action path |
+| P0 truth | `BI-FFCE0D22`, phase 6 | Reconcile one grant/governance discrepancy through the existing read boundary and its immediate summary/detail surfaces | Prove equal scope/denominator/freshness before comparing counts; repair or explicit partial/stale warning before operator grouping |
+| P1 daily work | `BI-971D6F22`, phase 2 | Workspace lets founder/operator find and act on the highest relevant exception, then return from its canonical room | Current baseline, trustworthy state and configured worker sentinel; first useful action visible, completion oracle and parent/child return pass |
+| P1 discovery | `BI-1F0B4184`, phase 4 | Business labels lead to the expected existing home, preserving external/internal separation | Test headings, navigation, breadcrumbs and return paths together; no route migration or global feature promotion |
+| P1 fresh install | `BI-CEB3FDF8`, phase 5 | Reuse report-kit empty/loading/failure treatment on Documents with matching Knowledge/Compliance instances only where the same contract applies | One next step per empty context; permission/provider state tests and valid CTA destination; no new setup model |
+| P2 feature flow | `BI-D8E00326`, phase 7 | One accepted Customer marketing job from local entry through preview, existing coworker work and receipt | Fit gate and purpose contract before adding surface; a broad campaign/funnel/automation build requires decomposition into live BIs before implementation |
+
+Each row is **one BI, one branch, one PR** for its bounded accepted outcome.
+The broader BI body is an upper bound, not permission to grow a PR. If source
+reproduction shows a row requires independently shippable outcomes, record the
+decomposition, create/reuse successor BIs and obtain coverage before code. Do not
+reuse the same BI for a train of unrelated PRs or leave residual accepted work
+only in this table. No new implementation BIs are created by this framework pass.
+
+Within each slice reserve roughly **20% of implementation effort for refactoring**:
+Workspace converges duplicate launch/readiness projection; trust converges message
+classification and failure presentation; AI removes duplicate grant/status joins;
+Business converges label definitions; empty states remove copied panels; Customer
+reuses existing launcher and receipt context. Verify exact files and duplication
+in the source before committing to removal. Record planned/actual effort and the
+removed pattern in the scorecard; unused allocation does not justify unrelated
+cleanup. In this documentation pass, refactoring means consolidating measurement
+rules in the framework and replacing competing first-view instructions with links.
+
+### Workroom and cross-cutting findings
+
+The first parent -> child -> evidence -> return audit is an acceptance task of
+`BI-971D6F22`, not authorization to rewrite all Workroom screens. Existing
+`/ops/workrooms` operational inventory and `/ea/workrooms` definitions have
+different purpose contracts; retain them. Audit the canonical case detail reached
+from a real permitted room. If it exposes an independent defect, query the live
+backlog for overlap and file under its owning epic before accepting implementation.
+Shared trust findings stay with `BI-36A2CF08`; source-truth findings stay with
+`BI-FFCE0D22`. Unobserved workroom redesign hypotheses are **pending audit**, not
+accepted build work with invented BI coverage.
+
+Architecture and missing-route recovery remain sampling sentinels. Existing May
+findings UX-09/UX-10 require current reproduction and owning-stream reconciliation;
+do not silently bundle Build Studio or a platform-wide 404 rewrite into the empty
+state PR. The framework itself is one atomic documentation outcome under
+`BI-D09EE31E`: rubric + template + spine + queue must stay internally consistent.
+
+## Route-audit sampling plan
+
+Build the current denominator from the canonical route/audience and purpose
+registries at the audited SHA. Reconcile the budget baseline's covered, excluded
+and unmeasured routes; the September counts are not a new inventory. Select
+representatives by job, density, state and risk, not whichever page looks worst.
+
+| Family | Initial route/task sentinels | Primary persona and contrast | Required adverse state |
+| --- | --- | --- | --- |
+| Workspace | `/workspace` -> priority exception -> actual work object/case -> next action -> return | Founder/operator plus configured worker/volunteer | No work, blocked work, provider failure, permission-limited user |
+| Business/Customer | `/customer`, existing customer detail and `/customer/marketing`; Business People/Storefront entries | Customer operator plus dispatcher or rescue director | Empty pipeline, unauthorized action, direct-link/return-state check |
+| Platform AI | `/platform`, `/platform/ai/overview`, `/platform/ai/runtime-health`, relevant governance/provider detail | Platform operator plus denied ordinary worker | Contradictory or stale counts, unavailable provider, missing configuration |
+| Workrooms | `/ops/workrooms` -> `/workspace/cases/[caseKey]`; one parent/child/evidence path; `/ea/workrooms` as definition-home contrast | Operator and participant with limited visibility | No live rooms, blocked child, stale room, restricted child/evidence |
+| Documents/Knowledge/Compliance | `/workspace/documents`, `/wiki`, `/compliance` and one existing obligation/detail; `/ea` as empty-state regression sentinel | Document owner/compliance worker plus normal reader | Fresh install, loading, upload/connect failure, read-only permission |
+| Storefront/Portal | `/storefront` internal management; `/s/[slug]` and `/portal` customer entry and one supported request/status flow | Internal operator and external customer/applicant | Unpublished/unconfigured, request failure, another customer's inaccessible data |
+| Build Studio, separate | `/build` and the current owning build/work detail | Contributor | Null/unknown states, interrupted stream, missing runtime evidence |
+
+For each of the six main families start with two task scorecards (primary and
+adverse/recovery), yielding **12 initial task scorecards**, each at desktop and
+narrow viewport. These are task samples, not 12 distinct URLs; one flow may cross
+several routes. Add keyboard, zoom/reflow and permission checks to each affected
+flow. Rotate a contrasting archetype through Workspace, Customer and Portal;
+use rescue as one sentinel, not a universal business default. Mark unsupported
+fixture paths pending rather than manufacturing work to fit the script.
+
+Then expand every confirmed important failure to its shared primitive consumers,
+one sibling route and its return/destination path. Audit every changed route in an
+implementation PR, even if it was absent from the initial sample. Stop expansion
+when the shared defect boundary is explained and each affected route has an owner;
+do not infer estate-wide quality from the initial sample. Publish
+tested/failed/unmeasured/excluded counts by family and reason. Exclusions do not
+count as passes. Refresh after shared navigation/component changes and before
+slice acceptance; rotate untouched families during the next planned audit.
+
+Build Studio has its own scorecards and `EP-BUILD-STUDIO-UX` stream. Its return to
+this execution path requires named served-SHA readiness, a successful end-to-end
+build/UX evidence path and an interruption/failure recovery check. Until then,
+external surfaces use the same MCP workroom and evidence gates.
+
+## Verification and limits of this revision
+
+This revision produces documents, not live UX verdicts or an install upgrade.
+Run the repository docs-only preflight and applicable index/link/status/coverage
+and UX-fit checks. The existing human comprehension, timing and manual accessibility
+checks remain human review requirements; this commit does not add automation.
+Keep immutable initiative coverage and independent review receipts separate from
+Markdown mapping. Missing receipts leave implementation readiness pending even
+when every planned slice has a BI. The historical coverage section below records
+the closeout packet's original gap and is not a receipt for this revision.
+
+Rollback: revert this documentation PR as one unit; it changes no routes,
+permissions, schema or runtime state. Later UI slices need their own route and
+data compatibility/rollback plan; preserve canonical work identity and existing
+deep links, with explicit redirect/return tests if a route move is approved.
 
 - **Backlog item:** `BI-436A9466`
 - **Workroom:** `WC-1183CC5B`
@@ -49,8 +167,8 @@ Delivered:
 
 Open:
 
-- The live install still needs a sanctioned self-upgrade/readiness check before
-  source-level delivery is equal to platform-level delivery.
+- The September audit left served verification open. Re-check readiness on the
+  current install before equating source-level and platform-level delivery.
 - The visible UX simplification work remains open and is split below.
 
 ## Phase 0: Closeout Packet
@@ -111,7 +229,9 @@ Scope:
 Verification:
 
 - Desktop and narrow browser evidence.
-- Link-count reduction against the May baseline.
+- Comparable before/after scorecard with task completion and reduced avoidable
+  traversal/choice cost. Do not compare first-viewport counts with May full-page
+  link counts or call historical counts current measurements.
 - First useful action and top exception visible without scrolling.
 - No overlapping text, no horizontal overflow, and no duplicate local/global nav
   layer for the same choice.

--- a/docs/superpowers/plans/2026-09-06-portal-ux-simplification-execution-plan.md
+++ b/docs/superpowers/plans/2026-09-06-portal-ux-simplification-execution-plan.md
@@ -39,15 +39,31 @@ decomposition, create/reuse successor BIs and obtain coverage before code. Do no
 reuse the same BI for a train of unrelated PRs or leave residual accepted work
 only in this table. No new implementation BIs are created by this framework pass.
 
-Within each slice reserve roughly **20% of implementation effort for refactoring**:
+The operator has reset the allocation to **80% refactoring/consolidation and
+20% net new**, superseding the previous 20% refactoring allowance. Treat the
+net-new portion as a ceiling, not a target to spend. Each slice first inventories
+and collapses existing redundancy, including the unnecessary internal details
+inside individual cards, rows, drawers and controls:
 Workspace converges duplicate launch/readiness projection; trust converges message
 classification and failure presentation; AI removes duplicate grant/status joins;
 Business converges label definitions; empty states remove copied panels; Customer
 reuses existing launcher and receipt context. Verify exact files and duplication
-in the source before committing to removal. Record planned/actual effort and the
-removed pattern in the scorecard; unused allocation does not justify unrelated
-cleanup. In this documentation pass, refactoring means consolidating measurement
+in the source before committing to removal. Record planned/actual effort in both
+categories, the removed pattern and migrated consumers in the scorecard. Inventory
+external services, packages, tools and user handoffs needed for the job; consolidate
+redundant dependency paths into existing platform capability where evidence supports
+it. Preserve necessary integrations and prove compatibility, recovery and rollback
+before removing one. A net-new feature must identify a gap reuse/refactoring cannot
+close. In this documentation pass, refactoring means consolidating measurement
 rules in the framework and replacing competing first-view instructions with links.
+
+Every priority row also carries item-level acceptance: inspect fields, metadata,
+status badges, actions and diagnostic controls inside the sampled items. Give
+each unnecessary detail a disposition and verify the remaining summary still
+supports action, decision and trust. Moving all internals into one expanded
+drawer or renaming them does not satisfy this criterion. Shared-item or dependency
+refactors take precedence over adding more cards, pages and feature entry points;
+the Customer net-new stream remains subordinate to this consolidation program.
 
 ### Workroom and cross-cutting findings
 
@@ -148,8 +164,9 @@ called done.
 4. Feature fit before new surface area. Every UI-impacting plan must answer the
    owner area, route family, persona, nav layer, component convergence, source
    truth, empty/failure state, AI boundary, and verification evidence questions.
-5. Refactor inside each slice. Reserve about 20% of the work for removing mixed
-   concepts, duplicated patterns, or leaky abstractions discovered by the slice.
+5. Use the operator's 80% refactoring/consolidation, 20% net-new allocation.
+   Collapse mixed concepts, duplicated patterns, item-level internal exposure
+   and unnecessary dependency burden before adding capability.
 6. Build Studio remains out of this execution path until its own UX/runtime
    evidence is reliable enough to own UX refactors.
 

--- a/docs/testing/portal-ux-scorecard-template.md
+++ b/docs/testing/portal-ux-scorecard-template.md
@@ -38,6 +38,9 @@ One row set per viewport and scenario; do not merge mobile and desktop results.
 | Pointer distance and start / keyboard focus stops | U | U | | |
 | Nav layers / repeated-intent pairs / return-state preserved | U | U | | |
 | Leakage occurrences / distinct values / justified exceptions | U | U | | |
+| Items inspected / items exposing unnecessary internals / unnecessary details | U | U | | |
+| Duplicate surfaces/components/projections retired / consumers migrated | U | U | | |
+| External dependencies / setup steps / failure points retained or removed | U | U | | |
 | Time to useful action / outcome / separate load and provider wait | U | U | | |
 | Workroom depth / parent return / blocking child / evidence freshness | U | U | | |
 | AI preview / confirmation / receipt / safe retry | U | U | | |
@@ -75,13 +78,25 @@ One row set per viewport and scenario; do not merge mobile and desktop results.
 
 ## Disposition and refactoring
 
+### Item-detail and dependency inventory
+
+| Item / field / control | Persona need now | Current exposure | Keep / summarize / disclose / operator-only / merge / remove | Canonical owner and acceptance proof |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+| Dependency or duplicate implementation | Job and consumers | User setup / failure burden | Retain / consolidate / replace / retire and rationale | Migration, verification and rollback |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
 - Blockers, including unmeasured safety/task scenarios:
 - Evidence coverage: observed / source-verified / estimated / proposed:
 - Fit verdict: fits / fits-with-guardrails / defer / reject:
 - Runtime verdict: passed / failed / inconclusive / not run:
 - Finding -> user harm -> existing BI -> bounded PR slice:
 - Reuse choice / exact duplication to remove / compatibility and rollback:
-- Refactoring allocation: planned about 20%; actual effort and removed duplication:
+- Effort allocation: planned 80% refactoring/consolidation, at most 20% net new; actual effort in both categories and variance rationale:
+- Net-new gap that existing capability cannot satisfy; evidence reuse/refactoring is insufficient:
+- Removed item-level internals, retired duplication and dependency burden (not merely hidden):
 - Required edits, accountable owner and review trigger:
 - Gate/UX-fit manifest and canonical Workroom evidence references:
 - Participant results (individual attempts, assistance, timing, order); or human evidence pending:

--- a/docs/testing/portal-ux-scorecard-template.md
+++ b/docs/testing/portal-ux-scorecard-template.md
@@ -7,6 +7,10 @@ Do not put proposed values in observed columns.
 
 ## Identity and purpose
 
+- PR / reviewed base and head SHA / reviewer:
+- UX impact: affected / no impact with source-backed reason / unknown:
+- Criterion-to-change mapping / affected shared consumers / coverage selection:
+- New regression / touched existing debt / unrelated existing debt:
 - Audit ID / date / reviewer / BI / Workroom:
 - Source SHA / served SHA / install and readiness evidence:
 - Route or flow / canonical home / owning area:

--- a/docs/testing/portal-ux-scorecard-template.md
+++ b/docs/testing/portal-ux-scorecard-template.md
@@ -1,0 +1,90 @@
+# Portal page / flow scorecard template
+
+Copy into the slice's audit artifact. Method and scoring anchors:
+[portal evaluation framework](../architecture/portal-ux-evaluation-framework.md).
+Replace every placeholder; use U for unmeasured and N/A with a reason.
+Do not put proposed values in observed columns.
+
+## Identity and purpose
+
+- Audit ID / date / reviewer / BI / Workroom:
+- Source SHA / served SHA / install and readiness evidence:
+- Route or flow / canonical home / owning area:
+- Primary persona / actual permissions / archetype / locale:
+- Fixture reference, configuration and data volume:
+- Trigger -> job -> meaningful outcome:
+- Start route / expected route sequence / completion oracle:
+- False success conditions (for example, prompt sent but work not done):
+- Current source-of-truth service/read model and freshness:
+- Navigation: global / section / local / filters / contextual command:
+- Workroom relevance: none / summary / linked room / detail; reason:
+- Current default content / deferred content and trigger / diagnostic audience:
+- Viewport / zoom / theme / input method / default disclosure state:
+- Measurement tool/version and scope / DOM settlement or timeout:
+- Predeclared task targets and why / comparison fixture parity:
+
+## Measures
+
+One row set per viewport and scenario; do not merge mobile and desktop results.
+
+| Measure | Before observed | After observed | Estimate or target (label it) | Evidence reference / verdict |
+| --- | --- | --- | --- | --- |
+| First-view clarity: job, attention, next step (0-3 correct) | U | U | | |
+| Default visible words / separate viewport-only words | U | U | | |
+| Canonical shell budget / lead-band words | U | U | | |
+| Visible choices: shell / task / disabled | U | U | | |
+| Primary actions / fields / max choices per control | U | U | | |
+| Action above fold / scroll pixels / clicks or taps / route changes | U | U | | |
+| Pointer distance and start / keyboard focus stops | U | U | | |
+| Nav layers / repeated-intent pairs / return-state preserved | U | U | | |
+| Leakage occurrences / distinct values / justified exceptions | U | U | | |
+| Time to useful action / outcome / separate load and provider wait | U | U | | |
+| Workroom depth / parent return / blocking child / evidence freshness | U | U | | |
+| AI preview / confirmation / receipt / safe retry | U | U | | |
+| Empty / loading / failure / permission / not-applicable | U | U | | |
+| Mobile overlap/overflow / zoom/reflow | U | U | | |
+| Axe findings / keyboard / focus / labels / announcements / contrast | U | U | | |
+
+## Rubric
+
+| Dimension | Before 0-3/U/N/A | After 0-3/U/N/A | Evidence and remaining harm |
+| --- | --- | --- | --- |
+| Outcome orientation | U | U | |
+| Persona/archetype fit | U | U | |
+| Progressive disclosure | U | U | |
+| Time/distance to action | U | U | |
+| Cognitive load | U | U | |
+| Data model leakage | U | U | |
+| Workroom relevance | U | U | |
+| AI context/trust | U | U | |
+| Navigation | U | U | |
+| State quality | U | U | |
+
+## Task and state evidence
+
+| Scenario | Start and fixture | Expected outcome / prohibited behavior | Actual result | Receipt, trace or screenshot |
+| --- | --- | --- | --- | --- |
+| Primary populated task | | | Unmeasured | |
+| Returning user / changed work | | | Unmeasured | |
+| Fresh install | | | Unmeasured | |
+| Loading / partial or stale data | | | Unmeasured | |
+| Failure and retry | | | Unmeasured | |
+| Permission-limited / unauthorized attempt | | | Unmeasured | |
+| Not applicable yet | | | Unmeasured | |
+| Parent -> child -> evidence -> return | | | Unmeasured | |
+
+## Disposition and refactoring
+
+- Blockers, including unmeasured safety/task scenarios:
+- Evidence coverage: observed / source-verified / estimated / proposed:
+- Fit verdict: fits / fits-with-guardrails / defer / reject:
+- Runtime verdict: passed / failed / inconclusive / not run:
+- Finding -> user harm -> existing BI -> bounded PR slice:
+- Reuse choice / exact duplication to remove / compatibility and rollback:
+- Refactoring allocation: planned about 20%; actual effort and removed duplication:
+- Required edits, accountable owner and review trigger:
+- Gate/UX-fit manifest and canonical Workroom evidence references:
+- Participant results (individual attempts, assistance, timing, order); or human evidence pending:
+
+No aggregate score can waive a blocker. Screenshots prove layout at the captured
+state; task completion and data/action boundaries need their own evidence.


### PR DESCRIPTION
The portal simplification effort needs shared acceptance criteria for both existing UX refactoring and future PRs. This publishes the ten-dimension framework, reproducible page/flow scorecard, and standing every-PR impact review contract, including unnecessary details inside cards and rows, redundant surfaces, external dependency burden, and the program's 80% refactoring / at most 20% net-new allocation.

The existing May spine and September execution plan point to the same criteria. Recent merged navigation and Workroom improvements are reconciled with remaining debt. Historical observations stay labeled; documentation does not claim automatic enforcement or new runtime UX improvements.

Validation: documentation links, spec status and changed-plan backlog coverage pass; generated documentation artifacts refreshed; semantic review receipt cmtta4v2t2gdd01o9dbh2fd1l passes for the committed diff. Runtime tests and migrations are not applicable to this documentation-only change.

Backlog: BI-D09EE31E

Local-CI-Override: docs-adjacent: documentation and generated doc indexes only; derived-artifact push gate confirmed docs exemption with every affected artifact fresh. All 66 preflight guards and the full PR-readiness checks passed. No application behavior, schema, dependency or runtime configuration changes.

Design-Grounding-Decision: extends the existing portal simplification spine, page-purpose contracts, UX budgets and UX-fit manifest workflow; introduces no runtime route, schema or parallel scoring service.

Convergence-Impact-Decision: auto-converges — documentation and generated documentation indexes ship with the portal release through the existing self-upgrade path; this records the review contract, not deployment of new enforcement.
