### PR TITLE
chore(image): ship only the runtime dependency set in the portal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -272,6 +272,34 @@ RUN mkdir -p /dpf-release-assets/scripts/lib /dpf-release-assets/scripts/install
     cd /dpf-release-assets && \
     find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
 
+# ─── Runtime dependency set (BI-C7C6D827, plan 2026-09-08 M1) ───────────────
+# The runner copies this stage's node_modules, and until this step that was the
+# whole DEV workspace tree: two TypeScript compilers, vitest/jsdom/msw, Prisma
+# Studio, the mobile toolchain, a 130 MB browser-only ONNX runtime — 1.8 GB and
+# ~1,170 packages the portal never executes. Everything the build stage needed
+# (prisma generate, the tools snapshot, the release assets) has already run
+# above, so the tree is now re-installed to exactly what the runner executes:
+#
+#   docker-entrypoint.sh  pnpm --filter @dpf/db exec prisma migrate deploy
+#                         pnpm --filter @dpf/db exec tsx src/seed.ts (+ sync/
+#                         reconcile scripts under packages/db/scripts)
+#   seed.ts               @dpf/storefront-templates and the other @dpf/* links
+#   /app/scripts/*.mjs    pure Node by design (gate-context, data-impact, SBOM)
+#
+# The Next.js server itself resolves from the standalone output's own traced
+# node_modules, and Build Studio's /workspace runs its own `pnpm install` from
+# the shipped lockfile at first boot, so neither depends on this tree.
+# `@dpf/db...` selects the db package plus every workspace package it links;
+# its devDependencies (prisma CLI, tsx) are runtime executables here, so the
+# install is deliberately NOT --prod. --offline: the pnpm store in this stage
+# already holds every package from the full install above.
+RUN rm -rf node_modules apps/*/node_modules packages/*/node_modules services/*/node_modules && \
+    pnpm install --frozen-lockfile --offline --filter "@dpf/db..." --config.confirmModulesPurge=false && \
+    pnpm --filter @dpf/db exec prisma generate && \
+    pnpm --filter @dpf/db exec tsx --version >/dev/null && \
+    pnpm --filter @dpf/db exec prisma --version >/dev/null && \
+    echo "runtime dependency set: $(find node_modules/.pnpm -maxdepth 1 -mindepth 1 -type d | wc -l) packages"
+
 # ─── Stage 5: runner (unified — serves app AND runs init) ─────────────────────
 FROM base AS runner
 LABEL org.opencontainers.image.title="Open Digital Product Factory"


### PR DESCRIPTION
## Summary

Plan move M1 (`docs/superpowers/plans/2026-09-08-dependency-diet-and-vertical-integration-plan.md`, BI-C7C6D827, EP-8DC217EB). The runner stage copied the init stage's `node_modules`, which was the whole DEV workspace tree: 1.83 GB / ~1,170 packages including two TypeScript compilers, vitest/jsdom/msw, Prisma Studio, the mobile toolchain and a 130 MB browser-only ONNX runtime. The portal executes none of it.

After prisma generate, the tools snapshot and the release assets are built, the init stage now re-installs offline, filtered to `@dpf/db...` (the db package and every workspace package it links; its devDependencies are kept because the Prisma CLI and tsx are runtime executables there), regenerates the Prisma client and asserts both executables resolve.

## Install shapes and sandbox

- **Release / consumer install:** the entrypoint's `prisma migrate deploy`, the tsx seed and sync scripts under `packages/db`, and the pure-Node `/app/scripts` all resolve from the filtered tree (proven below).
- **Source / dev install:** unaffected; it runs from the source checkout, not this image.
- **Build Studio sandbox:** `/workspace` performs its own `pnpm install --frozen-lockfile` from the shipped manifests at first boot and never resolved from `/app/node_modules`; `apps/web-src` and `packages-src` are unchanged.
- **Next.js server:** resolves from the standalone output's own traced `node_modules`, copied before this tree.

## Verification

Local `docker build --target runner` on this branch (8 min):

| Measure | Before (v2026.09.08-reviewer-recovery.3) | After |
|---|---|---|
| Image | 4.17 GB | 3.07 GB |
| `/app/node_modules` | 1,744 MB | 936 MB |
| `.pnpm` package dirs | 1,167 | 727 |

Inside the built image against a throwaway pgvector Postgres: `prisma migrate deploy` applied all migrations; `tsx scripts/sync-provider-registry.ts` completed; `scripts/sbom/generate-platform-sbom.mjs` ran; `apps/web/server.js` reported Ready. `scripts/gate-context.mjs --help` errors identically on the live image (pre-existing).

Local-CI gate PASS on 9a2c32605659, evidence cmttq0v9a02ot01pc07swnqvp.

Remaining dev-shaped packages in the image are `@dpf/db`'s own devDependencies (vitest, jsdom) and Prisma Studio (a Prisma CLI dependency); promoting tsx and prisma to `dependencies` would allow `--prod` and is a follow-on, not this PR. mermaid and puppeteer leave with #5253.

Convergence-Impact-Decision: auto-converges — the change is inside the portal image build; every install receives it with the next release through /ops/self-upgrade, and nothing outside the image changes.
Docs-Impact-Decision: build-stage packaging only; no user-facing documentation describes the image's node_modules layout.
Seed-Fit-Decision: not-applicable (image packaging; no seed, schema, template or install-path change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Evidence: cmttq0v9a02ot01pc07swnqvp
