### PR TITLE
fix(ai): dispatch Codex catalog through canonical engine

### DIFF
--- a/apps/web/lib/inference/ai-provider-internals.test.ts
+++ b/apps/web/lib/inference/ai-provider-internals.test.ts
@@ -63,7 +63,8 @@ describe("Codex authoritative discovery", () => {
       providerId: "codex",
       authMethod: "oauth2_authorization_code",
       category: "agent",
-      cliEngine: "codex-cli",
+      // Canonical providers-registry.json and live ModelProvider value.
+      cliEngine: "codex",
     });
   });
 

--- a/apps/web/lib/inference/ai-provider-internals.ts
+++ b/apps/web/lib/inference/ai-provider-internals.ts
@@ -461,7 +461,7 @@ export async function discoverModelsInternal(
   const provider = await prisma.modelProvider.findUnique({ where: { providerId } });
   if (!provider) return { discovered: 0, newCount: 0, error: "Provider not found" };
 
-  if (providerId === "codex" && provider.cliEngine === "codex-cli") {
+  if (providerId === "codex" && provider.cliEngine === "codex") {
     try {
       const { discoverCodexCliModels } = await import("@/lib/routing/codex-cli-model-catalog");
       const models = await discoverCodexCliModels(providerId);


### PR DESCRIPTION
## Summary
- route Codex model discovery through the account-scoped app-server path for the canonical `cliEngine="codex"` registry value
- lock the production-shaped provider record into the authoritative-discovery regression test

## Design grounding
Grounded in `docs/superpowers/specs/2026-09-08-codex-model-catalog-lifecycle-design.md`. The code substrate reviewed was `packages/db/data/providers-registry.json`, the live `ModelProvider` row, `apps/web/lib/inference/ai-provider-internals.ts`, and the deployed `inference/model-discovery-refresh` job. Live verification showed the registry and database both use `cliEngine="codex"`; the prior `codex-cli` predicate fell through to the generic OpenAI models endpoint and returned HTTP 403.

## Verification
- affected Vitest: 4 files, 39 tests passed
- `pnpm --filter web build` passed
- merged-code pregate passed

## Documentation impact
No user-facing documentation change. This corrects an implementation predicate to the already-documented account-authoritative discovery contract; no route, control, schema, or policy changed.