### PR TITLE
fix(work-capsules): anchor every room to its WorkItem — converger for the existing gap, and the producer that never anchored (BI-A5EEB5D1)

### DIFF
--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -301,6 +301,33 @@ export const taskrunWatchdog = inngest.createFunction(
       console.warn("[taskrun-watchdog] work-capsule reaper failed:", err);
     }
 
+    // BI-A5EEB5D1 (kernel: a room is reachable by construction): anchor rooms that
+    // carry no Workroom.workItemId, so their case page resolves. Passes each
+    // through the one canonical anchor helper in a bounded batch. Unlike the
+    // reaper this is ADDITIVE and reversible — a WorkItem is created, nothing is
+    // deleted — so it actuates by default and the fix reaches every install
+    // with no operator action (DI-B3E42B8A9B48). Kill switch only. Best-effort.
+    let workroomsAnchored = 0;
+    try {
+      const { WORKROOM_ANCHOR_CONVERGER_KILL_SWITCH, convergeWorkroomAnchorsWithPrisma } =
+        await import("@/lib/work-capsules/workroom-anchor-converger.server");
+      if (process.env[WORKROOM_ANCHOR_CONVERGER_KILL_SWITCH] !== "1") {
+        const result = await convergeWorkroomAnchorsWithPrisma();
+        workroomsAnchored = result.anchored;
+        if (result.anchored > 0 || result.failed.length > 0) {
+          console.warn(
+            `[workroom-anchor-converger] anchored ${result.anchored}/${result.candidates} room(s)` +
+              ` (${result.created} case(s) minted)` +
+              (result.failed.length > 0
+                ? `; ${result.failed.length} failed: ${result.failed.map((f) => `${f.capsuleId} (${f.reason})`).join(", ")}`
+                : ""),
+          );
+        }
+      }
+    } catch (err) {
+      console.warn("[taskrun-watchdog] workroom anchor converger failed:", err);
+    }
+
     // BI-B62B9F1E: release stale BacklogItem claims (dead sessions) so they do
     // not linger as "active" operator noise. Complements the atomic reclaim path.
     let staleBacklogClaimsReaped = 0;
@@ -313,14 +340,14 @@ export const taskrunWatchdog = inngest.createFunction(
     }
 
     if (!(await isStallWatchdogEnabled())) {
-      return { skipped: true, reason: "flag-off", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, staleBacklogClaimsReaped };
+      return { skipped: true, reason: "flag-off", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, workroomsAnchored, staleBacklogClaimsReaped };
     }
 
     const { prisma } = await import("@dpf/db");
 
     const thresholds = await prisma.buildStudioStallThreshold.findMany();
     if (thresholds.length === 0) {
-      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, staleBacklogClaimsReaped };
+      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, workroomsAnchored, staleBacklogClaimsReaped };
     }
 
     // Coarse SQL filter using the smallest applicable thresholds across all
@@ -372,7 +399,7 @@ export const taskrunWatchdog = inngest.createFunction(
     }
 
     if (decisions.length === 0) {
-      return { processed: 0, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped };
+      return { processed: 0, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, workroomsAnchored };
     }
 
     // Batch id-resolution: business taskRunId → cuid id for FK writes.
@@ -532,6 +559,6 @@ export const taskrunWatchdog = inngest.createFunction(
       processed += 1;
     }
 
-    return { processed, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped };
+    return { processed, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, workroomsAnchored };
   },
 );

--- a/apps/web/lib/work-capsules/capsule-workitem-anchor.server.ts
+++ b/apps/web/lib/work-capsules/capsule-workitem-anchor.server.ts
@@ -15,7 +15,7 @@ import {
 /** Stable queueId for the canonical queue capsule-anchored WorkItems land in. */
 const CANONICAL_ANCHOR_QUEUE_ID = "canonical-work-anchor";
 
-function prismaAnchorPorts(): WorkItemAnchorPorts {
+export function prismaAnchorPorts(): WorkItemAnchorPorts {
   return {
     findWorkItemBySource: (sourceType, sourceId) =>
       prisma.workItem.findFirst({ where: { sourceType, sourceId }, select: { id: true } }),
@@ -72,5 +72,28 @@ export async function ensureCapsuleWorkItemAnchorNonFatal(
     await ensureCapsuleWorkItemAnchorWithPrisma(capsule);
   } catch (error) {
     console.warn(`[work-convergence] WorkItem anchor skipped for ${action} ${capsule.capsuleId}: ${getErrorMessage(error)}`);
+  }
+}
+
+/**
+ * Anchor a capsule known only by id — for producers that get a capsuleId back
+ * from a lower layer (ensureExternalSessionCapsule) rather than the row. Reads
+ * the three fields the anchor needs, then runs the same non-fatal boundary as
+ * every other caller. Best-effort: a failed lookup is a warning, never a
+ * refusal of the work that produced the capsule (BI-A5EEB5D1).
+ */
+export async function anchorCapsuleByIdNonFatal(capsuleId: string, action: string): Promise<void> {
+  try {
+    const capsule = await prisma.workroom.findUnique({
+      where: { capsuleId },
+      select: { capsuleId: true, backlogItemId: true, title: true },
+    });
+    if (!capsule) {
+      console.warn(`[work-convergence] WorkItem anchor skipped for ${action} ${capsuleId}: capsule not found`);
+      return;
+    }
+    await ensureCapsuleWorkItemAnchorNonFatal(capsule, action);
+  } catch (error) {
+    console.warn(`[work-convergence] WorkItem anchor lookup failed for ${action} ${capsuleId}: ${getErrorMessage(error)}`);
   }
 }

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -1,6 +1,9 @@
 import { normalizePersistedScope, parseScopeInput } from "./scope-input";
 import { prisma } from "@dpf/db";
-import { ensureCapsuleWorkItemAnchorNonFatal } from "@/lib/work-capsules/capsule-workitem-anchor.server";
+import {
+  anchorCapsuleByIdNonFatal,
+  ensureCapsuleWorkItemAnchorNonFatal,
+} from "@/lib/work-capsules/capsule-workitem-anchor.server";
 import { computeChangeImpactContract } from "@/lib/build/gate-context-bridge";
 import type { ToolResult } from "@/lib/mcp-tools";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
@@ -723,6 +726,11 @@ export async function startExternalWorkTool(
     repositoryFullName: stringParam(params, "repositoryFullName"),
     baseBranch: stringParam(params, "baseBranch"),
   });
+  // Both branches of ensureExternalSessionCapsule create the room without its
+  // WorkItem anchor — the dominant producer of the 289 unreachable rooms
+  // measured on the live install (BI-A5EEB5D1). Anchor it here, the way the
+  // adopt handler does.
+  await anchorCapsuleByIdNonFatal(capsuleId, "started");
 
   return {
     success: true,

--- a/apps/web/lib/work-capsules/workroom-anchor-converger.server.ts
+++ b/apps/web/lib/work-capsules/workroom-anchor-converger.server.ts
@@ -1,0 +1,33 @@
+// Prisma binding for workroom-anchor-converger.ts. See that module for why.
+import { prisma } from "@dpf/db";
+
+import { TERMINAL_CAPSULE_STATUSES } from "./work-capsule-branch-identity";
+import { prismaAnchorPorts } from "./capsule-workitem-anchor.server";
+import {
+  convergeWorkroomAnchors,
+  type WorkroomAnchorConvergeResult,
+  type WorkroomAnchorConvergerPorts,
+} from "./workroom-anchor-converger";
+
+/** Set to "1" to stop the converger without a deploy. Absent by default: the
+ *  fix must reach every install with no operator action (DI-B3E42B8A9B48). */
+export const WORKROOM_ANCHOR_CONVERGER_KILL_SWITCH = "DPF_WORKROOM_ANCHOR_CONVERGER_DISABLED";
+
+export function prismaConvergerPorts(): WorkroomAnchorConvergerPorts {
+  return {
+    ...prismaAnchorPorts(),
+    // Oldest first so the long-standing gap closes before today's; terminal
+    // rooms are still anchored — completed work is listed and must open too.
+    listUnanchoredRooms: (limit) =>
+      prisma.workroom.findMany({
+        where: { archivedAt: null, workItemId: null, status: { notIn: TERMINAL_CAPSULE_STATUSES } },
+        orderBy: { createdAt: "asc" },
+        take: limit,
+        select: { capsuleId: true, backlogItemId: true, title: true },
+      }),
+  };
+}
+
+export async function convergeWorkroomAnchorsWithPrisma(): Promise<WorkroomAnchorConvergeResult> {
+  return convergeWorkroomAnchors({ ports: prismaConvergerPorts() });
+}

--- a/apps/web/lib/work-capsules/workroom-anchor-converger.test.ts
+++ b/apps/web/lib/work-capsules/workroom-anchor-converger.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  convergeWorkroomAnchors,
+  type UnanchoredRoom,
+  type WorkroomAnchorConvergerPorts,
+} from "./workroom-anchor-converger";
+
+// The three classes measured on the live install (BI-A5EEB5D1): a room whose
+// backlog item already has a WorkItem, one whose backlog item has none, and one
+// with no backlog item at all. All three must end up anchored, through the one
+// canonical helper, without any of them being special-cased here.
+function fakePorts(rooms: UnanchoredRoom[], opts: { failOn?: string } = {}) {
+  const workItems = new Map<string, string>([["backlog-item:BI-HAS", "wi-existing"]]);
+  const anchored = new Map<string, string>();
+  let minted = 0;
+  const ports: WorkroomAnchorConvergerPorts = {
+    listUnanchoredRooms: async (limit) => rooms.slice(0, limit),
+    findWorkItemBySource: async (sourceType, sourceId) => {
+      const id = workItems.get(`${sourceType}:${sourceId}`);
+      return id ? { id } : null;
+    },
+    resolveCanonicalQueueId: async () => "queue-anchor",
+    createWorkItem: async (data) => {
+      const id = `wi-new-${++minted}`;
+      workItems.set(`${data.sourceType}:${data.sourceId}`, id);
+      return { id };
+    },
+    setCapsuleWorkItem: async (capsuleId, workItemId) => {
+      if (capsuleId === opts.failOn) throw new Error(`refused ${capsuleId}`);
+      anchored.set(capsuleId, workItemId);
+    },
+  };
+  return { ports, anchored, workItems };
+}
+
+describe("convergeWorkroomAnchors", () => {
+  it("anchors all three measured classes through the canonical helper", async () => {
+    const { ports, anchored, workItems } = fakePorts([
+      { capsuleId: "WC-HAS", backlogItemId: "BI-HAS", title: "has a WorkItem" },
+      { capsuleId: "WC-NONE", backlogItemId: "BI-NONE", title: "backlog item, no WorkItem" },
+      { capsuleId: "WC-ADHOC", backlogItemId: null, title: "no backlog item" },
+    ]);
+
+    const result = await convergeWorkroomAnchors({ ports });
+
+    expect(result).toMatchObject({ candidates: 3, anchored: 3, created: 2, failed: [] });
+    // Linked to the existing case, not a second one for the same work.
+    expect(anchored.get("WC-HAS")).toBe("wi-existing");
+    // The backlog item's case was minted, and the room shares it.
+    expect(anchored.get("WC-NONE")).toBe(workItems.get("backlog-item:BI-NONE"));
+    // An ad-hoc room gets a stable capsule-keyed case, so the loader's
+    // convention query resolves it.
+    expect(anchored.get("WC-ADHOC")).toBe(workItems.get("work-capsule:WC-ADHOC"));
+  });
+
+  it("reports a room it could not anchor and carries on with the rest", async () => {
+    const { ports, anchored } = fakePorts(
+      [
+        { capsuleId: "WC-BAD", backlogItemId: null, title: "bad" },
+        { capsuleId: "WC-OK", backlogItemId: null, title: "ok" },
+      ],
+      { failOn: "WC-BAD" },
+    );
+
+    const result = await convergeWorkroomAnchors({ ports });
+
+    expect(result.anchored).toBe(1);
+    expect(result.failed).toEqual([{ capsuleId: "WC-BAD", reason: "refused WC-BAD" }]);
+    expect(anchored.has("WC-OK")).toBe(true);
+  });
+
+  it("is bounded by the batch so a tick never sweeps the whole estate", async () => {
+    const rooms = Array.from({ length: 5 }, (_, i) => ({
+      capsuleId: `WC-${i}`,
+      backlogItemId: null,
+      title: `room ${i}`,
+    }));
+    const { ports } = fakePorts(rooms);
+
+    const result = await convergeWorkroomAnchors({ ports, batch: 2 });
+
+    expect(result.candidates).toBe(2);
+    expect(result.anchored).toBe(2);
+  });
+
+  it("does nothing, and says so, when every room is already anchored", async () => {
+    const { ports } = fakePorts([]);
+    expect(await convergeWorkroomAnchors({ ports })).toEqual({
+      candidates: 0,
+      anchored: 0,
+      created: 0,
+      failed: [],
+    });
+  });
+});

--- a/apps/web/lib/work-capsules/workroom-anchor-converger.ts
+++ b/apps/web/lib/work-capsules/workroom-anchor-converger.ts
@@ -1,0 +1,83 @@
+// apps/web/lib/work-capsules/workroom-anchor-converger.ts
+//
+// A room is reachable by construction (kernel principle). On the live install
+// 289 of 468 open rooms had no Workroom.workItemId, so their case page 404'd:
+// 36 whose backlog item already had a WorkItem, 205 whose backlog item had none,
+// 48 with no backlog item at all. Every one of them is exactly what
+// ensureCapsuleWorkItemAnchor (BI-650994D7) already resolves — the creators just
+// never called it, or ran it best-effort and moved on.
+//
+// This converger closes the existing gap on every install and keeps it closed:
+// it walks unanchored rooms in bounded batches and passes each through the ONE
+// canonical anchor helper. Additive and reversible (the FK is nullable; a
+// WorkItem is created, nothing deleted), so unlike the reaper it actuates by
+// default — deployments are cumulative and an install must converge without an
+// operator remembering to run anything (BI-A5EEB5D1, decision DI-B3E42B8A9B48).
+//
+// Pure core with injected ports; the prisma binding lives in
+// workroom-anchor-converger.server.ts.
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+import { ensureCapsuleWorkItemAnchor, type WorkItemAnchorPorts } from "./capsule-workitem-anchor";
+
+export interface UnanchoredRoom {
+  capsuleId: string;
+  backlogItemId: string | null;
+  title: string;
+}
+
+export interface WorkroomAnchorConvergerPorts extends WorkItemAnchorPorts {
+  /** Non-archived rooms with no workItemId, oldest first, at most `limit`. */
+  listUnanchoredRooms(limit: number): Promise<UnanchoredRoom[]>;
+}
+
+export interface WorkroomAnchorConvergeResult {
+  /** Rooms examined this pass (bounded by the batch). */
+  candidates: number;
+  /** Rooms now carrying a workItemId. */
+  anchored: number;
+  /** Of those, how many needed a new WorkItem minted rather than linked. */
+  created: number;
+  /** Rooms that could not be anchored, with the reason — never silently skipped. */
+  failed: Array<{ capsuleId: string; reason: string }>;
+}
+
+/** Bounded so a tick never holds a long transaction over hundreds of rooms. */
+export const WORKROOM_ANCHOR_CONVERGER_BATCH = 50;
+
+export async function convergeWorkroomAnchors(args: {
+  ports: WorkroomAnchorConvergerPorts;
+  batch?: number;
+}): Promise<WorkroomAnchorConvergeResult> {
+  const batch = args.batch ?? WORKROOM_ANCHOR_CONVERGER_BATCH;
+  const rooms = await args.ports.listUnanchoredRooms(batch);
+  const result: WorkroomAnchorConvergeResult = {
+    candidates: rooms.length,
+    anchored: 0,
+    created: 0,
+    failed: [],
+  };
+
+  for (const room of rooms) {
+    try {
+      const outcome = await ensureCapsuleWorkItemAnchor({
+        ports: args.ports,
+        capsuleId: room.capsuleId,
+        backlogItemId: room.backlogItemId,
+        title: room.title,
+      });
+      if (outcome) {
+        result.anchored += 1;
+        if (outcome.created) result.created += 1;
+      }
+    } catch (error) {
+      // One bad room must not stop the rest of the batch; it is reported, not hidden.
+      result.failed.push({
+        capsuleId: room.capsuleId,
+        reason: getErrorMessage(error),
+      });
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Operator direction, 2026-09-07: *"the room should be reachable by design."* After the three addressing fixes, **289 of 468 open rooms** on the live install still could not be opened: `Workroom.workItemId` was null, so the case loader had nothing to project — while every inventory still offered them as links.

## Classified from the DB, not assumed

| class | count | resolution |
|---|---|---|
| backlog item already has a WorkItem | 36 | link |
| backlog item, no WorkItem | 205 | mint, then link |
| no backlog item at all | 48 | capsule-keyed WorkItem, then link |
| ambiguous | 0 | — |

Every one is exactly what `ensureCapsuleWorkItemAnchor` (BI-650994D7) already resolves. The creators just never called it: **both branches of `ensureExternalSessionCapsule`** — the dominant producer, 218 of the 289 — create the room and return without anchoring. The portal logs show **zero** anchor failures, so the best-effort path was not the leak; the missing call was.

## Two changes

**1. A converger.** `convergeWorkroomAnchors` walks unanchored rooms in bounded batches (50), oldest first, through the one canonical helper, reporting anchored / created / failed per pass. Wired into the taskrun watchdog beside the reapers.

Unlike the reaper it **actuates by default**: anchoring is additive and reversible (nullable FK; a WorkItem is created, nothing deleted), and deployments are cumulative — the fix must reach every install with no operator remembering to run anything. Kill switch only: `DPF_WORKROOM_ANCHOR_CONVERGER_DISABLED=1`.

Kernel `DI-B3E42B8A9B48` (stakes high): idempotent-server-converger **11.81** over stop-linking-unanchored 5.89, sql-migration-backfill 5.70, one-off-admin-run 4.44. Margin 5.92, zero flipping principles. SQL was rejected as a second home for the anchoring rule; a one-off run fixes one install and leaves the producers making more.

**2. The producer.** The session-start handler now anchors the capsule it just ensured via `anchorCapsuleByIdNonFatal` — the same non-fatal boundary the adopt handler uses — so the class cannot regrow from the path that grew it.

## Verification

- `vitest lib/work-capsules/workroom-anchor-converger` — 4/4: all three classes through the one helper, failure isolation, batch bound, no-op
- `vitest lib/work-capsules lib/queue/functions/taskrun-watchdog` — 362/362
- `tsc --noEmit` clean; `check-no-raw-error-message` clean
- Local-CI gate passed on `2bcafa6457ac`, production build compiled

**Not yet verified:** the live count. The converger runs on the watchdog tick after deploy — re-measure `workItemId is null` then; expected to fall from 289 to 0 over ~6 ticks.

Refs: BI-A5EEB5D1 · DI-B3E42B8A9B48 · BI-650994D7 · EP-WORK-CONVERGENCE

Local-CI-Evidence: cmttesd9a1k9101tc3p8kzuli

🤖 Generated with [Claude Code](https://claude.com/claude-code)