### PR TITLE
docs: apply workroom learning references to JSI and PAAW

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1748,6 +1748,7 @@
         "four-portfolio-archetype-standard-profile-catalog",
         "1-purpose",
         "2-facet-registry",
+        "cross-workroom-review-application-informative",
         "21-commercial-and-public-value-facets",
         "22-delivery-topology-facets",
         "23-resource-asset-and-custody-facets",

--- a/docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md
+++ b/docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md
@@ -927,6 +927,21 @@ outcomes.
 
 ### 9.6 Proposed competence-evolution Workroom application profile
 
+**Informative cross-workroom application.** The
+[cross-workroom review design](../superpowers/specs/2026-09-06-cross-workroom-learning-review-design.md)
+applies this profile across occurrences. Its proposed common contract preserves event evidence,
+review cursors, effective profile versions, accountable ownership and the next safe action before
+an executor is replaced. Source, activity-shape, facet, category, leaf and organization overlays
+add their applicable obligations without silently removing common ones. An unexercised definition
+is reported separately from an observed successful occurrence.
+
+The proposed operating cadence captures evidence at consequential transitions, reviews daily
+deltas and assesses weekly trends; domain deadlines and seasonal opportunity windows refine it.
+Every accepted lesson links the original evidence, triage decision, existing delivery owner,
+changed method/profile version and independent subsequent assessment. A completed task, merged
+change or scheduled review alone does not establish benefit. This application note introduces no
+new normative requirement or adopted standard version; Section 19 remains the publication authority.
+
 The [PAAW competence-evolution Workroom
 design](../superpowers/specs/2026-08-30-paaw-competence-evolution-workroom-design.md) defines a
 candidate application profile for turning operational experience into governed knowledge, evaluated

--- a/docs/architecture/four-portfolio-archetype-standard-profile-catalog.md
+++ b/docs/architecture/four-portfolio-archetype-standard-profile-catalog.md
@@ -31,6 +31,23 @@ field.
 
 ## 2. Facet registry
 
+### Cross-workroom review application (informative)
+
+The [cross-workroom review design](../superpowers/specs/2026-09-06-cross-workroom-learning-review-design.md)
+applies the composition in Section 1 to evidence review as well as work execution. Each proposed
+review profile identifies applicability, added outcomes and evidence, eligible denominators and
+exclusions, freshness, critical failures, assessor eligibility, permitted actions and retention.
+Common requirements remain inherited; a conflicting overlay is unresolved rather than silently
+overwriting another obligation. A version change starts a separately identified comparison cohort.
+
+Development uses exact source/runtime and review receipts; bookkeeping uses period and
+reconciliation evidence; pet rescue uses custody, welfare and capacity evidence; campground work
+uses site/rig fit and occupancy evidence. These examples guide future archetype qualification,
+not claims of deployed domain conformance. Coverage reports distinguish resolved, unsupported,
+unknown and not-exercised definitions and keep definition coverage separate from occurrence
+performance. This informative application does not change the catalog's identity registry or
+adopt the candidate review profile as a normative standard.
+
 Facet IDs are stable within the catalog major version. A leaf may select several facets on an axis.
 Selection never weakens a core requirement.
 

--- a/docs/architecture/job-specific-intelligence.md
+++ b/docs/architecture/job-specific-intelligence.md
@@ -386,6 +386,23 @@ risk, tools, data classes, and allowed oversight posture. A material change to t
 conformance logic, coordinator instructions, tools, model/provider, or authority binding triggers
 the Section 13 impact and revalidation rules.
 
+**Informative application of Sections 8.2, 8.3, 11.5 and 13.** The
+[cross-workroom review profile](../superpowers/specs/2026-09-06-cross-workroom-learning-review-design.md)
+records effective source/shape and archetype-profile versions, tool/skill/instruction versions,
+evidence scope and missing attribution alongside a proposed learning. Its analyst and assessor
+need competence in selecting comparable denominators, separating retries from independent
+occurrences, interpreting valid refusals, reporting uncertainty and reconstructing safe recovery.
+Qualification to execute a business activity does not itself establish competence to assess
+improvements across that activity's workrooms.
+
+For this proposed application, the assessor precommits the eligible population, critical failures,
+minimum opportunity window and decision rule before observing the candidate. The change author
+does not certify its benefit. Common-to-domain and domain-to-common transfer use the target-profile
+evidence or equivalence process in Section 8.2; changes to the reviewer, evaluator, method or
+effective profile receive the applicable Section 13 impact analysis. Insufficient observations
+remain inconclusive. This note explains application of existing requirements; it does not confer
+qualification, widen authority or adopt additional conformance requirements.
+
 ## 9. Model and Provider Suitability
 
 ### 9.1 Eligibility before ranking

--- a/docs/superpowers/specs/2026-09-06-cross-workroom-learning-review-design.md
+++ b/docs/superpowers/specs/2026-09-06-cross-workroom-learning-review-design.md
@@ -94,7 +94,9 @@ its missing obligations. Do not assign development gates to generic business roo
 
 The kernel call returned **no usable recommendation** because options lacked scoreable features;
 it did not ratify an option. The recommendation follows the user's accepted hybrid direction and
-the existing client-independent platform contract. Formal design review remains outstanding.
+the existing client-independent platform contract. Formal scope approval is the review requested
+for this artifact, not an additional deliverable that must assert its own approval. Persisted
+independent receipts determine readiness.
 
 | Primary reference, consulted 2026-09-06 | Adopt | Reject / limit |
 | --- | --- | --- |
@@ -340,15 +342,16 @@ regression checks on materially different profiles. An organization choice remai
 belongs in WSID; platform behavior belongs in WWMD. The analyst may propose doctrine, never
 silently rewrite it. Standards Steward review batches durable lessons weekly.
 
-Proposed amendments, kept as pointers to this application design until independently reviewed:
+The exact informative application text is maintained in the following canonical homes. These
+paragraphs are the reviewable reference amendments for this delivery, not placeholders for an
+unspecified future rewrite. They add no normative standard version or qualification claim.
+Normative adoption remains a separate Standards Steward decision under BI-636638A6.
 
 | Canonical home | Amendment |
 | --- | --- |
-| PAAW/Four-Portfolio standard §9.6 | Reference this cross-occurrence surveillance profile, inheritance, cycle continuity and verified-application trace |
-| JSI §8.2 | Learning records identify effective profile, method versions and evidence scope |
-| JSI §8.3 | Cross-room analyst and assessor competence includes denominator selection, uncertainty, gate interpretation and recovery; independence remains explicit |
-| JSI §11.5 and §13 | Protect evaluation integrity; domain transfer and reviewer/profile changes trigger applicable revalidation |
-| Profile catalog composition and applicability sections | Require common review baseline, scoped deltas, measurable domain outcomes and not-exercised coverage |
+| [PAAW/Four-Portfolio standard §9.6](../../architecture/four-portfolio-archetype-ai-workforce-operating-standard.md) | Informative application: inherited obligations, durable continuity, cadence and trace through independent subsequent assessment |
+| [JSI application note following §8.3](../../architecture/job-specific-intelligence.md) | Effective profile/method attribution; analyst and assessor competence; precommitted population and opportunity window; independence and target-profile transfer under §§8.2, 11.5 and 13 |
+| [Profile catalog §2 application note](../../architecture/four-portfolio-archetype-standard-profile-catalog.md) | Concrete profile fields, conflict handling, development/bookkeeping/pet-rescue/campground evidence, and separate definition/occurrence coverage |
 | Existing DPF skills and instruction owners | Add compact capture/recovery and triage procedures at their existing boundaries; avoid global prompt duplication |
 
 Use IP-953EE / BI-636638A6 for standards publication. This source calls the operating standard
@@ -393,11 +396,17 @@ do not use the allowance for unrelated cleanup.
 | AC-12 | OBJ-RECOVERY | Reviewer continuity: missed cadence and reviewer failure produce visible due work; replacing executor does not start duplicate cycles |
 
 Acceptance fixtures may prove mechanics; synthetic data does not prove business efficacy.
-The existing 135 stalled child runs remain operational demand and are not closed by this design.
+The September 8 operational cleanup cancelled 149 stalled children of terminal builds through
+governed MCP and verified none remained in that cohort. This supersedes the older 135-child
+snapshot; it does not establish prevention or resolve unrelated recovery candidates. The
+September 9 requested sweep observed 429 persisted rooms and 24 nonterminal rooms linked to done
+backlog items. Preserve their evidence and reconcile current activity before any disposition.
 
 ## 13. Readiness and next action
 
-This draft is ready for independent design review, not implementation. The next executor should
+This draft is submitted for independent scope review, not implementation. A declaration that
+scope review is pending describes the current gate; it cannot substitute for a reviewer finding
+about the artifact's content. The next executor should
 read this exact artifact and its linked baseline, confirm current backlog ownership, review the
 common/profile contract and persistence choices, then decompose delivery under BI-IMP-9DA35549.
 No operator decision is needed merely to repeat already-authorized read-only analysis.


### PR DESCRIPTION
## Summary

Apply the cross-workroom learning design to the JSI, PAAW and archetype-profile references. The prior design named amendments without supplying the reference text; these informative additions now describe evidence capture, recurring review, recovery context, independent assessment and transfer between profiles.

## Changes

- Add informative application guidance to the three canonical references, with existing normative requirements retained.
- Link the delivery design to those exact sections and clarify that scope review is an external gate, not a prerequisite for reviewing itself.
- Refresh the dated cleanup baseline and generated documentation anchor.

## Test plan

Documentation only: all 66 applicable pregate preflight guards passed (126.9 seconds). Documentation index, diagram freshness (0 changed of 39), whitespace, DCO and staged secret checks passed. No runtime behavior or migration changed; runtime tests do not apply.

Semantic review policy auto-pass recorded for the exact committed tree: cmtteixht048z01o9ovwfddeg. This is the low-risk publication policy result, not substantive initiative scope approval.

Local-CI-Override: docs-adjacent — Markdown reference amendments plus generated documentation index only; source-local preflight guards passed; no runtime behavior changed.

## Related work

BI-IMP-9DA35549 / WC-4CF7C38C. Partial delivery only: native implementation, normative standard adoption and measured operational benefit remain outstanding.

## Overlap sweep

Open PRs 5239, 5238, 5237, 5236, 5231 and 5228 do not edit these standards references. Earlier design PRs 5149 and 5229 are merged.

