### PR TITLE
fix(work): a fail-closed pause retries next cycle instead of locking forever

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2484,6 +2484,7 @@
         "who-may-coordinate-authority-and-a-gate-with-no-key",
         "concurrent-execution-and-recorded-state",
         "the-brief-and-what-advances-a-stage",
+        "failing-closed-is-not-the-same-as-locking",
         "related-references"
       ]
     },

--- a/apps/web/lib/work-management/drive-resolution.test.ts
+++ b/apps/web/lib/work-management/drive-resolution.test.ts
@@ -340,7 +340,7 @@ describe("resolveDrivePlan (BI-FCD639D9)", () => {
     const plan = resolveDrivePlan(baseInput({
       currentStageKey: "scan",
       receipts: [],
-      priorDrive: { action: "dispatch_agent", reason: "agent_stage", stageKey: "scan" },
+      priorDrive: { action: "dispatch_agent", reason: "agent_stage", stageKey: "scan", cycleKey: null },
     }));
     expect(plan.action).toBe("pause");
     expect(plan.reason).toBe("executor_writeback_unavailable");
@@ -357,7 +357,7 @@ describe("resolveDrivePlan (BI-FCD639D9)", () => {
       priorDrive: {
         action: "pause",
         reason: "executor_writeback_unavailable",
-        stageKey: "scan",
+        stageKey: "scan", cycleKey: null,
       },
     }));
     expect(plan.action).toBe("pause");
@@ -396,7 +396,7 @@ describe("resolveDrivePlan (BI-FCD639D9)", () => {
       priorDrive: {
         action: "pause",
         reason: "executor_writeback_unavailable",
-        stageKey: "scan",
+        stageKey: "scan", cycleKey: null,
       },
     }));
     expect(plan.action).toBe("dispatch_agent");

--- a/apps/web/lib/work-management/drive-resolution.ts
+++ b/apps/web/lib/work-management/drive-resolution.ts
@@ -24,6 +24,7 @@ import {
   type WorkroomShapeConformance,
   type WorkroomShapeConformanceDeviation,
 } from "./workroom-shape-conformance";
+import { writebackLatchHolds } from "./writeback-latch";
 import {
   EXECUTOR_WRITEBACK_UNAVAILABLE_REASON,
   WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND,
@@ -323,20 +324,17 @@ export function resolveDrivePlan(input: DriveResolutionInput): DrivePlan {
       receipt.stageKey === stage.key && receipt.kind === WORKROOM_DRIVE_BLOCKED_RECEIPT_KIND,
   );
   const prior = input.priorDrive;
-  const alreadyTriedWriteback = Boolean(
-    !completing
-    && (
-      blocked
-      || (
-        prior
-        && prior.stageKey === stage.key
-        && (
-          prior.action === "dispatch_agent"
-          || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE_REASON
-        )
-      )
-    ),
-  );
+  // Bounded, not permanent: the latch holds within a cycle and releases on the
+  // next, so a deployed fix can reach a room that previously failed closed.
+  // Without this the pause reason re-triggers the pause and the room is locked
+  // forever (12 of 24 rooms on this install were).
+  const alreadyTriedWriteback = !completing
+    && writebackLatchHolds({
+      prior: prior ?? null,
+      stageKey: stage.key,
+      currentCycleKey: cycle?.cycleKey ?? null,
+      blocked,
+    });
   if (alreadyTriedWriteback) {
     return {
       action: "pause",

--- a/apps/web/lib/work-management/workroom-drive-receipts.ts
+++ b/apps/web/lib/work-management/workroom-drive-receipts.ts
@@ -11,6 +11,9 @@ export type PriorWorkroomDrive = {
   action: string;
   reason: string;
   stageKey: string | null;
+  /** The cycle the prior tick belonged to; bounds the writeback latch so a
+   *  fail-closed pause is retried next cycle rather than held forever. */
+  cycleKey: string | null;
 };
 
 export function isCompletingWorkroomDriveReceipt(

--- a/apps/web/lib/work-management/workroom-drive-state.test.ts
+++ b/apps/web/lib/work-management/workroom-drive-state.test.ts
@@ -20,6 +20,7 @@ describe("readStoredWorkroomDriveState", () => {
       reviewDue: true,
       lastAction: null,
       lastReason: null,
+      lastCycleKey: null,
     });
   });
 
@@ -32,6 +33,7 @@ describe("readStoredWorkroomDriveState", () => {
       reviewDue: false,
       lastAction: null,
       lastReason: null,
+      lastCycleKey: null,
     });
   });
 
@@ -47,6 +49,7 @@ describe("readStoredWorkroomDriveState", () => {
       currentStageKey: "scan",
       lastAction: "dispatch_agent",
       lastReason: "agent_stage",
+      lastCycleKey: null,
     });
   });
 });

--- a/apps/web/lib/work-management/workroom-drive-state.ts
+++ b/apps/web/lib/work-management/workroom-drive-state.ts
@@ -9,6 +9,9 @@ export type StoredWorkroomDriveState = {
   reviewDue: boolean;
   lastAction: string | null;
   lastReason: string | null;
+  /** The cycle the last tick belonged to. The writeback latch is bounded by it,
+   *  so a room can retry once per cycle instead of locking forever. */
+  lastCycleKey: string | null;
 };
 
 /** Read only verifier-relevant observations from the persisted runner snapshot. */
@@ -41,6 +44,7 @@ export function readStoredWorkroomDriveState(workspaceState: unknown): StoredWor
     reviewDue: drive?.reviewDue === true,
     lastAction: typeof drive?.action === "string" ? drive.action : null,
     lastReason: typeof drive?.reason === "string" ? drive.reason : null,
+    lastCycleKey: typeof drive?.lastCycleKey === "string" ? drive.lastCycleKey : null,
   };
 }
 
@@ -50,5 +54,6 @@ export function priorDriveFromStored(stored: StoredWorkroomDriveState): PriorWor
     action: stored.lastAction,
     reason: stored.lastReason ?? "",
     stageKey: stored.currentStageKey,
+    cycleKey: stored.lastCycleKey,
   };
 }

--- a/apps/web/lib/work-management/writeback-latch.test.ts
+++ b/apps/web/lib/work-management/writeback-latch.test.ts
@@ -1,0 +1,211 @@
+// A fail-closed pause must not be a permanent lock (BI-WRITEBACK-LATCH).
+//
+// #5166 correctly stopped the re-dispatch loop: a stage that produced no
+// completing receipt pauses instead of being dispatched again every 15 minutes.
+// But the latch is self-sustaining —
+//
+//   alreadyTriedWriteback = ... || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE
+//
+// — so once a room pauses for this reason, the NEXT tick sees that same reason
+// and pauses again, forever. The only exit is a completing receipt, which can
+// never arrive because the room never dispatches again to produce one.
+//
+// Observed on this install: 12 of 24 rooms locked on
+// executor_writeback_unavailable, unable to recover even after the defect that
+// caused the empty writeback was fixed and deployed. A deploy that fixes the
+// cause cannot reach a room that will not try again.
+//
+// The fix keeps the capacity protection and bounds the retry: the latch holds
+// WITHIN a cycle, and a new cycle grants one fresh attempt. That is one attempt
+// per day per room instead of the 96 the guard was built to stop.
+
+import { describe, expect, it } from "vitest";
+
+import { writebackLatchHolds } from "./writeback-latch";
+
+const CYCLE_A = "dependency-advisory-watch@1.0.0:2026-09-08";
+const CYCLE_B = "dependency-advisory-watch@1.0.0:2026-09-09";
+
+describe("writebackLatchHolds", () => {
+  it("holds within the same cycle after a dispatch produced no receipt", () => {
+    // The behaviour #5166 added, preserved exactly.
+    expect(
+      writebackLatchHolds({
+        prior: { action: "dispatch_agent", reason: "agent_stage", stageKey: "sweep", cycleKey: CYCLE_A },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_A,
+        blocked: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("holds within the same cycle after a previous writeback pause", () => {
+    expect(
+      writebackLatchHolds({
+        prior: {
+          action: "pause",
+          reason: "executor_writeback_unavailable",
+          stageKey: "sweep",
+          cycleKey: CYCLE_A,
+        },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_A,
+        blocked: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("RELEASES on a new cycle, so a deployed fix can actually reach the room", () => {
+    // The defect this closes. Without it, twelve rooms stay locked forever and
+    // no amount of fixing the executor helps.
+    expect(
+      writebackLatchHolds({
+        prior: {
+          action: "pause",
+          reason: "executor_writeback_unavailable",
+          stageKey: "sweep",
+          cycleKey: CYCLE_A,
+        },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_B,
+        blocked: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("still holds on a new cycle when the stage carries a blocked receipt", () => {
+    // A recorded `blocked` receipt is a deliberate, durable statement about THIS
+    // stage — stronger than the prior-tick heuristic, and not time-bounded.
+    expect(
+      writebackLatchHolds({
+        prior: null,
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_B,
+        blocked: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not latch on a different stage's prior attempt", () => {
+    expect(
+      writebackLatchHolds({
+        prior: {
+          action: "pause",
+          reason: "executor_writeback_unavailable",
+          stageKey: "raise",
+          cycleKey: CYCLE_A,
+        },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_A,
+        blocked: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not latch with no prior drive at all", () => {
+    expect(
+      writebackLatchHolds({ prior: null, stageKey: "sweep", currentCycleKey: CYCLE_A, blocked: false }),
+    ).toBe(false);
+  });
+
+  it("holds when the cycle key is unknown, preferring the safe side", () => {
+    // An unknown cycle must not be read as "a new cycle" and silently re-open
+    // the loop the guard exists to prevent.
+    expect(
+      writebackLatchHolds({
+        prior: {
+          action: "pause",
+          reason: "executor_writeback_unavailable",
+          stageKey: "sweep",
+          cycleKey: null,
+        },
+        stageKey: "sweep",
+        currentCycleKey: null,
+        blocked: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not latch after a prior tick that neither dispatched nor blocked", () => {
+    expect(
+      writebackLatchHolds({
+        prior: { action: "pause", reason: "conformance_pause", stageKey: "sweep", cycleKey: CYCLE_A },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_A,
+        blocked: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+// ─── End-to-end release, through the real resolver ───────────────────────────
+//
+// The unit tests above exercise the predicate. This one proves the wiring: a
+// room latched in a previous cycle actually dispatches again through
+// resolveDrivePlan. Without it the predicate could be correct and unreachable —
+// the failure mode this codebase keeps producing.
+
+describe("the latch releases through resolveDrivePlan", () => {
+  it("re-dispatches a room whose writeback pause belongs to an earlier cycle", async () => {
+    const { resolveDrivePlan } = await import("./drive-resolution");
+    const { STANDING_SHAPES } = await import("./standing-operations-shapes");
+    const { readWorkShapeDefinitionContract } = await import("./work-shapes");
+    const shape = STANDING_SHAPES["dependency-advisory-watch"];
+    const definition = readWorkShapeDefinitionContract(shape);
+
+    const base = {
+      roomId: "WC-A69BCABB",
+      definition,
+      postureLevel: "balanced" as const,
+      collaborationShape: shape.collaborationShape ?? null,
+      participants: [
+        {
+          workroomId: "r1",
+          principalRef: "PRN-SEC",
+          displayName: "security-engineer",
+          kind: "agent" as const,
+          roles: ["coordinator"],
+          assignmentSource: "explicit",
+          coordinatorSource: "explicit" as const,
+          enteredReason: null,
+          currentWorkSummary: null,
+          sponsorPrincipalRef: null,
+          sponsorDisplayName: null,
+          authoritySummary: "",
+        },
+      ],
+      currentStageKey: "sweep",
+      receipts: [],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      substrateReachable: true,
+      substrateEmpty: false,
+      coordinatorEligibility: { jsi: "not-applicable" as const, authorityBinding: "eligible" as const },
+      now: new Date("2026-09-09T10:00:00Z"),
+    };
+
+    const stuck = resolveDrivePlan({
+      ...base,
+      priorDrive: {
+        action: "pause",
+        reason: "executor_writeback_unavailable",
+        stageKey: "sweep",
+        cycleKey: "dependency-advisory-watch@1.0.0:2026-09-09",
+      },
+    } as never);
+    expect(stuck.reason).toBe("executor_writeback_unavailable");
+
+    const released = resolveDrivePlan({
+      ...base,
+      priorDrive: {
+        action: "pause",
+        reason: "executor_writeback_unavailable",
+        stageKey: "sweep",
+        // Yesterday. This is the twelve locked rooms on this install.
+        cycleKey: "dependency-advisory-watch@1.0.0:2026-09-08",
+      },
+    } as never);
+    expect(released.reason).not.toBe("executor_writeback_unavailable");
+  });
+});

--- a/apps/web/lib/work-management/writeback-latch.ts
+++ b/apps/web/lib/work-management/writeback-latch.ts
@@ -1,0 +1,57 @@
+// When a fail-closed pause may be retried (BI-WRITEBACK-LATCH).
+//
+// #5166 stopped a real defect: a stage that produced no completing receipt was
+// re-dispatched every 15 minutes, burning model capacity on work that never
+// completed. Pausing instead was right.
+//
+// The latch it introduced is self-sustaining, though — the pause reason is
+// itself one of the conditions that causes the pause — so a room that enters
+// this state never leaves it. On this install that locked 12 of 24 rooms, and
+// they stayed locked after the executor defect was fixed and deployed: a fix
+// cannot reach a room that will not try again.
+//
+// So the latch is bounded rather than permanent. It holds WITHIN a cycle and
+// releases on the next one, giving one attempt per cycle — daily, for these
+// shapes — instead of the 96 per day the guard was built to stop. The capacity
+// protection is kept (a 96x reduction); the deadlock is not.
+
+import { EXECUTOR_WRITEBACK_UNAVAILABLE_REASON } from "./workroom-drive-receipts";
+
+export type PriorDriveForLatch = {
+  action: string;
+  reason: string;
+  stageKey: string | null;
+  /** The cycle the prior tick belonged to. Null when unknown. */
+  cycleKey: string | null;
+};
+
+/**
+ * Whether the writeback latch still holds for this stage.
+ *
+ * A recorded `blocked` receipt holds unconditionally: it is a durable statement
+ * about this stage rather than an inference from the previous tick, and nothing
+ * here should override it.
+ *
+ * An unknown cycle on either side holds too. Treating "unknown" as "a new cycle"
+ * would silently re-open the every-tick loop the guard exists to prevent.
+ */
+export function writebackLatchHolds(input: {
+  prior: PriorDriveForLatch | null;
+  stageKey: string;
+  currentCycleKey: string | null;
+  blocked: boolean;
+}): boolean {
+  if (input.blocked) return true;
+  const prior = input.prior;
+  if (!prior) return false;
+  if (prior.stageKey !== input.stageKey) return false;
+
+  const triedWriteback =
+    prior.action === "dispatch_agent" || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE_REASON;
+  if (!triedWriteback) return false;
+
+  // Same cycle — or an unknown one — keeps the latch. A genuinely new cycle
+  // releases it for exactly one fresh attempt.
+  if (prior.cycleKey === null || input.currentCycleKey === null) return true;
+  return prior.cycleKey === input.currentCycleKey;
+}

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -726,6 +726,41 @@ stage. Concurrent completing receipts in the same cycle are preserved.
 schema/handler parity guard protects it — the same seam already shipped broken
 once when `workShape` was advertised and silently dropped.
 
+## Failing closed is not the same as locking
+
+`#5166` stopped a real defect: a stage that produced no completing receipt was
+re-dispatched every fifteen minutes, burning model capacity on work that never
+completed. Pausing instead of re-dispatching was correct.
+
+The latch it introduced was self-sustaining, though — the pause reason is itself
+one of the conditions that produces the pause:
+
+    alreadyTriedWriteback = ... || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE
+
+so a room that entered the state never left it. The only exit is a completing
+receipt, and a room that never dispatches can never produce one. On this install
+that locked **12 of 24 rooms**, and they stayed locked after the defect causing
+the empty writeback was fixed and deployed. **A fix cannot reach a room that will
+not try again.**
+
+The latch is now bounded rather than permanent: it holds **within** a cycle and
+releases on the next, giving one attempt per cycle — daily for these shapes —
+instead of the 96 per day the guard was built to stop. The capacity protection is
+kept almost entirely (a 96x reduction); the deadlock is not.
+
+Two cases deliberately still hold unconditionally:
+
+- **A recorded `blocked` receipt.** That is a durable statement about the stage,
+  not an inference from the previous tick, and a cycle rollover should not erase
+  it.
+- **An unknown cycle key on either side.** Reading "unknown" as "a new cycle"
+  would silently re-open the every-tick loop.
+
+The general lesson is worth stating plainly, because it applies to any
+fail-closed guard: a guard whose own output re-triggers its input has no
+recovery path, and the estate it protects can only degrade. Bound the latch to
+something that changes on its own.
+
 ## Related references
 
 - [Workroom vocabulary boundary](workroom-vocabulary-boundary.md) — what the word means at each layer


### PR DESCRIPTION
## A fix cannot reach a room that will not try again

`#5166` stopped a real defect: a stage producing no completing receipt was re-dispatched every fifteen minutes, burning capacity on work that never completed. Pausing was correct.

The latch it introduced is **self-sustaining** — the pause reason is itself one of the conditions that produces the pause:

```ts
alreadyTriedWriteback = ... || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE
```

So a room entering that state never leaves it. The only exit is a completing receipt, and a room that never dispatches cannot produce one.

**Measured on this install: 12 of 24 rooms locked**, and they stayed locked after the defect causing the empty writeback was fixed and deployed in #5213. The deploy was real and verified in the lineage; the rooms simply never re-dispatched to receive it.

```
executor_writeback_unavailable   12
conformance_pause                 9
attention                         2
escalate                          1
dispatching                       0
```

## The fix

The latch is **bounded, not permanent**: it holds within a cycle and releases on the next — one attempt per cycle, daily for these shapes, instead of the 96 per day the guard was built to stop. That keeps a **96× capacity reduction** while removing the deadlock.

Two cases deliberately still hold unconditionally:

- **A recorded `blocked` receipt** — a durable statement about the stage, not an inference from the previous tick. A cycle rollover must not erase it.
- **An unknown cycle key on either side** — reading "unknown" as "a new cycle" would silently re-open the loop.

## The general lesson

A guard whose own output re-triggers its input has no recovery path, and the estate it protects can only degrade. Bind the latch to something that changes on its own. Documented as such, because it applies to any fail-closed guard in this codebase.

## Verification

- 66 pregate preflight guards clean
- **28,986 tests pass** (3,295 files) — 9 new
- `tsc --noEmit`: exit 0
- The end-to-end test drives the **real resolver**, not the predicate alone: a room latched in yesterday's cycle actually re-dispatches. A correct predicate that nothing calls is the failure mode this program keeps producing, so the release path is asserted through the code that runs in production.

**The heavy local-CI build was NOT run and is NOT passed** — fenced on `host-capacity-lost:host-memory-low`. Recorded `operator-emergency` override; cloud merge queue is the adjudicating build per AGENTS.md §4.

Local-CI-Override: operator-emergency: heavy build unrun (NOT passed) — local-CI fenced on host-capacity-lost:host-memory-low. Fast tier clean (66 preflight guards, 28986 tests, tsc --noEmit exit 0). Cloud merge queue is the adjudicating build per AGENTS.md 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
