### PR TITLE
fix(inference): reuse provider transport for embeddings

### DIFF
--- a/apps/web/lib/inference/embedding.test.ts
+++ b/apps/web/lib/inference/embedding.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const transport = vi.hoisted(() => ({ fetch: vi.fn() }));
+vi.mock("./provider-inference-transport", () => ({ providerInferenceFetch: transport.fetch }));
+
 vi.mock("@/lib/routing/local-provider-capacity", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/routing/local-provider-capacity")>()),
   assertLocalProviderCapacityAvailable: vi.fn(),
 }));
 
 import { LocalProviderCapacityDeferredError } from "@/lib/routing/local-provider-capacity";
-import { generateEmbedding, generateEmbeddingDetailed, isOversizeRejection } from "./embedding";
+import { generateEmbedding, generateEmbeddingDetailed, isEmbeddingAvailable, isOversizeRejection } from "./embedding";
 
 /** The exact rejection llama.cpp emits once n_batch is clamped to n_ubatch. */
 const OVERSIZE_BODY =
@@ -20,7 +23,9 @@ function okEmbedding(vec: number[]): Response {
 }
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
+  transport.fetch.mockReset();
 });
 
 describe("embedding is exempt from the local-CI capacity gate (BI-0AA939DF / DI-7F674966B4B2)", () => {
@@ -29,7 +34,7 @@ describe("embedding is exempt from the local-CI capacity gate (BI-0AA939DF / DI-
     // no gate, 10-20ms with an active gate and three queued, no observable
     // effect on the gate. Gating it suppressed retrieval platform-wide for the
     // duration of every gate run and bought nothing.
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchSpy = transport.fetch.mockResolvedValue(
       new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -59,7 +64,7 @@ describe("oversize retry (BI-633845B0)", () => {
   // observed live at 520, 550 and 599 tokens. Retrying shorter recovers it.
   it("retries at a shorter slice and returns the embedding instead of null", async () => {
     const sent: number[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+    transport.fetch.mockImplementation(async (_url, init) => {
       const body = JSON.parse(String((init as RequestInit).body)) as { input: string };
       sent.push(body.input.length);
       // Reject anything over 1000 chars, mimicking a dense-text token overflow.
@@ -81,8 +86,7 @@ describe("oversize retry (BI-633845B0)", () => {
   it("gives up after the last slice rather than retrying forever", async () => {
     // A fresh Response per call: a body can only be read once, so a single
     // shared Response would make the second read empty and mask the retry.
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
+    const fetchSpy = transport.fetch
       .mockImplementation(async () => new Response(OVERSIZE_BODY, { status: 500 }));
 
     await expect(generateEmbedding("x".repeat(5000))).resolves.toBeNull();
@@ -91,8 +95,7 @@ describe("oversize retry (BI-633845B0)", () => {
   });
 
   it("does NOT retry a non-oversize failure — one attempt, then null", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
+    const fetchSpy = transport.fetch
       .mockResolvedValue(new Response("model not found", { status: 404 }));
 
     await expect(generateEmbedding("durable knowledge")).resolves.toBeNull();
@@ -100,7 +103,7 @@ describe("oversize retry (BI-633845B0)", () => {
   });
 
   it("does not retry when the first attempt succeeds", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okEmbedding([0.9]));
+    const fetchSpy = transport.fetch.mockResolvedValue(okEmbedding([0.9]));
 
     await expect(generateEmbedding("short text")).resolves.toEqual([0.9]);
     expect(fetchSpy).toHaveBeenCalledOnce();
@@ -133,7 +136,7 @@ describe("generateEmbeddingDetailed reports WHY it produced no vector (BI-339C44
     // broken embedding model across the whole install.
     // No gate raises this any more, but the branch stays: any future capacity
     // boundary must still report a deferral as deferred rather than failed.
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+    transport.fetch.mockRejectedValue(
       new LocalProviderCapacityDeferredError("local-ci-active-capacity-reservation"),
     );
 
@@ -146,7 +149,7 @@ describe("generateEmbeddingDetailed reports WHY it produced no vector (BI-339C44
   });
 
   it("reports a genuine backend error as failed, not deferred", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connect ECONNREFUSED"));
+    transport.fetch.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
     const result = await generateEmbeddingDetailed("anything");
 
@@ -154,10 +157,26 @@ describe("generateEmbeddingDetailed reports WHY it produced no vector (BI-339C44
   });
 
   it("keeps generateEmbedding null-returning, so its existing callers are untouched", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+    transport.fetch.mockRejectedValue(
       new LocalProviderCapacityDeferredError("local-ci-active-capacity-reservation"),
     );
 
     await expect(generateEmbedding("anything")).resolves.toBeNull();
+  });
+});
+
+
+describe("canonical embedding transport", () => {
+  it("generates embeddings and checks availability when global fetch is unusable", async () => {
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("shared transport unavailable"));
+    transport.fetch
+      .mockResolvedValueOnce(okEmbedding([0.1, 0.2]))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: "ai/nomic-embed-text-v1.5" }] }), { status: 200 }));
+
+    await expect(generateEmbeddingDetailed("platform principles")).resolves.toEqual({ status: "ok", embedding: [0.1, 0.2] });
+    await expect(isEmbeddingAvailable()).resolves.toBe(true);
+    expect(globalFetch).not.toHaveBeenCalled();
+    expect(transport.fetch).toHaveBeenNthCalledWith(1, expect.stringContaining("/embeddings"), expect.objectContaining({ method: "POST" }));
+    expect(transport.fetch).toHaveBeenNthCalledWith(2, expect.stringContaining("/models"), expect.objectContaining({ signal: expect.any(AbortSignal) }));
   });
 });

--- a/apps/web/lib/inference/embedding.ts
+++ b/apps/web/lib/inference/embedding.ts
@@ -4,6 +4,7 @@ import { getErrorMessage } from "@/lib/shared/get-error-message";
 // barrier, so a local copy would leave js/log-injection unbroken.
 import { sanitizeForLog } from "@/lib/security/safe-log";
 import { LocalProviderCapacityDeferredError } from "@/lib/routing/local-provider-capacity";
+import { providerInferenceFetch } from "./provider-inference-transport";
 // apps/web/lib/embedding.ts
 // Generate text embeddings via local LLM inference (Docker Model Runner or compatible).
 // Uses OpenAI-compatible /v1/embeddings endpoint.
@@ -115,7 +116,7 @@ export async function generateEmbeddingDetailed(text: string): Promise<Embedding
       const limit = lengths[attempt]!;
       const truncated = text.slice(0, limit);
 
-      const res = await fetch(`${baseUrl}/embeddings`, {
+      const res = await providerInferenceFetch(`${baseUrl}/embeddings`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -179,7 +180,7 @@ export async function generateEmbeddingDetailed(text: string): Promise<Embedding
 export async function isEmbeddingAvailable(): Promise<boolean> {
   try {
     const baseUrl = getLlmBaseUrl();
-    const res = await fetch(`${baseUrl}/models`, { signal: AbortSignal.timeout(5000) });
+    const res = await providerInferenceFetch(`${baseUrl}/models`, { signal: AbortSignal.timeout(5000) });
     if (!res.ok) return false;
     const data = (await res.json()) as { data?: Array<{ id: string }> };
     return data.data?.some((m) => m.id.includes("nomic-embed-text") || m.id.includes("embed")) ?? false;

--- a/docs/superpowers/specs/2026-09-09-embedding-provider-transport-design.md
+++ b/docs/superpowers/specs/2026-09-09-embedding-provider-transport-design.md
@@ -1,0 +1,49 @@
+---
+status: draft
+---
+
+# Embedding provider transport
+
+BI-9298C4D5; WC-1077E882; small bug fix.
+
+## Reproduction and scope
+
+While delivering BI-E78DC21D on reviewer-recovery.3, research requests reached
+their immutable design and then failed to save a receipt. WWMD decisions
+DI-3BCF95FF6377 and DI-449FCE95C4FA reported unusable retrieval. Portal logs
+recorded embedding fetch failures and the eight-second retrieval deadline.
+Independent probes in that portal container returned an embedding with 768
+dimensions and a model list in 64 milliseconds. These observations establish
+an application-path failure, not that the model is absent or credentials expired.
+
+Source inspection found a transport inconsistency: `embedding.ts` uses global
+fetch for both generation and availability, while synchronous and asynchronous
+reasoning use `provider-inference-transport.ts`. PR #5075 introduced that shared
+transport to avoid the process-global libuv hostname lookup queue. Whether this
+inconsistency caused the observed live failure remains a hypothesis until
+served acceptance. A portal DNS probe confirmed the existing c-ares resolver
+can resolve the configured Docker Model Runner hostname.
+
+## Design and verification
+
+Reuse `providerInferenceFetch` for both embedding calls. Its process-lived
+dispatcher already owns inference transport; do not create another dispatcher
+or change the global fetch implementation. Retain the model, dimensions,
+endpoint selection, request deadlines, bounded oversize retries, and detailed
+failure/deferred results. No configuration, schema, dependency, permission,
+reviewer routing, or WWMD decision rule changes.
+
+First reproduce generation and availability failing when global fetch is
+unusable but the canonical provider transport succeeds. Then change both calls
+and run existing oversize, capacity-result, transport, and retrieval tests.
+Typecheck and protected CI remain required. Source implementation follows the
+operator's standing authorization to bypass the unavailable procedural research
+receipt; it does not assert a research or authority pass.
+
+After canonical publication and normal self-upgrade, retry a fresh exact-bound
+research request. Require the real WWMD result and persisted receipt, not a
+direct embedding probe alone. If retrieval still fails, retain that result and
+diagnose the remaining path; do not weaken usability or autonomy checks.
+
+The change is consolidation of existing transport ownership. Rollback reverts
+the two call sites and import without altering stored embeddings or receipts.


### PR DESCRIPTION
Embedding generation and availability still used global fetch after reasoning inference moved to the shared provider transport. This reuses `providerInferenceFetch` for those two calls, keeping the existing dispatcher lifecycle and hostname resolver in one place.

The source regression reproduces a healthy canonical transport being ignored when global fetch fails. After the change, six suites pass 51 tests, including generation, availability, bounded oversize retries, error reporting, DNS transport, and wiki retrieval. Web typecheck and style guard passed. The commit hook's duplicate typecheck was explicitly skipped after that successful run; secret scanning and DCO passed.

BI-9298C4D5; WC-1077E882. The observed live WWMD failure may have this cause, but that is not yet proven. Acceptance requires a real research receipt after canonical release and normal self-upgrade. The model, dimensions, endpoint configuration, timeouts, permissions, and WWMD quality requirements are unchanged. No schema, migration, dependency, or service is added.

Docs-Impact-Decision: documented reproduction, existing transport ownership, unchanged contracts, and live acceptance in docs/superpowers/specs/2026-09-09-embedding-provider-transport-design.md.
Design-Grounding-Decision: reviewed apps/web/lib/inference/provider-inference-transport.ts and its existing synchronous/asynchronous consumers from PR5075; consolidate the remaining embedding calls on that same substrate.
Local-CI-Override: operator-emergency: operator authorized procedural bypass to deliver this recovery; shared local runtime gate and additional full PR-readiness checks are unrun, not passed. Source tests/typecheck and required protected CI are retained. Supported --skip-gates validates Git/DCO/publication/trailers after exact-source preflight.

Independent-Review-Status: infrastructure-inconclusive. Exact-source high-assurance task TR-GATE-FDFC68A5422496DA2F0F746E paused with provider-outcome-uncertain and no branch result. Normal UI recovery was inaccessible from both active tasks. The operator's standing procedural bypass authorizes this publication through the checked-in operator-emergency override. No passing review receipt is asserted, no task identity or deadline is reset, and protected PR/merge-queue checks remain required.

Open PRs were checked before publication; no overlapping embedding transport change was found. The existing execution-reliability task owns the canonical release and self-upgrade.
