### PR TITLE
fix(work-capsules): register platform-maintenance in both copies of the source closed set; anchor converger reaches terminal rooms with per-room backoff (BI-A5EEB5D1)

### DIFF
--- a/apps/web/lib/wiki/embedding-coverage-workroom.ts
+++ b/apps/web/lib/wiki/embedding-coverage-workroom.ts
@@ -18,6 +18,7 @@ import {
   EMBEDDING_COVERAGE_ACTIVITY_KIND,
 } from "./embedding-coverage-constants";
 import type { WikiEmbeddingReconciliationResult } from "./embedding-reconciliation";
+import type { WorkCapsuleSource } from "@/lib/work-capsules";
 
 /** Structural client — satisfied by PrismaClient and by test fakes. */
 export type CorpusHealthClient = {
@@ -110,7 +111,7 @@ export async function recordCoverageRun(input: {
         title: CORPUS_HEALTH_WORKROOM_TITLE,
         objective: CORPUS_HEALTH_WORKROOM_OBJECTIVE,
         status: "working",
-        source: "platform-maintenance",
+        source: "platform-maintenance" satisfies WorkCapsuleSource,
         activityKind: EMBEDDING_COVERAGE_ACTIVITY_KIND,
       },
     });

--- a/apps/web/lib/work-capsules.ts
+++ b/apps/web/lib/work-capsules.ts
@@ -30,6 +30,13 @@ export const WORK_CAPSULE_SOURCES = [
   "worker-onboarding",
   "worker-change",
   "worker-offboarding",
+  // Platform maintenance rooms (embedding-coverage-workroom.ts). This value was
+  // written by a raw upsert without being registered here or in the DB check
+  // constraint, so the row it created could never be updated by anyone —
+  // every UPDATE re-validated the NOT VALID check and failed (BI-A5EEB5D1).
+  // The parity test beside the converger keeps this list and the migration
+  // that mirrors it from drifting apart again.
+  "platform-maintenance",
 ] as const;
 
 /**

--- a/apps/web/lib/work-capsules/work-capsule-source-closed-set.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-source-closed-set.test.ts
@@ -1,0 +1,37 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { WORK_CAPSULE_SOURCES } from "@/lib/work-capsules";
+
+// WorkCapsule.source is a closed set held in two places: WORK_CAPSULE_SOURCES
+// in TypeScript and the "WorkCapsule_source_closed_set" CHECK in Postgres. They
+// drifted twice — 20260902040000 for the employment sources, then
+// "platform-maintenance" (BI-A5EEB5D1), whose row could never be updated. The
+// migration is NOT VALID, so a value the code accepts but the check does not
+// fails only at the first UPDATE, long after the INSERT. This test makes the
+// drift a red build instead of a production 23514.
+const MIGRATIONS_DIR = fileURLToPath(new URL("../../../../packages/db/prisma/migrations/", import.meta.url));
+
+function latestDbClosedSet(): string[] {
+  const dirs = readdirSync(MIGRATIONS_DIR).filter((d) => /^\d{14}_/.test(d)).sort();
+  for (const dir of [...dirs].reverse()) {
+    let sql: string;
+    try {
+      sql = readFileSync(join(MIGRATIONS_DIR, dir, "migration.sql"), "utf8");
+    } catch {
+      continue;
+    }
+    const block = sql.match(/"WorkCapsule_source_closed_set" CHECK \(\s*source = ANY \(ARRAY\[([\s\S]*?)\]\)/);
+    if (block) return [...block[1].matchAll(/'([^']+)'::text/g)].map((m) => m[1]).sort();
+  }
+  throw new Error("no migration defines WorkCapsule_source_closed_set");
+}
+
+describe("WorkCapsule.source closed set", () => {
+  it("is the same set in TypeScript and in the latest Postgres check constraint", () => {
+    expect(latestDbClosedSet()).toEqual([...WORK_CAPSULE_SOURCES].sort());
+  });
+});

--- a/apps/web/lib/work-capsules/workroom-anchor-converger.server.ts
+++ b/apps/web/lib/work-capsules/workroom-anchor-converger.server.ts
@@ -1,9 +1,9 @@
 // Prisma binding for workroom-anchor-converger.ts. See that module for why.
 import { prisma } from "@dpf/db";
 
-import { TERMINAL_CAPSULE_STATUSES } from "./work-capsule-branch-identity";
 import { prismaAnchorPorts } from "./capsule-workitem-anchor.server";
 import {
+  AnchorFailureBackoff,
   convergeWorkroomAnchors,
   type WorkroomAnchorConvergeResult,
   type WorkroomAnchorConvergerPorts,
@@ -20,7 +20,10 @@ export function prismaConvergerPorts(): WorkroomAnchorConvergerPorts {
     // rooms are still anchored — completed work is listed and must open too.
     listUnanchoredRooms: (limit) =>
       prisma.workroom.findMany({
-        where: { archivedAt: null, workItemId: null, status: { notIn: TERMINAL_CAPSULE_STATUSES } },
+        // Terminal rooms included: a completed room whose case page 404s is still a
+        // room that exists but cannot be opened (79 of the 91 left behind by the
+        // first pass were "complete"). Only archived rows are out of scope.
+        where: { archivedAt: null, workItemId: null },
         orderBy: { createdAt: "asc" },
         take: limit,
         select: { capsuleId: true, backlogItemId: true, title: true },
@@ -28,6 +31,9 @@ export function prismaConvergerPorts(): WorkroomAnchorConvergerPorts {
   };
 }
 
+/** Process-wide so a room that cannot be anchored is retried hourly, not per tick. */
+const backoff = new AnchorFailureBackoff();
+
 export async function convergeWorkroomAnchorsWithPrisma(): Promise<WorkroomAnchorConvergeResult> {
-  return convergeWorkroomAnchors({ ports: prismaConvergerPorts() });
+  return convergeWorkroomAnchors({ ports: prismaConvergerPorts(), backoff });
 }

--- a/apps/web/lib/work-capsules/workroom-anchor-converger.test.ts
+++ b/apps/web/lib/work-capsules/workroom-anchor-converger.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AnchorFailureBackoff,
   convergeWorkroomAnchors,
   type UnanchoredRoom,
   type WorkroomAnchorConvergerPorts,
@@ -92,5 +93,26 @@ describe("convergeWorkroomAnchors", () => {
       created: 0,
       failed: [],
     });
+  });
+
+  it("backs off a room that failed, so an unfixable row is not hammered every tick", async () => {
+    const rooms = [
+      { capsuleId: "WC-STUCK", backlogItemId: null, title: "stuck" },
+      { capsuleId: "WC-FINE", backlogItemId: null, title: "fine" },
+    ];
+    const { ports } = fakePorts(rooms, { failOn: "WC-STUCK" });
+    const backoff = new AnchorFailureBackoff(1000);
+
+    const first = await convergeWorkroomAnchors({ ports, backoff, now: 0 });
+    expect(first.failed.map((f) => f.capsuleId)).toEqual(["WC-STUCK"]);
+
+    // Next tick, inside the window: the stuck room is not even a candidate.
+    const second = await convergeWorkroomAnchors({ ports, backoff, now: 500 });
+    expect(second.candidates).toBe(1);
+    expect(second.failed).toEqual([]);
+
+    // After the window it is retried once more, and backs off again.
+    const third = await convergeWorkroomAnchors({ ports, backoff, now: 1500 });
+    expect(third.failed.map((f) => f.capsuleId)).toEqual(["WC-STUCK"]);
   });
 });

--- a/apps/web/lib/work-capsules/workroom-anchor-converger.ts
+++ b/apps/web/lib/work-capsules/workroom-anchor-converger.ts
@@ -45,12 +45,45 @@ export interface WorkroomAnchorConvergeResult {
 /** Bounded so a tick never holds a long transaction over hundreds of rooms. */
 export const WORKROOM_ANCHOR_CONVERGER_BATCH = 50;
 
+/** How long a room that failed to anchor is left alone before it is retried.
+ *  A room can fail for a reason no retry will change — the first one found was
+ *  a row whose `source` violated the DB check constraint, so every UPDATE
+ *  failed. Retrying that once a minute logged 1,147 identical failures. Once
+ *  an hour keeps the room visible without drowning the log (BI-A5EEB5D1). */
+export const WORKROOM_ANCHOR_RETRY_AFTER_MS = 60 * 60 * 1000;
+
+/** In-memory, per-process. Losing it on restart is fine: the room is retried
+ *  once and backs off again. */
+export class AnchorFailureBackoff {
+  private readonly retryAt = new Map<string, number>();
+  constructor(private readonly retryAfterMs = WORKROOM_ANCHOR_RETRY_AFTER_MS) {}
+  recordFailure(capsuleId: string, now: number): void {
+    this.retryAt.set(capsuleId, now + this.retryAfterMs);
+  }
+  clear(capsuleId: string): void {
+    this.retryAt.delete(capsuleId);
+  }
+  /** Rooms still inside their backoff window — exclude these from the batch. */
+  skipped(now: number): string[] {
+    const out: string[] = [];
+    for (const [id, at] of this.retryAt) {
+      if (at > now) out.push(id);
+      else this.retryAt.delete(id);
+    }
+    return out;
+  }
+}
+
 export async function convergeWorkroomAnchors(args: {
   ports: WorkroomAnchorConvergerPorts;
   batch?: number;
+  backoff?: AnchorFailureBackoff;
+  now?: number;
 }): Promise<WorkroomAnchorConvergeResult> {
   const batch = args.batch ?? WORKROOM_ANCHOR_CONVERGER_BATCH;
-  const rooms = await args.ports.listUnanchoredRooms(batch);
+  const now = args.now ?? Date.now();
+  const skip = new Set(args.backoff?.skipped(now) ?? []);
+  const rooms = (await args.ports.listUnanchoredRooms(batch + skip.size)).filter((r) => !skip.has(r.capsuleId)).slice(0, batch);
   const result: WorkroomAnchorConvergeResult = {
     candidates: rooms.length,
     anchored: 0,
@@ -69,8 +102,10 @@ export async function convergeWorkroomAnchors(args: {
       if (outcome) {
         result.anchored += 1;
         if (outcome.created) result.created += 1;
+        args.backoff?.clear(room.capsuleId);
       }
     } catch (error) {
+      args.backoff?.recordFailure(room.capsuleId, now);
       // One bad room must not stop the rest of the batch; it is reported, not hidden.
       result.failed.push({
         capsuleId: room.capsuleId,

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -10,6 +10,6 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 |---|---:|---|
 | Prisma models | 626 | `packages/db/prisma/schema/` |
 | Prisma enums | 88 | `packages/db/prisma/schema/` |
-| Migrations | 572 | `packages/db/prisma/migrations/` |
+| Migrations | 573 | `packages/db/prisma/migrations/` |
 | Kernel principles | 102 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 659 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/data-impact/2026-09-09-workcapsule-source-platform-maintenance.data-impact.json
+++ b/docs/data-impact/2026-09-09-workcapsule-source-platform-maintenance.data-impact.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [],
+  "migration": {
+    "name": "20260909213000_workcapsule_source_platform_maintenance",
+    "backfill": "none \u2014 widens the WorkCapsule_source_closed_set CHECK by one value ('platform-maintenance'), recreated NOT VALID exactly as 20260902040000; no rows are rewritten"
+  },
+  "tests": [
+    "apps/web/lib/work-capsules/work-capsule-source-closed-set.test.ts",
+    "apps/web/lib/work-capsules/workroom-anchor-converger.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:workroom",
+      "prismaModel": "Workroom",
+      "lifecycleDisposition": "operational",
+      "fields": [
+        {
+          "fieldId": "data:workroom#source",
+          "resolution": "inherited",
+          "reason": "closed-set string widened by one registered value; not personal or sensitive data; the code set WORK_CAPSULE_SOURCES is the source of truth and the parity test keeps the DB check level with it",
+          "provenance": "manual/platform-architecture"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260909213000_workcapsule_source_platform_maintenance/migration.sql
+++ b/packages/db/prisma/migrations/20260909213000_workcapsule_source_platform_maintenance/migration.sql
@@ -1,0 +1,35 @@
+-- WorkCapsule.source closed set: register "platform-maintenance" (BI-A5EEB5D1).
+--
+-- apps/web/lib/wiki/embedding-coverage-workroom.ts upserts the corpus-health
+-- room with source = 'platform-maintenance'. That value was never added to
+-- "WorkCapsule_source_closed_set", and the constraint is NOT VALID, so the row
+-- existed but EVERY UPDATE to it re-validated the check and failed with 23514.
+-- The workroom anchor converger hit it once a minute, 1,147 times, and no
+-- status transition on that room could ever have succeeded either.
+--
+-- Same lesson as 20260902040000: TypeScript and Postgres each hold a copy of
+-- this closed set. This migration brings Postgres level with
+-- WORK_CAPSULE_SOURCES; the parity test in
+-- apps/web/lib/work-capsules/work-capsule-source-closed-set.test.ts asserts the
+-- two never drift again.
+--
+-- Recreated NOT VALID to match the original (20260816111000): new writes and
+-- updates are enforced, existing rows are not re-scanned. Forward-only; applies
+-- against any data state because it only widens the allowed set.
+
+ALTER TABLE "WorkCapsule" DROP CONSTRAINT IF EXISTS "WorkCapsule_source_closed_set";
+
+ALTER TABLE "WorkCapsule" ADD CONSTRAINT "WorkCapsule_source_closed_set" CHECK (
+  source = ANY (ARRAY[
+    'backlog'::text,
+    'build-studio'::text,
+    'external-adoption'::text,
+    'git-promotion'::text,
+    'manual'::text,
+    'scheduled-steward'::text,
+    'worker-onboarding'::text,
+    'worker-change'::text,
+    'worker-offboarding'::text,
+    'platform-maintenance'::text
+  ])
+) NOT VALID;


### PR DESCRIPTION
The converger from #5245 took the live install from **289 unanchored rooms to 91** in a day, then stalled. The stall is two defects — one of them not the converger's.

## 1. A row nobody could update

`apps/web/lib/wiki/embedding-coverage-workroom.ts` upserts the corpus-health room with `source: "platform-maintenance"`. That value was in **neither** `WORK_CAPSULE_SOURCES` nor the Postgres check `WorkCapsule_source_closed_set`. The check is `NOT VALID`, so the INSERT was never re-scanned — but **every UPDATE re-validated and failed** with `23514`. The converger retried it once a minute: **1,147 identical failures** in the portal log. No status transition on that room could ever have succeeded either.

This is the same drift the 20260902040000 migration's header already describes ("TypeScript said the source was valid; Postgres disagreed"), recurring. So the fix is at that altitude:

- the value is registered in the **one** code set (`WORK_CAPSULE_SOURCES`);
- the migration widens the DB check, recreated `NOT VALID` exactly as 0902 did — additive, no rows rewritten;
- the writer's literal now `satisfies WorkCapsuleSource`, so an unregistered value is a compile error;
- a **parity test** asserts the TypeScript set equals the latest migration's `ARRAY`, so the drift that has now happened twice becomes a red build instead of a production `23514`.

## 2. Terminal rooms were never candidates

My prisma port excluded `TERMINAL_CAPSULE_STATUSES`, so **79 complete + 9 abandoned + 2 archived** rooms stayed unreachable. A completed room whose case page 404s is still a room that exists but cannot be opened. Only `archivedAt` is out of scope now.

## Also

A room that fails to anchor is backed off for an hour (`AnchorFailureBackoff`, in-process) instead of retried every tick. It stays visible once an hour; it no longer drowns the log.

## Verification

- `vitest lib/work-capsules lib/wiki lib/queue/functions/taskrun-watchdog` — **862/862**: parity test, converger 5/5 (three measured classes, failure isolation, batch bound, no-op, backoff)
- `tsc --noEmit` — clean · migration safety guard — no tightening · data-impact manifest — satisfied
- Local-CI gate passed on gated sha `44812ebd2f88`, production build compiled, every migration applied

**Expected on the live install after deploy:** the 91 → 0 within two watchdog ticks (91 rooms ≤ 2 × 50 batch), and the 1,147-line failure stream stops. That is the measurement that closes BI-A5EEB5D1; I'll take it after the self-upgrade lands rather than claim it now.

Refs: BI-A5EEB5D1 · BI-650994D7 · DI-B3E42B8A9B48 · migration 20260902040000

Local-CI-Evidence: cmtumnqlr7zpi01ojammhv9bm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Check status note.** `Failure Readiness` is red here, as it is on every PR since #5231 landed (confirmed failing on the already-merged #5259 and #5262): the repository variable `DPF_REVIEW_STATUS_PUBLISHER` is unset, so the script exits before reading any evidence. It is not a required status and is unrelated to this diff. Filed for the operator as a repository-settings task.
