### PR TITLE
fix(evidence): offload every oversized string leaf in the evidence tree, not only evidence.output (BI-39AAE9B8 follow-up)

### DIFF
--- a/apps/web/lib/evidence/bounded-output.test.ts
+++ b/apps/web/lib/evidence/bounded-output.test.ts
@@ -105,6 +105,34 @@ describe("offloadEvidenceOutput (evidence writer side)", () => {
     expect(calls).toHaveLength(1);
   });
 
+  it("offloads oversized leaves anywhere in the tree (the live shape: content.execution.vitest.output)", async () => {
+    const calls: string[] = [];
+    const NL = String.fromCharCode(10);
+    const vitestLog = `${big(70_000, "v")}${NL} Tests 7406 passed${NL}`;
+    const buildLog = `${big(70_000, "b")}${NL}build ok${NL}`;
+    const evidence = {
+      sha: "abc",
+      output: "gate passed",
+      content: { execution: { vitest: { exitCode: 0, output: vitestLog }, productionBuild: { output: buildLog }, typecheck: { output: "clean" } } },
+    };
+    const result = (await offloadEvidenceOutput(evidence, { ceilingBytes: 1024, writeBlob: fakeWriter(calls) })) as typeof evidence & {
+      content: { execution: { vitest: { output: string; outputBlob: OffloadedTextReference; outputTruncated: boolean }; productionBuild: { outputBlob: OffloadedTextReference }; typecheck: { output: string } } };
+    };
+    expect(calls.sort()).toEqual([buildLog, vitestLog].sort());
+    expect(result.output).toBe("gate passed");
+    expect(result.content.execution.vitest.outputTruncated).toBe(true);
+    expect(result.content.execution.vitest.outputBlob.sha256).toBe(sha256Hex(vitestLog));
+    expect(result.content.execution.vitest.output.endsWith(` Tests 7406 passed${NL}`)).toBe(true);
+    expect(result.content.execution.productionBuild.outputBlob.sha256).toBe(sha256Hex(buildLog));
+    expect(result.content.execution.typecheck.output).toBe("clean");
+    // Unchanged subtrees keep their identity.
+    expect(result.content.execution.typecheck).toBe(evidence.content.execution.typecheck);
+    // Re-applying under the production ceiling is a no-op: the excerpt (8 KB head
+    // + 24 KB tail) is below 64 KB by construction.
+    const again = await offloadEvidenceOutput(result, { writeBlob: fakeWriter(calls) });
+    expect(again).toBe(result);
+  });
+
   it("ignores non-object evidence and evidence without a string output", async () => {
     const calls: string[] = [];
     expect(await offloadEvidenceOutput("raw", { writeBlob: fakeWriter(calls) })).toBe("raw");

--- a/apps/web/lib/evidence/bounded-output.ts
+++ b/apps/web/lib/evidence/bounded-output.ts
@@ -140,30 +140,76 @@ export async function writeEvidenceTextBlob(text: string): Promise<OffloadedText
   };
 }
 
+/** True when any string leaf in the tree exceeds the ceiling. Pure. */
+export function hasOversizedString(value: unknown, ceilingBytes = EVIDENCE_INLINE_CEILING_BYTES): boolean {
+  if (typeof value === "string") return utf8ByteLength(value) > ceilingBytes;
+  if (Array.isArray(value)) return value.some((v) => hasOversizedString(v, ceilingBytes));
+  if (value && typeof value === "object") return Object.values(value as Record<string, unknown>).some((v) => hasOversizedString(v, ceilingBytes));
+  return false;
+}
+
 /**
- * If `evidence.output` is a string above the ceiling, write it to the blob store
- * and return a new evidence object whose `output` is the bounded excerpt and
- * whose `outputBlob` is the reference. Anything else is returned untouched (same
- * reference), so small evidence costs nothing and idempotent re-application is
- * a no-op (an already-offloaded excerpt is below the ceiling by construction).
+ * Walk an evidence tree and offload EVERY string leaf above the ceiling —
+ * wherever it sits. The first cut only handled `evidence.output`; on the live
+ * install the console text actually lived under
+ * `evidence.content.execution.vitest.output` and `…productionBuild.output`
+ * (≈1 GB uncompressed across 385 rows), so a top-level-only rule missed 99% of
+ * the bytes. Each offloaded leaf keeps the same contract as before: the key
+ * still holds a string (a head+tail excerpt naming the digest), and two sibling
+ * keys are added — `<key>Blob` {sha256, storageKey, sizeBytes, mimeType} and
+ * `<key>Truncated: true`. Unchanged subtrees are returned by reference, so the
+ * common small case allocates nothing and re-applying is a no-op.
+ */
+export async function offloadLargeStrings<T>(
+  value: T,
+  options: { ceilingBytes?: number; writeBlob?: EvidenceBlobWriter } = {},
+): Promise<T> {
+  const ceiling = options.ceilingBytes ?? EVIDENCE_INLINE_CEILING_BYTES;
+  const writer = options.writeBlob ?? writeEvidenceTextBlob;
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next: unknown[] = [];
+    for (const entry of value) {
+      const v = await offloadLargeStrings(entry, { ceilingBytes: ceiling, writeBlob: writer });
+      if (v !== entry) changed = true;
+      next.push(v);
+    }
+    return (changed ? next : value) as T;
+  }
+  if (!value || typeof value !== "object") return value;
+  const record = value as Record<string, unknown>;
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    if (typeof entry === "string") {
+      const byteLength = utf8ByteLength(entry);
+      if (byteLength > ceiling) {
+        const reference = await writer(entry);
+        next[key] = excerptText(entry, reference.sha256, byteLength);
+        next[`${key}Blob`] = reference;
+        next[`${key}Truncated`] = true;
+        changed = true;
+        continue;
+      }
+      next[key] = entry;
+      continue;
+    }
+    const v = await offloadLargeStrings(entry, { ceilingBytes: ceiling, writeBlob: writer });
+    if (v !== entry) changed = true;
+    next[key] = v;
+  }
+  return (changed ? next : value) as T;
+}
+
+/**
+ * Offload oversized text anywhere in an evidence object. Kept under its
+ * original name for the writers that already call it; the behaviour is now the
+ * whole-tree walk above (the top-level `output` case is just one leaf of it).
  */
 export async function offloadEvidenceOutput<T>(
   evidence: T,
   options: { ceilingBytes?: number; writeBlob?: EvidenceBlobWriter } = {},
 ): Promise<T> {
-  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
-  const record = evidence as Record<string, unknown>;
-  const output = record.output;
-  if (typeof output !== "string") return evidence;
-  const ceiling = options.ceilingBytes ?? EVIDENCE_INLINE_CEILING_BYTES;
-  const byteLength = utf8ByteLength(output);
-  if (byteLength <= ceiling) return evidence;
-  const writer = options.writeBlob ?? writeEvidenceTextBlob;
-  const reference = await writer(output);
-  return {
-    ...record,
-    output: excerptText(output, reference.sha256, byteLength),
-    outputBlob: reference,
-    outputTruncated: true,
-  } as T;
+  if (!evidence || typeof evidence !== "object") return evidence;
+  return offloadLargeStrings(evidence, options);
 }

--- a/apps/web/scripts/offload-evidence-output.ts
+++ b/apps/web/scripts/offload-evidence-output.ts
@@ -17,6 +17,7 @@ import { prisma } from "@dpf/db";
 
 import {
   boundLargeStrings,
+  hasOversizedString,
   offloadEvidenceOutput,
   utf8ByteLength,
   EVIDENCE_INLINE_CEILING_BYTES,
@@ -49,8 +50,7 @@ async function offloadExternalEvidenceRecords(): Promise<{ scanned: number; rewr
       const details = row.details as Record<string, unknown> | null;
       const evidence = details?.evidence;
       if (!evidence || typeof evidence !== "object") continue;
-      const output = (evidence as Record<string, unknown>).output;
-      if (typeof output !== "string" || utf8ByteLength(output) <= EVIDENCE_INLINE_CEILING_BYTES) continue;
+      if (!hasOversizedString(evidence, EVIDENCE_INLINE_CEILING_BYTES)) continue;
       const before = jsonBytes(details);
       const bounded = await offloadEvidenceOutput(evidence);
       const nextDetails = { ...details, evidence: bounded };


### PR DESCRIPTION
## Summary
Live measurement after #5258 shipped: the console text did not sit at `evidence.output` (5 MB total) but under `evidence.content.execution.vitest.output` and `.productionBuild.output`: 910 MB + 127 MB uncompressed across 385 `ExternalEvidenceRecord` rows. A top-level-only rule missed 99% of the bytes; the backfill dry-run on the install reported 0 rows for that table.

- `offloadLargeStrings` walks the whole tree. Any string leaf above the 64 KB ceiling becomes a head+tail excerpt (still a string) with sibling `<key>Blob` `{sha256, storageKey, sizeBytes}` and `<key>Truncated` keys. Unchanged subtrees keep their identity; re-applying is a no-op.
- `offloadEvidenceOutput` keeps its name and now delegates to the walker, so the writer in `nonprod/local-integration.ts` needs no change.
- `hasOversizedString` drives the backfill's `ExternalEvidenceRecord` pass.

## Verification
- `vitest run lib/evidence lib/nonprod/local-integration lib/governed-tool-audit`: 22/22 (nested live shape, identity of untouched subtrees, idempotence under the production ceiling).
- Pre-commit scoped typecheck ok.

## Unproven
- Backfill on the install. Dry-run today (before this fix): ToolExecution 322 rows / 781 MB reclaimable, ExternalEvidenceRecord 0. After deploy the same dry-run should report ~385 evidence rows, then `--apply` reclaims both tables after autovacuum.

Docs-Impact-Decision: internal evidence-storage behaviour; the runbook section "Evidence payloads never live inline" already describes the rule and is unchanged.
Convergence-Impact-Decision: auto-converges — writer-side change inside the portal image; every install picks it up at its next self-upgrade, and the idempotent backfill script handles rows written before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)