### PR TITLE
fix(tests): resolve import.meta.url paths with fileURLToPath on every host

### DIFF
--- a/apps/web/lib/tools/integration-settings-href.test.ts
+++ b/apps/web/lib/tools/integration-settings-href.test.ts
@@ -1,4 +1,5 @@
 import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -10,7 +11,9 @@ import {
   routableIntegrationSlugs,
 } from "./integration-settings-href";
 
-const INTEGRATIONS_DIR = new URL("../../app/(shell)/platform/tools/integrations/", import.meta.url).pathname;
+// fileURLToPath, never `new URL(...).pathname`: on Windows the latter is
+// "/D:/..." and readdirSync fails on every host here (BI-5CBDC146 class).
+const INTEGRATIONS_DIR = fileURLToPath(new URL("../../app/(shell)/platform/tools/integrations/", import.meta.url));
 
 describe("integrationSettingsHref", () => {
   it("links an integration that has a page", () => {

--- a/scripts/apply-runtime-capability-transition.test.mjs
+++ b/scripts/apply-runtime-capability-transition.test.mjs
@@ -5,8 +5,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash, createHmac } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-const script = new URL("./apply-runtime-capability-transition.mjs", import.meta.url).pathname.replace(/^\/(.:\/)/, "$1");
+const script = fileURLToPath(new URL("./apply-runtime-capability-transition.mjs", import.meta.url)).replace(/^\/(.:\/)/, "$1");
 const canonical = (v) => JSON.stringify(v, Object.keys(v).sort());
 const secret = "s".repeat(32);
 function envelope(now = Date.now()) { return { version: 1, transitionId: "RCT-test", issuedAt: new Date(now - 100).toISOString(), expiresAt: new Date(now + 60_000).toISOString(), catalogHash: "a".repeat(64), previousStateHash: "b".repeat(64), desiredStateHash: "c".repeat(64), previousKeys: ["runtime:core"], desiredKeys: ["runtime:build", "runtime:core"], previousProfiles: [], desiredProfiles: ["build"], previousServices: ["portal", "postgres"], desiredServices: ["build", "portal", "postgres"] }; }

--- a/scripts/check-dockerfile-copied-script-imports.mjs
+++ b/scripts/check-dockerfile-copied-script-imports.mjs
@@ -30,10 +30,11 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { isEntryModule } from "./lib/entry-module.mjs";
 
-const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")), "..");
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(new URL(import.meta.url))), "..");
 
 /** Static `import ... from "x"` / `export ... from "x"`, plus bare `import "x"`. */
 const STATIC_IMPORT_RE =

--- a/scripts/check-dockerfile-copied-script-imports.test.mjs
+++ b/scripts/check-dockerfile-copied-script-imports.test.mjs
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   findMissingCopiedImports,
@@ -19,7 +20,7 @@ import {
 } from "./check-dockerfile-copied-script-imports.mjs";
 
 const REPO_ROOT = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")),
+  path.dirname(fileURLToPath(new URL(import.meta.url))),
   "..",
 );
 

--- a/scripts/check-no-substrate-regression.test.mjs
+++ b/scripts/check-no-substrate-regression.test.mjs
@@ -9,7 +9,7 @@ import { discoverGuardFiles } from "./check-guards.mjs";
 test("guard follows check-no convention and delegates to the canonical checker", async () => {
   const source=await readFile(new URL("./check-no-substrate-regression.mjs",import.meta.url),"utf8");
   assert.match(source,/runSubstrateMeasurement/);
-  assert.match(new URL("./check-no-substrate-regression.mjs",import.meta.url).pathname,/check-no-/);
+  assert.match(fileURLToPath(new URL("./check-no-substrate-regression.mjs",import.meta.url)),/check-no-/);
   const discovered=discoverGuardFiles(readdirSync(new URL(".",import.meta.url)));
   assert.ok(discovered.guards.includes("check-no-substrate-regression.mjs"));
   assert.ok(discovered.tests.has("check-no-substrate-regression.test.mjs"));

--- a/scripts/gate-context.test.mjs
+++ b/scripts/gate-context.test.mjs
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { buildGateContext, formatGateContextMarkdown } from "./lib/gate-context.mjs";
 import { parseStdinChanges } from "./gate-context.mjs";
@@ -24,7 +25,7 @@ import {
 import { decide as specPlanDocDecide } from "../packages/dpf-skill-pack/hooks/spec-plan-doc-precheck.mjs";
 import { decide as uxFitDecide } from "../packages/dpf-skill-pack/hooks/ux-fit-precheck.mjs";
 
-const repoRoot = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 
 const build = (changedFiles, extra = {}) =>
   buildGateContext({ changedFiles, repoRoot, ...extra });

--- a/scripts/installer/native-edge-host-contract.test.mjs
+++ b/scripts/installer/native-edge-host-contract.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 
 const read = (path) => readFile(new URL(`../../${path}`, import.meta.url), "utf8");
 const execFileAsync = promisify(execFile);
@@ -196,7 +197,7 @@ test("macOS host install preserves the one-time token in its protected runtime e
     await chmod(join(fakeBin, name), 0o755);
   }
 
-  const installerPath = new URL("./native-edge-host.sh", import.meta.url).pathname;
+  const installerPath = fileURLToPath(new URL("./native-edge-host.sh", import.meta.url));
   await execFileAsync("/bin/bash", ["-c", [
     "warn() { :; }", "ok() { :; }", `. ${JSON.stringify(installerPath)}`,
     `dpf_native_edge_install ${JSON.stringify(repo)} dpfboot_TEST_TOKEN test-mac`,

--- a/scripts/installer/pki-contract.test.mjs
+++ b/scripts/installer/pki-contract.test.mjs
@@ -4,6 +4,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 const read = (path) => readFile(new URL(`../../${path}`, import.meta.url), "utf8");
 
@@ -136,7 +137,7 @@ test("join packages are short-lived, intended-peer-bound, and never require a CA
 test("Bash join rejects an expired package before Docker is invoked", async () => {
   const directory = await mkdtemp(join(tmpdir(), "dpf-join-expired-"));
   const packagePath = join(directory, "expired.dpfjoin");
-  const script = new URL("../bootstrap-organization-pki.sh", import.meta.url).pathname;
+  const script = fileURLToPath(new URL("../bootstrap-organization-pki.sh", import.meta.url));
 
   try {
     await writeFile(packagePath, [
@@ -164,7 +165,7 @@ test("Bash join rejects an expired package before Docker is invoked", async () =
 test("Bash join rejects a package intended for a different installation", async () => {
   const directory = await mkdtemp(join(tmpdir(), "dpf-join-peer-"));
   const packagePath = join(directory, "wrong-peer.dpfjoin");
-  const script = new URL("../bootstrap-organization-pki.sh", import.meta.url).pathname;
+  const script = fileURLToPath(new URL("../bootstrap-organization-pki.sh", import.meta.url));
 
   try {
     await writeFile(packagePath, [
@@ -191,7 +192,7 @@ test("Bash join rejects a package intended for a different installation", async 
 test("Bash join rejects a public CA origin before Docker is invoked", async () => {
   const directory = await mkdtemp(join(tmpdir(), "dpf-join-public-ca-"));
   const packagePath = join(directory, "public-ca.dpfjoin");
-  const script = new URL("../bootstrap-organization-pki.sh", import.meta.url).pathname;
+  const script = fileURLToPath(new URL("../bootstrap-organization-pki.sh", import.meta.url));
 
   try {
     await writeFile(packagePath, [
@@ -289,7 +290,7 @@ test("Caddy exposes a dedicated verified-client action listener and strips spoof
 });
 
 test("Bash bootstrap rejects public binds and argument injection before Docker", () => {
-  const script = new URL("../bootstrap-organization-pki.sh", import.meta.url).pathname;
+  const script = fileURLToPath(new URL("../bootstrap-organization-pki.sh", import.meta.url));
   const publicBind = spawnSync("bash", [script, "--hostname", "dpf.local", "--bind-address", "8.8.8.8"], { encoding: "utf8" });
   assert.equal(publicBind.status, 64);
   assert.match(publicBind.stderr, /private IPv4/i);

--- a/scripts/lib/govern-capability-compose-args.test.mjs
+++ b/scripts/lib/govern-capability-compose-args.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { governCapabilityComposeArgs, governCapabilityComposeEnvironment } from "./govern-capability-compose-args.mjs";
 
@@ -74,7 +75,7 @@ test("disabled environment aliases fail closed", () => {
 });
 
 test("dpf-compose emits the exact disabled-profile failure before Docker", async () => {
-  const root = resolve(new URL("../..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+  const root = fileURLToPath(new URL("../..", import.meta.url));
   const catalog = JSON.parse(await readFile(join(root, "scripts", "capability-service-catalog.generated.json"), "utf8"));
   const enabled = new Set(["runtime:core"]);
   const lines = catalog.capabilities.map(({ capabilityId }) => `${capabilityId}=${enabled.has(capabilityId) ? "active" : "disabled"}`).sort().join("\n");
@@ -101,7 +102,7 @@ test("dpf-compose emits the exact disabled-profile failure before Docker", async
 });
 
 test("dpf-compose governs profile and topology environment before fake Docker", async () => {
-  const root = resolve(new URL("../..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+  const root = fileURLToPath(new URL("../..", import.meta.url));
   const catalog = JSON.parse(await readFile(join(root, "scripts", "capability-service-catalog.generated.json"), "utf8"));
   const dir = await mkdtemp(join(tmpdir(), "dpf-compose-env-"));
   const statePath = join(dir, "install-state.json");

--- a/scripts/lib/lifecycle-capability-profile-contract.test.mjs
+++ b/scripts/lib/lifecycle-capability-profile-contract.test.mjs
@@ -6,8 +6,9 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { signTransitionPayload } from "./transition-signing.mjs";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-const root = resolve(new URL("../..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+const root = fileURLToPath(new URL("../..", import.meta.url));
 const bashPath = (path) => resolve(path).replace(/^([A-Za-z]):\\/, (_, drive) => `/mnt/${drive.toLowerCase()}/`).replaceAll("\\", "/");
 const runBash = (body, env = {}) => spawnSync("bash", [], { cwd: root, encoding: "utf8", input: body, env: { ...process.env, ...env } });
 

--- a/scripts/pre-push-dco-check.test.mjs
+++ b/scripts/pre-push-dco-check.test.mjs
@@ -14,11 +14,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { isSignedOff, findUnsignedCommits, resolvePushRange } from "./lib/dco-signoff.mjs";
 import { parseArgs, evaluateDcoPush, main } from "./pre-push-dco-check.mjs";
 
-const repoRoot = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const dcoCli = join(repoRoot, "scripts", "pre-push-dco-check.mjs");
 
 const US = "\x1f";

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -32,7 +32,7 @@ import { RUNNER_FAILURE_EXIT_CODE } from "./check-guards.mjs";
 import { loadPinnedGuardTypeScript } from "./lib/load-pinned-guard-typescript.mjs";
 import { shouldRunPreflight } from "./pregate.mjs";
 
-const repoRoot = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const preflightCli = join(repoRoot, "scripts", "pregate-preflight.mjs");
 const pregateCli = join(repoRoot, "scripts", "pregate.mjs");
 

--- a/scripts/promote-host-bind-address.test.mjs
+++ b/scripts/promote-host-bind-address.test.mjs
@@ -9,8 +9,9 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-const root = resolve(new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const bash = process.platform === "win32" ? "C:\\Program Files\\Git\\bin\\bash.exe" : "bash";
 const bashPath = (path) => process.platform === "win32"
   ? resolve(path).replace(/^([A-Za-z]):\\/, (_, drive) => `/${drive.toLowerCase()}/`).replaceAll("\\", "/")

--- a/scripts/promote-install-state-rollback.test.mjs
+++ b/scripts/promote-install-state-rollback.test.mjs
@@ -5,11 +5,12 @@ import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { projectInstallState } from "./installer/migrate-install-state.mjs";
 import { signTransitionPayload } from "./lib/transition-signing.mjs";
 
-const root = resolve(new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const bash = process.platform === "win32" ? "C:\\Program Files\\Git\\bin\\bash.exe" : "bash";
 const bashPath = (path) => process.platform === "win32"
   ? resolve(path).replace(/^([A-Za-z]):\\/, (_, drive) => `/${drive.toLowerCase()}/`).replaceAll("\\", "/")

--- a/scripts/promoter-build-context.test.mjs
+++ b/scripts/promoter-build-context.test.mjs
@@ -2,10 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { access, readFile } from "node:fs/promises";
 import { dirname, join, posix, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
 
-const root = resolve(dirname(new URL(import.meta.url).pathname.replace(/^\/(.:\/)/, "$1")), "..");
+const root = resolve(dirname(fileURLToPath(new URL(import.meta.url)).replace(/^\/(.:\/)/, "$1")), "..");
 const validatorAssets = [
   "scripts/installer/validate-install-state.mjs",
   "scripts/installer/install-state-schema-registry.mjs",

--- a/scripts/promoter-contract.test.mjs
+++ b/scripts/promoter-contract.test.mjs
@@ -3,9 +3,10 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
 
-const root = resolve(new URL("..", import.meta.url).pathname.replace(/^\/(.:\/)/, "$1"));
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)).replace(/^\/(.:\/)/, "$1"));
 
 test("schema-v1 manifest declares the complete pre-drain contract", async () => {
   const schema = JSON.parse(await readFile(resolve(root, "promoter-contract.schema.json"), "utf8"));

--- a/scripts/promoter-migration-envelope.test.mjs
+++ b/scripts/promoter-migration-envelope.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 // End-to-end through the promoter entrypoint: an N-1 caller sends no handoff at
 // all, so the CLI must self-issue from the mounted state instead of exiting 78.
@@ -24,7 +25,7 @@ test("CLI self-issues when the caller sends no handoff", async () => {
   }));
   writeFileSync(join(root, "secret"), "s".repeat(32));
 
-  const stdout = execFileSync(process.execPath, [new URL("./promoter-migration-envelope.mjs", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")], {
+  const stdout = execFileSync(process.execPath, [fileURLToPath(new URL("./promoter-migration-envelope.mjs", import.meta.url))], {
     encoding: "utf8",
     env: {
       ...process.env,

--- a/scripts/promoter-readiness.test.mjs
+++ b/scripts/promoter-readiness.test.mjs
@@ -2,8 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = resolve(new URL("..", import.meta.url).pathname.replace(/^\/(.:\/)/, "$1"));
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)).replace(/^\/(.:\/)/, "$1"));
 
 test("readiness contract is non-mutating and reports every required dependency", async () => {
   const script = await readFile(resolve(root, "scripts/promote.sh"), "utf8");

--- a/scripts/rotate-runtime-transition-secret.test.mjs
+++ b/scripts/rotate-runtime-transition-secret.test.mjs
@@ -4,8 +4,9 @@ import { mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-const script = new URL("./rotate-runtime-transition-secret.mjs", import.meta.url).pathname.replace(/^\/(.:\/)/, "$1");
+const script = fileURLToPath(new URL("./rotate-runtime-transition-secret.mjs", import.meta.url)).replace(/^\/(.:\/)/, "$1");
 const run = (stateDir, ...args) => spawnSync(process.execPath, [script, "--state-dir", stateDir, ...args], { encoding: "utf8" });
 
 test("creates a cryptographically random owner-only secret", async () => {

--- a/scripts/runtime-transition-authority.test.mjs
+++ b/scripts/runtime-transition-authority.test.mjs
@@ -4,8 +4,9 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-const script = new URL("./runtime-transition-authority.mjs", import.meta.url).pathname.replace(/^\/(.:\/)/, "$1");
+const script = fileURLToPath(new URL("./runtime-transition-authority.mjs", import.meta.url)).replace(/^\/(.:\/)/, "$1");
 const run = (dir, args, env = {}) => spawnSync(process.execPath, [script, ...args], { encoding: "utf8", env: { ...process.env, DPF_PROMOTER_STATE_DIR: dir, ...env } });
 
 test("same transition id cannot acquire concurrent authority", async () => {

--- a/scripts/self-upgrade-sensitive-paths.test.mjs
+++ b/scripts/self-upgrade-sensitive-paths.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
 import {
@@ -55,7 +56,7 @@ test("every file baked into the promoter image is self-upgrade sensitive", async
   // means a newly baked file cannot silently escape the acceptance gate.
   // (Dockerfile.promoter deliberately copies directories rather than files, so
   // the closure — not the Dockerfile — is what enumerates them: BI-A04D61B9.)
-  const baked = await readPromoterBuildContextSources(new URL("..", import.meta.url).pathname);
+  const baked = await readPromoterBuildContextSources(fileURLToPath(new URL("..", import.meta.url)));
   assert.ok(baked.length >= 15, `expected the promoter closure, parsed ${baked.length} staged inputs`);
   assert.deepEqual(findUnownedLifecyclePaths(baked), [], "a file baked into the promoter image must trigger the self-upgrade acceptance gate");
 });

--- a/scripts/test-n-minus-one-upgrade.test.mjs
+++ b/scripts/test-n-minus-one-upgrade.test.mjs
@@ -5,6 +5,7 @@ import { readFile, realpath, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   assertSafeHarnessConfig,
@@ -298,7 +299,7 @@ test("completed evidence must preserve the exact observed baseline bytes", async
 });
 
 test("acceptance workflow executes the real baseline-to-candidate N-1 runner", async () => {
-  const workflow = await readFile(join(new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"), ".github/workflows/self-upgrade-acceptance.yml"), "utf8");
+  const workflow = await readFile(join(fileURLToPath(new URL("..", import.meta.url)), ".github/workflows/self-upgrade-acceptance.yml"), "utf8");
   assert.match(workflow, /node scripts\/test-n-minus-one-upgrade\.mjs \\/);
   for (const flag of ["--base-sha", "--candidate-sha", "--repository", "--project", "--evidence-dir"]) assert.match(workflow, new RegExp(flag));
   assert.match(workflow, /--pr-number "\$\{\{ steps\.baseline\.outputs\.pr_number \}\}"/);

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -13,10 +13,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:http";
 import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import { detectWorkingShell } from "../../scripts/pregate.mjs";
 
-const repoRoot = new URL("../..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const pregateScript = join(repoRoot, "scripts", "pregate.mjs");
 const gateScript = join(repoRoot, "scripts", "gate-worktree.mjs");
 const runnerScript = join(repoRoot, "scripts", "local-ci-runner.mjs");
@@ -848,6 +849,7 @@ test("gate-worktree.mjs carries content-addressed local integration metadata int
   const writerScript = join(temp, "write-metadata.mjs");
   writeFileSync(writerScript, `
 import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 writeFileSync(process.env.DPF_LOCAL_CI_METADATA_FILE, JSON.stringify({
   schemaVersion: 2,
   bi: "BI-76551B2D",


### PR DESCRIPTION
## Summary

`new URL(..., import.meta.url).pathname` is `/D:/...` on Windows, so any filesystem call built on it fails on every Windows host while staying green in CI. The integration-settings-href test added by #5247 reintroduced the pattern and failed the local-CI gate for every branch on this host (evidence cmttka1tp0okm01o9g7g8m5l0: 1 failed / 29,074 passed).

Twenty-three files used the raw `.pathname` or a hand-rolled `.replace(/^\/([A-Za-z]:)/, "$1")` workaround; all now use `fileURLToPath`. `hooks-dir.mjs` and `converge-git-hooks*` keep the string only in comments that explain the trap.

## Verification

- Failing-to-passing: `vitest run lib/tools/integration-settings-href.test.ts` fails on main (`ENOENT scandir 'D:\D:\...'`) and passes on this branch (6/6).
- Pure-Node script tests: 231 pass on main, 232 pass here, same 13 Windows-host bash-dependent failures on both.
- Local-CI gate PASS on 3395c6cafc6b, evidence cmttm0j3j0wfz01o9mwow97qt.

Ratchet follow-up filed as BI-5CC4159D (guard against the pattern returning). Readiness-probe defect met on the way filed as BI-D5E18921.

Convergence-Impact-Decision: not-reachable — test files and one guard script's own path resolution; no installed runtime reads them.
Docs-Impact-Decision: test-only change; no user-facing documentation describes these paths.
Seed-Fit-Decision: not-applicable (tests only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)