### PR TITLE
feat(workforce): give FPAW §10's performer/allocation vocabulary a home in code

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1427,6 +1427,9 @@
       "docs/professions/data-architect/wiki/dedupe-migration-means-the-constraint-is-wrong.md",
       "docs/runbooks/2026-07-20-collation-drift-index-corruption.md"
     ],
+    "packages/db/src/performer-allocation.ts": [
+      "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md"
+    ],
     "packages/db/src/pg-graph.ts": [
       "docs/architecture/platform-overview.md"
     ],
@@ -2585,6 +2588,7 @@
     ],
     "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md": [
       "packages/db/scripts/generate-taxonomy-v3-json.ts",
+      "packages/db/src/performer-allocation.ts",
       "packages/db/src/reference-model-applicability.ts",
       "packages/db/src/seed-ea-reference-models.ts"
     ],

--- a/docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md
+++ b/docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md
@@ -976,6 +976,20 @@ qualification model, or action-permission engine.
 
 ## 10. Performer and work-allocation model
 
+> **Implementation status.** The two closed vocabularies below — performer kinds
+> (§10.1) and allocation patterns (§10.3) — plus the §10.2 eligibility gates are
+> declared in code at [`packages/db/src/performer-allocation.ts`](../../packages/db/src/performer-allocation.ts),
+> exported from `@dpf/db`. A conformance test parses this section and fails in
+> both directions, so a term added here and not there (or the reverse) breaks the
+> build: the standard stays the source of truth and the code stays its only
+> spelling. Consume the exported constants; never retype these strings.
+>
+> Not yet implemented: the allocation RECORD itself (which performer executes a
+> given activity under which pattern) and runtime evaluation of the §10.2 gates.
+> Tracked as `BI-40B36B94`, which carries the remaining slices and the open
+> design questions. Until those land, this section constrains vocabulary, not
+> behaviour.
+
 ### 10.1 Performer kinds
 
 An implementation **MUST** distinguish at least:

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -639,6 +639,7 @@ export * from "./discovery-fingerprint-store";
 export * from "./installation-operating-intent";
 export * from "./installation-instance-stance";
 export * from "./reference-freshness";
+export * from "./performer-allocation";
 
 // Contributor-inventory-sync ScheduledJob constants — shared between the
 // seed helper and the apps/web Inngest runner so the heartbeat row's name +

--- a/packages/db/src/performer-allocation.test.ts
+++ b/packages/db/src/performer-allocation.test.ts
@@ -1,0 +1,176 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  ALLOCATION_PATTERNS,
+  ELIGIBILITY_GATES,
+  PERFORMER_KINDS,
+  allowsAiExecution,
+  isAllocationPattern,
+  isPerformerKind,
+  requiresHumanInControlPath,
+  type AllocationPattern,
+} from "./performer-allocation";
+
+// THE POINT OF THIS FILE. A vocabulary copied out of a standard drifts from it
+// silently — that is how the standard came to have twelve patterns and the code
+// zero (BI-40B36B94). These tests parse FPAW §10 and fail in BOTH directions:
+// a term added to the standard and not here, or a term here that the standard
+// does not contain. The standard stays the source of truth; this module stays
+// the only place the code spells the terms.
+
+const STANDARD_PATH = join(
+  __dirname,
+  "../../../docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md",
+);
+
+function section10(): string {
+  const text = readFileSync(STANDARD_PATH, "utf8");
+  // Anchor on the real heading, not the table-of-contents entry that
+  // repeats the same words earlier in the file.
+  const start = text.indexOf("\n## 10. Performer and work-allocation model");
+  expect(start, "FPAW §10 heading not found — the standard was restructured").toBeGreaterThan(-1);
+  const end = text.indexOf("\n## 11.", start);
+  return text.slice(start, end > -1 ? end : undefined);
+}
+
+/** The §10.3 allocation-pattern table, which alone fixes the gradient order. */
+function patternTable(): string {
+  const body = section10();
+  const start = body.indexOf("### 10.3");
+  return body.slice(start, body.indexOf("### 10.4", start));
+}
+
+/**
+ * Collapse newlines and runs of spaces. The standard hard-wraps its prose, so
+ * "data clearance" is literally "data\n   clearance" in the file and a naive
+ * substring match misses a gate that is plainly there.
+ */
+function flatten(text: string): string {
+  return text.replace(/\s+/g, " ").toLowerCase();
+}
+
+/** Backtick-quoted terms inside a slice, in document order, de-duplicated. */
+function quotedTermsInOrder(body: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const match of body.matchAll(/`([a-z][a-z0-9-]{2,})`/g)) {
+    const term = match[1];
+    if (!seen.has(term)) {
+      seen.add(term);
+      out.push(term);
+    }
+  }
+  return out;
+}
+
+describe("FPAW §10 conformance", () => {
+  it("declares every performer kind the standard requires", () => {
+    const body = section10();
+    for (const kind of PERFORMER_KINDS) {
+      expect(body, `performer kind "${kind}" is not in FPAW §10`).toContain(`\`${kind}\``);
+    }
+  });
+
+  it("declares every allocation pattern the standard requires", () => {
+    const body = section10();
+    for (const pattern of ALLOCATION_PATTERNS) {
+      expect(body, `allocation pattern "${pattern}" is not in FPAW §10`).toContain(`\`${pattern}\``);
+    }
+  });
+
+  it("misses no allocation pattern the standard adds later (drift, the other direction)", () => {
+    // Every row of the §10.3 table names its pattern in the leading cell.
+    const table = patternTable();
+    const rowPatterns = [...table.matchAll(/^\|\s*`([a-z][a-z0-9-]+)`\s*\|/gm)].map((m) => m[1]);
+
+    expect(rowPatterns.length, "parsed no rows from the §10.3 table").toBeGreaterThan(0);
+    expect([...ALLOCATION_PATTERNS].sort()).toEqual([...rowPatterns].sort());
+  });
+
+  it("keeps the human-to-AI gradient in the order the standard sets", () => {
+    // Order is measured inside the §10.3 table ONLY. "deterministic-automation"
+    // is both a performer kind (§10.1) and an allocation pattern (§10.3), so a
+    // whole-section scan meets it first and the gradient reads as broken when
+    // it is not.
+    const order = quotedTermsInOrder(patternTable()).filter((t) => isAllocationPattern(t));
+    expect(order).toEqual([...ALLOCATION_PATTERNS]);
+  });
+
+  it("names every eligibility gate in §10.2", () => {
+    // The gates are prose, not backticked, so match on the words the standard uses.
+    const body = section10();
+    const gateStart = body.indexOf("### 10.2");
+    const step1 = flatten(body.slice(gateStart, body.indexOf("### 10.3", gateStart)));
+    const PROSE: Record<string, string> = {
+      authority: "authority",
+      "license-credential": "license/credential",
+      safety: "safety",
+      "physical-reach": "physical reach",
+      "data-clearance": "data clearance",
+      "tool-resource-availability": "tool/resource availability",
+      qualification: "qualification",
+      "contractual-legal": "contractual and legal",
+    };
+    for (const gate of ELIGIBILITY_GATES) {
+      expect(step1, `eligibility gate "${gate}" not found in §10.2`).toContain(PROSE[gate]);
+    }
+  });
+
+  it("preserves the MUST NOT that makes eligibility a gate and not a score", () => {
+    // If this sentence ever leaves the standard, the predicate below is no
+    // longer grounded and this module must be re-derived, not quietly kept.
+    // The standard bolds the modal: "**MUST NOT** become eligible ...".
+    expect(section10()).toContain("become eligible merely because it is faster");
+  });
+});
+
+describe("allowsAiExecution", () => {
+  it("is true only where the standard lets AI execute the work", () => {
+    const executing = ALLOCATION_PATTERNS.filter(allowsAiExecution);
+    expect(executing).toEqual([
+      "ai-led-human-approved",
+      "ai-primary-human-exception",
+      "bounded-autonomous-ai",
+    ]);
+  });
+
+  it("does not treat ai-prepare-human-decide as AI execution", () => {
+    // The AI prepares; an authorized human decides. Collapsing "AI is involved"
+    // into "AI executes" is exactly the misreading this guards.
+    expect(allowsAiExecution("ai-prepare-human-decide")).toBe(false);
+  });
+
+  it("does not treat human-led-ai-assisted as AI execution", () => {
+    expect(allowsAiExecution("human-led-ai-assisted")).toBe(false);
+  });
+});
+
+describe("requiresHumanInControlPath", () => {
+  it("holds for human-only work", () => {
+    expect(requiresHumanInControlPath("human-only")).toBe(true);
+  });
+
+  it("holds for every AI-executing pattern except the bounded-autonomous one", () => {
+    expect(requiresHumanInControlPath("ai-led-human-approved")).toBe(true);
+    expect(requiresHumanInControlPath("ai-primary-human-exception")).toBe(true);
+    expect(requiresHumanInControlPath("bounded-autonomous-ai")).toBe(false);
+  });
+
+  it("holds for robot work — the safety supervisor is the human in the path", () => {
+    expect(requiresHumanInControlPath("robot-primary-safety-supervised")).toBe(true);
+  });
+});
+
+describe("narrowing guards", () => {
+  it("accepts declared values and rejects everything else", () => {
+    expect(isPerformerKind("authorized-robot")).toBe(true);
+    expect(isAllocationPattern("bounded-autonomous-ai")).toBe(true);
+
+    for (const bad of [null, undefined, 42, "", "robot", "ai", "AI-COWORKER", {}]) {
+      expect(isPerformerKind(bad)).toBe(false);
+      expect(isAllocationPattern(bad as AllocationPattern)).toBe(false);
+    }
+  });
+});

--- a/packages/db/src/performer-allocation.ts
+++ b/packages/db/src/performer-allocation.ts
@@ -1,0 +1,133 @@
+// Performer kinds and work-allocation patterns — the human / AI / robot boundary.
+//
+// WHY THIS EXISTS. FPAW §10 ("Performer and work-allocation model") normatively
+// specifies two closed axes: five performer kinds an implementation MUST
+// distinguish, and twelve allocation patterns that say who executes and who
+// controls. Until this module, a grep for every one of those terms across
+// packages/db/prisma, apps/web/lib and packages/ returned ZERO hits outside the
+// standard document itself (BI-40B36B94).
+//
+// That is the defect shape this codebase keeps finding: doctrine that reads as
+// shipped and is inert. A standard with no consumer cannot refuse anything, so
+// the §10.2 prohibition — "an ineligible performer MUST NOT become eligible
+// merely because it is faster, cheaper, available, or preferred by a model" —
+// had nothing to enforce it.
+//
+// WHAT THIS SLICE DOES AND DOES NOT DO. It makes the vocabulary canonical and
+// drift-proof: performer-allocation.test.ts parses FPAW §10 and fails if the
+// standard and this module disagree in either direction. It deliberately adds
+// NO Prisma enum and NO column. An allocation record has to be designed against
+// the activity substrate, not guessed at from a staffing shift; inventing a
+// column nothing writes would reproduce the very defect being closed. Later
+// slices import from here instead of retyping string literals, so the closed set
+// has exactly one home (AGENTS.md §8).
+//
+// Standard: docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md §10
+
+/**
+ * Who — or what — can be assigned work. FPAW §10.1.
+ *
+ * Passive machinery is a Resource, not a Performer. An authorized robot has
+ * both a performer identity and a separately managed physical asset, controller
+ * and safety configuration. A mixed team is a Collaboration over these kinds,
+ * not a sixth kind of its own.
+ */
+export const PERFORMER_KINDS = [
+  "human",
+  "ai-coworker",
+  "deterministic-automation",
+  "authorized-robot",
+  "partner-organization",
+] as const;
+export type PerformerKind = (typeof PERFORMER_KINDS)[number];
+
+/**
+ * How execution and control are split between performers. FPAW §10.3.
+ *
+ * Ordered as the standard orders them: from work a human must do, through the
+ * graduated hand-offs, to work a qualified AI may do unattended inside a
+ * TAK-enforced ceiling — then the non-agentic and multi-party patterns. The
+ * order is the human-to-AI gradient and is asserted by the conformance test.
+ */
+export const ALLOCATION_PATTERNS = [
+  "human-only",
+  "human-led-ai-assisted",
+  "ai-prepare-human-decide",
+  "paired-execution",
+  "ai-led-human-approved",
+  "ai-primary-human-exception",
+  "bounded-autonomous-ai",
+  "deterministic-automation",
+  "robot-primary-safety-supervised",
+  "partner-primary-internal-accountable",
+  "mixed-sequential",
+  "mixed-parallel",
+] as const;
+export type AllocationPattern = (typeof ALLOCATION_PATTERNS)[number];
+
+/**
+ * The eligibility gates of FPAW §10.2 step 1.
+ *
+ * These are a GATE, not a score. Every one must pass before suitability is
+ * considered at all — that ordering is the whole point of §10.2, and it is why
+ * "faster / cheaper / available / preferred by a model" cannot promote an
+ * ineligible performer.
+ *
+ * `license-credential` is the join to EP-LIC-C64FC2: the platform already
+ * tracks credentials and renewal posture, and this is the axis that consumes
+ * one as a constraint on who may execute.
+ */
+export const ELIGIBILITY_GATES = [
+  "authority",
+  "license-credential",
+  "safety",
+  "physical-reach",
+  "data-clearance",
+  "tool-resource-availability",
+  "qualification",
+  "contractual-legal",
+] as const;
+export type EligibilityGate = (typeof ELIGIBILITY_GATES)[number];
+
+/** Whether a pattern permits an AI performer to EXECUTE (rather than assist). */
+const AI_EXECUTING_PATTERNS: ReadonlySet<AllocationPattern> = new Set([
+  "ai-led-human-approved",
+  "ai-primary-human-exception",
+  "bounded-autonomous-ai",
+]);
+
+/**
+ * True when the pattern lets an AI coworker execute the work itself.
+ *
+ * `ai-prepare-human-decide` is deliberately FALSE: the AI prepares, and an
+ * authorized human makes the consequential decision. Reading "AI is involved"
+ * as "AI executes" is the collapse this predicate exists to prevent.
+ */
+export function allowsAiExecution(pattern: AllocationPattern): boolean {
+  return AI_EXECUTING_PATTERNS.has(pattern);
+}
+
+/**
+ * True when the pattern requires a named human in the control path — as
+ * decider, approver, exception handler, or safety supervisor.
+ *
+ * `bounded-autonomous-ai` is the only AI-executing pattern that returns false:
+ * it runs without per-occurrence review. Accountability and escalation are
+ * still separate assignments (§10.4) — unreviewed is not unaccountable.
+ */
+export function requiresHumanInControlPath(pattern: AllocationPattern): boolean {
+  return pattern !== "bounded-autonomous-ai" && pattern !== "deterministic-automation";
+}
+
+/** Narrowing guards for values arriving from JSON, config or a model. */
+export function isPerformerKind(value: unknown): value is PerformerKind {
+  return typeof value === "string" && (PERFORMER_KINDS as readonly string[]).includes(value);
+}
+
+export function isAllocationPattern(value: unknown): value is AllocationPattern {
+  return typeof value === "string" && (ALLOCATION_PATTERNS as readonly string[]).includes(value);
+}
+
+export function isEligibilityGate(value: unknown): value is EligibilityGate {
+  return typeof value === "string" && (ELIGIBILITY_GATES as readonly string[]).includes(value);
+}


### PR DESCRIPTION
## The finding

FPAW §10 normatively specifies the human / AI / robot boundary: **five performer kinds** an implementation `MUST` distinguish, **twelve allocation patterns**, and a two-step allocation decision whose first step is a gate, not a score.

A grep for every one of those terms across `packages/db/prisma`, `apps/web/lib` and `packages/` returned **zero hits outside the standard document itself.**

That is the defect shape this codebase keeps surfacing — declared substrate with no production consumer, the same as proactive-workrooms finding #1 and the four split-registry scanner defects in the capability-completeness work. A standard nothing consumes cannot refuse anything, so §10.2's prohibition — *"an ineligible performer `MUST NOT` become eligible merely because it is faster, cheaper, available, or preferred by a model"* — had nothing to enforce it.

## Why it matters beyond tidiness

This is the substrate for **which work AI coworkers may do and which stays human**. Without it the platform cannot answer, per activity, which performer kinds are eligible, what oversight pattern governs, or why an allocation was permitted.

Two joins were already waiting:

- **`authorized-robot`** is a first-class performer kind in the standard, for archetypes where physical work is already being automated. Nothing could express it.
- **`license-credential`** is an eligibility gate. `EP-LIC-C64FC2` already tracks credentials, renewal posture and evidence — the credential exists, and nothing consumed it as a constraint on who may execute.

## What this slice does

`packages/db/src/performer-allocation.ts`, exported from `@dpf/db`:

- `PERFORMER_KINDS`, `ALLOCATION_PATTERNS` (in the standard's own human-to-AI gradient order), `ELIGIBILITY_GATES`
- `allowsAiExecution()` — true only for the three patterns where an AI *executes* rather than assists. `ai-prepare-human-decide` is deliberately **false**: the AI prepares, an authorized human decides. Collapsing "AI is involved" into "AI executes" is the misreading this prevents.
- `requiresHumanInControlPath()` — false only for `bounded-autonomous-ai` and `deterministic-automation`. Unreviewed is not unaccountable; §10.4 keeps accountability and escalation as separate assignments.
- narrowing guards for values arriving from JSON, config, or a model

**The conformance test is the durable part.** It parses §10 out of the standard and fails in *both* directions — a term added to the standard and not to the module, or a term here the standard does not contain. The standard stays the source of truth; this module stays the only place the code spells the terms (AGENTS.md §8).

Two things it learned the hard way and now encodes:
- the standard hard-wraps prose, so `data clearance` is literally `data\n   clearance` — gate matching normalizes whitespace
- `deterministic-automation` is **both** a performer kind (§10.1) and an allocation pattern (§10.3), so the gradient order is measured inside the §10.3 table only

## What this slice deliberately does not do

**No Prisma enum, no column.** An allocation record must be designed against the activity substrate, not guessed at from a staffing shift — `StaffingDemand` already carries `occupationProfileId`, `requiredSkills` and `requiredCredentials` but is shift-shaped, while FPAW allocation is activity-level and broader. Adding a column nothing writes would reproduce the exact defect being closed.

Slices 2–4 (allocation record, eligibility evaluation, oversight enforcement) and their open design questions live on **BI-40B36B94** rather than in a plan document — filing a plan would imply they are scheduled.

## Not duplicated

`EP-LIC-C64FC2` (licensing/credential readiness), `2026-07-17-organization-workforce-staffing-scheduling-design` (staffing domain; AI staffing coworker as proposal-only), `2026-07-16-employee-occupation-onboarding` (occupation dimension) are all already filed and implemented. This adds the allocation vocabulary they were missing, not a second home for any of them.

## Verification

- `pregate` **PASS** — 13 conformance tests, `@dpf/db` typecheck clean
- FPAW §10 carries an implementation-status note pointing at the module and naming what is still unimplemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)