### PR TITLE
fix(mailroom): carry Postmark's headers into intake and match the animal references the platform issues (BI-D2ED96B1, BI-92DDAD88)

### DIFF
--- a/apps/web/app/api/integrations/email-postmark/inbound/route.test.ts
+++ b/apps/web/app/api/integrations/email-postmark/inbound/route.test.ts
@@ -6,7 +6,7 @@ const h = vi.hoisted(() => ({
   stored: { signingSecret: "sig", fromAddress: "a@b.com", replyToAddress: null, serverToken: "token" } as unknown,
   verified: true,
   parsed: { externalMessageId: "MSG-1", externalThreadId: "THREAD-1", fromAddress: "from@example.com", fromDisplayName: "Founder", subject: "Hello", textBody: "Body", receivedAt: new Date("2026-01-01"), metadata: { stream: "inbound" } } as unknown,
-  create: vi.fn(), send: vi.fn(), audit: vi.fn(), execute: vi.fn(), verify: vi.fn(), parse: vi.fn(),
+  create: vi.fn(), send: vi.fn(), audit: vi.fn(), execute: vi.fn(), verify: vi.fn(), parse: vi.fn(), mailroom: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({ prisma: {
@@ -19,6 +19,7 @@ vi.mock("@/lib/marketing/channels/email-postmark/client", () => ({
   verifyInboundSignature: h.verify,
   parseInboundPayload: h.parse,
 }));
+vi.mock("@/lib/mailroom/runtime.server", () => ({ ingestPostmarkInboundForMailbox: h.mailroom }));
 vi.mock("@/lib/queue/inngest-client", () => ({ inngest: { send: h.send } }));
 vi.mock("@/lib/integrations/kernel/audit", () => ({
   createDurableConnectorAudit: () => ({ record: h.audit }),
@@ -44,6 +45,9 @@ beforeEach(() => {
   h.create.mockResolvedValue({ inboundId: "inbound-1" });
   h.send.mockResolvedValue({});
   h.audit.mockResolvedValue(undefined);
+  // Default: no declared Mailroom mailbox for this recipient, so the marketing
+  // responder path the rest of this suite asserts stays unchanged.
+  h.mailroom.mockResolvedValue(null);
   h.execute.mockImplementation(async (input) => {
     const domain = await input.performDomainWrite({ inboundChannelMessage: { create: h.create } });
     return { ...domain, replayed: false, operationalErrors: [] };
@@ -101,5 +105,30 @@ describe("Postmark inbound compatibility", () => {
     h.execute.mockRejectedValueOnce(Object.assign(new Error("serialization conflict"), { code: "P2034" }));
     await expect(POST(request() as never)).rejects.toMatchObject({ code: "P2034" });
     expect(h.send).not.toHaveBeenCalled();
+  });
+});
+
+describe("Mailroom branch header fidelity (BI-D2ED96B1)", () => {
+  it("hands intake the headers Postmark sent, so the noise rules can judge bulk mail", async () => {
+    // The route used to pass `headers: {}`, which left the rules-first noise
+    // stage (auto-submitted / list-id / list-unsubscribe / precedence) with
+    // nothing to read. Live acceptance 2026-09-10 routed a `Precedence: bulk`
+    // newsletter into the veterinary queue because of it.
+    h.parsed = {
+      externalMessageId: "MSG-BULK", externalThreadId: "MSG-BULK",
+      fromAddress: "newsletter@supplier.example", fromDisplayName: "Supplier Monthly",
+      toAddress: "vet@rescue.example", subject: "September deals", textBody: "Unsubscribe below.",
+      htmlBody: null, receivedAt: new Date("2026-09-10"),
+      headers: { precedence: "bulk", "list-unsubscribe": "<https://supplier.example/u>" },
+      metadata: { stream: "inbound" },
+    };
+    h.mailroom.mockResolvedValue({ inboundId: "inbound-mailroom-1" });
+
+    const res = await POST(request() as never);
+
+    expect(res.status).toBe(200);
+    expect(h.mailroom).toHaveBeenCalledTimes(1);
+    const passed = h.mailroom.mock.calls[0]![0] as { mail: { headers: Record<string, string> } };
+    expect(passed.mail.headers).toEqual({ precedence: "bulk", "list-unsubscribe": "<https://supplier.example/u>" });
   });
 });

--- a/apps/web/app/api/integrations/email-postmark/inbound/route.ts
+++ b/apps/web/app/api/integrations/email-postmark/inbound/route.ts
@@ -92,7 +92,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       textBody: parsed.textBody,
       htmlBody: parsed.htmlBody,
       receivedAt: parsed.receivedAt,
-      headers: {},
+      headers: parsed.headers,
       attachments: [],
     },
   }).catch(() => null);

--- a/apps/web/lib/mailroom/triage.test.ts
+++ b/apps/web/lib/mailroom/triage.test.ts
@@ -70,15 +70,19 @@ describe("hint matching", () => {
     expect(matchReasonByHints(profile, mail({ textBody: "I want to adopt and also donate" }))).toBeNull();
   });
   it("a vet's message about a named animal carries the animal reference", async () => {
+    // BI-92DDAD88: this test used to spell the reference "A-1234", a format no
+    // install has ever issued, so it passed while the shipped pattern could not
+    // match a single real animal. Use the format the roster actually holds.
+    const ref = "ANML-23E98CB8";
     const result = await triageInboundMail({
       profile,
-      mail: mail({ subject: "Bloodwork results for A-1234", textBody: "Lab results attached from the clinic." }),
-      lookupSubject: async (kind, candidate) => (kind === "animal" && candidate === "A-1234" ? "A-1234" : null),
+      mail: mail({ subject: `Bloodwork results for ${ref}`, textBody: "Lab results attached from the clinic." }),
+      lookupSubject: async (kind, candidate) => (kind === "animal" && candidate === ref ? ref : null),
     });
     expect(result.reasonKey).toBe("veterinary-correspondence");
     expect(result.queueKey).toBe("veterinary");
-    expect(result.subjectRef).toBe("A-1234");
-    expect(extractSubjectCandidate(profile, "animal", mail({ subject: "re: A-1234" }))).toBe("A-1234");
+    expect(result.subjectRef).toBe(ref);
+    expect(extractSubjectCandidate(profile, "animal", mail({ subject: `re: ${ref}` }))).toBe(ref);
   });
 });
 

--- a/apps/web/lib/marketing/channels/email-postmark/client.test.ts
+++ b/apps/web/lib/marketing/channels/email-postmark/client.test.ts
@@ -97,6 +97,33 @@ describe("parseInboundPayload", () => {
     expect(parsed?.externalThreadId).toBe("MSG-3");
   });
 
+  it("folds every header to lowercase so the noise rules can read them (BI-D2ED96B1)", () => {
+    const parsed = parseInboundPayload({
+      MessageID: "MSG-4",
+      TextBody: "x",
+      Headers: [
+        { Name: "Precedence", Value: "bulk" },
+        { Name: "List-Unsubscribe", Value: "<https://supplier.example/u>" },
+        { Name: "Auto-Submitted", Value: "auto-generated" },
+        { Name: "X-Broken" },
+      ],
+    });
+    expect(parsed?.headers).toEqual({
+      precedence: "bulk",
+      "list-unsubscribe": "<https://supplier.example/u>",
+      "auto-submitted": "auto-generated",
+    });
+  });
+
+  it("reads In-Reply-To whatever case the sender used (RFC 5322 3.6.4)", () => {
+    const parsed = parseInboundPayload({
+      MessageID: "MSG-5",
+      TextBody: "x",
+      Headers: [{ Name: "in-reply-to", Value: "<earlier@example.com>" }],
+    });
+    expect(parsed?.externalThreadId).toBe("<earlier@example.com>");
+  });
+
   it("returns null on missing MessageID", () => {
     expect(parseInboundPayload({ TextBody: "no id" })).toBeNull();
     expect(parseInboundPayload(null)).toBeNull();

--- a/apps/web/lib/marketing/channels/email-postmark/client.test.ts
+++ b/apps/web/lib/marketing/channels/email-postmark/client.test.ts
@@ -115,6 +115,22 @@ describe("parseInboundPayload", () => {
     });
   });
 
+  it("never lets a sender's header name become a property name", () => {
+    const parsed = parseInboundPayload({
+      MessageID: "MSG-6",
+      TextBody: "x",
+      Headers: [
+        { Name: "__proto__", Value: "polluted" },
+        { Name: "constructor", Value: "polluted" },
+        { Name: "X-Whatever", Value: "ignored" },
+        { Name: "Precedence", Value: "bulk" },
+      ],
+    });
+    expect(parsed?.headers).toEqual({ precedence: "bulk" });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+  });
+
   it("reads In-Reply-To whatever case the sender used (RFC 5322 3.6.4)", () => {
     const parsed = parseInboundPayload({
       MessageID: "MSG-5",

--- a/apps/web/lib/marketing/channels/email-postmark/client.ts
+++ b/apps/web/lib/marketing/channels/email-postmark/client.ts
@@ -119,6 +119,21 @@ export function verifyInboundSignature(input: {
 
 // ─── Inbound payload parsing ────────────────────────────────────────────────
 
+/**
+ * The header names the Mailroom's noise stage and the threading logic read —
+ * the same closed set the IMAP adapter lifts (MailHeaderSubset). Keeping the
+ * exposed map keyed from this literal tuple, rather than from whatever names a
+ * sender sends, is what keeps a remote value from ever naming a property.
+ */
+const READ_HEADERS = [
+  "auto-submitted",
+  "list-id",
+  "list-unsubscribe",
+  "precedence",
+  "x-auto-response-suppress",
+  "content-type",
+] as const;
+
 export type ParsedInboundEmail = {
   externalMessageId: string | null;
   externalThreadId: string;
@@ -130,7 +145,7 @@ export type ParsedInboundEmail = {
   htmlBody: string | null;
   receivedAt: Date;
   /**
-   * Every header Postmark sent, keyed lowercase.
+   * The headers the platform reads, keyed lowercase (READ_HEADERS).
    *
    * BI-D2ED96B1 (found by live acceptance 2026-09-10): the Mailroom's noise
    * stage judges `auto-submitted`, `list-id`, `list-unsubscribe` and
@@ -138,7 +153,8 @@ export type ParsedInboundEmail = {
    * an empty header map, so on the Postmark path that whole rules-first stage
    * was dead and a `Precedence: bulk` newsletter was routed into a business
    * queue with an acknowledge-by time. Parsing them ONCE here keeps the
-   * Postmark path at parity with the IMAP adapter.
+   * Postmark path at parity with the IMAP adapter, which reads exactly these
+   * names from the parsed message (MailHeaderSubset).
    */
   headers: Record<string, string>;
   metadata: Record<string, unknown>;
@@ -168,15 +184,22 @@ export function parseInboundPayload(raw: unknown): ParsedInboundEmail | null {
 
   // Use the In-Reply-To / References header for thread continuity when
   // available; fall back to the message id itself for a new conversation.
-  const headerList = Array.isArray(p.Headers) ? p.Headers : [];
-  const headers: Record<string, string> = {};
-  for (const entry of headerList) {
+  // Fold the sender's headers into a Map first. A Map cannot be prototype-
+  // polluted, and nothing below ever uses a sender-controlled string as a
+  // property name — the exposed object is keyed only from READ_HEADERS.
+  const folded = new Map<string, string>();
+  for (const entry of Array.isArray(p.Headers) ? p.Headers : []) {
     if (typeof entry?.Name !== "string" || typeof entry.Value !== "string") continue;
-    headers[entry.Name.trim().toLowerCase()] = entry.Value;
+    folded.set(entry.Name.trim().toLowerCase(), entry.Value);
+  }
+  const headers: Record<string, string> = {};
+  for (const name of READ_HEADERS) {
+    const value = folded.get(name);
+    if (value) headers[name] = value;
   }
   // Header names are case-insensitive (RFC 5322 §3.6.4), so read the folded map
   // rather than matching the exact spelling a sender happened to use.
-  const inReplyTo = headers["in-reply-to"] ?? null;
+  const inReplyTo = folded.get("in-reply-to") ?? null;
   const externalThreadId = inReplyTo ?? messageId;
 
   const textBody =

--- a/apps/web/lib/marketing/channels/email-postmark/client.ts
+++ b/apps/web/lib/marketing/channels/email-postmark/client.ts
@@ -129,6 +129,18 @@ export type ParsedInboundEmail = {
   textBody: string;
   htmlBody: string | null;
   receivedAt: Date;
+  /**
+   * Every header Postmark sent, keyed lowercase.
+   *
+   * BI-D2ED96B1 (found by live acceptance 2026-09-10): the Mailroom's noise
+   * stage judges `auto-submitted`, `list-id`, `list-unsubscribe` and
+   * `precedence` (RFC 3834 / RFC 2369). The inbound route used to hand intake
+   * an empty header map, so on the Postmark path that whole rules-first stage
+   * was dead and a `Precedence: bulk` newsletter was routed into a business
+   * queue with an acknowledge-by time. Parsing them ONCE here keeps the
+   * Postmark path at parity with the IMAP adapter.
+   */
+  headers: Record<string, string>;
   metadata: Record<string, unknown>;
 };
 
@@ -156,8 +168,15 @@ export function parseInboundPayload(raw: unknown): ParsedInboundEmail | null {
 
   // Use the In-Reply-To / References header for thread continuity when
   // available; fall back to the message id itself for a new conversation.
-  const headers = Array.isArray(p.Headers) ? p.Headers : [];
-  const inReplyTo = headers.find((h) => h.Name === "In-Reply-To")?.Value ?? null;
+  const headerList = Array.isArray(p.Headers) ? p.Headers : [];
+  const headers: Record<string, string> = {};
+  for (const entry of headerList) {
+    if (typeof entry?.Name !== "string" || typeof entry.Value !== "string") continue;
+    headers[entry.Name.trim().toLowerCase()] = entry.Value;
+  }
+  // Header names are case-insensitive (RFC 5322 §3.6.4), so read the folded map
+  // rather than matching the exact spelling a sender happened to use.
+  const inReplyTo = headers["in-reply-to"] ?? null;
   const externalThreadId = inReplyTo ?? messageId;
 
   const textBody =
@@ -177,6 +196,7 @@ export function parseInboundPayload(raw: unknown): ParsedInboundEmail | null {
     textBody,
     htmlBody: typeof p.HtmlBody === "string" ? p.HtmlBody : null,
     receivedAt: p.Date ? new Date(p.Date) : new Date(),
+    headers,
     metadata: {
       messageStream: p.MessageStream ?? "inbound",
       headerCount: headers.length,

--- a/packages/storefront-templates/src/archetypes/nonprofit-community.ts
+++ b/packages/storefront-templates/src/archetypes/nonprofit-community.ts
@@ -82,7 +82,12 @@ const ANIMAL_WELFARE_MAILROOM_PROFILE: MailroomProfile = {
   subjectKinds: [
     // An animal reference is the platform's animal id token or a listed
     // animal's name; the app layer confirms the candidate against the roster.
-    { kind: "animal", referencePattern: "\\b(?:ANI|A)-[A-Z0-9]{4,12}\\b", lookup: "animal-roster" },
+    // The platform issues animal references as `ANML-<id>` (AdoptableAnimal /
+    // AnimalProfile.animalRef). The first pattern shipped here matched `ANI-`
+    // and `A-`, which no reference has ever used, so no vet or adopter message
+    // ever linked to the animal it was about — found by live acceptance
+    // 2026-09-10 (BI-92DDAD88). `ANI` stays as a tolerated alias.
+    { kind: "animal", referencePattern: "\\b(?:ANML|ANI)-[A-Z0-9]{4,12}\\b", lookup: "animal-roster" },
   ],
   defaultReasonKey: "adopt-animal",
 };

--- a/packages/storefront-templates/src/mailroom-profile.test.ts
+++ b/packages/storefront-templates/src/mailroom-profile.test.ts
@@ -60,6 +60,17 @@ describe("mailroom profile registry", () => {
     );
   });
 
+  it("the animal reference pattern matches the reference format the platform issues (BI-92DDAD88)", () => {
+    // Live acceptance 2026-09-10: every animalRef on a real install looks like
+    // ANML-23E98CB8, and the pattern shipped here matched only ANI-/A-, so a
+    // vet's lab-result email never linked to the animal it was about.
+    const kind = (resolveMailroomProfile(petRescue).subjectKinds ?? []).find((k) => k.kind === "animal")!;
+    const pattern = new RegExp(kind.referencePattern);
+    expect(pattern.test("Lab results ready for ANML-23E98CB8 (Pip)")).toBe(true);
+    expect("Lab results ready for ANML-23E98CB8 (Pip)".match(pattern)?.[0]).toBe("ANML-23E98CB8");
+    expect(pattern.test("no reference here")).toBe(false);
+  });
+
   it("merge replaces by key and keeps the rest", () => {
     const merged = mergeMailroomProfile(COMMON_MAILROOM_PROFILE, {
       expectedMailboxes: [{ purposeKey: "general", label: "Front desk", examples: ["desk@"], why: "x" }],


### PR DESCRIPTION
## Summary

Two Mailroom defects found by running the Mailroom for Second Chance Animal Rescue on the live install (BI-E6BAF90F live acceptance), not by a test.

**Bulk mail reached a clinician's queue.** The Postmark inbound route handed intake `headers: {}`, so the rules-first noise stage (auto-submitted, list-id, list-unsubscribe, precedence — RFC 3834 / RFC 2369) had nothing to read on that path. A supplier newsletter carrying `Precedence: bulk` was classified `veterinary-correspondence` and routed into the veterinary queue with an acknowledge-by time. `parseInboundPayload` now folds every header to lowercase once and the route passes that map through, which also makes In-Reply-To threading case-insensitive as RFC 5322 §3.6.4 requires.

**No message ever linked to the animal it was about.** The pet-rescue profile's animal `referencePattern` matched `ANI-` and `A-`. Every reference the platform issues is `ANML-<id>`, so `subjectRef` stayed null on every item. The pattern now matches the issued format, with `ANI` kept as a tolerated alias.

## Changes

- `apps/web/lib/marketing/channels/email-postmark/client.ts`: `ParsedInboundEmail` gains a lowercase `headers` map; In-Reply-To is read from it.
- `apps/web/app/api/integrations/email-postmark/inbound/route.ts`: passes `parsed.headers` to `ingestPostmarkInboundForMailbox` instead of `{}`.
- `packages/storefront-templates/src/archetypes/nonprofit-community.ts`: animal `referencePattern` matches `ANML-`/`ANI-`.
- Tests: route asserts intake receives the sender's headers; client asserts the folded map and case-insensitive In-Reply-To; profile asserts the pattern matches a roster-format reference; the triage test that spelled its reference `A-1234` now uses `ANML-23E98CB8`.

## Test plan

### Failure analysis and recovery

The triage test meant to cover the second defect used a reference format no install has ever issued, so it passed against a pattern that could not match a single real animal. That is why both defects reached a release: the unit suite asserted the pipeline against fixtures it invented rather than against the shape the platform produces. Corrected here by pinning the fixtures to the issued format and by asserting the Postmark path's header map against what the route actually forwards.

- **Prevention:** the route test now fails if the header map is dropped again; the profile and triage tests fail if the reference format drifts from the roster.
- **Detection:** both behaviours are observable on the Mailroom page (a bulk message appears under "show everything, including noise" rather than in a queue; a vet message shows "about ANML-…").
- **Containment:** no schema change. Items already misrouted keep their recorded reason and can be re-triaged by hand.
- **Residual risk:** the reference pattern is still a literal string in the archetype registry rather than derived from the id generator, so a future change to the ref format can drift again. Noted in the follow-up on BI-92DDAD88.

- [x] **Runtime-bound change** (API route, archetype registry)
  - [x] `pnpm typecheck`, targeted vitest, full suite, Next build and Docker image in the local-CI gate
  - [x] Functional verification against the **canonical runtime**: the defects were found on the live install and the fix is verified there after release

### Verification evidence

Local-CI-Evidence: cmtuzjaz10sr301omtuv0toak (fix/mailroom-noise-headers-and-animal-ref@ecec2d7dfab62d5daf6343393f0ef06f05c1fb10)

Live evidence for the defects, on Arcamanus DEV at v2026.09.09-mailroom.1: a signed Postmark webhook carrying `Precedence: bulk` produced item `cmtuu2hiw06ap01omny5jktlq` with reason `veterinary-correspondence`, status `routed`, queue `veterinary`; the vet message `cmtuu2hfu06af01omvxkx1jp5` naming `ANML-23E98CB8` recorded `subjectRef` null.

## Pre-PR readiness

- [x] `pnpm run pregate:preflight` passed (67 guards)
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready` returned READY

## Related issues / Epic

Parent: BI-4F7BB48B (Mailroom: email triage and dispatch). Closes BI-D2ED96B1 and BI-92DDAD88. Found by BI-E6BAF90F.

## Overlap sweep

`gh pr list --state open`: no open PR touches the Mailroom, the Postmark connector or the archetype registry.

## Notes for the reviewer

A second commit answers a CodeQL high finding on the first: the map was keyed by the sender's header name, so a `__proto__` header named a property. It is now keyed from the same closed six-name set the IMAP adapter reads, with the sender's headers folded into a Map first. The header map is built once in the parser rather than in the route, so the marketing responder and the Mailroom see the same headers. `ANI-` is kept in the pattern only so any hand-written reference in an existing message still resolves.

Seed-Fit-Decision: global-default
Seed-fit note: the archetype registry change is a corrected pattern inside the existing pet-rescue entry, read through `resolveMailroomProfile` on every install.

Convergence-Impact-Decision: auto-converges — both fixes ship inside the portal image and the archetype registry is re-read by the boot-time seed chain.
Data-Impact-Decision: none — no schema change.
Design-Grounding-Decision: docs/superpowers/specs/2026-09-09-mailroom-email-triage-and-dispatch-design.md §4.4 and §4.5.
Docs-Impact-Decision: none — the design already specified both behaviours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
