### PR TITLE
feat(ui): operator break-glass clearance-override panel (BI-FA412D44)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -20,6 +20,8 @@ import { AiProviderFinancePanel } from "@/components/finance/AiProviderFinancePa
 import { getAiProviderFinanceDetail } from "@/lib/finance/ai-provider-finance";
 import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
 import { ProviderAccountPostureForm } from "@/components/platform/ProviderAccountPostureForm";
+import { ProviderClearanceOverridePanel } from "@/components/platform/ProviderClearanceOverridePanel";
+import { listActiveProviderClearanceOverrides } from "@/lib/actions/provider-clearance-override";
 import { ProviderTrustEvidencePanel } from "@/components/platform/ProviderTrustEvidencePanel";
 import { PROVIDER_TRUST_CLAIM_KEYS, resolveProviderTrustEvidence, type ProviderTrustClaimKey } from "@/lib/routing/provider-suitability/evidence";
 import { connectionPosture, loadBusinessSuitabilityContext, providerCatalogFacts } from "@/lib/routing/provider-suitability/provider-onboarding-data";
@@ -135,6 +137,11 @@ export default async function ProviderDetailPage({ params }: Props) {
   const user = session?.user;
   const canWrite = !!user && can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_provider_connections");
   const showPosture = shouldShowProviderAccountPosture(providerId, pw.provider.endpointType);
+  // Break-glass overrides (BI-FA412D44) — operator-only read; empty for everyone
+  // else and on any error, so a read-only viewer never triggers the capability throw.
+  const clearanceOverrides = canWrite
+    ? await listActiveProviderClearanceOverrides(providerId).catch(() => [])
+    : [];
 
   // Fetch hardware info for local providers via Neo4j InfraCI.
   // Wrapped in try/catch — Neo4j is best-effort; a graph error must never crash the page.
@@ -271,6 +278,12 @@ export default async function ProviderDetailPage({ params }: Props) {
               actions={connectionReview?.actions ?? []}
             />
           )}
+          <ProviderClearanceOverridePanel
+            providerId={providerId}
+            canWrite={canWrite}
+            genuinelyCleared={(pw.provider.sensitivityClearance ?? []) as string[]}
+            overrides={clearanceOverrides}
+          />
           {/* BI-87D93A71 (Minimum): surface OAuth callback port mismatch
               BEFORE the user clicks Connect — eliminates the silent
               :3000 → :1455 origin divergence that the shared OpenAI

--- a/apps/web/components/platform/ProviderClearanceOverridePanel.tsx
+++ b/apps/web/components/platform/ProviderClearanceOverridePanel.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Surface } from "@/components/ui/Surface";
+import { Button } from "@/components/ui/Button";
+import {
+  grantProviderClearanceOverride,
+  revokeProviderClearanceOverride,
+  type ClearanceOverrideView,
+} from "@/lib/actions/provider-clearance-override";
+
+// Break-glass panel (BI-FA412D44). Distinct from the attestation form on purpose:
+// attestation asserts the account IS safe; an override records that it is NOT and
+// that we accept the exposure. Defaults off; the education lives on the ack step.
+
+const OVERRIDABLE = ["internal", "confidential", "restricted"] as const;
+type Overridable = (typeof OVERRIDABLE)[number];
+
+function defaultExpiryValue(): string {
+  const d = new Date(Date.now() + 30 * 86_400_000);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function riskStatement(providerId: string, levels: string[]): string {
+  const list = levels.length ? levels.join(", ") : "the selected";
+  return (
+    `I understand this lets "${providerId}" — not verified safe for ${list} data ` +
+    `(no confirmed no-training agreement) — receive ${list} work, and I accept the exposure.`
+  );
+}
+
+export function ProviderClearanceOverridePanel({
+  providerId,
+  canWrite,
+  genuinelyCleared,
+  overrides,
+}: {
+  providerId: string;
+  canWrite: boolean;
+  genuinelyCleared: string[];
+  overrides: ClearanceOverrideView[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [selected, setSelected] = useState<Set<Overridable>>(new Set());
+  const [rationale, setRationale] = useState("");
+  const [expiresAt, setExpiresAt] = useState<string>("");
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const cleared = useMemo(() => new Set(genuinelyCleared), [genuinelyCleared]);
+  const offerable = OVERRIDABLE.filter((level) => !cleared.has(level));
+  const selectedLevels = [...selected];
+
+  function toggle(level: Overridable) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      return next;
+    });
+  }
+
+  function submit() {
+    setMessage(null);
+    const expiryIso = expiresAt ? new Date(expiresAt).toISOString() : "";
+    startTransition(async () => {
+      const res = await grantProviderClearanceOverride({
+        providerId,
+        acceptedSensitivities: selectedLevels,
+        rationale,
+        acknowledgedRisk: riskStatement(providerId, selectedLevels),
+        acknowledged,
+        expiresAt: expiryIso,
+      });
+      if (res.error) {
+        setMessage(res.error);
+        return;
+      }
+      setSelected(new Set());
+      setRationale("");
+      setExpiresAt("");
+      setAcknowledged(false);
+      setShowForm(false);
+      router.refresh();
+    });
+  }
+
+  function revoke(overrideId: string) {
+    setMessage(null);
+    startTransition(async () => {
+      const res = await revokeProviderClearanceOverride({ overrideId });
+      if (res.error) setMessage(res.error);
+      else router.refresh();
+    });
+  }
+
+  const canSubmit =
+    canWrite && !pending && selectedLevels.length > 0 && rationale.trim().length >= 10 && !!expiresAt && acknowledged;
+
+  return (
+    <Surface
+      as="section"
+      level={1}
+      padding="md"
+      rounded="lg"
+      aria-labelledby="clearance-override-heading"
+      className="mb-4 border border-[var(--dpf-warning)] bg-[var(--dpf-warning-surface)]"
+    >
+      <h3 id="clearance-override-heading" className="text-dpf-heading text-[var(--dpf-warning-text)]">
+        Break-glass: accept the risk of using this provider for sensitive work
+      </h3>
+      <p className="mt-1 text-dpf-caption text-[var(--dpf-warning-text)]">
+        This is <strong>not</strong> an attestation. Use the account-posture form above if the account genuinely has a
+        no-training agreement, or run a capable local model. An override records that this provider is <strong>not</strong>{" "}
+        verified safe and that you accept the exposure. Overrides default off, are audited, expire, and can be revoked.
+      </p>
+
+      {overrides.length > 0 && (
+        <div className="mt-3">
+          <div className="text-dpf-caption text-[var(--dpf-muted)] uppercase tracking-wide">Active overrides</div>
+          <ul className="mt-1 space-y-2">
+            {overrides.map((o) => (
+              <li key={o.overrideId}>
+                <Surface
+                  level={1}
+                  padding="sm"
+                  rounded="md"
+                  className="flex items-start justify-between gap-3 border border-[var(--dpf-border)]"
+                >
+                  <div className="text-dpf-caption text-[var(--dpf-text)]">
+                    <div>
+                      <strong>{o.acceptedSensitivities.join(", ")}</strong> — expires {new Date(o.expiresAt).toLocaleString()}
+                    </div>
+                    <div className="text-[var(--dpf-muted)]">
+                      {o.rationale} · accepted by {o.approverRef ?? "unknown"}
+                    </div>
+                  </div>
+                  {canWrite && (
+                    <Button variant="danger" size="sm" onClick={() => revoke(o.overrideId)} disabled={pending}>
+                      Revoke
+                    </Button>
+                  )}
+                </Surface>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {canWrite && offerable.length > 0 && (
+        <div className="mt-3">
+          {!showForm ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setShowForm(true);
+                setExpiresAt(defaultExpiryValue());
+              }}
+            >
+              Accept risk / add an override…
+            </Button>
+          ) : (
+            <Surface level={1} padding="sm" rounded="md" className="border border-[var(--dpf-warning)]">
+              <fieldset>
+                <legend className="text-dpf-caption text-[var(--dpf-muted)] uppercase tracking-wide">
+                  Sensitivities to risk-accept
+                </legend>
+                <div className="mt-1 flex flex-wrap gap-3">
+                  {offerable.map((level) => (
+                    <label key={level} className="flex items-center gap-1.5 text-dpf-caption text-[var(--dpf-text)]">
+                      <input type="checkbox" checked={selected.has(level)} onChange={() => toggle(level)} />
+                      {level}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              <label className="mt-3 block text-dpf-caption text-[var(--dpf-text)]">
+                Justification (why accept this risk?)
+                <textarea
+                  value={rationale}
+                  onChange={(e) => setRationale(e.target.value)}
+                  rows={2}
+                  className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-dpf-caption text-[var(--dpf-text)]"
+                  placeholder="At least 10 characters — recorded in the audit trail."
+                />
+              </label>
+
+              <label className="mt-3 block text-dpf-caption text-[var(--dpf-text)]">
+                Expires
+                <input
+                  type="datetime-local"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                  className="mt-1 block rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-1.5 text-dpf-caption text-[var(--dpf-text)]"
+                />
+              </label>
+
+              {selectedLevels.length > 0 && (
+                <label className="mt-3 flex items-start gap-2 text-dpf-caption text-[var(--dpf-warning-text)]">
+                  <input
+                    type="checkbox"
+                    checked={acknowledged}
+                    onChange={(e) => setAcknowledged(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>{riskStatement(providerId, selectedLevels)}</span>
+                </label>
+              )}
+
+              <div className="mt-3 flex items-center gap-2">
+                <Button variant="danger" size="sm" onClick={submit} disabled={!canSubmit}>
+                  {pending ? "Saving…" : "Accept risk & save override"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowForm(false);
+                    setMessage(null);
+                  }}
+                  disabled={pending}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </Surface>
+          )}
+        </div>
+      )}
+
+      {canWrite && offerable.length === 0 && overrides.length === 0 && (
+        <p className="mt-3 text-dpf-caption text-[var(--dpf-muted)]">
+          This provider is already cleared for internal, confidential, and restricted work — no override is needed.
+        </p>
+      )}
+
+      {message && <p className="mt-2 text-dpf-caption text-[var(--dpf-error-text)]">{message}</p>}
+    </Surface>
+  );
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10997,6 +10997,7 @@
         "how-oauth-works",
         "choosing-the-right-method",
         "business-safe-review",
+        "break-glass-accepting-a-risk-on-purpose",
         "openrouter-and-other-router-accounts",
         "finance-bridge",
         "where-to-review-it",

--- a/docs/user-guide/ai-workforce/connecting-providers.md
+++ b/docs/user-guide/ai-workforce/connecting-providers.md
@@ -136,6 +136,29 @@ technical boundaries DPF applies to clinical, financial, legal,
 criminal-justice, safety, youth, employee, source-code, credential, customer,
 and unknown governed data before provider selection.
 
+### Break-glass: accepting a risk on purpose
+
+Attestation above says an account *is* contractually safe. Sometimes an
+organization instead wants to knowingly proceed on an account that is **not**
+verified safe — an acceptable risk, made with eyes open. The provider detail
+page has a separate, warning-toned **Accept risk / add an override** panel for
+exactly that. It is deliberately not the attestation form: attestation records
+that the account is protected; an override records that it is **not**, and that
+you accept the exposure anyway.
+
+An override is operator-only, defaults off, and is never the path of least
+resistance — the attested-account and capable-local-model paths remain the
+recommended answers. To create one, you pick the specific sensitivities to
+accept (only those the provider is not already cleared for), type a
+justification, set a required expiry, and check an acknowledgment that states
+the exact risk. The decision is audited (who accepted, when, scope, the frozen
+risk text), listed on the page, and revocable with one click; revoking restores
+the block. Routing then permits that provider for those sensitivities until the
+override expires or is revoked — without changing what the provider is genuinely
+cleared for. Without an override, a coworker whose only cleared provider is a
+too-weak local model is told plainly why it cannot answer, rather than being
+routed onto an uncleared provider.
+
 ### OpenRouter and other router accounts
 
 A router connection is two trust decisions: the OpenRouter account and the underlying provider that actually handles the request. For public work, DPF may use normal price or latency routing. For private or regulated work, DPF requires an explicit underlying-provider allowlist, disables unbounded fallback, requests parameter-compatible endpoints, enables Zero Data Retention, denies provider data collection, and requires returned router metadata before releasing the answer.

--- a/docs/ux-fit/2026-09-08-break-glass-override-panel.ux-fit.json
+++ b/docs/ux-fit/2026-09-08-break-glass-override-panel.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "progressive-disclosure",
+  "decisionInteractionId": "DI-C474E1BD0F07",
+  "scope": {
+    "files": [
+      "apps/web/components/platform/ProviderClearanceOverridePanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "progressive-disclosure",
+      "always-expanded",
+      "separate-route"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -7327,6 +7327,14 @@
     "longSentences": 0,
     "textMass": 137
   },
+  "apps/web/components/platform/ProviderClearanceOverridePanel.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 81
+  },
   "apps/web/components/platform/ProviderCostSourcePanel.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,
@@ -7485,7 +7493,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 60
+    "textMass": 38
   },
   "apps/web/components/platform/TokenSpendPanel.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Increment 2 of **BI-4512E7D2** — the operator UI for the break-glass informed-risk override. The backend spine merged in #4948; this is the human surface that makes it usable, and the last-mile deliverable of the override capability.

## What
An operator-only break-glass panel on the provider detail page (`platform/ai/providers/[providerId]`):
- **Warning-toned, distinct from attestation** — attestation asserts the account *is* safe; this records that it is **not** and that you accept the exposure. Copy makes the asymmetry explicit.
- **Progressive disclosure** — collapsed behind an "Accept risk…" button so the default provider view stays uncluttered (chosen over always-expanded / separate-route via `principle_decide` DI-C474E1BD0F07, verdict *proceed*).
- Offers **only the sensitivities the provider is not already genuinely cleared for**; requires a typed justification, a required expiry, and an explicit acknowledgment of the specific risk before it will grant.
- Lists active overrides with **one-click revoke**; reads them operator-only (empty on any error, so a read-only viewer never trips the capability check).
- Composes the spine's `grant`/`revoke`/`list` server actions — **no new contract**.

## Quality gates
- Composes the shared **`Surface` + `Button`** primitives and the **`text-dpf-*`** type scale (UX-primitive-adoption + style-drift green); theme-aware via `--dpf-*` tokens.
- **UX-Fit manifest** committed (`docs/ux-fit/2026-09-08-break-glass-override-panel.ux-fit.json`, propose-n-pick).
- **User-guide documented** — `connecting-providers.md` gains a "Break-glass: accepting a risk on purpose" section (docs-impact + spec-plan-doc green).
- **Local-CI sandbox gate passed** — full production build (compiled in 2.3min) + tests + UX Route Sweep, evidence `cmttei7bq163c`, gated sha `7dfd09f8`. Typecheck clean.

Design-Grounding-Decision recorded in the commit; Convergence-Impact-Decision: auto-converges (portal route/component — ships in the next portal image via self-upgrade, no operator action, no data migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)