### PR TITLE
fix(mcp): check in the tier=full bootstrap URL the standard already requires

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "dpf": {
       "type": "http",
-      "url": "http://127.0.0.1:3000/api/mcp/v1",
+      "url": "http://127.0.0.1:3000/api/mcp/v1?tier=full",
       "headers": {
         "Authorization": "Bearer ${DPF_MCP_BEARER_TOKEN}"
       }


### PR DESCRIPTION
The repository contradicted its own standard.

`docs/architecture/context-engineering-standards.md` P4 states that Claude Code and Codex use explicit `?tier=full` bootstrap URLs, and that the explicit URL is **required** because current Codex HTTP requests omit User-Agent and its top-level registry does not refresh after `list_changed`. The checked-in `.mcp.json` did not carry it.

## What goes wrong without it

`defaultTierForClient` identifies a client by User-Agent. Codex sends none, so it cannot be matched and falls back to the lean core tier — roughly 30 tools instead of the authorized catalogue, with no signal to the session that anything is missing.

## This is a restoration, not a new decision

The line existed as an uncommitted edit in the shared clone. **I reverted it earlier today on my own mistaken reading:** I concluded from `defaultTierForClient` that `full` was already the default for these clients and the parameter was pure cost. That is true for Claude Code, which does send a matching User-Agent. It is false for Codex, which is the case the standard was written for.

Committing it stops the line living only in a working tree, one careless revert away from silently narrowing every Codex session on the install — which is exactly what my revert did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
