### PR TITLE
fix(links): the four baselined unreachable links, plus a fifth the retighten exposed (BI-235E9F00)

### DIFF
--- a/apps/web/app/(shell)/finance/my-expenses/MyExpensesTable.tsx
+++ b/apps/web/app/(shell)/finance/my-expenses/MyExpensesTable.tsx
@@ -5,7 +5,6 @@
 
 "use client";
 
-import Link from "next/link";
 
 import { LocalTime } from "@/components/ui/LocalTime";
 import {
@@ -35,17 +34,16 @@ export function MyExpensesTable({
   rows: MyExpenseRow[];
   currencySymbol: string;
 }) {
+  // Claim id and title are text, not links. There is no claimant detail page
+  // (/finance/my-expenses/[id] does not exist), and the manager view hands the
+  // approval token to any viewer (BI-D43F1516). A row that cannot open is not
+  // offered as a link (BI-235E9F00).
   const columns: Column<MyExpenseRow>[] = [
     {
       key: "claimId",
       header: "Claim ID",
       cell: (c) => (
-        <Link
-          href={`/finance/my-expenses/${c.id}`}
-          className="text-[9px] font-mono text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
-        >
-          {c.claimId}
-        </Link>
+        <span className="text-[9px] font-mono text-[var(--dpf-muted)]">{c.claimId}</span>
       ),
       sortAccessor: (c) => c.claimId,
     },
@@ -53,12 +51,7 @@ export function MyExpensesTable({
       key: "title",
       header: "Title",
       cell: (c) => (
-        <Link
-          href={`/finance/my-expenses/${c.id}`}
-          className="text-[var(--dpf-text)] hover:underline"
-        >
-          {c.title}
-        </Link>
+        <span className="text-[var(--dpf-text)]">{c.title}</span>
       ),
       sortAccessor: (c) => c.title,
     },

--- a/apps/web/components/customer-marketing/PublishEmailButton.tsx
+++ b/apps/web/components/customer-marketing/PublishEmailButton.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import {
+  INTEGRATIONS_INDEX_HREF,
+  integrationSettingsHrefForChannel,
+} from "@/lib/tools/integration-settings-href";
 import { publishOutboundDraftAction } from "@/app/(shell)/customer/marketing/actions";
 
 type Props = {
@@ -59,7 +63,7 @@ export function PublishEmailButton({
     return (
       <div className="flex flex-wrap items-center gap-2">
         <a
-          href={`/platform/tools/integrations/${channelId}`}
+          href={integrationSettingsHrefForChannel(channelId) ?? INTEGRATIONS_INDEX_HREF}
           className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
         >
           Connect Postmark first

--- a/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
+++ b/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { ExternalPublicationControl } from "./ExternalPublicationControl";
+import {
+  INTEGRATIONS_INDEX_HREF,
+  integrationSettingsHrefForChannel,
+} from "@/lib/tools/integration-settings-href";
 
 type Props = {
   draftId: string;
@@ -26,7 +30,7 @@ export function PublishLinkedInButton({
     <ExternalPublicationControl
       draftId={draftId}
       channelConnected={channelConnected}
-      connectHref={`/platform/tools/integrations/${channelId}`}
+      connectHref={integrationSettingsHrefForChannel(channelId) ?? INTEGRATIONS_INDEX_HREF}
       fitBlocked={fitBlocked}
       artifactTitle={artifactTitle}
       audience={audience}

--- a/apps/web/components/portfolio/CoveragePanel.tsx
+++ b/apps/web/components/portfolio/CoveragePanel.tsx
@@ -6,6 +6,7 @@
 // report-kit StatusBadge (theme-tokened intents). No new route.
 
 import Link from "next/link";
+import { integrationSettingsHref } from "@/lib/tools/integration-settings-href";
 
 import { StatusBadge } from "@/components/ui/report-kit";
 
@@ -75,9 +76,10 @@ export function CoveragePanel({ products, className = "" }: Props) {
       </p>
       <div className="flex flex-col gap-2">
         {rows.map((p) => {
+          // Only a slug with a page behind it is offered as a link (BI-235E9F00).
           const enableHref =
             p.source === "integration_registry" && p.coverage === "potential"
-              ? `/platform/tools/integrations/${p.productId.replace(/^int-/, "")}`
+              ? integrationSettingsHref(p.productId.replace(/^int-/, ""))
               : null;
           return (
             <div

--- a/apps/web/lib/decision/decision-origin.test.ts
+++ b/apps/web/lib/decision/decision-origin.test.ts
@@ -71,7 +71,7 @@ describe("resolveDecisionOrigin", () => {
     );
     expect(origin.matchedVia).toBe("build");
     expect(origin.workroom?.capsuleId).toBe("WC-1234");
-    expect(origin.activity?.href).toBe("/build/BUILD-9");
+    expect(origin.activity?.href).toBe("/build?buildId=BUILD-9");
   });
 
   it("resolves the task run before the room, because the key spaces differ", async () => {

--- a/apps/web/lib/decision/decision-origin.ts
+++ b/apps/web/lib/decision/decision-origin.ts
@@ -279,7 +279,8 @@ export async function resolveDecisionOrigin(
           kind: "build",
           label: build.title ?? row.buildId,
           detail: null,
-          href: `/build/${encodeURIComponent(row.buildId)}`,
+          // The build address every other surface uses; /build/<id> has no route (BI-235E9F00).
+          href: `/build?buildId=${encodeURIComponent(row.buildId)}`,
         },
         recurrence,
       };

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1137,6 +1137,9 @@
       "docs/architecture/context-engineering-standards.md",
       "docs/architecture/mcp-tool-authorization-runbook.md"
     ],
+    "apps/web/lib/tools/integration-settings-href.ts": [
+      "docs/testing/pre-pr-gate.md"
+    ],
     "apps/web/lib/ux-budget/budgets.ts": [
       "docs/platform-usability-standards.md"
     ],
@@ -3106,6 +3109,7 @@
       ".github/workflows/policy-guards-recheck.yml",
       "apps/web/lib/testing/degenerate-env/index.ts",
       "apps/web/lib/testing/degenerate-env/probe-conformance.test.ts",
+      "apps/web/lib/tools/integration-settings-href.ts",
       "docker-compose.local-ci.yml",
       "packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs",
       "scripts/check-agent-principal-convergence-wired.mjs",

--- a/apps/web/lib/tools/integration-settings-href.test.ts
+++ b/apps/web/lib/tools/integration-settings-href.test.ts
@@ -1,0 +1,53 @@
+import { readdirSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { getNativeIntegrationIds } from "./native-integration-catalog";
+import {
+  INTEGRATIONS_INDEX_HREF,
+  integrationSettingsHref,
+  integrationSettingsHrefForChannel,
+  routableIntegrationSlugs,
+} from "./integration-settings-href";
+
+const INTEGRATIONS_DIR = new URL("../../app/(shell)/platform/tools/integrations/", import.meta.url).pathname;
+
+describe("integrationSettingsHref", () => {
+  it("links an integration that has a page", () => {
+    expect(integrationSettingsHref("email-postmark")).toBe("/platform/tools/integrations/email-postmark");
+  });
+
+  it("refuses to link an integration with no page, instead of 404ing the reader", () => {
+    // Five catalog ids have no route behind them (found by the room-addressing guard).
+    expect(integrationSettingsHref("greenhouse")).toBeNull();
+    expect(integrationSettingsHref("nonsense")).toBeNull();
+    expect(integrationSettingsHref(null)).toBeNull();
+  });
+
+  it("maps a marketing channel id to its integration, which is what the approval queue meant", () => {
+    expect(integrationSettingsHrefForChannel("email")).toBe("/platform/tools/integrations/email-postmark");
+    expect(integrationSettingsHrefForChannel("linkedin")).toBe("/platform/tools/integrations/linkedin-personal-social");
+    // A slug passed as a channel still works.
+    expect(integrationSettingsHrefForChannel("linkedin-personal-social")).toBe("/platform/tools/integrations/linkedin-personal-social");
+    // A channel with no integration page yields nothing rather than a guess.
+    expect(integrationSettingsHrefForChannel("tiktok")).toBeNull();
+  });
+
+  it("agrees with the filesystem: every routable slug is a real directory and vice versa", () => {
+    const dirs = readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+    expect(routableIntegrationSlugs()).toEqual(dirs);
+  });
+
+  it("documents which catalog ids currently have no page, so the drift is visible", () => {
+    const unroutable = getNativeIntegrationIds().filter((id) => integrationSettingsHref(id) === null);
+    expect(unroutable.sort()).toEqual(["facebook", "google", "greenhouse", "linkedin-ads", "microsoft365"]);
+  });
+
+  it("offers the index as the fallback, which is a real page", () => {
+    expect(routableIntegrationSlugs().length).toBeGreaterThan(0);
+    expect(INTEGRATIONS_INDEX_HREF).toBe("/platform/tools/integrations");
+  });
+});

--- a/apps/web/lib/tools/integration-settings-href.ts
+++ b/apps/web/lib/tools/integration-settings-href.ts
@@ -1,0 +1,52 @@
+// apps/web/lib/tools/integration-settings-href.ts
+//
+// The ONE place that says where an integration's settings page is. Three
+// surfaces used to spell `/platform/tools/integrations/${id}` out by hand, and
+// each got it wrong differently: marketing drafts carry a channel id ("email",
+// "linkedin") that is not an integration slug, and the native-integration
+// catalog lists five ids with no page behind them. The room-addressing guard
+// caught all three as links whose route prefix cannot accept a dynamic segment
+// (BI-235E9F00; kernel principle: a room is reachable by construction).
+//
+// Routability is read from the generated App Router manifest, not from a
+// catalog that may drift from the filesystem. A slug with no page yields null,
+// and the caller must not offer a link.
+import routeManifestData from "@/lib/ea/route-manifest.json";
+
+const INTEGRATIONS_PREFIX = "/platform/tools/integrations/";
+/** The integrations index — a real page, and the honest fallback when a
+ *  specific integration has no page of its own. */
+export const INTEGRATIONS_INDEX_HREF = "/platform/tools/integrations";
+
+type ManifestRoute = { routePath: string; kind: string; dynamicParams: string[] };
+
+const ROUTABLE_SLUGS: ReadonlySet<string> = new Set(
+  (routeManifestData as { routes: ManifestRoute[] }).routes
+    .filter((r) => r.kind === "page" && r.dynamicParams.length === 0 && r.routePath.startsWith(INTEGRATIONS_PREFIX))
+    .map((r) => r.routePath.slice(INTEGRATIONS_PREFIX.length))
+    .filter((slug) => slug.length > 0 && !slug.includes("/")),
+);
+
+/** Marketing channel ids are not integration slugs. This is the mapping the
+ *  approval queue already relied on implicitly (isEmailChannel / isLinkedInChannel). */
+const CHANNEL_TO_INTEGRATION: Readonly<Record<string, string>> = {
+  email: "email-postmark",
+  linkedin: "linkedin-personal-social",
+};
+
+/** Settings page for an integration slug, or null when no such page exists. */
+export function integrationSettingsHref(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  return ROUTABLE_SLUGS.has(slug) ? `${INTEGRATIONS_PREFIX}${slug}` : null;
+}
+
+/** Settings page for a marketing channel (or an integration slug passed as one). */
+export function integrationSettingsHrefForChannel(channelId: string | null | undefined): string | null {
+  if (!channelId) return null;
+  return integrationSettingsHref(CHANNEL_TO_INTEGRATION[channelId] ?? channelId);
+}
+
+/** Every slug that has a page — for tests and guards. */
+export function routableIntegrationSlugs(): string[] {
+  return [...ROUTABLE_SLUGS].sort();
+}

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -1090,7 +1090,15 @@ Two rules:
 - **Rule 2 — no provably-unreachable link.** An interpolated link whose route
   prefix names an App Router directory with no dynamic child can never resolve.
   Baselined (`scripts/room-addressing-baseline.json`, owned and expiring) so the
-  class cannot grow while each pre-existing entry is judged on its own.
+  class cannot grow while a pre-existing entry is judged on its own. The
+  baseline shipped with four entries and is now **empty** (BI-235E9F00):
+  judging them found that two claimant links had no page at all, three
+  integration links spelled a slug the filesystem did not have, and — once the
+  first four were gone — a fifth (`/build/<id>`) that had been hiding behind
+  them. Retightening a baseline is how you find the next instance; leaving it
+  is how you keep it. Integration pages are now addressed only through
+  `apps/web/lib/tools/integration-settings-href.ts`, which reads routability
+  from the generated route manifest rather than a catalog that drifts.
 
 Only link contexts are considered. `revalidatePath`, `fetch` and cache keys take
 the same shape but cannot 404 at a person; folding them in would make the guard

--- a/scripts/room-addressing-baseline.json
+++ b/scripts/room-addressing-baseline.json
@@ -3,10 +3,5 @@
   "owner": "platform-architecture",
   "expiry": "2026-12-07",
   "note": "Room-addressing Rule 2 baseline (BI-00727E59). Shrink-only: each entry is a link whose route prefix cannot accept a dynamic segment, recorded so the class cannot grow while each is judged on its own. Regenerate with: node scripts/check-no-unreachable-room-links.mjs --update",
-  "unreachableLinks": [
-    "apps/web/app/(shell)/finance/my-expenses/MyExpensesTable.tsx::/finance/my-expenses/",
-    "apps/web/components/customer-marketing/PublishEmailButton.tsx::/platform/tools/integrations/",
-    "apps/web/components/customer-marketing/PublishLinkedInButton.tsx::/platform/tools/integrations/",
-    "apps/web/lib/decision/decision-origin.ts::/build/"
-  ]
+  "unreachableLinks": []
 }


### PR DESCRIPTION
The room-addressing guard (#5204) shipped with four pre-existing links recorded in its baseline — links whose route prefix cannot accept a dynamic segment, so they can never resolve. This judges each, as the baseline demanded, and retightens it to **zero**. Doing so exposed a fifth.

## The five

**`/finance/my-expenses/${c.id}`** — two claimant row links. `/finance/my-expenses` has no `[id]` route. The only claim detail page is the manager view — and reading it turned up something worse than a dead link: it hands the **approval token** to any signed-in viewer, and `respondToExpenseApproval` is token-only with no session check. Filed as **BI-D43F1516** (security), not fixed here. A claimant row that cannot open is not offered as a link: claim id and title are now text.

**`/platform/tools/integrations/${channelId}`** (two publish buttons) and **`…/${productId minus int-}`** (coverage panel) — three surfaces spelled the path by hand and each was wrong differently: marketing drafts carry a channel id (`email`, `linkedin`) that is not an integration slug, and the native-integration catalog lists **five ids with no page behind them**. `integration-settings-href.ts` is now the one place that says where an integration's page is, reading routability from the **generated route manifest** rather than a catalog that drifts from the filesystem. A slug with no page yields null: publish buttons fall back to the integrations index (a real page); the coverage panel offers no link.

**`/build/${buildId}`** — the fifth, in `decision-origin.ts`, hidden behind the others. `/build/` has no dynamic child. Six other surfaces address a build as `/build?buildId=…`; this one now does too. Its test had asserted the dead form.

## Verification

- `vitest lib/tools/integration-settings-href` — 6/6, including a filesystem-agreement test (routable slugs == integration route dirs) and the five unroutable catalog ids named explicitly so the drift stays visible
- `vitest lib/decision + customer-marketing + portfolio + finance` — 90/90
- `node scripts/check-no-unreachable-room-links.mjs` — baseline **0 entries**, guard passes
- `tsc --noEmit` clean; prose-lint clean
- Local-CI gate passed on `d13b0379b616`, production build compiled
- `docs/testing/pre-pr-gate.md` updated: the baseline is empty, and why retightening one is how you find the next instance

Refs: BI-235E9F00 · BI-D43F1516 · BI-00727E59

Local-CI-Evidence: cmttf22g71ryf01tchnqyzfrx

🤖 Generated with [Claude Code](https://claude.com/claude-code)