### PR TITLE
fix(tests): trunk merge-scanner test uses the trunk tip's own squash commit, not a fixed PR number

### DIFF
--- a/apps/web/lib/work-capsules/git-scanner.test.ts
+++ b/apps/web/lib/work-capsules/git-scanner.test.ts
@@ -1,6 +1,10 @@
+import { execFile } from "node:child_process";
 import { tmpdir } from "node:os";
+import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
 
 import {
   isReachableFromTrunk,
@@ -108,8 +112,17 @@ describe("trunkHasMergedPullRequest (BI-AFE8BB73)", () => {
   it("finds a merged PR's squash commit on a present local trunk and not a never-merged number", async () => {
     const repoRoot = process.cwd();
     if (!(await trunkRefExists(repoRoot))) return; // no local trunk here → skip
-    // #5119 landed on main on 2026-09-06 (fix(readiness): child inherits parent scope).
-    expect(await trunkHasMergedPullRequest(repoRoot, 5119)).toBe(true);
+    // Use whatever squash-merge commit the local trunk tip carries, so the
+    // assertion does not depend on how much history the checkout fetched or
+    // on a fixed PR number that a shallow or partial trunk cannot see.
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", repoRoot, "log", "origin/main", "-20", "--format=%s"],
+      { timeout: 5000, windowsHide: true },
+    );
+    const merged = stdout.split("\n").map((line) => line.match(/\(#(\d+)\)\s*$/)?.[1]).find(Boolean);
+    if (!merged) return; // a trunk with no squash-merge subject in reach → nothing to assert
+    expect(await trunkHasMergedPullRequest(repoRoot, Number(merged))).toBe(true);
     expect(await trunkHasMergedPullRequest(repoRoot, 99999999)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Main CI has been red since 2026-09-09 02:45Z on `git-scanner.test.ts > trunkHasMergedPullRequest > finds a merged PR's squash commit on a present local trunk`, and every merge-group run fails on it, so nothing merges. The unit-test job checks out with `fetch-depth: 1`; the test asserted that PR #5119 (merged 2026-09-06) is visible in `git log origin/main`, which a depth-1 trunk cannot see once main moves on.

The test now derives the PR number from the newest squash-merge subject the local trunk carries and asserts that, plus the never-merged negative. Passes locally against a full clone (10/10) and is valid at any checkout depth.

## Verification

- `pnpm --filter web exec vitest run lib/work-capsules/git-scanner.test.ts` — 10 passed.
- Test-only change; no runtime code.

Refs: BI-AFE8BB73 (the test's owning slice)

Local-CI-Override: docs-adjacent: test-only change to a unit test file; no runtime code; merge-queue CI is the verifier

Process-Spine-Decision: test-only change; no spec, plan or user-facing doc affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
