### PR TITLE
fix(work): a blocked receipt is scoped to its cycle, not permanent

### DIFF
--- a/apps/web/lib/work-management/writeback-latch.test.ts
+++ b/apps/web/lib/work-management/writeback-latch.test.ts
@@ -209,3 +209,145 @@ describe("the latch releases through resolveDrivePlan", () => {
     expect(released.reason).not.toBe("executor_writeback_unavailable");
   });
 });
+
+// ─── A blocked receipt is cycle-scoped too ───────────────────────────────────
+//
+// Found on the live install AFTER the bounded latch deployed. The cycle rolled
+// (stored lastCycleKey 2026-09-08, current 2026-09-09) and the rooms stayed
+// locked anyway, because every one of them carries:
+//
+//   [{"kind": "blocked", "stageKey": "sweep"}]
+//
+// and the first version of this function returned true unconditionally on that,
+// before any cycle comparison. The reasoning was that a recorded receipt is a
+// durable statement rather than a prior-tick inference — which preserved the
+// exact deadlock the bounded latch was written to remove, for exactly the twelve
+// rooms that were already stuck.
+//
+// A blocked receipt records "this stage produced no writeback in THIS cycle".
+// It is not a finding that the stage is permanently unfit.
+
+describe("a blocked receipt does not outlive its cycle", () => {
+  const CYCLE_YESTERDAY = "dependency-advisory-watch@1.0.0:2026-09-08";
+  const CYCLE_TODAY = "dependency-advisory-watch@1.0.0:2026-09-09";
+
+  it("holds inside the cycle that recorded it", () => {
+    expect(
+      writebackLatchHolds({
+        prior: {
+          action: "pause",
+          reason: "executor_writeback_unavailable",
+          stageKey: "sweep",
+          cycleKey: CYCLE_TODAY,
+        },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_TODAY,
+        blocked: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("RELEASES on the next cycle — the live case that stayed locked", () => {
+    expect(
+      writebackLatchHolds({
+        prior: {
+          action: "pause",
+          reason: "executor_writeback_unavailable",
+          stageKey: "sweep",
+          cycleKey: CYCLE_YESTERDAY,
+        },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_TODAY,
+        blocked: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still holds when the cycle cannot be determined", () => {
+    // Unknown must never be read as "a new cycle"; that re-opens the loop.
+    expect(
+      writebackLatchHolds({
+        prior: { action: "pause", reason: "executor_writeback_unavailable", stageKey: "sweep", cycleKey: null },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_TODAY,
+        blocked: true,
+      }),
+    ).toBe(true);
+    expect(
+      writebackLatchHolds({ prior: null, stageKey: "sweep", currentCycleKey: CYCLE_TODAY, blocked: true }),
+    ).toBe(true);
+  });
+
+  it("does not let another stage's blocked receipt hold this stage", () => {
+    expect(
+      writebackLatchHolds({
+        prior: { action: "pause", reason: "executor_writeback_unavailable", stageKey: "raise", cycleKey: CYCLE_TODAY },
+        stageKey: "sweep",
+        currentCycleKey: CYCLE_TODAY,
+        blocked: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+// ─── The live state, through the real resolver ───────────────────────────────
+//
+// Reproduces WC-A69BCABB exactly as the database held it on 2026-09-09:
+//   receipts     [{"kind":"blocked","stageKey":"sweep"}]
+//   lastCycleKey dependency-advisory-watch@1.0.0:2026-09-08
+//   reason       executor_writeback_unavailable
+// and asserts it dispatches. The predicate tests above would all have passed
+// while this room stayed locked, which is how the first fix shipped believing
+// itself complete.
+
+describe("the twelve locked rooms, reproduced", () => {
+  it("dispatches WC-A69BCABB from its real stored state", async () => {
+    const { resolveDrivePlan } = await import("./drive-resolution");
+    const { STANDING_SHAPES } = await import("./standing-operations-shapes");
+    const { readWorkShapeDefinitionContract } = await import("./work-shapes");
+    const shape = STANDING_SHAPES["dependency-advisory-watch"];
+
+    const plan = resolveDrivePlan({
+      roomId: "WC-A69BCABB",
+      definition: readWorkShapeDefinitionContract(shape),
+      collaborationShape: shape.collaborationShape ?? null,
+      postureLevel: "balanced" as const,
+      participants: [
+        {
+          workroomId: "r1",
+          principalRef: "PRN-SEC",
+          displayName: "security-engineer",
+          kind: "agent" as const,
+          roles: ["coordinator"],
+          assignmentSource: "explicit",
+          coordinatorSource: "explicit" as const,
+          enteredReason: null,
+          currentWorkSummary: null,
+          sponsorPrincipalRef: null,
+          sponsorDisplayName: null,
+          authoritySummary: "",
+        },
+      ],
+      currentStageKey: "sweep",
+      // The live rows, verbatim.
+      receipts: [{ stageKey: "sweep", kind: "blocked" }],
+      priorDrive: {
+        action: "pause",
+        reason: "executor_writeback_unavailable",
+        stageKey: "sweep",
+        cycleKey: "dependency-advisory-watch@1.0.0:2026-09-08",
+      },
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      substrateReachable: true,
+      substrateEmpty: false,
+      coordinatorEligibility: { jsi: "not-applicable" as const, authorityBinding: "eligible" as const },
+      now: new Date("2026-09-09T10:00:00Z"),
+    } as never);
+
+    expect(plan.reason).not.toBe("executor_writeback_unavailable");
+    expect(plan.action).toBe("dispatch_agent");
+    expect(plan.stageKey).toBe("sweep");
+  });
+});

--- a/apps/web/lib/work-management/writeback-latch.ts
+++ b/apps/web/lib/work-management/writeback-latch.ts
@@ -28,12 +28,20 @@ export type PriorDriveForLatch = {
 /**
  * Whether the writeback latch still holds for this stage.
  *
- * A recorded `blocked` receipt holds unconditionally: it is a durable statement
- * about this stage rather than an inference from the previous tick, and nothing
- * here should override it.
+ * A recorded `blocked` receipt records "this stage produced no writeback in THIS
+ * cycle" — not a finding that the stage is permanently unfit. It is therefore
+ * bounded by the cycle exactly like the prior-tick signal.
  *
- * An unknown cycle on either side holds too. Treating "unknown" as "a new cycle"
- * would silently re-open the every-tick loop the guard exists to prevent.
+ * ⟦An earlier version of this function returned true unconditionally on a
+ * blocked receipt, reasoning that a recorded receipt outranks a prior-tick
+ * inference. That preserved the very deadlock the bounded latch was written to
+ * remove, and preserved it precisely for the rooms already stuck: on this
+ * install the cycle rolled from 2026-09-08 to 2026-09-09 and all twelve stayed
+ * locked. A guard that cannot be re-entered by the fix for its own cause is not
+ * a guard.⟧
+ *
+ * An unknown cycle on either side still holds. Treating "unknown" as "a new
+ * cycle" would silently re-open the every-tick loop the guard exists to prevent.
  */
 export function writebackLatchHolds(input: {
   prior: PriorDriveForLatch | null;
@@ -41,13 +49,15 @@ export function writebackLatchHolds(input: {
   currentCycleKey: string | null;
   blocked: boolean;
 }): boolean {
-  if (input.blocked) return true;
   const prior = input.prior;
-  if (!prior) return false;
+  // A blocked receipt with no readable prior tick cannot be dated, so it holds.
+  if (!prior) return input.blocked;
   if (prior.stageKey !== input.stageKey) return false;
 
   const triedWriteback =
-    prior.action === "dispatch_agent" || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE_REASON;
+    input.blocked
+    || prior.action === "dispatch_agent"
+    || prior.reason === EXECUTOR_WRITEBACK_UNAVAILABLE_REASON;
   if (!triedWriteback) return false;
 
   // Same cycle — or an unknown one — keeps the latch. A genuinely new cycle

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -748,11 +748,25 @@ releases on the next, giving one attempt per cycle — daily for these shapes �
 instead of the 96 per day the guard was built to stop. The capacity protection is
 kept almost entirely (a 96x reduction); the deadlock is not.
 
-Two cases deliberately still hold unconditionally:
+A **`blocked` receipt is bounded by its cycle too**. It records "this stage
+produced no writeback in THIS cycle" — not a finding that the stage is
+permanently unfit.
 
-- **A recorded `blocked` receipt.** That is a durable statement about the stage,
-  not an inference from the previous tick, and a cycle rollover should not erase
-  it.
+That correction was itself a live defect. The first bounded latch returned early
+and unconditionally on a blocked receipt, reasoning that a recorded receipt
+outranks a prior-tick inference. It preserved the exact deadlock the bounded
+latch existed to remove, and preserved it precisely for the rooms already stuck:
+the cycle rolled from 2026-09-08 to 2026-09-09 and all twelve stayed locked,
+because every one of them carried `[{"kind":"blocked","stageKey":"sweep"}]`.
+Every predicate test passed while the estate did not move.
+
+**A guard that cannot be re-entered by the fix for its own cause is not a
+guard.** The test that catches this reproduces a real room's stored state — its
+receipts, its `lastCycleKey`, its pause reason — and asserts it dispatches
+through the real resolver.
+
+One case still holds unconditionally:
+
 - **An unknown cycle key on either side.** Reading "unknown" as "a new cycle"
   would silently re-open the every-tick loop.
 


### PR DESCRIPTION
## The bounded latch shipped believing itself complete, and changed nothing

`#5238` bounded the writeback latch to a cycle so a fail-closed pause would retry rather than lock forever. Both it and the stage-brief fix are confirmed in the deployed lineage, the drive is ticking, and the cycle rolled — stored `lastCycleKey` `2026-09-08`, current `2026-09-09`.

**All twelve rooms stayed locked.**

Because the latch returned early and unconditionally on a recorded `blocked` receipt, before any cycle comparison:

```ts
if (input.blocked) return true;   // checked before the cycle logic
```

and every locked room carries one:

```
WC-A69BCABB | [{"kind": "blocked", "stageKey": "sweep"}]
WC-B02C8BFA | [{"kind": "blocked", "stageKey": "read"}]
```

I reasoned about that case explicitly and got it wrong — argued a receipt is a durable statement about the stage rather than a prior-tick inference, so a cycle rollover shouldn't clear it. That preserved the exact deadlock the bounded latch existed to remove, and preserved it **precisely for the twelve rooms that were already stuck**, which were the only rooms it was written for.

## The fix

A `blocked` receipt records *"this stage produced no writeback in **this** cycle"* — not a finding that the stage is permanently unfit. It is now bounded by the cycle exactly like the prior-tick signal.

An unknown cycle key on either side still holds unconditionally, because reading "unknown" as "a new cycle" re-opens the every-tick loop the guard exists to prevent.

**A guard that cannot be re-entered by the fix for its own cause is not a guard.**

## The test that would have caught it

Every predicate test in #5238 passed while the estate did not move. So this one reproduces a real room's stored state — its receipts, its `lastCycleKey`, its pause reason, verbatim from the database — and asserts it dispatches **through the real resolver**:

```ts
receipts:   [{ stageKey: "sweep", kind: "blocked" }],
priorDrive: { reason: "executor_writeback_unavailable",
              cycleKey: "dependency-advisory-watch@1.0.0:2026-09-08" },
now:        2026-09-09
→ expect(plan.action).toBe("dispatch_agent")
```

## Verification

- 67 pregate preflight guards clean
- **29,130 tests pass** (3,305 files) — 5 new, 2 of which fail against the previous implementation
- `tsc --noEmit`: exit 0

**The heavy local-CI build was NOT run and is NOT passed** — fenced on `host-capacity-lost:host-memory-low`. Recorded `operator-emergency` override; cloud merge queue is the adjudicating build per AGENTS.md §4.

Local-CI-Override: operator-emergency: heavy build unrun (NOT passed) — local-CI fenced on host-capacity-lost:host-memory-low. Fast tier clean (67 preflight guards, 29130 tests, tsc --noEmit exit 0, live-state reproduction). Cloud merge queue is the adjudicating build per AGENTS.md 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
