### PR TITLE
feat(govern): escalation is a property of the decision, not of the actor's trust tier (BI-6B3DA9DD)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 703,
+  "pageCount": 704,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -3905,6 +3905,17 @@
         "decision-dimensions",
         "examples",
         "related"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/escalation-is-a-gate-not-a-trust-tier.md": {
+      "publicHref": "/founder-kernel/wiki/principles/escalation-is-a-gate-not-a-trust-tier/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply"
       ]
     },
     "docs/founder-kernel/wiki/principles/evidence-before-diagnosis.md": {

--- a/apps/web/lib/govern/authority/coworker-authority-decision.ts
+++ b/apps/web/lib/govern/authority/coworker-authority-decision.ts
@@ -10,6 +10,11 @@ import {
   canAccessAuthoritySubject,
   type AuthoritySubject,
 } from "./authority-subject";
+import {
+  resolveEscalation,
+  type EscalationDecision,
+  type EscalationSteering,
+} from "./escalation-gate";
 
 export const COWORKER_AUTHORITY_OUTCOMES = [
   "allow",
@@ -86,8 +91,17 @@ export type CoworkerAuthorityInput = {
     /** False when an explicit operator policy forbids policy projection. */
     policyProjectionAllowed?: boolean;
     consequence?: ToolConsequence | null;
+    /** A Work Case may elevate an otherwise ordinary mutation to consequential. */
+    workCaseConsequential?: boolean;
     requiresDelegationChain?: boolean;
   };
+  /**
+   * BI-6B3DA9DD: what can decide this action without a person, server-resolved.
+   * Absent means `none` — nothing recorded can steer it. See escalation-gate.ts:
+   * a trust tier is a ceiling on what a coworker may attempt, never a reason to
+   * put a non-damaging, steered action in front of a human.
+   */
+  steering?: EscalationSteering;
   subject?: CoworkerAuthoritySubject | null;
   /** The Workroom the call runs in, for the receipt; null when unroomed. */
   room?: {
@@ -150,6 +164,8 @@ type CoworkerAuthorityAllowDecision = {
   reasonCode: "authorized";
   explanation: string;
   nextAction: "execute";
+  /** Which escalation branch decided; recorded on the authority evidence. */
+  escalation?: EscalationDecision;
 };
 
 type CoworkerAuthorityDenyDecision = {
@@ -168,6 +184,8 @@ type CoworkerAuthorityApprovalDecision = {
   explanation: string;
   nextAction: "request-approval";
   approvalBinding: CoworkerApprovalBinding;
+  /** Which escalation branch decided; recorded on the authority evidence. */
+  escalation?: EscalationDecision;
 };
 
 export type CoworkerAuthorityDecision =
@@ -282,11 +300,33 @@ function deny(
   };
 }
 
-function requiresApproval(input: CoworkerAuthorityInput): boolean {
-  if (input.action.executionMode === "proposal") return true;
-  if (!input.action.sideEffect) return false;
-  return input.action.approvalPolicy === "all"
-    || input.action.approvalPolicy === "side-effects";
+/**
+ * BI-6B3DA9DD — escalation is a property of the decision, not of the actor.
+ *
+ * This used to be `requiresApproval`, which asked only whether the acting
+ * coworker's HITL tier said "approve side effects" and minted a human envelope
+ * for any side effect if it did. That escalated the specialist reviewers' own
+ * governance receipts to a person, which is what the founder's ruling forbids.
+ *
+ * The operator's standing configuration is carried through unchanged as
+ * `operatorRequiresApproval`; the gate only decides, among the actions that
+ * configuration would have escalated, which ones genuinely need a person.
+ */
+function escalationFor(input: CoworkerAuthorityInput): EscalationDecision {
+  return resolveEscalation({
+    operatorRequiresApproval: input.action.approvalPolicy === "all"
+      || input.action.approvalPolicy === "side-effects",
+    action: {
+      sideEffect: input.action.sideEffect,
+      executionMode: input.action.executionMode,
+      consequence: input.action.consequence ?? null,
+      ...(input.action.workCaseConsequential !== undefined
+        ? { workCaseConsequential: input.action.workCaseConsequential }
+        : {}),
+    },
+    dataPolicy: { sensitivity: input.dataPolicy.sensitivity },
+    steering: input.steering ?? "none",
+  });
 }
 
 function sameBinding(
@@ -388,12 +428,14 @@ export function evaluateCoworkerAuthority(
     return deny("policy-version-stale");
   }
 
-  if (!requiresApproval(input)) {
+  const escalation = escalationFor(input);
+  if (escalation.verdict === "automated") {
     return {
       outcome: "allow",
       reasonCode: "authorized",
       explanation: EXPLANATIONS.authorized,
       nextAction: "execute",
+      escalation,
     };
   }
 
@@ -405,6 +447,7 @@ export function evaluateCoworkerAuthority(
       explanation: EXPLANATIONS["approval-required"],
       nextAction: "request-approval",
       approvalBinding: currentBinding,
+      escalation,
     };
   }
   if (input.approval.status !== "approved") {
@@ -422,5 +465,6 @@ export function evaluateCoworkerAuthority(
     reasonCode: "authorized",
     explanation: EXPLANATIONS.authorized,
     nextAction: "execute",
+    escalation,
   };
 }

--- a/apps/web/lib/govern/authority/escalation-gate.conformance.test.ts
+++ b/apps/web/lib/govern/authority/escalation-gate.conformance.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Escalation Gate CONFORMANCE (BI-6B3DA9DD).
+ *
+ * The founder's rule is enforced by `resolveEscalation`, not by prose. This is
+ * what stops it drifting back into prose, and it runs in the existing test job
+ * on every PR rather than as a new CI job nobody wires up:
+ *
+ *   1. EXHAUSTIVE DOMAIN PROOF. The gate's input space is closed and small, so
+ *      this walks EVERY combination. The load-bearing property: the gate may
+ *      only REMOVE escalations, never add one the retired tier-only rule did
+ *      not already make — proved against that rule, encoded below. A fix for
+ *      over-escalation that introduced new approval envelopes would be the
+ *      same defect wearing the opposite coat. Walking the whole domain
+ *      subsumes a per-tool table: no future tool shape can slip a human step
+ *      back in, because every shape a tool could have is already covered.
+ *   2. WIRING. The authority evaluator must decide through the gate, and must
+ *      no longer mint an envelope from the acting coworker's HITL tier alone.
+ *   3. THE PRINCIPLE FOLLOWS THE PROCESS. The kernel principle page must state
+ *      exactly the sentences the gate exports, so what an agent reads and what
+ *      the platform enforces cannot disagree on any install.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DAMAGING_SENSITIVITIES,
+  describeEscalationRule,
+  ESCALATION_STEERING,
+  resolveEscalation,
+  type EscalationInput,
+} from "./escalation-gate";
+
+// `new URL(...).pathname` returns "/D:/..." on Windows and breaks readFileSync.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..", "..", "..");
+const PRINCIPLE_PATH = join(
+  REPO_ROOT,
+  "docs/founder-kernel/wiki/principles/escalation-is-a-gate-not-a-trust-tier.md",
+);
+const EVALUATOR_PATH = join(HERE, "coworker-authority-decision.ts");
+
+const CONSEQUENCES = [null, "outward", "irreversible", "authority"] as const;
+const SENSITIVITIES = ["public", "internal", "confidential", "restricted"] as const;
+const EXECUTION_MODES = ["immediate", "proposal"] as const;
+
+/**
+ * The rule the platform ran BEFORE this gate: a proposal escalates, a read
+ * never does, and otherwise the acting coworker's HITL-derived approval policy
+ * alone decided. Encoded so the walk can prove the new rule adds nothing.
+ */
+function retiredTierOnlyRule(shape: {
+  sideEffect: boolean;
+  executionMode: "proposal" | "immediate";
+  operatorRequiresApproval: boolean;
+}): "automated" | "human" {
+  if (shape.executionMode === "proposal") return "human";
+  if (!shape.sideEffect) return "automated";
+  return shape.operatorRequiresApproval ? "human" : "automated";
+}
+
+type Case = { input: EscalationInput; damaging: boolean; shape: string };
+
+function everyCase(): Case[] {
+  const cases: Case[] = [];
+  for (const sideEffect of [true, false]) {
+    for (const executionMode of EXECUTION_MODES) {
+      for (const consequence of CONSEQUENCES) {
+        for (const workCaseConsequential of [true, false]) {
+          for (const sensitivity of SENSITIVITIES) {
+            for (const steering of ESCALATION_STEERING) {
+              for (const operatorRequiresApproval of [true, false]) {
+                cases.push({
+                  input: {
+                    action: { sideEffect, executionMode, consequence, workCaseConsequential },
+                    dataPolicy: { sensitivity },
+                    operatorRequiresApproval,
+                    steering,
+                  },
+                  damaging:
+                    workCaseConsequential
+                    || consequence !== null
+                    || (DAMAGING_SENSITIVITIES as readonly string[]).includes(sensitivity),
+                  shape:
+                    `sideEffect=${sideEffect} mode=${executionMode} consequence=${consequence} `
+                    + `workCase=${workCaseConsequential} sensitivity=${sensitivity} `
+                    + `steering=${steering} operatorRequiresApproval=${operatorRequiresApproval}`,
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return cases;
+}
+
+const CASES = everyCase();
+
+describe("escalation gate conformance — exhaustive domain proof", () => {
+  it("covers the gate's entire input space", () => {
+    expect(CASES.length).toBe(
+      2 * 2 * CONSEQUENCES.length * 2 * SENSITIVITIES.length * ESCALATION_STEERING.length * 2,
+    );
+  });
+
+  it("only ever REMOVES an escalation, never adds one", () => {
+    const added = CASES.filter(({ input, shape }) => {
+      const retired = retiredTierOnlyRule({
+        sideEffect: input.action.sideEffect,
+        executionMode: input.action.executionMode,
+        operatorRequiresApproval: input.operatorRequiresApproval,
+      });
+      return resolveEscalation(input).verdict === "human" && retired === "automated"
+        ? shape
+        : false;
+    });
+    expect(added).toEqual([]);
+  });
+
+  it("removes exactly the wrong escalations: non-damaging, steered side effects", () => {
+    const removed = CASES.filter(({ input }) => {
+      const retired = retiredTierOnlyRule({
+        sideEffect: input.action.sideEffect,
+        executionMode: input.action.executionMode,
+        operatorRequiresApproval: input.operatorRequiresApproval,
+      });
+      return retired === "human" && resolveEscalation(input).verdict === "automated";
+    });
+    expect(removed.length).toBeGreaterThan(0);
+    for (const { input, damaging } of removed) {
+      expect(damaging).toBe(false);
+      expect(input.steering).not.toBe("none");
+      expect(input.action.sideEffect).toBe(true);
+      expect(input.action.executionMode).toBe("immediate");
+      expect(input.operatorRequiresApproval).toBe(true);
+    }
+  });
+
+  it("keeps a damaging action in front of a person wherever it escalated before", () => {
+    const leaked = CASES.filter(
+      ({ input, damaging, shape }) =>
+        damaging
+        && input.operatorRequiresApproval
+        && input.action.sideEffect
+        && input.action.executionMode === "immediate"
+        && resolveEscalation(input).verdict !== "human"
+        && shape,
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("never escalates an immediate read", () => {
+    const escalated = CASES.filter(
+      ({ input }) =>
+        !input.action.sideEffect
+        && input.action.executionMode === "immediate"
+        && resolveEscalation(input).verdict === "human",
+    );
+    expect(escalated).toEqual([]);
+  });
+
+  it("records a damage classification that matches the rule", () => {
+    for (const { input, damaging, shape } of CASES) {
+      expect(resolveEscalation(input).damaging, shape).toBe(damaging);
+    }
+  });
+});
+
+describe("escalation gate conformance — wiring", () => {
+  const evaluator = readFileSync(EVALUATOR_PATH, "utf8");
+
+  it("decides escalation through the gate", () => {
+    expect(evaluator).toContain("resolveEscalation(");
+  });
+
+  it("no longer mints an envelope from the acting coworker's trust tier alone", () => {
+    expect(evaluator).not.toMatch(
+      /return input\.action\.approvalPolicy === "all"\s*\n?\s*\|\| input\.action\.approvalPolicy === "side-effects";/,
+    );
+  });
+});
+
+describe("escalation gate conformance — the principle follows the process", () => {
+  it("states every rule the gate enforces, verbatim", () => {
+    const principle = readFileSync(PRINCIPLE_PATH, "utf8");
+    const missing = describeEscalationRule().filter((rule) => !principle.includes(rule));
+    expect(missing).toEqual([]);
+  });
+});

--- a/apps/web/lib/govern/authority/escalation-gate.test.ts
+++ b/apps/web/lib/govern/authority/escalation-gate.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeEscalationRule,
+  isDamagingAction,
+  resolveEscalation,
+  type EscalationInput,
+  type EscalationSteering,
+} from "./escalation-gate";
+
+function input(overrides: {
+  sideEffect?: boolean;
+  executionMode?: "proposal" | "immediate";
+  consequence?: EscalationInput["action"]["consequence"];
+  workCaseConsequential?: boolean;
+  sensitivity?: EscalationInput["dataPolicy"]["sensitivity"];
+  operatorRequiresApproval?: boolean;
+  steering?: EscalationSteering;
+} = {}): EscalationInput {
+  return {
+    action: {
+      sideEffect: overrides.sideEffect ?? true,
+      executionMode: overrides.executionMode ?? "immediate",
+      consequence: overrides.consequence ?? null,
+      ...(overrides.workCaseConsequential !== undefined
+        ? { workCaseConsequential: overrides.workCaseConsequential }
+        : {}),
+    },
+    dataPolicy: { sensitivity: overrides.sensitivity ?? "internal" },
+    // The default is the coworker the gate exists for: one whose operator
+    // configuration DOES require approval for ordinary side effects.
+    operatorRequiresApproval: overrides.operatorRequiresApproval ?? true,
+    steering: overrides.steering ?? "none",
+  };
+}
+
+const STEERINGS: Exclude<EscalationSteering, "none">[] = [
+  "independent-reviewer",
+  "room-authority",
+  "wwmd",
+];
+
+describe("resolveEscalation — the operator's standing configuration is untouched", () => {
+  it("lets a graduated coworker act alone, damaging or not, steered or not", () => {
+    for (const consequence of [null, "outward"] as const) {
+      for (const steering of [...STEERINGS, "none" as const]) {
+        const decision = resolveEscalation(
+          input({ operatorRequiresApproval: false, consequence, steering }),
+        );
+        expect(decision.verdict).toBe("automated");
+        expect(decision.reasonCode).toBe("operator-graduated-coworker");
+      }
+    }
+  });
+});
+
+describe("resolveEscalation — damaging reaches a human", () => {
+  it.each(["outward", "irreversible", "authority"] as const)(
+    "escalates a declared %s consequence even when steering is available",
+    (consequence) => {
+      for (const steering of STEERINGS) {
+        const decision = resolveEscalation(input({ consequence, steering }));
+        expect(decision.verdict).toBe("human");
+        expect(decision.reasonCode).toBe("damaging-consequence");
+        expect(decision.damaging).toBe(true);
+      }
+    },
+  );
+
+  it("escalates restricted data even with no declared consequence", () => {
+    const decision = resolveEscalation(
+      input({ sensitivity: "restricted", steering: "independent-reviewer" }),
+    );
+    expect(decision.verdict).toBe("human");
+    expect(decision.reasonCode).toBe("damaging-sensitivity");
+  });
+
+  it("escalates an ordinary mutation a Work Case declared consequential", () => {
+    const decision = resolveEscalation(
+      input({ workCaseConsequential: true, steering: "room-authority" }),
+    );
+    expect(decision.verdict).toBe("human");
+    expect(decision.reasonCode).toBe("damaging-work-case");
+  });
+
+  it("never lets a coworker's steering decide damage — the safety property", () => {
+    for (const steering of [...STEERINGS, "none" as const]) {
+      expect(resolveEscalation(input({ consequence: "outward", steering })).verdict).toBe("human");
+    }
+  });
+
+  it("adds no escalation the retired tier-only rule did not already make", () => {
+    // The retired rule escalated every side effect for a coworker whose policy
+    // required approval. So every `human` here must be one of those.
+    for (const consequence of [null, "outward", "irreversible", "authority"] as const) {
+      for (const steering of [...STEERINGS, "none" as const]) {
+        const decision = resolveEscalation(input({ consequence, steering }));
+        if (decision.verdict === "human") expect(input({ consequence }).action.sideEffect).toBe(true);
+      }
+    }
+  });
+});
+
+describe("resolveEscalation — non-damaging", () => {
+  it.each(STEERINGS)("decides automatically when %s steers it", (steering) => {
+    const decision = resolveEscalation(input({ steering }));
+    expect(decision.verdict).toBe("automated");
+    expect(decision.damaging).toBe(false);
+    expect(decision.reasonCode).toBe(`steered-by-${steering}`);
+  });
+
+  it("reaches a human when nothing can steer a side effect", () => {
+    const decision = resolveEscalation(input({ steering: "none" }));
+    expect(decision.verdict).toBe("human");
+    expect(decision.reasonCode).toBe("unsteered-side-effect");
+  });
+
+  it("never escalates a read, steered or not", () => {
+    for (const steering of [...STEERINGS, "none" as const]) {
+      const decision = resolveEscalation(input({ sideEffect: false, steering }));
+      expect(decision.verdict).toBe("automated");
+      expect(decision.reasonCode).toBe("routine-read");
+    }
+  });
+
+  it("keeps a declared proposal tool a proposal", () => {
+    const decision = resolveEscalation(
+      input({ executionMode: "proposal", steering: "independent-reviewer" }),
+    );
+    expect(decision.verdict).toBe("human");
+    expect(decision.reasonCode).toBe("declared-proposal");
+  });
+});
+
+describe("resolveEscalation — the defect it exists to close (BI-6B3DA9DD)", () => {
+  // record_initiative_evidence: sideEffect, immediate, NO declared consequence,
+  // internal sensitivity. AGT-WS-PORTFOLIO ships at hitlTierDefault 1, which
+  // made deriveCoworkerApprovalPolicy return "all" and minted a human envelope
+  // for a platform receipt that decides nothing damaging.
+  const researchReceipt = input({
+    sideEffect: true,
+    executionMode: "immediate",
+    consequence: null,
+    sensitivity: "internal",
+  });
+
+  it("does not escalate a governance receipt written by an independent reviewer", () => {
+    const decision = resolveEscalation({ ...researchReceipt, steering: "independent-reviewer" });
+    expect(decision.verdict).toBe("automated");
+    expect(decision.damaging).toBe(false);
+  });
+
+  it("still escalates the same receipt when no independent reviewer is steering it", () => {
+    const decision = resolveEscalation({ ...researchReceipt, steering: "none" });
+    expect(decision.verdict).toBe("human");
+    expect(decision.reasonCode).toBe("unsteered-side-effect");
+  });
+
+  it("does not consult a trust tier at all — the input has no such field", () => {
+    expect(Object.keys(researchReceipt.action)).not.toContain("approvalPolicy");
+    expect(JSON.stringify(researchReceipt)).not.toMatch(/hitl/i);
+  });
+});
+
+describe("isDamagingAction", () => {
+  it("is true on any single ground and false on none", () => {
+    expect(isDamagingAction(input({ consequence: "outward" }))).toBe(true);
+    expect(isDamagingAction(input({ sensitivity: "restricted" }))).toBe(true);
+    expect(isDamagingAction(input({ workCaseConsequential: true }))).toBe(true);
+    expect(isDamagingAction(input({ sensitivity: "confidential" }))).toBe(false);
+  });
+});
+
+describe("describeEscalationRule", () => {
+  it("states the two-condition rule the gate runs on", () => {
+    const text = describeEscalationRule().join(" ");
+    expect(text).toContain("damaging");
+    expect(text).toContain("nothing recorded can steer it");
+    expect(text).toContain("does not decide damage");
+    expect(text).toContain("never widens that");
+    expect(text).toContain("trust tier");
+  });
+});

--- a/apps/web/lib/govern/authority/escalation-gate.ts
+++ b/apps/web/lib/govern/authority/escalation-gate.ts
@@ -1,0 +1,203 @@
+/**
+ * ESCALATION IS A PROPERTY OF THE DECISION, NOT OF THE ACTOR (BI-6B3DA9DD).
+ *
+ * Founder ruling, 2026-09-09: "The only reason to escalate to a human is for
+ * more sensitive, damaging decisions, notably if there is no automated
+ * decision process to steer decisions, as the delegation system for the human
+ * in the loop." And, on where the rule belongs: "less prose, more process" —
+ * so it lives here, in the seam every install runs with no AI client present,
+ * not in an agent's memory and not only in a principle page.
+ *
+ * WHAT WAS WRONG. `requiresApproval` asked one question: does this coworker's
+ * HITL tier say "approve side effects"? That is a property of the ACTOR. Every
+ * specialist reviewer (AGT-WS-PORTFOLIO / -REVIEW / -EA) ships at
+ * `hitlTierDefault: 1`, which `deriveCoworkerApprovalPolicy` maps to "all", so
+ * every side-effecting call they made minted a human approval envelope —
+ * including `record_initiative_evidence`, a platform receipt that declares no
+ * consequence and decides nothing damaging. The reviewers ARE the automated
+ * decision process, and the platform escalated them anyway. Observed
+ * 2026-09-05 (WC-375F098A) and again 2026-09-09 driving BI-947780FE /
+ * BI-F114354D / BI-7ADEBDC1, where it reached the founder as an approval
+ * request — the thing that must never happen.
+ *
+ * TWO AUTHORITIES, DELIBERATELY SEPARATE.
+ *
+ *   The OPERATOR decides, per coworker, whether ordinary side effects need
+ *   approval at all. That is a standing configuration and this gate does not
+ *   touch it: a coworker the operator has already graduated keeps acting alone,
+ *   exactly as before.
+ *
+ *   THIS GATE decides, for a coworker whose configuration does require
+ *   approval, whether this particular action truly needs a person:
+ *     • damaging          → yes. A coworker's steering does not decide damage.
+ *     • steered           → no. The delegation system is the human in the loop.
+ *     • unsteered         → yes. Nothing can decide it, so someone must.
+ *
+ * TIGHTEN-ONLY, INVERTED. Every branch below either matches what the platform
+ * did before or REMOVES an escalation the rule says should not exist. Nothing
+ * here escalates an action that did not escalate before, because a gate that
+ * fixed over-escalation by adding new envelopes would be the same defect
+ * wearing the opposite coat.
+ *
+ * Pure and synchronous by construction: it sits on the governed hot path and
+ * every input is already resolved by the caller.
+ */
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
+import type { ToolConsequence, ToolConsequenceScope } from "@/lib/mcp-tools";
+
+/**
+ * Sensitivities at which an action is damaging on data grounds alone,
+ * independent of what the tool declares about its reach.
+ */
+export const DAMAGING_SENSITIVITIES: readonly PrincipalSensitivity[] = ["restricted"];
+
+/**
+ * What can steer a decision without a person.
+ *
+ * Each is a RECORDED, server-resolved fact about THIS action, never a caller
+ * claim and never a standing property of the actor:
+ *  • independent-reviewer — the actor executes a server-validated immutable
+ *    initiative-review binding. Separation of duties is enforced as distinct
+ *    principals, so a human click adds nothing the binding has not established.
+ *  • room-authority — the turn runs in a Workroom the coworker participates in
+ *    whose resolved action boundary is `preauthorized`; the room definition is
+ *    the recorded decision (EP-WORK-POSTURE §8.2). A boundary of `advise` or
+ *    `propose` supplies NO steering, so a room can only narrow, never widen.
+ *  • wwmd — a recorded `principle_decide` outcome that is autonomy-eligible
+ *    for this exact action.
+ */
+export const ESCALATION_STEERING = [
+  "independent-reviewer",
+  "room-authority",
+  "wwmd",
+  "none",
+] as const;
+export type EscalationSteering = (typeof ESCALATION_STEERING)[number];
+
+export const ESCALATION_REASON_CODES = [
+  "routine-read",
+  "operator-graduated-coworker",
+  "steered-by-independent-reviewer",
+  "steered-by-room-authority",
+  "steered-by-wwmd",
+  "damaging-consequence",
+  "damaging-sensitivity",
+  "damaging-work-case",
+  "declared-proposal",
+  "unsteered-side-effect",
+] as const;
+export type EscalationReasonCode = (typeof ESCALATION_REASON_CODES)[number];
+
+export type EscalationDecision = {
+  /** `human` mints an approval envelope; `automated` never does. */
+  verdict: "automated" | "human";
+  reasonCode: EscalationReasonCode;
+  /** Recorded on the authority evidence so an operator sees which branch decided. */
+  damaging: boolean;
+  steering: EscalationSteering;
+};
+
+export type EscalationInput = {
+  action: {
+    sideEffect: boolean;
+    executionMode: "proposal" | "immediate";
+    /** Declared reach. Any declared consequence is damaging. */
+    consequence?: ToolConsequence | null;
+    consequenceScope?: ToolConsequenceScope | null;
+    /** A Work Case may elevate an otherwise ordinary mutation. */
+    workCaseConsequential?: boolean;
+  };
+  dataPolicy: { sensitivity: PrincipalSensitivity };
+  /**
+   * The operator's standing configuration for this coworker: does it require
+   * approval for ordinary side effects at all? False means the operator has
+   * already graduated it, and this gate leaves that untouched.
+   */
+  operatorRequiresApproval: boolean;
+  /** Server-resolved; `none` when nothing recorded can steer this action. */
+  steering: EscalationSteering;
+};
+
+/** Is this action damaging? Any one of the three grounds is enough. */
+export function isDamagingAction(input: EscalationInput): boolean {
+  if (input.action.workCaseConsequential === true) return true;
+  if (input.action.consequence) return true;
+  return DAMAGING_SENSITIVITIES.includes(input.dataPolicy.sensitivity);
+}
+
+function damagingReason(input: EscalationInput): EscalationReasonCode {
+  if (input.action.workCaseConsequential === true) return "damaging-work-case";
+  if (input.action.consequence) return "damaging-consequence";
+  return "damaging-sensitivity";
+}
+
+const STEERED_REASON: Record<
+  Exclude<EscalationSteering, "none">,
+  EscalationReasonCode
+> = {
+  "independent-reviewer": "steered-by-independent-reviewer",
+  "room-authority": "steered-by-room-authority",
+  wwmd: "steered-by-wwmd",
+};
+
+/**
+ * The one escalation decision. The ORDER is the safety property, so every
+ * branch is pinned by a test and by the conformance guard's exhaustive walk.
+ */
+export function resolveEscalation(input: EscalationInput): EscalationDecision {
+  const damaging = isDamagingAction(input);
+  const steering = input.steering;
+  const base = { damaging, steering } as const;
+
+  // 1. A tool declared as a proposal exists to be put to someone. That is its
+  //    declared shape, not a judgment about damage, and it outranks every
+  //    branch below — including the read shortcut, since a proposal tool that
+  //    reads nothing is still a proposal.
+  if (input.action.executionMode === "proposal") {
+    return { verdict: "human", reasonCode: "declared-proposal", ...base };
+  }
+
+  // 2. An immediate read decides nothing and commits nothing.
+  if (!input.action.sideEffect) {
+    return { verdict: "automated", reasonCode: "routine-read", ...base };
+  }
+
+  // 3. The operator already graduated this coworker. Not this gate's call.
+  if (!input.operatorRequiresApproval) {
+    return { verdict: "automated", reasonCode: "operator-graduated-coworker", ...base };
+  }
+
+  // 4. Damage is decided by a person, not by a coworker's steering.
+  if (damaging) {
+    return { verdict: "human", reasonCode: damagingReason(input), ...base };
+  }
+
+  // 5. Something recorded can decide this. The delegation system is the human
+  //    in the loop — this is the branch the reviewer lane was missing.
+  if (steering !== "none") {
+    return { verdict: "automated", reasonCode: STEERED_REASON[steering], ...base };
+  }
+
+  // 6. Nothing can decide it, and it commits something. Ask a person.
+  return { verdict: "human", reasonCode: "unsteered-side-effect", ...base };
+}
+
+/**
+ * The rule in words, derived from the same constants the gate runs on.
+ * `check-escalation-gate.ts` fails the build unless the kernel principle page
+ * states these verbatim, so what an agent reads and what the platform enforces
+ * cannot drift (BI-6B3DA9DD: the principle follows the process).
+ */
+export function describeEscalationRule(): string[] {
+  return [
+    "Escalation is a property of the decision, not of the acting coworker's trust tier.",
+    "A coworker whose operator has already graduated it keeps acting alone; this gate never widens that.",
+    "For every other coworker, a human is engaged only when the action is damaging, or when nothing recorded can steer it.",
+    `An action is damaging when it declares a consequence (${["outward", "irreversible", "authority"].join(", ")}), when a Work Case declares it consequential, or when its data sensitivity is ${DAMAGING_SENSITIVITIES.join(" or ")}.`,
+    "A damaging action is decided by a person; a coworker's steering does not decide damage.",
+    `Automated steering is a recorded, server-resolved fact about the action itself: ${ESCALATION_STEERING.filter((s) => s !== "none").join(", ")}.`,
+    "A non-damaging action with steering is decided automatically and mints no approval envelope.",
+    "A non-damaging action with no steering reaches a human only when it has a side effect; an immediate read never escalates.",
+    "A tool declared as a proposal is always put to a person, because that is its declared shape.",
+  ];
+}

--- a/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
+++ b/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
@@ -4,9 +4,11 @@ import { prisma } from "@dpf/db";
 import { coerceDataSensitivity } from "@dpf/db/principal-sensitivity";
 
 import { findApprovedAuthorityEnvelope } from "@/lib/coworker/authority-approval-envelope";
+import { getWorkCaseAction } from "@/lib/work-management/action-registry";
 import { loadEffectiveAuthContext } from "@/lib/identity/load-effective-auth-context";
 import type { GovernedExecuteContext } from "@/lib/mcp-governed-execute";
 import { getGrantedCapabilities } from "@/lib/permissions";
+import type { EscalationSteering } from "./escalation-gate";
 import { roomAuthorizesTool } from "@/lib/work-management/room-turn-authority";
 import {
   parseInitiativeReviewBinding,
@@ -226,6 +228,38 @@ export function deriveCoworkerApprovalPolicy(input: {
   return "none";
 }
 
+/**
+ * BI-6B3DA9DD — the ONLY producers of automated steering, both server-resolved.
+ *
+ * `independent-reviewer`: the call carries a server-validated immutable
+ * initiative-review binding. `resolveBoundInitiativeReviewBinding` fails closed
+ * on every mismatch and the writer lane refuses an author reviewing their own
+ * artifact, so separation of duties is already enforced as distinct principals
+ * by the time the binding exists — a human click adds nothing to it.
+ *
+ * `room-authority`: the turn runs in a Workroom the coworker participates in
+ * whose resolved action boundary is `preauthorized` — the room definition is
+ * the recorded decision (EP-WORK-POSTURE §8.2). `advise` and `propose` supply
+ * no steering, so a room can only ever narrow what a coworker may do alone.
+ */
+export function resolveSteering(input: {
+  initiativeReviewBinding: InitiativeReviewBinding | null;
+  roomAuthority: { actionBoundary?: string | null; memberOfRoom?: boolean } | null;
+}): EscalationSteering {
+  if (input.initiativeReviewBinding) return "independent-reviewer";
+  const room = input.roomAuthority;
+  if (room && room.memberOfRoom !== false && room.actionBoundary === "preauthorized") {
+    return "room-authority";
+  }
+  return "none";
+}
+
+/** A Work Case action the registry marks consequential elevates the call. */
+function isWorkCaseConsequential(workCase: { action: string }): boolean {
+  const action = getWorkCaseAction(workCase.action);
+  return action?.consequential === true;
+}
+
 export function deriveAllowedRouteContexts(
   screenSurface: string | undefined,
 ): readonly string[] | undefined {
@@ -370,8 +404,16 @@ export const resolveCoworkerToolAuthorityInput: CoworkerAuthorityInputResolver =
         policyProjectionAllowed:
           agent.governanceProfile?.hitlPolicy.trim().toLowerCase() !== "always",
         consequence: tool.consequence ?? null,
+        ...(execution.context?.workCase
+          ? { workCaseConsequential: isWorkCaseConsequential(execution.context.workCase) }
+          : {}),
         requiresDelegationChain: Boolean(execution.context?.delegationChainId),
       },
+      // BI-6B3DA9DD: what can decide this without a person. Recorded facts only.
+      steering: resolveSteering({
+        initiativeReviewBinding,
+        roomAuthority: execution.context?.roomAuthority ?? null,
+      }),
       subject: initiativeAuthority.subject,
       room: roomAuthority
         ? {

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -11,5 +11,5 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma models | 628 | `packages/db/prisma/schema/` |
 | Prisma enums | 93 | `packages/db/prisma/schema/` |
 | Migrations | 576 | `packages/db/prisma/migrations/` |
-| Kernel principles | 102 | `docs/founder-kernel/wiki/principles/` |
+| Kernel principles | 103 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 661 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/founder-kernel/wiki/principles/escalation-is-a-gate-not-a-trust-tier.md
+++ b/docs/founder-kernel/wiki/principles/escalation-is-a-gate-not-a-trust-tier.md
@@ -1,0 +1,70 @@
+---
+title: Escalation Is a Gate, Not a Trust Tier
+pageKind: principle
+status: published
+abstract: A human is engaged only when the action is damaging, or when nothing recorded can steer it; a coworker's trust tier is a ceiling on what it may attempt, never a reason to escalate.
+principleTier: commandment
+principleDirection: A human is engaged only when the action is damaging, or when nothing recorded can steer it; a coworker's trust tier is a ceiling on what it may attempt, never a reason to escalate.
+principleWeight: 0.3
+principleWeightRationale: >-
+  Procedural meta-principle. It decides WHO decides, not WHAT to decide, so it
+  deliberately carries a low structured decision weight and a focused vector:
+  scored at commandment default it pulled the canonical quick-vs-proper decision
+  below its margin floor by rewarding low operator effort, a trade-off it has no
+  bearing on. Its force is as an enforced gate (resolveEscalation) and a followed
+  directive, not as decision math.
+principleDimensionVector: {"governance_compliance": 0.5, "human_cognitive_load": -0.9}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - ring-1-coworker
+  - ring-2-workflow
+  - universal-ring
+principleConsumerArchetype: universal
+principlePublic: true
+principlePublicRationale: Adopters need to know exactly when the platform will interrupt a person and when it will not, because that boundary is the difference between an autonomous workforce and a queue of approval clicks.
+sources:
+  - frameworks/nist-ai-rmf
+---
+
+## Rule
+
+Escalation is a property of the decision, not of the acting coworker's trust tier.
+
+A coworker whose operator has already graduated it keeps acting alone; this gate never widens that.
+
+For every other coworker, a human is engaged only when the action is damaging, or when nothing recorded can steer it.
+
+An action is damaging when it declares a consequence (outward, irreversible, authority), when a Work Case declares it consequential, or when its data sensitivity is restricted.
+
+A damaging action is decided by a person; a coworker's steering does not decide damage.
+
+Automated steering is a recorded, server-resolved fact about the action itself: independent-reviewer, room-authority, wwmd.
+
+A non-damaging action with steering is decided automatically and mints no approval envelope.
+
+A non-damaging action with no steering reaches a human only when it has a side effect; an immediate read never escalates.
+
+A tool declared as a proposal is always put to a person, because that is its declared shape.
+
+## Why
+
+Founder ruling, 2026-09-09: "The only reason to escalate to a human is for more sensitive, damaging decisions, notably if there is no automated decision process to steer decisions, as the delegation system for the human in the loop." And, on where the rule belongs: "less prose, more process."
+
+The platform had the opposite shape. Approval was minted from the acting coworker's HITL tier, a property of the actor rather than of the decision. Every specialist reviewer ships at the most cautious tier, so the receipts those reviewers exist to write — the governance evidence that lets initiative readiness advance at all — each raised an approval envelope that only the delegating human could clear. A routine platform receipt that decides nothing damaging was put in front of a person, and on 2026-09-09 that reached the founder, who had never been asked to approve anything in the project's history. The delegation system is the human in the loop; asking a person to confirm what the delegation system already decided is waste wearing a governance costume.
+
+The emphatic half of the ruling is a second path TO a human, never a path away from one. Reading "if there is no automated decision process" as an exemption would let a reviewer coworker's judgment stand in for the human go on an outbound send or an irreversible change, which `outbound-and-irreversible-actions-require-explicit-go` and `destructive-actions-require-explicit-go` forbid at commandment tier. So a coworker's steering does not decide damage.
+
+Two authorities stay separate on purpose. The operator decides, per coworker, whether ordinary side effects need approval at all; a graduated coworker keeps acting alone and this rule does not touch that. This rule decides only, among the actions that configuration would have escalated, which ones genuinely need a person. Its conformance guard proves exhaustively that it can only remove escalations, never add one — a fix for over-escalation that introduced new approval envelopes would be the same defect wearing the opposite coat.
+
+This page is generated against the gate it describes. `resolveEscalation` exports these sentences and `check-escalation-gate.ts` fails the build if this page does not state them verbatim, so doctrine and enforcement cannot drift apart on any install.
+
+## How to apply
+
+Do not ask a person to confirm an action that is neither damaging nor unsteered — and do not write a rule into an agent's memory to make that true. Memory does not reach the next install. Put the decision in the gate, where every install runs it with no AI client present.
+
+When an approval envelope appears for a routine action, treat it as a defect in the gate's inputs, not as a step to perform. Either the action's declared consequence is wrong, or the steering that should have decided it was not recorded — a reviewer binding that never resolved, or a room whose action boundary nobody declared. Fix the input.
+
+When a human genuinely must decide, give them the consequence before the confirm, per `show-the-consequence-before-the-confirm`.


### PR DESCRIPTION
## What

Escalation becomes a property of the decision instead of a property of the actor, enforced in the seam every install runs with no AI client present.

**The defect.** `requiresApproval` asked one question: does this coworker's HITL tier say "approve side effects"? Every specialist reviewer ships at the most cautious tier, which maps to "all", so every side-effecting call they made minted a human approval envelope only the delegating admin could clear. That included `record_initiative_evidence`, a platform receipt that declares no consequence and decides nothing damaging. The reviewers are the automated decision process, and the platform escalated them anyway, which is why initiative readiness could not advance without a person.

**The rule, from the founder's ruling on 2026-09-09.** A human is engaged only when the action is damaging, or when nothing recorded can steer it. Steering is a recorded, server-resolved fact about the action: an independent reviewer binding, a Workroom whose declared action boundary is preauthorized, or an autonomy-eligible WWMD outcome. It is never a standing property of the actor.

**Two authorities stay separate.** The operator decides, per coworker, whether ordinary side effects need approval at all; a coworker the operator has already graduated keeps acting alone and this gate does not touch that. The gate decides only, among the actions that configuration would have escalated, which genuinely need a person.

## Tighten-only, inverted, and proved

A fix for over-escalation that added new approval envelopes would be the same defect wearing the opposite coat. So the conformance test walks all 1024 input combinations and proves the gate can only remove escalations, never add one, against the retired rule encoded beside it. Sixty of the 135 active coworkers run at the graduated tier; none gains an envelope. The same walk proves a damaging action still reaches a person wherever it did before, an immediate read never escalates, and the removed set is exactly the non-damaging steered side effects.

## The principle follows the process

`resolveEscalation` exports the rule in words, and the conformance test fails the build unless the kernel principle page states those sentences verbatim. Doctrine and enforcement cannot drift apart on any install. The agent memory note that carried this rule is deleted: memory does not reach the next install, and the gate does.

The principle carries a low `principleWeight` with a rationale, because at commandment default its vector pulled the canonical quick-versus-proper decision below its margin floor by rewarding low operator effort, a trade-off it has no bearing on. The golden-decisions guard caught that and both canonical decisions now hold.

## Also fixed

A proposal-mode tool that is not a side effect stayed a proposal, caught by an existing test during the rewrite.

## Verification

- `tsc --noEmit` on `apps/web`: clean.
- vitest: 121 in `lib/govern/authority`, 1192 across the governed-execute, coworker and authority suites.
- Local-CI gate PASSED on c515c84d6843 (evidence cmtv0styq0ylc01ompvtmhv1y): typecheck, vitest, production build, image export.
- Not proven here: the readiness chain running end to end with zero envelopes on the live install. That is AC-ESC-04 on BI-6B3DA9DD and needs this deployed.

## Filed on the way

BI-00B8C7E0: `prisma generate` fails on this host because prisma 7.9.1 imports `createJiti` from jiti 1.21.7, which does not export it. It reproduces in the root clone, and the pre-commit staleness path turns it into a commit rejection in every fresh worktree.

Seed-Fit-Decision: global-default
Design-Grounding-Decision: extends the TAK pre-execution seam from 2026-08-13-wwwd-constitutional-alignment-gate.md; code substrate reviewed under apps/web/lib/govern/authority.
Docs-Impact-Decision: not-applicable — no documented user-facing route changed; a kernel principle page is added.
Convergence-Impact-Decision: not-reachable — application code and a kernel principle; converges by image rebuild and the ordinary wiki seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
