### PR TITLE
fix(ai): refresh Codex models from account catalog

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.test.tsx
@@ -19,9 +19,17 @@ vi.mock("@dpf/db", () => ({
           jobId: "provider-registry-sync",
           schedule: "daily",
           lastRunAt: new Date("2026-06-28T12:00:00.000Z"),
-          nextRunAt: new Date("2099-01-01T00:00:00.000Z"),
+          nextRunAt: new Date(Date.now() + 86_400_000),
           lastStatus: "ok",
           lastError: null,
+        },
+        {
+          jobId: "model-discovery-refresh",
+          schedule: "daily",
+          lastRunAt: new Date("2026-09-08T03:10:00.000Z"),
+          nextRunAt: new Date(Date.now() + 86_400_000),
+          lastStatus: "partial",
+          lastError: "codex: app-server unavailable",
         },
       ]),
       update: vi.fn(),
@@ -41,9 +49,17 @@ vi.mock("@/lib/ai-provider-data", () => ({
       jobId: "provider-registry-sync",
       schedule: "daily",
       lastRunAt: new Date("2026-06-28T12:00:00.000Z"),
-      nextRunAt: new Date("2099-01-01T00:00:00.000Z"),
+      nextRunAt: new Date(Date.now() + 86_400_000),
       lastStatus: "ok",
       lastError: null,
+    },
+    {
+      jobId: "model-discovery-refresh",
+      schedule: "daily",
+      lastRunAt: new Date("2026-09-08T03:10:00.000Z"),
+      nextRunAt: new Date(Date.now() + 86_400_000),
+      lastStatus: "partial",
+      lastError: "codex: app-server unavailable",
     },
   ]),
   groupByEndpointTypeAndCategory: vi.fn().mockReturnValue([]),
@@ -170,5 +186,6 @@ describe("ProvidersPage", () => {
     expect(html).toContain("Last updated");
     expect(html).not.toContain("Refresh Provider Catalog");
     expect(html).not.toContain("Sync Provider Registry");
+    expect(html).toMatch(/Provider catalog[\s\S]*Last updated[\s\S]*Sep 8, 2026/);
   });
 });

--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -147,6 +147,7 @@ export default async function ProvidersPage() {
   }
 
   const lastSync = freshJobs.find((j) => j.jobId === "provider-registry-sync")?.lastRunAt;
+  const lastCatalogRefresh = freshJobs.find((j) => j.jobId === "model-discovery-refresh")?.lastRunAt;
 
   // F11 (BI-1A75E068): tie provider → blocked phase. Reuse the SAME resolver
   // runtime-health uses; for any phase blocked with `no-eligible-endpoint`, it
@@ -208,7 +209,7 @@ export default async function ProvidersPage() {
           <div style={{ color: "var(--dpf-accent)", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>
             Providers
           </div>
-          <ProviderCatalogStatus lastSyncAt={lastSync ?? null} />
+          <ProviderCatalogStatus lastSyncAt={lastCatalogRefresh ?? null} />
         </div>
 
         {aiProviders.length === 0 ? (

--- a/apps/web/lib/inference/ai-provider-internals.test.ts
+++ b/apps/web/lib/inference/ai-provider-internals.test.ts
@@ -14,8 +14,13 @@ const discoveredModelMock = vi.hoisted(() => ({
   createMany: vi.fn(),
 }));
 const modelProfileMock = vi.hoisted(() => ({
+  findMany: vi.fn(),
   updateMany: vi.fn<(args: Record<string, any>) => Promise<{ count: number }>>(async () => ({ count: 0 })),
 }));
+const modelProviderMock = vi.hoisted(() => ({ findUnique: vi.fn() }));
+const agentModelConfigMock = vi.hoisted(() => ({ updateMany: vi.fn() }));
+const seedKnownModelsMock = vi.hoisted(() => vi.fn());
+const discoverCodexCliModelsMock = vi.hoisted(() => vi.fn());
 vi.mock("@dpf/db", () => ({
   prisma: {
     credentialEntry: {
@@ -27,7 +32,13 @@ vi.mock("@dpf/db", () => ({
     },
     discoveredModel: discoveredModelMock,
     modelProfile: modelProfileMock,
+    modelProvider: modelProviderMock,
+    agentModelConfig: agentModelConfigMock,
   },
+}));
+vi.mock("@/lib/inference/known-model-seeding", () => ({ seedKnownModels: seedKnownModelsMock }));
+vi.mock("@/lib/routing/codex-cli-model-catalog", () => ({
+  discoverCodexCliModels: discoverCodexCliModelsMock,
 }));
 
 import {
@@ -39,7 +50,63 @@ import {
   upsertDiscoveredModels,
   reconcileDiscoveredModelPresence,
   PERMANENT_RETIRE_REASONS,
+  autoDiscoverAndProfile,
+  clearStaleCodexPins,
 } from "./ai-provider-internals";
+
+describe("Codex authoritative discovery", () => {
+  beforeEach(() => {
+    modelProviderMock.findUnique.mockReset();
+    seedKnownModelsMock.mockReset();
+    discoverCodexCliModelsMock.mockReset();
+    modelProviderMock.findUnique.mockResolvedValue({
+      providerId: "codex",
+      authMethod: "oauth2_authorization_code",
+      category: "agent",
+      cliEngine: "codex-cli",
+    });
+  });
+
+  it("does not seed the static catalog when the account-authoritative CLI list fails", async () => {
+    discoverCodexCliModelsMock.mockRejectedValue(new Error("app-server unavailable"));
+
+    await expect(autoDiscoverAndProfile("codex")).resolves.toMatchObject({
+      discovered: 0,
+      profiled: 0,
+      error: "app-server unavailable",
+    });
+    expect(seedKnownModelsMock).not.toHaveBeenCalled();
+    expect(discoveredModelMock.createMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearStaleCodexPins", () => {
+  beforeEach(() => {
+    modelProfileMock.findMany.mockReset();
+    agentModelConfigMock.updateMany.mockReset();
+  });
+
+  it("clears stale Codex pins only after a freshly listed active replacement exists", async () => {
+    modelProfileMock.findMany.mockResolvedValue([{ modelId: "gpt-6-astra" }]);
+
+    await clearStaleCodexPins(["gpt-6-astra", "gpt-5.6-sol"]);
+
+    expect(agentModelConfigMock.updateMany).toHaveBeenCalledWith({
+      where: {
+        pinnedProviderId: "codex",
+        pinnedModelId: { notIn: ["gpt-6-astra"] },
+      },
+      data: { pinnedProviderId: null, pinnedModelId: null },
+    });
+  });
+
+  it("leaves pins untouched on failure, empty inventory, or no active replacement", async () => {
+    await clearStaleCodexPins([]);
+    modelProfileMock.findMany.mockResolvedValue([]);
+    await clearStaleCodexPins(["gpt-6-astra"]);
+    expect(agentModelConfigMock.updateMany).not.toHaveBeenCalled();
+  });
+});
 
 describe("extractTokenUsage", () => {
   it("reads OpenAI-compatible prompt and completion token fields", () => {

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -457,9 +457,21 @@ export async function upsertDiscoveredModels(
 
 export async function discoverModelsInternal(
   providerId: string,
-): Promise<{ discovered: number; newCount: number; error?: string }> {
+): Promise<{ discovered: number; newCount: number; modelIds?: string[]; error?: string }> {
   const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
   if (!provider) return { discovered: 0, newCount: 0, error: "Provider not found" };
+
+  if (providerId === "codex" && provider.cliEngine === "codex-cli") {
+    try {
+      const { discoverCodexCliModels } = await import("@/lib/routing/codex-cli-model-catalog");
+      const models = await discoverCodexCliModels(providerId);
+      const newCount = await upsertDiscoveredModels(providerId, models);
+      await reconcileDiscoveredModelPresence(providerId, new Set(models.map((model) => model.modelId)));
+      return { discovered: models.length, newCount, modelIds: models.map((model) => model.modelId) };
+    } catch (err) {
+      return { discovered: 0, newCount: 0, error: err instanceof Error ? err.message : "Codex CLI discovery failed" };
+    }
+  }
 
   // Codex and ChatGPT subscription providers use the ChatGPT backend
   // /backend-api/models endpoint (not the standard /v1/models). Discover
@@ -539,35 +551,13 @@ export async function discoverModelsInternal(
   return { discovered: models.length, newCount };
 }
 
-/**
- * Retirement reasons that record the PROVIDER ITSELF confirming a model is
- * dead even though it may still appear in the provider's catalog listing —
- * Google keeps sunset aliases listed while rejecting calls. Cloud presence
- * reconciliation never auto-reactivates these. Local serving engines
- * (DMR/Ollama) are exempt: their /models list is the serving truth — a listed
- * model is loadable, so a model_not_found recorded during an engine outage
- * must heal once the model is listed again (BI-B6B8C1F9).
- */
+// Provider-confirmed retirement survives cloud relisting; local serving lists heal it.
 export const PERMANENT_RETIRE_REASONS = [
   "model_not_found from provider",
   "Deprecated by provider at discovery time",
 ];
 
-/**
- * EP-INF-002: Discovery reconciliation — heal returned models, detect gone ones.
- *
- * A retired ModelProfile is reactivated whenever the provider currently lists
- * the model. This deliberately does NOT depend on missedDiscoveryCount:
- * profiles retired by a runtime 404 during an outage or demoted by a
- * dedupe/retriage migration (BI-84792669 left reactivation as an unowned
- * "operational decision") carry a count of 0 and previously stayed retired
- * forever while discovery listed the model every day — the "no AI model
- * available" coworker outage (BI-B6B8C1F9).
- *
- * Missed-discovery counting and retirement stay cloud-only: a local list miss
- * is more likely an engine hiccup than a removal, and retiring the bundled
- * local fallback is exactly what stranded restricted-sensitivity routing.
- */
+// EP-INF-002: heal listed models; count cloud absences without penalizing local hiccups.
 export async function reconcileDiscoveredModelPresence(
   providerId: string,
   freshModelIds: ReadonlySet<string>,
@@ -629,6 +619,19 @@ export async function reconcileDiscoveredModelPresence(
       console.log(`[discovery] Retired model ${JSON.stringify(known.modelId)} from ${JSON.stringify(providerId)} (missed ${newMissedCount} discoveries)`);
     }
   }
+}
+
+export async function clearStaleCodexPins(freshModelIds: string[]): Promise<void> {
+  if (freshModelIds.length === 0) return;
+  const active = await prisma.modelProfile.findMany({
+    where: { providerId: "codex", modelId: { in: freshModelIds }, modelStatus: "active" },
+    select: { modelId: true },
+  });
+  if (active.length === 0) return;
+  await prisma.agentModelConfig.updateMany({
+    where: { pinnedProviderId: "codex", pinnedModelId: { notIn: active.map((row) => row.modelId) } },
+    data: { pinnedProviderId: null, pinnedModelId: null },
+  });
 }
 
 
@@ -1116,16 +1119,7 @@ export async function seedAllRecipes(): Promise<number> {
   return seeded;
 }
 
-/**
- * Auto-discover and profile models for a provider after activation.
- * Called from OAuth callback and API key save flows.
- *
- * For all providers: tries discoverModelsInternal first (dynamic discovery).
- * For codex/chatgpt: discoverModelsInternal calls /backend-api/models via OAuth.
- * If dynamic discovery fails, falls back to KNOWN_PROVIDER_MODELS catalog.
- *
- * Errors are logged but never thrown (activation should succeed even if discovery fails).
- */
+/** Discover and profile after activation; failures never break activation. */
 export async function autoDiscoverAndProfile(providerId: string): Promise<{
   discovered: number;
   profiled: number;
@@ -1140,14 +1134,15 @@ export async function autoDiscoverAndProfile(providerId: string): Promise<{
     if (discovery.discovered > 0) {
       // Dynamic discovery succeeded — profile the discovered models
       const profiling = await profileModelsInternal(providerId);
+      if (providerId === "codex") await clearStaleCodexPins(discovery.modelIds ?? []);
       result = {
         discovered: discovery.discovered,
         profiled: profiling.profiled,
         error: profiling.error,
       };
     } else {
-      // 2. Dynamic discovery returned 0 — fall back to known catalog if available
-      const knownModels = KNOWN_PROVIDER_MODELS[providerId];
+      // Codex inventory is account-specific; a static catalog must never impersonate success.
+      const knownModels = providerId === "codex" ? undefined : KNOWN_PROVIDER_MODELS[providerId];
       if (knownModels) {
         console.log(
           `[auto-discover] Dynamic discovery returned 0 for ${JSON.stringify(providerId)}` +

--- a/apps/web/lib/inference/model-revalidation.test.ts
+++ b/apps/web/lib/inference/model-revalidation.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findProviders = vi.hoisted(() => vi.fn());
+const autoDiscover = vi.hoisted(() => vi.fn());
+
+vi.mock("@dpf/db", () => ({ prisma: { modelProvider: { findMany: findProviders } } }));
+vi.mock("./ai-provider-internals", () => ({ autoDiscoverAndProfile: autoDiscover }));
+vi.mock("@/lib/routing/provider-eligibility", () => ({ canRunStartupModelDiscovery: () => true }));
+
+import { runModelRevalidation } from "./model-revalidation";
+
+function pool() {
+  const client = {
+    query: vi.fn()
+      .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+      .mockResolvedValueOnce({ rows: [] }),
+    release: vi.fn(),
+  };
+  return { connect: vi.fn().mockResolvedValue(client) } as never;
+}
+
+describe("runModelRevalidation", () => {
+  beforeEach(() => {
+    findProviders.mockReset();
+    autoDiscover.mockReset();
+    findProviders.mockResolvedValue([
+      { providerId: "codex" },
+      { providerId: "openai" },
+    ]);
+  });
+
+  it("retains resolved provider errors instead of reporting the run as successful", async () => {
+    autoDiscover
+      .mockResolvedValueOnce({ discovered: 0, profiled: 0, error: "app-server unavailable" })
+      .mockResolvedValueOnce({ discovered: 4, profiled: 4 });
+
+    const result = await runModelRevalidation({ source: "scheduled" }, pool());
+
+    expect(result).toEqual({
+      acquired: true,
+      outcomes: [
+        { providerId: "codex", status: "failed", error: "app-server unavailable" },
+        { providerId: "openai", status: "ok", discovered: 4, profiled: 4 },
+      ],
+    });
+  });
+});

--- a/apps/web/lib/inference/model-revalidation.ts
+++ b/apps/web/lib/inference/model-revalidation.ts
@@ -10,8 +10,14 @@ import { prisma } from "@dpf/db";
 import { Pool } from "pg";
 import { autoDiscoverAndProfile } from "./ai-provider-internals";
 import { canRunStartupModelDiscovery } from "@/lib/routing/provider-eligibility";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 const LOCK_KEY = 0x4d434156; // "MCAV" as int32 (deterministic, stable)
+
+export type ModelRevalidationOutcome =
+  | { providerId: string; status: "ok"; discovered: number; profiled: number }
+  | { providerId: string; status: "failed"; error: string };
+export type ModelRevalidationSummary = { acquired: boolean; outcomes: ModelRevalidationOutcome[] };
 
 /**
  * Acquire a session-scoped Postgres advisory lock on a dedicated connection.
@@ -46,8 +52,9 @@ async function withAdvisoryLock(
 export async function runModelRevalidation(
   opts: { source: "startup" | "scheduled" | "manual" },
   pgPool: Pool,
-): Promise<void> {
+): Promise<ModelRevalidationSummary> {
   console.log(`[model-revalidation] Starting (source=${opts.source})`);
+  const outcomes: ModelRevalidationOutcome[] = [];
 
   const acquired = await withAdvisoryLock(pgPool, async () => {
     const totalDeadline = Date.now() + 10 * 60 * 1000; // 10-min hard cap
@@ -74,7 +81,7 @@ export async function runModelRevalidation(
       }
       try {
         // Per-provider 60s timeout: race the discovery against a rejection
-        await Promise.race([
+        const result = await Promise.race([
           autoDiscoverAndProfile(providerId),
           new Promise<never>((_, reject) =>
             setTimeout(
@@ -83,8 +90,15 @@ export async function runModelRevalidation(
             ),
           ),
         ]);
+        if (result.error) {
+          outcomes.push({ providerId, status: "failed", error: result.error });
+          console.warn(`[model-revalidation] ${providerId} failed (non-fatal): ${result.error}`);
+          continue;
+        }
+        outcomes.push({ providerId, status: "ok", discovered: result.discovered, profiled: result.profiled });
         console.log(`[model-revalidation] Refreshed ${providerId}`);
       } catch (err) {
+        outcomes.push({ providerId, status: "failed", error: getErrorMessage(err) });
         console.warn(
           `[model-revalidation] ${providerId} failed (non-fatal):`,
           err,
@@ -96,4 +110,5 @@ export async function runModelRevalidation(
   if (!acquired) {
     console.log("[model-revalidation] Skipped — another instance is running");
   }
+  return { acquired, outcomes };
 }

--- a/apps/web/lib/queue/functions/model-discovery-refresh.test.ts
+++ b/apps/web/lib/queue/functions/model-discovery-refresh.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { scheduledModelDiscoveryStatus } from "./model-discovery-refresh";
+
+describe("scheduledModelDiscoveryStatus", () => {
+  it("records partial when any provider failed", () => {
+    expect(scheduledModelDiscoveryStatus({
+      acquired: true,
+      outcomes: [
+        { providerId: "codex", status: "failed", error: "unavailable" },
+        { providerId: "openai", status: "ok", discovered: 3, profiled: 3 },
+      ],
+    })).toBe("partial");
+  });
+
+  it("records ok only when every attempted provider succeeded", () => {
+    expect(scheduledModelDiscoveryStatus({
+      acquired: true,
+      outcomes: [{ providerId: "codex", status: "ok", discovered: 6, profiled: 6 }],
+    })).toBe("ok");
+  });
+});

--- a/apps/web/lib/queue/functions/model-discovery-refresh.ts
+++ b/apps/web/lib/queue/functions/model-discovery-refresh.ts
@@ -2,6 +2,7 @@ import { cron } from "inngest";
 import { Pool } from "pg";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
+import type { ModelRevalidationSummary } from "@/lib/inference/model-revalidation";
 
 // jobId of the catalog ScheduledJob row this cron corresponds to.
 const JOB_ID = "model-discovery-refresh";
@@ -22,7 +23,7 @@ function getPool(): Pool {
  * while the cron fired — hiding whether discovery was healthy and making it look
  * permanently "never run". Best-effort: never fail the job over a stamp.
  */
-async function recordRun(status: "ok" | "error", error?: string): Promise<void> {
+async function recordRun(status: "ok" | "partial" | "error", error?: string): Promise<void> {
   const { prisma } = await import("@dpf/db");
   await prisma.scheduledJob
     .update({
@@ -30,6 +31,10 @@ async function recordRun(status: "ok" | "error", error?: string): Promise<void> 
       data: { lastRunAt: new Date(), lastStatus: status, lastError: error ?? null },
     })
     .catch(() => {});
+}
+
+export function scheduledModelDiscoveryStatus(summary: ModelRevalidationSummary): "ok" | "partial" {
+  return summary.outcomes.some((outcome) => outcome.status === "failed") ? "partial" : "ok";
 }
 
 export const modelDiscoveryRefresh = inngest.createFunction(
@@ -44,13 +49,19 @@ export const modelDiscoveryRefresh = inngest.createFunction(
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     try {
-      await step.run("refresh-all-providers", async () => {
+      const summary = await step.run("refresh-all-providers", async () => {
         const { runModelRevalidation } = await import(
           "@/lib/inference/model-revalidation"
         );
-        await runModelRevalidation({ source: "scheduled" }, getPool());
+        return runModelRevalidation({ source: "scheduled" }, getPool());
       });
-      await step.run("record-success", () => recordRun("ok"));
+      const status = scheduledModelDiscoveryStatus(summary);
+      const error = summary.outcomes
+        .filter((outcome) => outcome.status === "failed")
+        .map((outcome) => `${outcome.providerId}: ${outcome.error}`)
+        .join("; ")
+        .slice(0, 500) || undefined;
+      await step.run("record-success", () => recordRun(status, error));
     } catch (err) {
       await step.run("record-failure", () => recordRun("error", String(err).slice(0, 500)));
       throw err;

--- a/apps/web/lib/routing/codex-cli-adapter.test.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.test.ts
@@ -99,6 +99,7 @@ import {
   writeContainerFileViaStdin,
   looksLikeCliAuthFailure,
   looksLikeCliRateLimit,
+  looksLikeCliUnsupportedModel,
 } from "./codex-cli-adapter";
 import type { AdapterRequest } from "./adapter-types";
 import type { RoutedExecutionPlan } from "./recipe-types";
@@ -230,6 +231,19 @@ describe("writeContainerFileViaStdin", () => {
     proc.emit("close", 1);
 
     await expect(writePromise).rejects.toThrow("timed out");
+  });
+});
+
+describe("Codex CLI unsupported-model classification", () => {
+  it("recognizes the account-entitlement rejection as model_not_found", () => {
+    expect(looksLikeCliUnsupportedModel(
+      "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+    )).toBe(true);
+  });
+
+  it("does not confuse auth or capacity failures with an unsupported model", () => {
+    expect(looksLikeCliUnsupportedModel("401 unauthorized")).toBe(false);
+    expect(looksLikeCliUnsupportedModel("You've hit your weekly usage limit")).toBe(false);
   });
 });
 

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -73,6 +73,12 @@ export function looksLikeCliRateLimit(text: string): boolean {
   return CLI_RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(text));
 }
 
+export function looksLikeCliUnsupportedModel(text: string): boolean {
+  return /model is not supported when using Codex with a ChatGPT account/i.test(text)
+    || /unsupported model/i.test(text)
+    || /model [`'\"]?[^`'\"\s]+[`'\"]? (?:is )?not (?:available|supported)/i.test(text);
+}
+
 // ─── Container file writer ─────────────────────────────────────────────────
 
 /**
@@ -152,7 +158,7 @@ export function extractMentionedPlatformToolNames(text: string): string[] {
  * - tokens.access_token: the OAuth access token
  * - tokens.id_token: a JWT (same as access_token if JWT, or synthetic)
  */
-async function injectAuth(providerId: string): Promise<{ mode: "oauth" } | { mode: "apikey"; apiKey: string }> {
+export async function prepareCodexCliAuth(providerId: string): Promise<{ mode: "oauth" } | { mode: "apikey"; apiKey: string }> {
   const credential = await getDecryptedCredential(providerId);
   if (!credential) {
     throw new InferenceError(
@@ -216,7 +222,7 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
     const startMs = Date.now();
 
     // 1. Inject auth
-    const auth = await injectAuth(providerId);
+    const auth = await prepareCodexCliAuth(providerId);
 
     // 2. Build prompt from messages
     const promptParts: string[] = [];
@@ -371,6 +377,12 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
               reject(new InferenceError(
                 `Codex CLI auth failed: ${stderr.slice(0, 300)}`,
                 "auth",
+                providerId,
+              ));
+            } else if (looksLikeCliUnsupportedModel(stderr)) {
+              reject(new InferenceError(
+                `Codex CLI model not found: ${stderr.slice(0, 300)}`,
+                "model_not_found",
                 providerId,
               ));
             } else if (looksLikeCliRateLimit(stderr)) {

--- a/apps/web/lib/routing/codex-cli-model-catalog.test.ts
+++ b/apps/web/lib/routing/codex-cli-model-catalog.test.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from "events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const authMock = vi.hoisted(() => vi.fn().mockResolvedValue({ mode: "oauth" }));
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyChildProcess: () => ({ spawn: spawnMock }),
+}));
+vi.mock("./codex-cli-adapter", () => ({ prepareCodexCliAuth: authMock }));
+
+import { discoverCodexCliModels, parseCodexModelListPage } from "./codex-cli-model-catalog";
+
+function processMock() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  spawnMock.mockReturnValue(proc);
+  return proc;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("parseCodexModelListPage", () => {
+  it("preserves account metadata and excludes hidden models", () => {
+    const result = parseCodexModelListPage({
+      data: [
+        {
+          id: "gpt-6-astra",
+          model: "gpt-6-astra",
+          displayName: "GPT-6-Astra",
+          hidden: false,
+          isDefault: true,
+          inputModalities: ["text", "image"],
+          supportedReasoningEfforts: [{ reasoningEffort: "high", description: "Deep" }],
+        },
+        { id: "internal-model", model: "internal-model", hidden: true },
+      ],
+      nextCursor: "page-2",
+    });
+
+    expect(result.nextCursor).toBe("page-2");
+    expect(result.models).toEqual([
+      {
+        modelId: "gpt-6-astra",
+        rawMetadata: expect.objectContaining({
+          source: "codex_cli_model_list",
+          displayName: "GPT-6-Astra",
+          isDefault: true,
+          inputModalities: ["text", "image"],
+        }),
+      },
+    ]);
+  });
+
+  it("rejects malformed authoritative output instead of treating it as an empty list", () => {
+    expect(() => parseCodexModelListPage({ nextCursor: null })).toThrow(
+      "Malformed Codex model/list response",
+    );
+  });
+
+  it("accepts an explicitly empty authoritative page", () => {
+    expect(parseCodexModelListPage({ data: [], nextCursor: null })).toEqual({
+      models: [],
+      nextCursor: null,
+    });
+  });
+});
+
+describe("discoverCodexCliModels", () => {
+  it("initializes app-server and follows pagination", async () => {
+    const proc = processMock();
+    const result = discoverCodexCliModels();
+    await Promise.resolve();
+    proc.stdout.emit("data", Buffer.from('{"id":1,"result":{}}\n'));
+    proc.stdout.emit("data", Buffer.from('{"id":2,"result":{"data":[{"model":"gpt-6-astra","hidden":false}],"nextCursor":"c2"}}\n'));
+    proc.stdout.emit("data", Buffer.from('{"id":3,"result":{"data":[{"model":"gpt-5.6-sol","hidden":false}],"nextCursor":null}}\n'));
+
+    await expect(result).resolves.toEqual([
+      { modelId: "gpt-6-astra", rawMetadata: expect.objectContaining({ source: "codex_cli_model_list" }) },
+      { modelId: "gpt-5.6-sol", rawMetadata: expect.objectContaining({ source: "codex_cli_model_list" }) },
+    ]);
+    expect(proc.stdin.write.mock.calls.map(([line]) => JSON.parse(line))).toEqual([
+      expect.objectContaining({ method: "initialize" }),
+      { method: "initialized", params: {} },
+      { method: "model/list", id: 2, params: { cursor: null, limit: 100 } },
+      { method: "model/list", id: 3, params: { cursor: "c2", limit: 100 } },
+    ]);
+  });
+
+  it("fails closed on timeout", async () => {
+    vi.useFakeTimers();
+    const proc = processMock();
+    const result = discoverCodexCliModels();
+    const rejection = expect(result).rejects.toThrow("timed out");
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejection;
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});

--- a/apps/web/lib/routing/codex-cli-model-catalog.ts
+++ b/apps/web/lib/routing/codex-cli-model-catalog.ts
@@ -1,0 +1,103 @@
+import { lazyChildProcess } from "@/lib/shared/lazy-node";
+import { prepareCodexCliAuth } from "./codex-cli-adapter";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+const MODEL_LIST_TIMEOUT_MS = 30_000;
+
+type DiscoveredModel = { modelId: string; rawMetadata: Record<string, unknown> };
+
+export function parseCodexModelListPage(value: unknown): {
+  models: DiscoveredModel[];
+  nextCursor: string | null;
+} {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { data?: unknown }).data)) {
+    throw new Error("Malformed Codex model/list response");
+  }
+  const page = value as { data: unknown[]; nextCursor?: unknown };
+  const models = page.data.flatMap((entry): DiscoveredModel[] => {
+    if (!entry || typeof entry !== "object") return [];
+    const metadata = entry as Record<string, unknown>;
+    const modelId = typeof metadata.model === "string"
+      ? metadata.model
+      : typeof metadata.id === "string" ? metadata.id : null;
+    if (!modelId || metadata.hidden === true) return [];
+    return [{ modelId, rawMetadata: { ...metadata, source: "codex_cli_model_list" } }];
+  });
+  return {
+    models,
+    nextCursor: typeof page.nextCursor === "string" ? page.nextCursor : null,
+  };
+}
+
+export async function discoverCodexCliModels(providerId = "codex"): Promise<DiscoveredModel[]> {
+  const auth = await prepareCodexCliAuth(providerId);
+  const args = ["exec", "-i"];
+  if (auth.mode === "apikey") args.push("-e", "OPENAI_API_KEY");
+  args.push(SANDBOX_CONTAINER, "codex", "app-server", "--stdio");
+
+  return new Promise<DiscoveredModel[]>((resolve, reject) => {
+    const proc = lazyChildProcess().spawn("docker", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: auth.mode === "apikey"
+        ? { ...process.env, OPENAI_API_KEY: auth.apiKey }
+        : process.env,
+    });
+    let buffer = "";
+    let stderr = "";
+    let settled = false;
+    let nextId = 2;
+    const models: DiscoveredModel[] = [];
+    const finish = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      proc.stdin?.end();
+      proc.kill("SIGTERM");
+      if (err) reject(err); else resolve(models);
+    };
+    const send = (payload: unknown) => proc.stdin?.write(`${JSON.stringify(payload)}\n`);
+    const timer = setTimeout(
+      () => finish(new Error(`Codex model/list timed out after ${MODEL_LIST_TIMEOUT_MS / 1000}s`)),
+      MODEL_LIST_TIMEOUT_MS,
+    );
+
+    proc.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let message: { id?: number; result?: unknown; error?: unknown };
+        try { message = JSON.parse(line); } catch { continue; }
+        if (message.id === 1) {
+          send({ method: "initialized", params: {} });
+          send({ method: "model/list", id: nextId, params: { cursor: null, limit: 100 } });
+        } else if (message.id === nextId) {
+          if (message.error) return finish(new Error(`Codex model/list failed: ${JSON.stringify(message.error)}`));
+          try {
+            const page = parseCodexModelListPage(message.result);
+            models.push(...page.models);
+            if (page.nextCursor) {
+              nextId += 1;
+              send({ method: "model/list", id: nextId, params: { cursor: page.nextCursor, limit: 100 } });
+            } else {
+              finish();
+            }
+          } catch (err) {
+            finish(err instanceof Error ? err : new Error("Malformed Codex model/list response"));
+          }
+        }
+      }
+    });
+    proc.on("error", (err: Error) => finish(err));
+    proc.on("close", (code: number | null) => {
+      if (!settled) finish(new Error(`Codex app-server exited ${code ?? "?"}: ${stderr.slice(0, 300)}`));
+    });
+    send({
+      method: "initialize",
+      id: 1,
+      params: { clientInfo: { name: "dpf-model-catalog", version: "1.0.0" }, capabilities: {} },
+    });
+  });
+}

--- a/docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md
@@ -61,20 +61,14 @@ reconfirm the catalog.
 with the installed CLI/account while failing visibly when authoritative
 discovery is unavailable.
 
-- **AC-1:** `model/list` parsing admits current visible models such as
-  `gpt-6-astra`, preserves provider metadata, and excludes hidden entries.
-- **AC-2:** Codex discovery failure never falls back to `KNOWN_PROVIDER_MODELS`,
-  advances `lastSeenAt`, or records a successful scheduled refresh.
-- **AC-3:** authoritative absence uses the existing two-cycle retirement rule;
-  explicit unsupported-model stderr retires immediately as
-  `model_not_found`.
-- **AC-4:** stale Codex model pins clear only when an account-listed active
-  replacement exists; failure or an empty inventory leaves configuration
-  untouched.
-- **AC-5:** the Providers page reports the model-discovery job's real last run
-  and status.
-- **AC-6:** focused tests, graph-linked tests, production build, and a live
-  sandbox `model/list` probe pass.
+| Acceptance ID | Objective IDs | Acceptance statement |
+|---|---|---|
+| AC-1 | OBJ-CODEX-CATALOG-LIFECYCLE | `model/list` parsing admits current visible models such as `gpt-6-astra`, preserves provider metadata, and excludes hidden entries. |
+| AC-2 | OBJ-CODEX-CATALOG-LIFECYCLE | Codex discovery failure never falls back to `KNOWN_PROVIDER_MODELS`, advances `lastSeenAt`, or records a successful scheduled refresh. |
+| AC-3 | OBJ-CODEX-CATALOG-LIFECYCLE | Authoritative absence uses the existing two-cycle retirement rule; explicit unsupported-model stderr retires immediately as `model_not_found`. |
+| AC-4 | OBJ-CODEX-CATALOG-LIFECYCLE | Stale Codex model pins clear only when an account-listed active replacement exists; failure or an empty inventory leaves configuration untouched. |
+| AC-5 | OBJ-CODEX-CATALOG-LIFECYCLE | The Providers page reports the model-discovery job's real last run and status. |
+| AC-6 | OBJ-CODEX-CATALOG-LIFECYCLE | Focused tests, graph-linked tests, production build, and a live sandbox `model/list` probe pass. |
 
 ## Ordered implementation
 

--- a/docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md
@@ -23,6 +23,30 @@ models, their default marker, modalities, descriptions, and reasoning efforts.
 That is the existing adapter's true serving boundary; the ChatGPT/OpenAI HTTP
 catalog and DPF's known-model registry are not equivalent entitlement sources.
 
+The source baseline for this diagnosis is repository ref
+`9b434cd228002e326223ec6c3d7c07c445f73e28`:
+
+- `apps/web/lib/inference/ai-provider-internals.ts:1125-1161` documents and
+  implements the zero-result fallback from dynamic discovery to
+  `KNOWN_PROVIDER_MODELS`, including for Codex.
+- `apps/web/lib/inference/model-revalidation.ts:44-82` treats a resolved
+  `{ error }` result as a successful refresh because it does not inspect the
+  return value from `autoDiscoverAndProfile`.
+- `apps/web/lib/queue/functions/model-discovery-refresh.ts:47-58` consequently
+  records `ok` whenever the revalidation promise resolves.
+- `apps/web/app/(shell)/platform/ai/providers/page.tsx:149` projects the
+  provider-registry timestamp as catalog freshness.
+- `apps/web/lib/routing/codex-cli-adapter.ts:43-75` distinguishes auth and
+  rate-limit failures but has no unsupported-model classifier.
+
+The runtime observations were reproduced on deployed ref
+`3a98f9e879c20c14ab73b9aeb09cbab01982bc49`: the `ScheduledJob` row for
+`model-discovery-refresh` reported `ok`; Codex-discovered rows carried
+`rawMetadata.source=known_catalog`; `codex exec --model gpt-5.4` was rejected;
+and the same authenticated sandbox returned `gpt-6-astra`, `gpt-5.6-sol`,
+`gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, and
+`gpt-5.3-codex-spark` from `initialize` → `model/list`.
+
 ## Decision
 
 For the `codex` provider running through `codex-cli`, discovery SHALL query
@@ -94,14 +118,15 @@ the workforce.
 
 ## Research and benchmarking
 
-- **Codex CLI 0.153.4 app-server:** generated JSON schema and a live
+- **Codex CLI 0.153.4 app-server (chosen):** generated JSON schema and a live
   `initialize` → `model/list` exchange establish the current account-specific
   contract. Adopt as serving authority.
-- **OpenAI/ChatGPT HTTP catalogs:** already used by DPF for direct and ChatGPT
-  provider discovery, but rejected for Codex entitlement because the CLI
-  account surface demonstrably differs.
-- **DPF known-model catalog:** retain as bootstrap metadata for catalog-based
-  providers; reject as freshness evidence for a subscription CLI.
+- **OpenAI/ChatGPT HTTP catalogs (rejected):** already used by DPF for direct
+  and ChatGPT provider discovery, but rejected for Codex entitlement because
+  the CLI account surface demonstrably differs.
+- **DPF known-model catalog (rejected for Codex freshness):** retain as
+  bootstrap metadata for catalog-based providers; reject as freshness evidence
+  for a subscription CLI.
 
 ## Compatibility, risks, and rollback
 

--- a/docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md
@@ -1,0 +1,126 @@
+---
+status: active
+---
+
+# Codex model-catalog lifecycle — BI-067EE115
+
+**Epic:** EP-413F2602  
+**Extends:** `2026-09-01-codex-subscription-model-eligibility-design.md`
+
+## Problem and live evidence
+
+The daily `model-discovery-refresh` job can report `ok` while Codex discovery
+has fallen back to `KNOWN_PROVIDER_MODELS`. On 2026-09-08 the live job ran at
+03:10 and re-stamped `codex-mini-latest`, `gpt-5.3-codex`, and `gpt-5.4`
+with `rawMetadata.source=known_catalog`. Codex CLI 0.153.4 rejected forced
+`gpt-5.4` for the connected ChatGPT account, while an unpinned execution
+selected `gpt-6-astra`. Build Specialist and Change Reviewer remained pinned
+to `codex/gpt-5.4`, so the stale fallback became a repeated runtime failure.
+
+The installed CLI exposes the account-authoritative inventory through its
+app-server JSON-RPC `model/list` method. A live probe returned six visible
+models, their default marker, modalities, descriptions, and reasoning efforts.
+That is the existing adapter's true serving boundary; the ChatGPT/OpenAI HTTP
+catalog and DPF's known-model registry are not equivalent entitlement sources.
+
+## Decision
+
+For the `codex` provider running through `codex-cli`, discovery SHALL query
+`codex app-server` inside the same sandbox and with the same injected account
+credential used for inference. The returned `model/list` page is authoritative
+for that connection. Static known-model fallback remains available to providers
+whose contract is catalog-based, but it SHALL NOT refresh, reactivate, or report
+success for Codex subscription inventory.
+
+The result flows through the existing `DiscoveredModel`, `ModelProfile`,
+missed-discovery retirement, preference-finalization, and `ScheduledJob`
+contracts:
+
+1. A successful CLI list upserts returned models and reconciles absence.
+2. Two absent authoritative cycles retire a model using the existing counter.
+3. An explicit CLI unsupported-model response is classified as
+   `model_not_found`, causing immediate model retirement through the existing
+   fallback handler.
+4. Once a stale pin points at a retired/missing model and at least one freshly
+   listed active replacement exists, both pin fields are cleared. No replacement
+   is hard-pinned; normal capability and quality routing resumes.
+5. Per-provider failures are retained in the revalidation summary. A scheduled
+   run with any failed provider records `partial`, not `ok`.
+6. The Providers page's catalog freshness reads `model-discovery-refresh`,
+   rather than the unrelated provider-registry timestamp.
+
+The model-list call is the reachability proof for catalog admission: it is
+served by the installed CLI after account initialization and identifies the
+models that CLI will accept. Daily paid inference smoke calls are deliberately
+rejected because they spend capacity and can mutate provider limits merely to
+reconfirm the catalog.
+
+## Objective and acceptance
+
+**OBJ-CODEX-CATALOG-LIFECYCLE:** Keep Codex subscription routing synchronized
+with the installed CLI/account while failing visibly when authoritative
+discovery is unavailable.
+
+- **AC-1:** `model/list` parsing admits current visible models such as
+  `gpt-6-astra`, preserves provider metadata, and excludes hidden entries.
+- **AC-2:** Codex discovery failure never falls back to `KNOWN_PROVIDER_MODELS`,
+  advances `lastSeenAt`, or records a successful scheduled refresh.
+- **AC-3:** authoritative absence uses the existing two-cycle retirement rule;
+  explicit unsupported-model stderr retires immediately as
+  `model_not_found`.
+- **AC-4:** stale Codex model pins clear only when an account-listed active
+  replacement exists; failure or an empty inventory leaves configuration
+  untouched.
+- **AC-5:** the Providers page reports the model-discovery job's real last run
+  and status.
+- **AC-6:** focused tests, graph-linked tests, production build, and a live
+  sandbox `model/list` probe pass.
+
+## Ordered implementation
+
+1. Add failing parser/transport tests for paginated app-server `model/list`,
+   malformed output, timeout, and hidden models.
+2. Add failing discovery tests proving Codex cannot use static fallback and
+   that authoritative absence reaches the existing retirement reconciler.
+3. Add failing pin tests for retired, present, replacement-absent, and
+   non-Codex configurations.
+4. Add failing adapter classification tests for the observed `gpt-5.4`
+   unsupported-model response.
+5. Implement the thin app-server adapter, wire discovery/reconciliation, and
+   return per-provider revalidation outcomes.
+6. Bind the Providers freshness label to `model-discovery-refresh` and verify
+   the route without adding controls or visible prose.
+7. Run affected Vitest suites, typecheck/build and repository guards, then
+   verify the live app-server inventory from the canonical sandbox.
+
+All steps are one atomic fix: admitting the new list without retiring stale
+models leaves invalid endpoints; retiring without truthful job status preserves
+false success; clearing pins without an authoritative replacement can strand
+the workforce.
+
+## Research and benchmarking
+
+- **Codex CLI 0.153.4 app-server:** generated JSON schema and a live
+  `initialize` → `model/list` exchange establish the current account-specific
+  contract. Adopt as serving authority.
+- **OpenAI/ChatGPT HTTP catalogs:** already used by DPF for direct and ChatGPT
+  provider discovery, but rejected for Codex entitlement because the CLI
+  account surface demonstrably differs.
+- **DPF known-model catalog:** retain as bootstrap metadata for catalog-based
+  providers; reject as freshness evidence for a subscription CLI.
+
+## Compatibility, risks, and rollback
+
+No migration or new persistence concept is required. API-key/direct OpenAI,
+ChatGPT, Claude, Grok, and local-provider discovery remain unchanged. The main
+risk is app-server protocol drift; parsing is defensive, timeout-bounded, and
+turns drift into a visible partial refresh without modifying last-seen state or
+pins. Rollback is one PR revert; previously persisted model and configuration
+rows remain readable.
+
+## Documentation impact
+
+This design is the durable operator/developer contract. No user guide change is
+needed: the visible Providers page keeps the same layout and wording, but its
+date becomes truthful. No principle, route map, schema, migration, or
+AI-coworker prompt changes.


### PR DESCRIPTION
## Summary

- make the installed Codex CLI account's `model/list` response authoritative for the `codex` provider
- retire absent models through the existing two-cycle reconciliation and classify explicit unsupported-model errors as `model_not_found`
- clear stale Codex pins only when a freshly listed active replacement exists
- retain per-provider refresh outcomes, record mixed scheduled runs as `partial`, and show the discovery job's real freshness on Providers

Closes BI-067EE115.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md` and its predecessor `docs/superpowers/specs/2026-09-01-codex-subscription-model-eligibility-design.md`.
- Current code substrate reviewed: `codex-cli-adapter.ts`, `ai-provider-internals.ts`, `model-revalidation.ts`, `model-discovery-refresh.ts`, and the Providers page.
- Source of truth: the authenticated installed CLI's app-server `model/list` response for the connected account; existing `DiscoveredModel`, `ModelProfile`, pin configuration, and `ScheduledJob` rows remain the persistence substrate.
- Decision: remove static known-catalog fallback only for Codex CLI inventory, preserve existing reconciliation, and expose failure as `partial` without adding a table, migration, or new verification engine.

## Verification

- `pnpm --filter web exec vitest run lib/routing/codex-cli-model-catalog.test.ts lib/routing/codex-cli-adapter.test.ts lib/inference/ai-provider-internals.test.ts lib/inference/model-revalidation.test.ts lib/queue/functions/model-discovery-refresh.test.ts 'app/(shell)/platform/ai/providers/page.test.tsx' lib/inference/ollama-health.test.ts` — 7 files, 83 tests passed
- `pnpm --filter web typecheck` — passed
- `pnpm --filter web build` — passed
- `pnpm run pregate:preflight` — 66 guards passed
- `pnpm run pregate` — exact-tree merged-code gate passed in 6m19s
- Live sandbox probe: authenticated `codex app-server --stdio` `initialize` → `model/list` returned six visible account models, including `gpt-6-astra`
- Live UX: `/platform/ai/providers` rendered successfully with the existing Provider catalog status, layout, and controls; the change adds no visible copy or interaction

Local-CI-Evidence: cmttbgwmp33kd01qh63iq0bqd (fix/codex-model-catalog-lifecycle@98ae3cd70d20a048d1c3e65aa5545e364f8c3f74)

Docs-Impact-Decision: No user-facing copy, controls, or route shape changed; the existing catalog status now reads its owning discovery job.

Migration-Impact-Decision: No migration; this reuses existing model, pin, and scheduled-job fields.
