### PR TITLE
feat(work-posture): room participants, room-wide alignment, and the room's own page complete the room authority term (BI-F114354D, BI-947780FE)

### DIFF
--- a/apps/web/lib/mcp-governed-execute-alignment.test.ts
+++ b/apps/web/lib/mcp-governed-execute-alignment.test.ts
@@ -231,4 +231,44 @@ describe("TAK alignment interception", () => {
     expect(result.error).toBe("receipt_reservation_failed");
     expect(execute).not.toHaveBeenCalled();
   });
+
+  it("inside a Workroom, every consequential tool clears alignment — not only outward ones (spec 8.2, BI-F114354D)", async () => {
+    const alignmentGate = vi.fn(async () => alignmentDecision("approve"));
+    const setup = () => _setGovernanceForTests({
+      alignmentGate, executeTool: execute,
+      resolveAgentGrants: async () => ["backlog_write"], isAllowedByGrants: () => true,
+      resolveCoworkerAuthorityInput: async () => ({
+        ...authorityInput(),
+        action: { ...authorityInput().action, toolName: "retire_backlog_item", requiredCapability: null },
+      }) as never,
+      authorizationDecisionCreate: async () => ({}),
+      toolExecutionCreate: async (data) => { audits.push(data); return { id: "room" }; },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); return { id: "room-receipt" }; },
+      toolExecutionUpdate: async () => {},
+      toolExecutionReceiptUpdate: async () => {},
+      gaidActorResolver: resolveActor,
+    });
+    // retire_backlog_item is irreversible but not outward: unroomed it is receipted, not aligned.
+    setup();
+    await governedExecuteTool({
+      toolName: "retire_backlog_item", rawParams: { itemId: "BI-1", reason: "duplicate" },
+      userId: "user-1", userContext: USER, source: "agentic-loop",
+      context: { agentId: "AGT-100", threadId: "thread-1" },
+    });
+    expect(alignmentGate).not.toHaveBeenCalled();
+    // The same call inside a room runs the WWWD x WSID gate.
+    setup();
+    await governedExecuteTool({
+      toolName: "retire_backlog_item", rawParams: { itemId: "BI-1", reason: "duplicate" },
+      userId: "user-1", userContext: USER, source: "agentic-loop",
+      context: {
+        agentId: "AGT-100", threadId: "thread-1",
+        roomAuthority: {
+          workroomId: "WC-ROOM", collaborationShape: "craft-stewardship", workShapeKey: null,
+          authorizedGrants: null, actionBoundary: "propose", participantRoles: null, memberOfRoom: true,
+        },
+      },
+    });
+    expect(alignmentGate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -589,9 +589,16 @@ export async function governedExecuteTool(
     return hookRejection;
   }
 
+  // EP-WORK-POSTURE 8.2 (BI-F114354D item 6): inside a Workroom, EVERY tool the
+  // classification marks consequential clears the WWWD x WSID alignment gate,
+  // not only the outward/legacy-named subset. The room is where the coworker's
+  // job (WSID) and the org's constitution (WWWD) are both in scope; unroomed
+  // calls keep the narrower reach so nothing outside a room changes.
+  const alignmentRequired = consequence.alignmentRequired
+    || (consequence.consequential && Boolean(args.context?.roomAuthority?.workroomId));
   const preexecution = await enforceTakPreexecution({
     args,
-    alignmentRequired: consequence.alignmentRequired,
+    alignmentRequired,
     preconditionRequired: consequence.preconditionRequired,
     writeAudit: ({ result, alignmentDecision: alignment, preconditionDecision: precondition }) => writeAudit({
       toolName: args.toolName, rawParams: args.rawParams, result, userId: args.userId,

--- a/apps/web/lib/work-management/room-turn-authority.server.ts
+++ b/apps/web/lib/work-management/room-turn-authority.server.ts
@@ -10,7 +10,6 @@ import "server-only";
 // whatever we could guess".
 import { prisma } from "@dpf/db";
 
-import { normalizePortalContextPathname, resolveCapsuleIdFromPathname } from "@/lib/coworker/agent-coworker-core";
 import { getAgentToolGrantsAsync } from "@/lib/tak/agent-grants";
 import { shapeBiasFor } from "@/lib/work-posture/derive";
 
@@ -21,6 +20,7 @@ import { readWorkroomShapeClaim } from "./workroom-shape-claim";
 import { getWorkroomPostureDefault } from "./workroom-posture-defaults";
 import {
   deriveRoomTurnAuthority,
+  workroomIdFromRoute,
   type RoomTurnAuthority,
   type RoomTurnAuthorityFacts,
 } from "./room-turn-authority";
@@ -99,11 +99,7 @@ export async function loadRoomTurnAuthority(input: {
   db?: RoomTurnAuthorityDb;
 }): Promise<RoomTurnAuthority> {
   const db = input.db ?? (prisma as unknown as RoomTurnAuthorityDb);
-  const capsuleId =
-    input.capsuleId
-    ?? (input.routeContext
-      ? resolveCapsuleIdFromPathname(normalizePortalContextPathname(input.routeContext))
-      : null);
+  const capsuleId = input.capsuleId ?? workroomIdFromRoute(input.routeContext);
   const [agentGrants, room, platformDefault] = await Promise.all([
     getAgentToolGrantsAsync(input.agentId).catch(() => [] as string[]),
     capsuleId ? loadRoomFacts(capsuleId, input.agentId, db).catch(() => null) : Promise.resolve(null),

--- a/apps/web/lib/work-management/room-turn-authority.server.ts
+++ b/apps/web/lib/work-management/room-turn-authority.server.ts
@@ -28,20 +28,44 @@ import {
 export type RoomTurnAuthorityDb = {
   workroom: {
     findFirst(args: unknown): Promise<{
+      id: string;
       capsuleId: string;
       scopeClaims: unknown;
+      participants?: Array<{ principalId: string; roles: string[] }>;
     } | null>;
+  };
+  principalAlias: {
+    findFirst(args: unknown): Promise<{ principalId: string } | null>;
   };
 };
 
 async function loadRoomFacts(
   capsuleId: string,
+  agentId: string,
   db: RoomTurnAuthorityDb,
 ): Promise<RoomTurnAuthorityFacts["room"]> {
-  const room = await db.workroom.findFirst({
-    where: { OR: [{ capsuleId }, { id: capsuleId }] },
-    select: { capsuleId: true, scopeClaims: true },
-  });
+  const [room, alias] = await Promise.all([
+    db.workroom.findFirst({
+      where: { OR: [{ capsuleId }, { id: capsuleId }] },
+      select: {
+        id: true,
+        capsuleId: true,
+        scopeClaims: true,
+        participants: {
+          where: { lifecycle: "active" },
+          select: { principalId: true, roles: true },
+        },
+      },
+    }),
+    // The coworker's Principal ROW id (WorkroomParticipant.principalId is the
+    // row id, not the semantic principalId) via its internal agent alias.
+    db.principalAlias
+      .findFirst({
+        where: { aliasType: "agent", aliasValue: agentId, issuer: "" },
+        select: { principalId: true },
+      })
+      .catch(() => null),
+  ]);
   if (!room) return null;
   const collaborationShape = readWorkroomShapeClaim(room.scopeClaims);
   const workShapeKey = readDeclaredWorkShapeKey(room.scopeClaims);
@@ -55,6 +79,8 @@ async function loadRoomFacts(
     declaredActionBoundary: declaration?.actionBoundary ?? null,
     declaredPriority: declaration?.priority ?? null,
     shapeActionBoundary: shapeBiasFor(collaborationShape)?.actionBoundary ?? null,
+    participants: room.participants?.length ? room.participants : null,
+    agentPrincipalId: alias?.principalId ?? null,
   };
 }
 
@@ -80,7 +106,7 @@ export async function loadRoomTurnAuthority(input: {
       : null);
   const [agentGrants, room, platformDefault] = await Promise.all([
     getAgentToolGrantsAsync(input.agentId).catch(() => [] as string[]),
-    capsuleId ? loadRoomFacts(capsuleId, db).catch(() => null) : Promise.resolve(null),
+    capsuleId ? loadRoomFacts(capsuleId, input.agentId, db).catch(() => null) : Promise.resolve(null),
     getWorkroomPostureDefault().catch(() => null),
   ]);
   return deriveRoomTurnAuthority({

--- a/apps/web/lib/work-management/room-turn-authority.test.ts
+++ b/apps/web/lib/work-management/room-turn-authority.test.ts
@@ -5,6 +5,7 @@ import { COWORKER_READ_BASELINE_GRANTS } from "@/lib/tak/agent-grants";
 import {
   deriveRoomTurnAuthority,
   roomAuthorizesTool,
+  workroomIdFromRoute,
   roomGrantsFromWorkShape,
   toRoomAuthorityContext,
   unroomedTurnAuthority,
@@ -177,6 +178,19 @@ describe("deriveRoomTurnAuthority — participant term (W2)", () => {
   it("an unresolved agent principal in a participant-recording room is not a member", () => {
     const out = deriveRoomTurnAuthority({ room: withParticipants(null, ["specialist"]), agentGrants: [], platformDefaultActionBoundary: null });
     expect(out.memberOfRoom).toBe(false);
+  });
+});
+
+describe("workroomIdFromRoute", () => {
+  it("names the room from the Build Studio work page and the Workroom case page", () => {
+    expect(workroomIdFromRoute("/build/work/WC-ROOM")).toBe("WC-ROOM");
+    expect(workroomIdFromRoute("/workspace/cases/work-capsule%3AWC-F99E0B98")).toBe("WC-F99E0B98");
+    expect(workroomIdFromRoute("/workspace/cases/work-capsule:WC-F99E0B98?tab=details")).toBe("WC-F99E0B98");
+  });
+  it("returns null for routes that do not name a room directly", () => {
+    expect(workroomIdFromRoute("/workspace/cases/booking%3ABK-1")).toBeNull();
+    expect(workroomIdFromRoute("/finance")).toBeNull();
+    expect(workroomIdFromRoute(null)).toBeNull();
   });
 });
 

--- a/apps/web/lib/work-management/room-turn-authority.test.ts
+++ b/apps/web/lib/work-management/room-turn-authority.test.ts
@@ -133,6 +133,53 @@ describe("deriveRoomTurnAuthority — Golden Triangle", () => {
   });
 });
 
+describe("deriveRoomTurnAuthority — participant term (W2)", () => {
+  const withParticipants = (agentPrincipalId: string | null, roles: string[] | null) =>
+    room({
+      workShapeGrants: ["tool:read", "tool:web_search"],
+      participants: [
+        { principalId: "PR-OTHER", roles: ["coordinator"] },
+        ...(roles ? [{ principalId: "PR-AGENT", roles }] : []),
+      ],
+      agentPrincipalId,
+    });
+
+  it("does not narrow a room that records no participants", () => {
+    const out = deriveRoomTurnAuthority({ room: room(), agentGrants: ["web_search"], platformDefaultActionBoundary: null });
+    expect(out.participantRoles).toBeNull();
+    expect(out.memberOfRoom).toBe(true);
+    expect(out.handsOn.enabled).toBe(true);
+  });
+
+  it("narrows a coworker the room does not list to the read baseline, hands off", () => {
+    const out = deriveRoomTurnAuthority({ room: withParticipants("PR-AGENT", null), agentGrants: ["web_search"], platformDefaultActionBoundary: null });
+    expect(out.memberOfRoom).toBe(false);
+    expect(out.participantRoles).toEqual([]);
+    expect(out.authorizedGrants).toEqual([...COWORKER_READ_BASELINE_GRANTS]);
+    expect(out.externalAccess).toEqual({ enabled: false, reason: "room-does-not-authorize-web" });
+    expect(out.handsOn).toEqual({ enabled: false, reason: "not-a-room-participant" });
+  });
+
+  it("treats an observer as read-only", () => {
+    const out = deriveRoomTurnAuthority({ room: withParticipants("PR-AGENT", ["observer"]), agentGrants: ["web_search"], platformDefaultActionBoundary: null });
+    expect(out.memberOfRoom).toBe(true);
+    expect(out.handsOn.reason).toBe("not-a-room-participant");
+    expect(out.authorizedGrants).toEqual([...COWORKER_READ_BASELINE_GRANTS]);
+  });
+
+  it("keeps the activity surface for a listed specialist", () => {
+    const out = deriveRoomTurnAuthority({ room: withParticipants("PR-AGENT", ["specialist"]), agentGrants: ["web_search"], platformDefaultActionBoundary: null });
+    expect(out.participantRoles).toEqual(["specialist"]);
+    expect(out.externalAccess.enabled).toBe(true);
+    expect(out.handsOn.enabled).toBe(true);
+  });
+
+  it("an unresolved agent principal in a participant-recording room is not a member", () => {
+    const out = deriveRoomTurnAuthority({ room: withParticipants(null, ["specialist"]), agentGrants: [], platformDefaultActionBoundary: null });
+    expect(out.memberOfRoom).toBe(false);
+  });
+});
+
 describe("toRoomAuthorityContext", () => {
   it("projects only the executor-relevant fields and null when unroomed", () => {
     const ctx = toRoomAuthorityContext(deriveRoomTurnAuthority({

--- a/apps/web/lib/work-management/room-turn-authority.ts
+++ b/apps/web/lib/work-management/room-turn-authority.ts
@@ -35,6 +35,14 @@ export type RoomTurnAuthority = {
   authorizedGrants: readonly string[] | null;
   /** The action boundary the room resolved (declared → shape bias → default). */
   actionBoundary: ProactivityActionBoundary | null;
+  /**
+   * The coworker's recorded participant roles in the room, or null when the
+   * room records no participants at all (pre-W2 rooms). An empty array means
+   * the room DOES record participants and this coworker is not one of them.
+   */
+  participantRoles: readonly string[] | null;
+  /** False only when the room records participants and this coworker is absent. */
+  memberOfRoom: boolean;
   externalAccess: {
     enabled: boolean;
     reason:
@@ -47,6 +55,7 @@ export type RoomTurnAuthority = {
     reason:
       | "room-action-boundary"
       | "room-advises-only"
+      | "not-a-room-participant"
       | "platform-default-boundary"
       | "platform-default-advises-only"
       | "no-authority-declared";
@@ -68,6 +77,13 @@ export type RoomTurnAuthorityFacts = {
     declaredPriority: GoldenTrianglePreference | null;
     /** The shape-derived action boundary (work-posture derive.ts), when any. */
     shapeActionBoundary: ProactivityActionBoundary | null;
+    /**
+     * Every active participant the room records (principal row id → roles).
+     * Null when the room records none — the pre-W2 shape, which does not narrow.
+     */
+    participants?: ReadonlyArray<{ principalId: string; roles: readonly string[] }> | null;
+    /** The coworker's Principal row id, when its alias resolves. */
+    agentPrincipalId?: string | null;
   } | null;
   /** The coworker's standing grants (AgentToolGrant / registry), already loaded. */
   agentGrants: readonly string[];
@@ -122,7 +138,20 @@ function boundaryPermitsHandsOn(boundary: ProactivityActionBoundary | null): boo
 export function deriveRoomTurnAuthority(facts: RoomTurnAuthorityFacts): RoomTurnAuthority {
   const room = facts.room;
   const hasWebGrant = facts.agentGrants.includes("web_search");
-  const authorizedGrants = room?.workShapeGrants ? roomGrantsFromWorkShape(room.workShapeGrants) : null;
+  // Participant term (BI-F114354D, W2 substrate): a room that records who is
+  // in it narrows a coworker that is not. Tighten-only — a room with no
+  // participant rows is exactly as permissive as before.
+  const recorded = room?.participants ?? null;
+  const participantRoles: readonly string[] | null = recorded
+    ? recorded.find((p) => room?.agentPrincipalId && p.principalId === room.agentPrincipalId)?.roles ?? []
+    : null;
+  const memberOfRoom = participantRoles === null || participantRoles.length > 0;
+  const observerOnly = participantRoles !== null && participantRoles.length > 0
+    && participantRoles.every((r) => r === "observer");
+  const shapeGrants = room?.workShapeGrants ? roomGrantsFromWorkShape(room.workShapeGrants) : null;
+  const authorizedGrants = !memberOfRoom || observerOnly
+    ? [...COWORKER_READ_BASELINE_GRANTS]
+    : shapeGrants;
 
   let externalAccess: RoomTurnAuthority["externalAccess"];
   if (!hasWebGrant) {
@@ -138,7 +167,9 @@ export function deriveRoomTurnAuthority(facts: RoomTurnAuthorityFacts): RoomTurn
     : facts.platformDefaultActionBoundary;
 
   let handsOn: RoomTurnAuthority["handsOn"];
-  if (room) {
+  if (room && (!memberOfRoom || observerOnly)) {
+    handsOn = { enabled: false, reason: "not-a-room-participant" };
+  } else if (room) {
     handsOn = boundaryPermitsHandsOn(actionBoundary)
       ? { enabled: true, reason: "room-action-boundary" }
       : actionBoundary
@@ -168,6 +199,8 @@ export function deriveRoomTurnAuthority(facts: RoomTurnAuthorityFacts): RoomTurn
     workShapeKey: room?.workShapeKey ?? null,
     authorizedGrants,
     actionBoundary,
+    participantRoles,
+    memberOfRoom,
     externalAccess,
     handsOn,
     priority,
@@ -186,7 +219,13 @@ export function unroomedTurnAuthority(agentGrants: readonly string[]): RoomTurnA
  */
 export type RoomAuthorityContext = Pick<
   RoomTurnAuthority,
-  "workroomId" | "collaborationShape" | "workShapeKey" | "authorizedGrants" | "actionBoundary"
+  | "workroomId"
+  | "collaborationShape"
+  | "workShapeKey"
+  | "authorizedGrants"
+  | "actionBoundary"
+  | "participantRoles"
+  | "memberOfRoom"
 >;
 
 export function toRoomAuthorityContext(authority: RoomTurnAuthority): RoomAuthorityContext | null {
@@ -197,5 +236,7 @@ export function toRoomAuthorityContext(authority: RoomTurnAuthority): RoomAuthor
     workShapeKey: authority.workShapeKey,
     authorizedGrants: authority.authorizedGrants,
     actionBoundary: authority.actionBoundary,
+    participantRoles: authority.participantRoles,
+    memberOfRoom: authority.memberOfRoom,
   };
 }

--- a/apps/web/lib/work-management/room-turn-authority.ts
+++ b/apps/web/lib/work-management/room-turn-authority.ts
@@ -208,6 +208,37 @@ export function deriveRoomTurnAuthority(facts: RoomTurnAuthorityFacts): RoomTurn
   };
 }
 
+/**
+ * The Workroom a portal route names, when it names one directly. Two shapes
+ * today: the Build Studio work page (`/build/work/<WC-id>`) and the Workroom
+ * case page (`/workspace/cases/work-capsule%3A<WC-id>`). Live acceptance on
+ * 2026-09-09 found the second was never resolved, so a coworker opened on a
+ * room's own page ran UNROOMED — the exact surface the founder direction
+ * names ("in the context of the UX"). Any other route returns null and the
+ * caller falls back to the portal envelope's capsule, then to unroomed.
+ */
+export function workroomIdFromRoute(routeContext: string | null | undefined): string | null {
+  if (!routeContext) return null;
+  const pathname = routeContext.split("?")[0] ?? "";
+  const build = pathname.match(/^\/build\/work\/([^/]+)\/?$/);
+  if (build?.[1]) return safeDecode(build[1]);
+  const cases = pathname.match(/^\/workspace\/cases\/([^/]+)\/?$/);
+  if (cases?.[1]) {
+    const key = safeDecode(cases[1]);
+    const sep = key.indexOf(":");
+    if (sep > 0 && key.slice(0, sep) === "work-capsule") return key.slice(sep + 1) || null;
+  }
+  return null;
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 /** The unroomed, no-authority-declared answer: everything denied, nothing inherited. */
 export function unroomedTurnAuthority(agentGrants: readonly string[]): RoomTurnAuthority {
   return deriveRoomTurnAuthority({ room: null, agentGrants, platformDefaultActionBoundary: null });


### PR DESCRIPTION
## What

Completes the room authority term shipped in #5263 (spec section 8.2) with the three gaps live acceptance and the plan's out-of-scope list left open.

**Participant term (W2 substrate) — BI-F114354D.** `loadRoomTurnAuthority` now reads the room's active `WorkroomParticipant` rows and the coworker's Principal row id through its internal agent alias. A room that records participants narrows a coworker it does not list, and an observer, to the coworker read baseline with hands-on off (`not-a-room-participant`). A room with no participant rows is exactly as permissive as before. The roles travel on `RoomAuthorityContext` for the receipt.

**Room-wide WWWD × WSID alignment — BI-F114354D item 6.** Inside a Workroom, every tool the classification marks consequential clears the alignment gate, not only the outward or legacy-named subset. Unroomed calls keep the narrower reach. Asserted with `retire_backlog_item` (irreversible, not outward): unroomed runs no gate, roomed runs it once.

**A coworker opened on a room's own page runs in that room — BI-947780FE.** Live acceptance on the install found the resolver only recognised `/build/work/<id>`; the Workroom case page `/workspace/cases/work-capsule%3A<id>` was never resolved, so the coworker there ran unroomed. `workroomIdFromRoute` names the room from both routes.

## Design grounding

Extends `docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md` section 8.2 and the plan `docs/superpowers/plans/2026-09-08-room-owns-coworker-controls-plan.md` (its out-of-scope list). Current code substrate reviewed: `apps/web/lib/work-management/room-turn-authority.ts`, `apps/web/lib/work-management/room-participation-prisma.server.ts`, `apps/web/lib/identity/principal-linking.ts`, `apps/web/lib/mcp-governed-execute.ts`, `apps/web/lib/tak/consequential-tool-policy.ts`. No new engine or table.

## Verification

- `tsc --noEmit` on `apps/web`: clean.
- vitest: room-turn-authority (21), governed-execute alignment (9), govern/authority, agent-coworker suites pass.
- Local-CI gate PASSED on d9e691d9bd15 (evidence cmtuwprf50gbw01omts2wh1eq): typecheck, vitest, next build 109 s, image export; 16:57 run.
- Live acceptance of the room triangle on the install is recorded on BI-7ADEBDC1 (WC-F99E0B98, Assured persisted and governing). The room-scoped denial from a case page needs this PR deployed; it is recorded on BI-F114354D once the install advances.

Design-Grounding-Decision: extends spec 2026-08-22-workroom-work-posture-design.md (8.2); code substrate reviewed under apps/web/lib/work-management and apps/web/lib/mcp-governed-execute.ts.
Docs-Impact-Decision: not-applicable — no documented user-facing route changed.
Convergence-Impact-Decision: not-reachable — application code under apps/ only; converges by image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
