### PR TITLE
fix(inference): settle an unsatisfiable TaskRun binding as failed instead of throwing before the lease

### DIFF
--- a/apps/web/lib/inference/async-operation-runtime-dispatch-binding.test.ts
+++ b/apps/web/lib/inference/async-operation-runtime-dispatch-binding.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    taskRun: { findUnique: vi.fn() },
+  },
+  loadForWorker: vi.fn(),
+  requestAuthorizedCancellation: vi.fn(),
+  runWorker: vi.fn(),
+  enqueueWake: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("./ai-inference", () => ({ callProvider: vi.fn() }));
+vi.mock("./async-inference", () => ({ pollAsyncProviderOperation: vi.fn() }));
+vi.mock("./async-operation-store", () => ({
+  PrismaAsyncOperationStore: class {
+    loadForWorker = mocks.loadForWorker;
+    requestAuthorizedCancellation = mocks.requestAuthorizedCancellation;
+  },
+}));
+vi.mock("./async-operation-worker", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./async-operation-worker")>()),
+  runDurableAsyncOperationWorker: mocks.runWorker,
+}));
+vi.mock("@/lib/execution/adapters/async-operation-events", () => ({
+  enqueueAsyncOperationWake: mocks.enqueueWake,
+  publishAsyncOperationTransitionEvent: vi.fn(),
+}));
+
+import { DURABLE_INFERENCE_TASK_CONTRACT_FAMILY } from "@/lib/mcp-task-durable-inference-contract";
+import type { AsyncOperationRecord } from "./async-operation-lifecycle";
+import {
+  DURABLE_INFERENCE_TASKRUN_BINDING_MISSING,
+  resolveDurableTaskDispatchBinding,
+  runPrismaAsyncOperationWake,
+} from "./async-operation-runtime";
+
+const now = new Date("2026-09-05T02:32:30.518Z");
+
+function durableOperation(overrides: Partial<AsyncOperationRecord> = {}): AsyncOperationRecord {
+  return {
+    id: "cmtnrpb9200003cu44gm1bbf7",
+    authorityScopeKey: "workroom:WC-1",
+    requestKey: "request-1",
+    requestDigest: "a".repeat(64),
+    bindingDigest: "b".repeat(64),
+    providerId: "gemini",
+    modelId: "gemini-3.1-pro-preview",
+    contractFamily: DURABLE_INFERENCE_TASK_CONTRACT_FAMILY,
+    screenedRequestContext: { promptRef: "screened:1" },
+    taskRunId: null,
+    workroomId: "workroom-row-1",
+    status: "pending",
+    providerOperationId: null,
+    checkpointSequence: 0,
+    transitionSequence: 0,
+    startClaimFence: 0,
+    startAttemptedAt: null,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    cancelRequestedAt: null,
+    nextPollAt: null,
+    resultText: null,
+    resultData: null,
+    errorMessage: null,
+    progressPct: null,
+    progressMessage: null,
+    createdAt: now,
+    updatedAt: now,
+    startedAt: null,
+    completedAt: null,
+    expiresAt: new Date(now.getTime() + 60_000),
+    ...overrides,
+  };
+}
+
+describe("durable TaskRun dispatch binding resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports a durable-family operation with no TaskRun id as unsatisfiable without touching the database", async () => {
+    const binding = await resolveDurableTaskDispatchBinding(durableOperation({ taskRunId: null }));
+
+    expect(binding).toEqual({ kind: "unsatisfiable", error: DURABLE_INFERENCE_TASKRUN_BINDING_MISSING });
+    expect(mocks.prisma.taskRun.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("reports a TaskRun id whose row is gone as unsatisfiable", async () => {
+    mocks.prisma.taskRun.findUnique.mockResolvedValue(null);
+
+    const binding = await resolveDurableTaskDispatchBinding(durableOperation({ taskRunId: "task-row-gone" }));
+
+    expect(binding).toEqual({ kind: "unsatisfiable", error: DURABLE_INFERENCE_TASKRUN_BINDING_MISSING });
+    expect(mocks.prisma.taskRun.findUnique).toHaveBeenCalledWith({
+      where: { id: "task-row-gone" },
+      select: { progressPayload: true },
+    });
+  });
+
+  it("returns the TaskRun progress payload when the binding holds", async () => {
+    mocks.prisma.taskRun.findUnique.mockResolvedValue({ progressPayload: { operationId: "op" } });
+
+    const binding = await resolveDurableTaskDispatchBinding(durableOperation({ taskRunId: "task-row-1" }));
+
+    expect(binding).toEqual({ kind: "bound", progressPayload: { operationId: "op" } });
+  });
+
+  it("leaves non-TaskRun contract families alone", async () => {
+    const binding = await resolveDurableTaskDispatchBinding(durableOperation({
+      contractFamily: "research",
+      taskRunId: null,
+    }));
+
+    expect(binding).toEqual({ kind: "not-durable-task" });
+    expect(mocks.prisma.taskRun.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("runPrismaAsyncOperationWake with an unsatisfiable binding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hands the orphan to the fenced worker instead of throwing before the claim", async () => {
+    const orphan = durableOperation({ taskRunId: null });
+    mocks.loadForWorker
+      .mockResolvedValueOnce(orphan)
+      .mockResolvedValue(durableOperation({ taskRunId: null, status: "failed" }));
+    mocks.runWorker.mockResolvedValue({ status: "failed", disposition: "failed" });
+
+    const result = await runPrismaAsyncOperationWake({ operationId: orphan.id, workerId: "worker-1" });
+
+    expect(mocks.runWorker).toHaveBeenCalledTimes(1);
+    const [workerInput, workerDeps] = mocks.runWorker.mock.calls[0] as [
+      { operationId: string; workerId: string },
+      { resolveDispatchBinding?: (operation: AsyncOperationRecord) => Promise<unknown> },
+    ];
+    expect(workerInput).toEqual({ operationId: orphan.id, workerId: "worker-1" });
+    await expect(workerDeps.resolveDispatchBinding?.(orphan)).resolves.toEqual({
+      kind: "unsatisfiable",
+      error: DURABLE_INFERENCE_TASKRUN_BINDING_MISSING,
+    });
+    expect(result).toEqual({ status: "failed", disposition: "failed", nextWakeAt: null });
+    expect(mocks.enqueueWake).not.toHaveBeenCalled();
+  });
+
+  it("still gates a bound TaskRun wake on the durable task disposition", async () => {
+    const bound = durableOperation({ taskRunId: "task-row-1" });
+    mocks.loadForWorker.mockResolvedValue(bound);
+    mocks.prisma.taskRun.findUnique.mockResolvedValue({
+      progressPayload: { durableInference: { state: "pending" } },
+    });
+
+    const result = await runPrismaAsyncOperationWake({ operationId: bound.id, workerId: "worker-1" });
+
+    expect(result).toEqual({ status: "pending", disposition: "busy", nextWakeAt: null });
+    expect(mocks.runWorker).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/inference/async-operation-runtime.ts
+++ b/apps/web/lib/inference/async-operation-runtime.ts
@@ -15,6 +15,7 @@ import {
 import {
   admitDurableAsyncOperation,
   type AdmitDurableAsyncOperationInput,
+  type AsyncOperationRecord,
 } from "./async-operation-lifecycle";
 import {
   createDurableAsyncProviderDependencies,
@@ -258,16 +259,14 @@ export async function runPrismaAsyncOperationWake(input: {
 }) {
   const store = createStore();
   const operation = await store.loadForWorker(input.operationId);
-  if (operation?.contractFamily === DURABLE_INFERENCE_TASK_CONTRACT_FAMILY) {
-    if (!operation.taskRunId) throw new Error("DURABLE_INFERENCE_TASKRUN_BINDING_MISSING");
-    const taskRun = await prisma.taskRun.findUnique({
-      where: { id: operation.taskRunId },
-      select: { progressPayload: true },
-    });
-    if (!taskRun) throw new Error("DURABLE_INFERENCE_TASKRUN_BINDING_MISSING");
+  const binding = operation ? await resolveDurableTaskDispatchBinding(operation) : null;
+  // An unsatisfiable binding is NOT refused here. Throwing before the claim
+  // never leases or transitions the row, so bounded recovery re-enqueues it
+  // every tick forever; the fenced worker settles it as `failed` instead.
+  if (operation && binding?.kind === "bound") {
     const disposition = durableMcpTaskWakeDisposition({
       operationId: operation.id,
-      progressPayload: taskRun.progressPayload,
+      progressPayload: binding.progressPayload,
     });
     if (disposition === "wait") {
       return { status: operation.status, disposition: "busy" as const, nextWakeAt: null };
@@ -286,11 +285,56 @@ export async function runPrismaAsyncOperationWake(input: {
       store,
       now: () => new Date(),
       ...provider,
+      resolveDispatchBinding: async (candidate) => {
+        const resolved = await resolveDurableTaskDispatchBinding(candidate);
+        return resolved.kind === "unsatisfiable" ? resolved : { kind: "bound" };
+      },
     }),
     loadForWorker: (operationId) => store.loadForWorker(operationId),
     enqueue: enqueueWake,
     now: () => new Date(),
   });
+}
+
+export const DURABLE_INFERENCE_TASKRUN_BINDING_MISSING = "DURABLE_INFERENCE_TASKRUN_BINDING_MISSING";
+
+export type DurableTaskDispatchBinding =
+  | { kind: "not-durable-task" }
+  | { kind: "bound"; progressPayload: unknown }
+  | { kind: "unsatisfiable"; error: typeof DURABLE_INFERENCE_TASKRUN_BINDING_MISSING };
+
+interface DurableTaskBindingDatabase {
+  taskRun: {
+    findUnique(args: {
+      where: { id: string };
+      select: { progressPayload: true };
+    }): Promise<{ progressPayload: unknown } | null>;
+  };
+}
+
+/**
+ * Resolve the server-owned TaskRun a durable MCP inference operation dispatches
+ * under. The binding is written before the wake is enqueued (#5065), so a
+ * missing id or a vanished row cannot heal by waiting: it is unsatisfiable.
+ */
+export async function resolveDurableTaskDispatchBinding(
+  operation: Pick<AsyncOperationRecord, "contractFamily" | "taskRunId">,
+  db: DurableTaskBindingDatabase = prisma as unknown as DurableTaskBindingDatabase,
+): Promise<DurableTaskDispatchBinding> {
+  if (operation.contractFamily !== DURABLE_INFERENCE_TASK_CONTRACT_FAMILY) {
+    return { kind: "not-durable-task" };
+  }
+  if (!operation.taskRunId) {
+    return { kind: "unsatisfiable", error: DURABLE_INFERENCE_TASKRUN_BINDING_MISSING };
+  }
+  const taskRun = await db.taskRun.findUnique({
+    where: { id: operation.taskRunId },
+    select: { progressPayload: true },
+  });
+  if (!taskRun) {
+    return { kind: "unsatisfiable", error: DURABLE_INFERENCE_TASKRUN_BINDING_MISSING };
+  }
+  return { kind: "bound", progressPayload: taskRun.progressPayload };
 }
 
 export async function reconcilePrismaAsyncOperationWakes(input: { limit?: number }) {

--- a/apps/web/lib/inference/async-operation-worker.test.ts
+++ b/apps/web/lib/inference/async-operation-worker.test.ts
@@ -284,6 +284,72 @@ describe("durable async operation worker", () => {
     expect(result).toEqual({ status: "failed", disposition: "failed" });
   });
 
+  it("settles an unsatisfiable dispatch binding as failed under the fenced lease instead of throwing", async () => {
+    const store = workerStore();
+    const deps = {
+      ...dependencies(store),
+      resolveDispatchBinding: vi.fn().mockResolvedValue({
+        kind: "unsatisfiable" as const,
+        error: "DURABLE_INFERENCE_TASKRUN_BINDING_MISSING",
+      }),
+    };
+
+    const result = await runDurableAsyncOperationWorker({ operationId: "op-1", workerId: "worker-1" }, deps);
+
+    expect(store.claimOperation).toHaveBeenCalledTimes(1);
+    expect(deps.resolveDispatchBinding).toHaveBeenCalledWith(expect.objectContaining({
+      id: "op-1",
+      leaseOwner: "worker-1",
+    }));
+    expect(store.markStartAttempted).not.toHaveBeenCalled();
+    expect(deps.startProvider).not.toHaveBeenCalled();
+    expect(store.transitionOwned).toHaveBeenCalledWith(expect.objectContaining({
+      from: "pending",
+      to: "failed",
+      workerId: "worker-1",
+      checkpoint: {
+        phase: "dispatch-binding-unsatisfiable",
+        error: "DURABLE_INFERENCE_TASKRUN_BINDING_MISSING",
+      },
+      data: { errorMessage: "DURABLE_INFERENCE_TASKRUN_BINDING_MISSING" },
+    }));
+    expect(result).toEqual({ status: "failed", disposition: "failed" });
+  });
+
+  it("settles an unsatisfiable dispatch binding on a running row without polling the provider", async () => {
+    const store = workerStore(operation({ status: "running", providerOperationId: "operations/provider-1" }));
+    const deps = {
+      ...dependencies(store),
+      resolveDispatchBinding: vi.fn().mockResolvedValue({
+        kind: "unsatisfiable" as const,
+        error: "DURABLE_INFERENCE_TASKRUN_BINDING_MISSING",
+      }),
+    };
+
+    const result = await runDurableAsyncOperationWorker({ operationId: "op-1", workerId: "worker-1" }, deps);
+
+    expect(deps.pollProvider).not.toHaveBeenCalled();
+    expect(store.transitionOwned).toHaveBeenCalledWith(expect.objectContaining({
+      from: "running",
+      to: "failed",
+      data: { errorMessage: "DURABLE_INFERENCE_TASKRUN_BINDING_MISSING" },
+    }));
+    expect(result).toEqual({ status: "failed", disposition: "failed" });
+  });
+
+  it("dispatches normally when the binding resolver reports the operation bound", async () => {
+    const store = workerStore();
+    const deps = {
+      ...dependencies(store),
+      resolveDispatchBinding: vi.fn().mockResolvedValue({ kind: "bound" as const }),
+    };
+
+    const result = await runDurableAsyncOperationWorker({ operationId: "op-1", workerId: "worker-1" }, deps);
+
+    expect(deps.startProvider).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ status: "running", disposition: "started" });
+  });
+
   it("persists terminal result and provenance after a completed poll", async () => {
     const store = workerStore(operation({ status: "running", providerOperationId: "operations/provider-1" }));
     const deps = dependencies(store);

--- a/apps/web/lib/inference/async-operation-worker.ts
+++ b/apps/web/lib/inference/async-operation-worker.ts
@@ -103,12 +103,28 @@ export type AsyncProviderStartReconciliation =
   | { kind: "failed"; error: string }
   | { kind: "unresolved" };
 
+/**
+ * Whether the row can legally reach its provider. `unsatisfiable` names a
+ * precondition no retry can ever meet (for example a durable TaskRun binding
+ * that was never written), so the worker settles the row instead of throwing.
+ */
+export type AsyncOperationDispatchBinding =
+  | { kind: "bound" }
+  | { kind: "unsatisfiable"; error: string };
+
 export interface AsyncOperationWorkerDependencies {
   store: AsyncOperationWorkerStore;
   now(): Date;
   startProvider(operation: AsyncOperationRecord): Promise<{ providerOperationId: string }>;
   pollProvider(operation: AsyncOperationRecord): Promise<AsyncProviderPollResult>;
   reconcileIndeterminateStart(operation: AsyncOperationRecord): Promise<AsyncProviderStartReconciliation>;
+  /**
+   * Optional dispatch precondition evaluated under the fenced lease, before any
+   * provider call. A throw before the claim leaves the row with no lease and no
+   * next poll, so bounded cron recovery re-enqueues it on every tick forever;
+   * an unsatisfiable answer here becomes a durable `failed` transition instead.
+   */
+  resolveDispatchBinding?(operation: AsyncOperationRecord): Promise<AsyncOperationDispatchBinding>;
 }
 
 export type AsyncOperationWorkerResult = {
@@ -288,6 +304,20 @@ export async function runDurableAsyncOperationWorker(
       phase: "expired-before-provider-call",
     });
     return { status: "expired", disposition: "expired" };
+  }
+
+  // A binding that can never be satisfied is a terminal fact about the row,
+  // not a transient fault. Settling it here, under the lease, is what stops
+  // recovery from waking the same orphan on every cron tick.
+  const binding = dependencies.resolveDispatchBinding
+    ? await dependencies.resolveDispatchBinding(operation)
+    : { kind: "bound" as const };
+  if (binding.kind === "unsatisfiable") {
+    await transition(dependencies, operation, claim, now, "failed", {
+      phase: "dispatch-binding-unsatisfiable",
+      error: binding.error,
+    }, { errorMessage: binding.error });
+    return { status: "failed", disposition: "failed" };
   }
 
   if (operation.status === "pending") {

--- a/docs/superpowers/specs/2026-09-04-async-delivery-task-hub-design.md
+++ b/docs/superpowers/specs/2026-09-04-async-delivery-task-hub-design.md
@@ -36,6 +36,8 @@ This task-hub slice neither defines nor replaces a queue, worker, retry policy, 
 
 Live acceptance found a producer-side contract gap rather than a Task Hub consumer defect. A server-authorized Workroom request could admit the closed `background.mcp-durable-inference-one-shot` contract directly against `Workroom`. The generic row was durable, but the closed worker correctly refused it with `DURABLE_INFERENCE_TASKRUN_BINDING_MISSING`; no terminal transition therefore existed for Task Hub to deliver.
 
+That refusal was itself a second defect (BI-B28F6940). The worker threw before claiming the lease, so the orphan row kept no lease and no next poll, and bounded cron recovery re-enqueued it on every tick with no terminal state, indefinitely. The rule now: a dispatch binding that can never be satisfied is a terminal fact about the row, not a transient fault. The worker evaluates the binding under the fenced lease and settles the row as `failed` through the ordinary owned transition (checkpoint phase `dispatch-binding-unsatisfiable`), which publishes a terminal transition Task Hub can deliver and removes the row from recovery.
+
 For that one closed contract family, the production admission boundary must bridge a Workroom authority to a canonical TaskRun before provider dispatch:
 
 1. authorize the public Workroom and actor against committed server records;


### PR DESCRIPTION
## Summary

The durable inference worker threw `DURABLE_INFERENCE_TASKRUN_BINDING_MISSING` before claiming the operation lease. A row that is never leased never transitions, so `listRecoverableOperationIds` returned the same orphan on every `*/2` recovery cron tick, Inngest ran all three attempts, and the loop repeated with no backoff and no terminal state. One orphan created before #5065 fixed the producer produced ~115 failing step runs an hour and a 71% CPU portal, which the founder saw as the portal hanging in the browser.

A dispatch binding that can never be satisfied is a terminal fact about the row, not a transient fault. The worker now evaluates it under the fenced lease and settles the row as `failed` through the ordinary owned transition, which publishes a terminal transition and drops the row out of recovery. The existing orphan self-heals on the first tick after deploy; no SQL surgery.

Break-fix lane (BI-B28F6940, `delivery-break-fix@1.0.0`). The post-implementation review receipt is owed within 48 hours by someone other than the declarer.

## Changes

- `async-operation-worker.ts`: optional `resolveDispatchBinding` dependency, evaluated after the fenced re-read and the cancellation/expiry checks, before any provider call. An `unsatisfiable` answer transitions to `failed` (checkpoint phase `dispatch-binding-unsatisfiable`, `errorMessage` = the code).
- `async-operation-runtime.ts`: new `resolveDurableTaskDispatchBinding` resolves the TaskRun binding once; bound rows keep the existing wait/cancel wake gate; unsatisfiable rows are handed to the worker instead of thrown on. The pre-claim throws are gone.
- Tests: three worker cases (pending row settles, running row settles without polling, bound row dispatches normally); new `async-operation-runtime-dispatch-binding.test.ts` covering the resolver and proving `runPrismaAsyncOperationWake` no longer throws on the orphan shape.
- Spec `2026-09-04-async-delivery-task-hub-design.md`: records the rule under the live-acceptance repair section.

## Test plan

- [x] **Source-only change**
  - [x] `tsc --noEmit -p apps/web/tsconfig.json` exit 0
  - [x] `vitest run` on `async-operation-worker`, `async-operation-runtime`, `async-operation-runtime-dispatch-binding`, `async-operation-runtime-workroom-task`, `async-operation-queue`: 5 files, 44 tests pass
- [x] Failing-then-passing proof: with the two source files stashed at the branch base, the 7 new tests fail (the runtime case with the exact live error); with the change they pass.
- [x] `pnpm run pregate`: local-CI gate PASS at the PR head (typecheck, 3383 tests, production build, image export).
- [ ] Live acceptance (left on BI-B28F6940 AC-3, after deploy): the orphan row reads `failed`, and portal logs show zero `DURABLE_INFERENCE_TASKRUN_BINDING_MISSING` in the following hour.

### Verification evidence

Red/green output, live database rows, and ruled-out causes are recorded as execution evidence on BI-B28F6940.

## Pre-PR readiness

- [x] `pnpm run pregate:preflight` passed
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] Docs impact: spec section updated; no user/install/route surface changed

## Related issues / Epic

BI-B28F6940 (break-fix). Follows #5065 (producer-side binding) and #5051 (async delivery task hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
