### PR TITLE
fix(decision): refuse an option set principle_decide cannot tell apart (BI-9889566B)

### DIFF
--- a/apps/web/lib/decision/evidence-grounding.test.ts
+++ b/apps/web/lib/decision/evidence-grounding.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { groundOptionFeatures, isAdmissibleGrade, type OptionEvidenceMap } from "./evidence-grounding";
+import {
+  groundOptionFeatures,
+  groundOptionsFromParams,
+  buildScoredDecisionOptions,
+  isAdmissibleGrade,
+  type OptionEvidenceMap,
+} from "./evidence-grounding";
 
 const codeLocator = { sourceType: "code", filePath: "resume.txt", line: 12 };
 
@@ -79,5 +85,50 @@ describe("evidence-grounding", () => {
     });
     expect(typeof r.evidenceDigests.cand.skill_match).toBe("string");
     expect(r.evidenceDigests.cand.skill_match).toHaveLength(16);
+  });
+});
+
+describe("evidence-grounding — the feature handoff is positional (BI-9889566B)", () => {
+  it("keeps each option's own features when two options share an id", async () => {
+    // The failure this replaces: groundedFeatures was a Map keyed on the
+    // caller-supplied id, so a shared id (including the "" every id-less
+    // option collapsed to) meant one map won and every option was scored with
+    // it — identical composites, no discrimination, no warning.
+    const params = {
+      options: [
+        { id: "", description: "A", features: { reusability: 0.9 } },
+        { id: "", description: "B", features: { reusability: 0.1 } },
+      ],
+    };
+    const { groundedFeaturesByIndex } = groundOptionsFromParams(params);
+    expect(groundedFeaturesByIndex).toEqual([{ reusability: 0.9 }, { reusability: 0.1 }]);
+
+    const built = await buildScoredDecisionOptions({
+      optionsParam: params.options,
+      groundedFeaturesByIndex,
+      generateEmbedding: async () => undefined,
+    });
+    expect(built.map((o) => o.features)).toEqual([
+      { reusability: 0.9 },
+      { reusability: 0.1 },
+    ]);
+  });
+
+  it("stays aligned when a non-object entry sits between two real options", async () => {
+    const optionsParam = [
+      { id: "a", description: "A", features: { reusability: 0.9 } },
+      null,
+      { id: "b", description: "B", features: { reusability: 0.1 } },
+    ];
+    const { groundedFeaturesByIndex } = groundOptionsFromParams({ options: optionsParam });
+    const built = await buildScoredDecisionOptions({
+      optionsParam,
+      groundedFeaturesByIndex,
+      generateEmbedding: async () => undefined,
+    });
+    expect(built.map((o) => [o.id, o.features])).toEqual([
+      ["a", { reusability: 0.9 }],
+      ["b", { reusability: 0.1 }],
+    ]);
   });
 });

--- a/apps/web/lib/decision/evidence-grounding.ts
+++ b/apps/web/lib/decision/evidence-grounding.ts
@@ -17,6 +17,7 @@
 import { normalizeLocator, type StructuredLocator } from "@/lib/deliberation/evidence";
 import { CLAIM_EVIDENCE_GRADES, type ClaimEvidenceGrade } from "@/lib/deliberation/types";
 import { digestEvidence } from "@/lib/decision/decision-chain";
+import { readOptionRecords } from "@/lib/decision/option-input-contract";
 
 /** One citation attached to a single option's single dimension score. */
 export type EvidenceRef = {
@@ -204,13 +205,23 @@ export type LedgerEvidenceArgs = {
 
 /**
  * Parse a tool-call `params` object (with `options`, `evidence`, `requireEvidence`)
- * and run the grounding pass. Returns the grounded feature map keyed by option id
+ * and run the grounding pass. Returns the grounded features in caller order
  * and the args the kernel-consult ledger needs. Extracted from the pack handler so
  * the hot-path module stays small.
  */
 export function groundOptionsFromParams(params: Record<string, unknown>): {
   grounding: GroundingResult;
-  groundedFeaturesById: Map<string, Record<string, number>>;
+  /**
+   * Grounded features in caller order — positional, NOT keyed by option id.
+   *
+   * BI-9889566B: this was a `Map` keyed on the caller-supplied id, so any two
+   * options sharing an id (including the empty string every id-less option
+   * collapsed to) silently overwrote each other, last one winning. Identity
+   * supplied by the caller cannot be trusted to be unique; a position always
+   * is. `validateOptionIdentities` keeps the ids meaningful for the ledger and
+   * the evidence map; this keeps the feature handoff correct regardless.
+   */
+  groundedFeaturesByIndex: Record<string, number>[];
   ledgerArgs: LedgerEvidenceArgs;
 } {
   const requireEvidence = params["requireEvidence"] === true;
@@ -222,22 +233,20 @@ export function groundOptionsFromParams(params: Record<string, unknown>): {
       : undefined;
   const optionsParam = Array.isArray(params["options"]) ? params["options"] : [];
   const grounding = groundOptionFeatures({
-    options: optionsParam
-      .filter((o): o is Record<string, unknown> => typeof o === "object" && o !== null)
-      .map((o) => ({
-        id: String(o["id"] ?? ""),
-        description: String(o["description"] ?? ""),
-        features:
-          typeof o["features"] === "object" && o["features"] !== null && !Array.isArray(o["features"])
-            ? (o["features"] as Record<string, number>)
-            : undefined,
-      })),
+    options: readOptionRecords(optionsParam).map((o) => ({
+      id: String(o["id"] ?? ""),
+      description: String(o["description"] ?? ""),
+      features:
+        typeof o["features"] === "object" && o["features"] !== null && !Array.isArray(o["features"])
+          ? (o["features"] as Record<string, number>)
+          : undefined,
+    })),
     evidence,
     requireEvidence,
   });
   return {
     grounding,
-    groundedFeaturesById: new Map(grounding.options.map((o) => [o.id, o.features ?? {}])),
+    groundedFeaturesByIndex: grounding.options.map((o) => o.features ?? {}),
     ledgerArgs: {
       citations: grounding.citations,
       scoredCriteria: Object.fromEntries(grounding.options.map((o) => [o.id, o.features ?? {}])),
@@ -254,14 +263,13 @@ export function groundOptionsFromParams(params: Record<string, unknown>): {
  */
 export async function buildScoredDecisionOptions(input: {
   optionsParam: unknown[];
-  groundedFeaturesById: Map<string, Record<string, number>>;
+  groundedFeaturesByIndex: Record<string, number>[];
   generateEmbedding: (text: string) => Promise<number[] | null | undefined>;
 }): Promise<import("@/lib/decision/option-scoring").DecisionOption[]> {
   return Promise.all(
-    input.optionsParam
-      .filter((o): o is Record<string, unknown> => typeof o === "object" && o !== null)
-      .map(async (o) => {
-        const features = input.groundedFeaturesById.get(String(o["id"] ?? "")) ?? {};
+    readOptionRecords(input.optionsParam)
+      .map(async (o, index) => {
+        const features = input.groundedFeaturesByIndex[index] ?? {};
         const description = String(o["description"] ?? "");
         let embedding: number[] | undefined;
         if (Array.isArray(o["embedding"])) {

--- a/apps/web/lib/decision/option-input-contract.test.ts
+++ b/apps/web/lib/decision/option-input-contract.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  readOptionRecords,
+  validateOptionIdentities,
+  validateOptionInputs,
+} from "./option-input-contract";
+
+describe("option-input-contract — identity (BI-9889566B)", () => {
+  it("refuses an option whose identity arrived under the wrong key", () => {
+    // The live reproduction: a caller wrote `key` where the schema says `id`.
+    const errors = validateOptionIdentities([
+      { key: "opt-a", description: "A", features: { reusability: 0.9 } },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("id");
+    // The message must name what the caller DID send, or they cannot see the
+    // typo — this is the whole difference from a silent zero.
+    expect(errors[0].detail).toContain("key");
+  });
+
+  it("refuses a blank or whitespace-only id", () => {
+    expect(validateOptionIdentities([{ id: "", description: "A" }])).toHaveLength(1);
+    expect(validateOptionIdentities([{ id: "   ", description: "A" }])).toHaveLength(1);
+  });
+
+  it("refuses duplicate ids and names both positions", () => {
+    const errors = validateOptionIdentities([
+      { id: "same", description: "A" },
+      { id: "same", description: "B" },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].index).toBe(1);
+    expect(errors[0].detail).toContain("option 0");
+  });
+
+  it("refuses a missing description", () => {
+    const errors = validateOptionIdentities([{ id: "a" }]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("description");
+  });
+
+  it("refuses a non-object entry rather than skipping it", () => {
+    expect(validateOptionIdentities(["a", null])).toHaveLength(2);
+  });
+
+  it("accepts a well-formed set", () => {
+    expect(
+      validateOptionIdentities([
+        { id: "a", description: "A" },
+        { id: "b", description: "B" },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("option-input-contract — combined refusal ordering", () => {
+  it("reports identity before features: an id-less option cannot be NAMED in a feature error", () => {
+    const rejection = validateOptionInputs([
+      { key: "a", description: "A", features: { not_a_dimension: 0.5 } },
+    ]);
+    expect(rejection?.error).toBe("Invalid option identity");
+  });
+
+  it("still refuses an unknown feature key once identity is sound (BI-E0151DB2 preserved)", () => {
+    const rejection = validateOptionInputs([
+      { id: "a", description: "A", features: { not_a_dimension: 0.5 } },
+    ]);
+    expect(rejection?.error).toBe("Invalid option features");
+    expect(rejection?.message).toContain("[a]");
+  });
+
+  it("returns null for a well-formed set", () => {
+    expect(
+      validateOptionInputs([
+        { id: "a", description: "A", features: { reusability: 0.8 } },
+        { id: "b", description: "B", features: { blast_radius: 0.2 } },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("option-input-contract — readOptionRecords", () => {
+  it("drops non-object entries so both consumers walk the same records in the same order", () => {
+    expect(readOptionRecords([{ id: "a" }, null, "x", { id: "b" }])).toEqual([
+      { id: "a" },
+      { id: "b" },
+    ]);
+  });
+});

--- a/apps/web/lib/decision/option-input-contract.ts
+++ b/apps/web/lib/decision/option-input-contract.ts
@@ -1,0 +1,153 @@
+// The caller-input contract for a `principle_decide` option set (BI-9889566B).
+//
+// One home for "is this option set well-formed enough to score": identity
+// first, then the dimension features. Both refusals existed for the same
+// reason — `make-silent-failures-observable` — but only the feature half was
+// enforced, and the pack held the wiring for it inline.
+//
+// THE DEFECT THIS CLOSES
+// `required` in an MCP tool inputSchema is documentation, not enforcement:
+// nothing on the call path validates it (`coerceMcpToolArgs` only reshapes
+// values). So an option that carried its identity under some other key — a
+// caller writing `key` where the schema says `id` — arrived with `id: ""`.
+// Every such option then collapsed onto the same entry of the id-keyed feature
+// map built in evidence-grounding.ts: one feature map survived, all options
+// were scored with it, every composite came back byte-identical, `optionId`
+// echoed back empty, and `margin` was 0.000.
+//
+// The damage is that the result still LOOKED governed. `signalQuality.usable`
+// was true and `featureCoverage.minKeys` reported the surviving map's width,
+// so the abstention path added by BI-E0151DB2 never fired — it correctly
+// observed that features had arrived, just not that three of them had been
+// thrown away. The tool reported "uncertain / low-margin", which reads as a
+// genuine close call rather than as scoring that could not discriminate at all.
+//
+// Two things had to change and both live here or next door:
+//   1. A missing, blank or duplicated `id` is REFUSED, the same fail-fast
+//      posture `ringScope` and unknown feature keys already get.
+//   2. The feature handoff in evidence-grounding.ts is keyed by POSITION, not
+//      by the caller-supplied id (see groundOptionsFromParams). Identity the
+//      caller controls cannot be trusted to be unique; a position always is.
+//      The refusal keeps ids meaningful; the positional handoff keeps scoring
+//      correct even if some future path skips the refusal.
+
+import {
+  validateOptionFeatures,
+  featureErrorRemedy,
+  type FeatureValidationError,
+} from "@/lib/decision/dimension-catalog";
+
+/**
+ * The option records the scoring path will actually see, in caller order.
+ *
+ * Single home for this filter: the grounding pass and the DecisionOption build
+ * must walk the SAME records in the SAME order, because the features they
+ * exchange are handed over positionally. Two independent `.filter()` calls
+ * that happen to agree today are a silent misalignment waiting to happen.
+ */
+export function readOptionRecords(optionsParam: unknown[]): Record<string, unknown>[] {
+  return optionsParam.filter(
+    (o): o is Record<string, unknown> => typeof o === "object" && o !== null,
+  );
+}
+
+export type OptionIdentityError = {
+  index: number;
+  field: "id" | "description";
+  detail: string;
+};
+
+/** A refusal ready to be spread onto a failed ToolResult. */
+export type OptionInputRejection = { message: string; error: string };
+
+/**
+ * Validate the identity fields the tool's own inputSchema marks required.
+ *
+ * A duplicate id is refused on the same grounds as a missing one: it collapses
+ * identically, and the caller cannot tell which option the surviving row
+ * describes.
+ */
+export function validateOptionIdentities(optionsParam: unknown[]): OptionIdentityError[] {
+  const errors: OptionIdentityError[] = [];
+  const seen = new Map<string, number>();
+  optionsParam.forEach((raw, index) => {
+    if (typeof raw !== "object" || raw === null) {
+      errors.push({
+        index,
+        field: "id",
+        detail: `option ${index} is not an object, so it carries no identity.`,
+      });
+      return;
+    }
+    const o = raw as Record<string, unknown>;
+    const id = typeof o["id"] === "string" ? o["id"].trim() : "";
+    if (id === "") {
+      errors.push({
+        index,
+        field: "id",
+        detail:
+          `option ${index} has no \`id\`. Every option needs a stable, distinct \`id\` — ` +
+          `the scores, the recommendation and the evidence map are all keyed on it` +
+          (Object.keys(o).length > 0 ? `. Keys present: ${Object.keys(o).join(", ")}.` : "."),
+      });
+    } else if (seen.has(id)) {
+      errors.push({
+        index,
+        field: "id",
+        detail: `option ${index} reuses the \`id\` "${id}" already used by option ${seen.get(id)}; ids must be distinct.`,
+      });
+    } else {
+      seen.set(id, index);
+    }
+    if (typeof o["description"] !== "string" || o["description"].trim() === "") {
+      errors.push({
+        index,
+        field: "description",
+        detail:
+          `option ${index}${id ? ` ("${id}")` : ""} has no \`description\`; it is what the ` +
+          `semantic path scores when an option carries no features.`,
+      });
+    }
+  });
+  return errors;
+}
+
+/**
+ * The whole option-set input check, in the order a caller should hear about
+ * problems: an option with no identity cannot even be NAMED in a feature
+ * error, so identity is reported first and alone.
+ *
+ * Returns null when the set is well-formed.
+ */
+export function validateOptionInputs(optionsParam: unknown[]): OptionInputRejection | null {
+  const identityErrors = validateOptionIdentities(optionsParam);
+  if (identityErrors.length > 0) {
+    return {
+      message:
+        `principle_decide rejected ${identityErrors.length} option identity problem(s): ` +
+        identityErrors.map((e) => e.detail).join(" ") +
+        " Each entry in `options` must be an object with a non-empty `id` (distinct across " +
+        "the set) and a non-empty `description`. Both are declared required by the tool schema.",
+      error: "Invalid option identity",
+    };
+  }
+
+  const featureErrors: FeatureValidationError[] = [];
+  for (const o of readOptionRecords(optionsParam)) {
+    const f = o["features"];
+    if (typeof f !== "object" || f === null || Array.isArray(f)) continue;
+    featureErrors.push(
+      ...validateOptionFeatures(String(o["id"]), f as Record<string, unknown>),
+    );
+  }
+  if (featureErrors.length > 0) {
+    return {
+      message:
+        `principle_decide rejected ${featureErrors.length} option feature(s): ` +
+        featureErrors.map((e) => `[${e.optionId}] ${e.detail}`).join(" ") +
+        ` ${featureErrorRemedy()}`,
+      error: "Invalid option features",
+    };
+  }
+  return null;
+}

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -684,6 +684,9 @@
     "apps/web/lib/decision/golden-decisions.test.ts": [
       "docs/founder-kernel/AUTHORING.md"
     ],
+    "apps/web/lib/decision/option-input-contract.ts": [
+      "docs/architecture/principle-decide-mcda-identity.md"
+    ],
     "apps/web/lib/deliberation/external-review-activation.ts": [
       "docs/architecture/agent-client-capability-parity.md"
     ],
@@ -2734,6 +2737,9 @@
     ],
     "docs/architecture/portal-ux-evaluation-framework.md": [
       "scripts/check-ux-fit-decision.mjs"
+    ],
+    "docs/architecture/principle-decide-mcda-identity.md": [
+      "apps/web/lib/decision/option-input-contract.ts"
     ],
     "docs/architecture/section-navigation.md": [
       "apps/web/components/shell/SectionNav.tsx",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2140,6 +2140,7 @@
         "principledecide-math-identity-mcda",
         "what-the-scorer-is",
         "what-it-is-not",
+        "option-set-input-contract-bi-9889566b",
         "autonomy-gate-bi-1d23ec26",
         "operator-surfaces",
         "design-grounding"

--- a/apps/web/lib/mcp/packs/principle-decide-pack.option-identity.test.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.option-identity.test.ts
@@ -1,0 +1,196 @@
+// Option identity is enforced, not merely declared — BI-9889566B.
+//
+// Split out of principle-decide-pack.test.ts to keep both files under the
+// module-size ceiling. The mock scaffolding is the same shape as its sibling:
+// the pack lazy-imports Postgres, Qdrant and the embedding provider, so every
+// one of them is stubbed and the handler runs its real validation path.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  listPrinciplesByTier: vi.fn(),
+  organizationFindFirst: vi.fn(),
+  wikiPageFindMany: vi.fn(),
+}));
+const wiki = vi.hoisted(() => ({
+  searchWikiPages: vi.fn(),
+  decide: vi.fn(),
+  principleMatchesRingScope: vi.fn(),
+  generateEmbedding: vi.fn(),
+  isEmbeddingAvailable: vi.fn(),
+}));
+const decision = vi.hoisted(() => ({
+  resolveDecisionCallerContext: vi.fn(),
+  recordKernelConsultInteraction: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: {
+      findFirst: (...a: unknown[]) => db.organizationFindFirst(...a),
+    },
+    // RC2 (BI-E1267C6D): core/contextual principles are relevance-ranked by
+    // Qdrant and then rehydrated from Postgres for their signed vector and
+    // weight override. Without this the rehydration throws into its own
+    // catch and every test silently exercises the pre-fix path.
+    wikiPage: {
+      findMany: (...a: unknown[]) => db.wikiPageFindMany(...a),
+    },
+  },
+  listPrinciplesByTier: (...a: unknown[]) => db.listPrinciplesByTier(...a),
+  PRINCIPLE_DECIDE_DEFAULTS: {
+    maxPrinciples: 20,
+    tieMargin: 0.2,
+    contextualSimilarityThreshold: 0.5,
+    semanticFallbackWarnRatio: 0.5,
+  },
+}));
+// Spread the ACTUAL taxonomy rather than hand-listing it: the pack now imports
+// PRINCIPLE_DIMENSIONS / PRINCIPLE_COST_DIMENSIONS (via the dimension catalogue,
+// BI-E0151DB2), and a hand-maintained fake registry here would drift from the
+// real one — reintroducing the class of defect the catalogue exists to prevent.
+// The ring scopes stay pinned because these tests assert on them directly.
+vi.mock("@dpf/db/wiki-taxonomy", async (importActual) => ({
+  ...(await importActual<typeof import("@dpf/db/wiki-taxonomy")>()),
+  PRINCIPLE_RING_SCOPES: [
+    "ring-1-coworker",
+    "ring-2-workflow",
+    "ring-3-archetype",
+    "ring-4-sandbox-prod",
+    "ring-5-hive",
+    "external-coordination",
+    "universal-ring",
+  ],
+}));
+vi.mock("@/lib/wiki/embeddings", () => ({
+  searchWikiPages: (...a: unknown[]) => wiki.searchWikiPages(...a),
+}));
+vi.mock("@/lib/wiki/principle-decide", () => ({
+  decide: (...a: unknown[]) => wiki.decide(...a),
+}));
+vi.mock("@/lib/wiki/calling-ring-map", () => ({
+  principleMatchesRingScope: (...a: unknown[]) => wiki.principleMatchesRingScope(...a),
+}));
+vi.mock("@/lib/inference/embedding", () => ({
+  generateEmbedding: (...a: unknown[]) => wiki.generateEmbedding(...a),
+  isEmbeddingAvailable: (...a: unknown[]) => wiki.isEmbeddingAvailable(...a),
+}));
+vi.mock("@/lib/decision/caller-context", () => ({
+  resolveDecisionCallerContext: (...a: unknown[]) => decision.resolveDecisionCallerContext(...a),
+}));
+vi.mock("@/lib/decision/kernel-consult-ledger", () => ({
+  recordKernelConsultInteraction: (...a: unknown[]) => decision.recordKernelConsultInteraction(...a),
+}));
+
+import { principleDecidePack } from "./principle-decide-pack";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.listPrinciplesByTier.mockResolvedValue([]);
+  db.organizationFindFirst.mockResolvedValue({ id: "org-1" });
+  wiki.searchWikiPages.mockResolvedValue([]);
+  db.wikiPageFindMany.mockResolvedValue([]);
+  wiki.generateEmbedding.mockResolvedValue(undefined);
+  // Provider healthy by default; the degradation tests flip this to false.
+  wiki.isEmbeddingAvailable.mockResolvedValue(true);
+  wiki.principleMatchesRingScope.mockReturnValue(true);
+  decision.resolveDecisionCallerContext.mockResolvedValue({
+    governingProfileId: "prof-1",
+    governingProfileKind: "platform_kernel",
+    resolvedVia: "default",
+  });
+  decision.recordKernelConsultInteraction.mockResolvedValue({ interactionId: "int-1" });
+});
+
+describe("principle-decide pack — option identity validation (BI-9889566B)", () => {
+  const base = { context: "x", callingPopulation: "human" as const };
+
+  it("REFUSES an option whose identity arrived under the wrong key, before any lookup", async () => {
+    const res = await principleDecidePack.handlers.principle_decide(
+      {
+        ...base,
+        options: [
+          { key: "a", description: "A", features: { reusability: 0.9 } },
+          { key: "b", description: "B", features: { reusability: 0.1 } },
+        ],
+      },
+      "u1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Invalid option identity");
+    // Same fail-fast posture as ringScope and unknown feature keys.
+    expect(db.listPrinciplesByTier).not.toHaveBeenCalled();
+    // It must NOT score: an id-less set used to come back with identical
+    // composites, an empty recommendation.optionId and signalQuality.usable
+    // true — a verdict that looked governed and carried no information.
+    expect(wiki.decide).not.toHaveBeenCalled();
+  });
+
+  it("names the offending keys so the caller can see the typo", async () => {
+    const res = await principleDecidePack.handlers.principle_decide(
+      { ...base, options: [{ key: "a", description: "A" }] },
+      "u1",
+    );
+    expect(res.message).toContain("key");
+    expect(res.message).toContain("`id`");
+  });
+
+  it("REFUSES duplicate ids — they collapse exactly like blank ones", async () => {
+    const res = await principleDecidePack.handlers.principle_decide(
+      {
+        ...base,
+        options: [
+          { id: "same", description: "A", features: { reusability: 0.9 } },
+          { id: "same", description: "B", features: { reusability: 0.1 } },
+        ],
+      },
+      "u1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Invalid option identity");
+  });
+
+  it("REFUSES a missing description", async () => {
+    const res = await principleDecidePack.handlers.principle_decide(
+      { ...base, options: [{ id: "a" }] },
+      "u1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("Invalid option identity");
+  });
+
+  it("identity is reported before features — an id-less option cannot be named in a feature error", async () => {
+    const res = await principleDecidePack.handlers.principle_decide(
+      { ...base, options: [{ key: "a", description: "A", features: { maintainability: 0.9 } }] },
+      "u1",
+    );
+    expect(res.error).toBe("Invalid option identity");
+  });
+
+  it("a well-formed set still reaches scoring, and each option keeps its own features", async () => {
+    const scored: Array<{ id: string; features: Record<string, number> }> = [];
+    wiki.decide.mockImplementation((options: Array<{ id: string; features: Record<string, number> }>) => {
+      scored.push(...options.map((o) => ({ id: o.id, features: o.features })));
+      return {
+        recommendation: { optionId: "a", composite: 1, margin: 0.5, confidence: "high" },
+        scores: [],
+        flags: { insufficientSignal: false, structuredCoverage: "strong", semanticFallbackRatio: 0 },
+        reasoning: "ok",
+      };
+    });
+    const res = await principleDecidePack.handlers.principle_decide(
+      {
+        ...base,
+        options: [
+          { id: "a", description: "A", features: { reusability: 0.9 } },
+          { id: "b", description: "B", features: { reusability: 0.1 } },
+        ],
+      },
+      "u1",
+    );
+    expect(res.success).toBe(true);
+    expect(scored).toEqual([
+      { id: "a", features: { reusability: 0.9 } },
+      { id: "b", features: { reusability: 0.1 } },
+    ]);
+  });
+});

--- a/apps/web/lib/mcp/packs/principle-decide-pack.option-identity.test.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.option-identity.test.ts
@@ -74,7 +74,11 @@ vi.mock("@/lib/inference/embedding", () => ({
   generateEmbedding: (...a: unknown[]) => wiki.generateEmbedding(...a),
   isEmbeddingAvailable: (...a: unknown[]) => wiki.isEmbeddingAvailable(...a),
 }));
-vi.mock("@/lib/decision/caller-context", () => ({
+// Spread the ACTUAL module: the pack lazy-imports more than one binding from
+// it (resolveDecisionDomainParam arrived with BI-9C384562), and a hand-listed
+// mock silently loses whichever binding is added next.
+vi.mock("@/lib/decision/caller-context", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/decision/caller-context")>()),
   resolveDecisionCallerContext: (...a: unknown[]) => decision.resolveDecisionCallerContext(...a),
 }));
 vi.mock("@/lib/decision/kernel-consult-ledger", () => ({

--- a/apps/web/lib/mcp/packs/principle-decide-pack.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.ts
@@ -22,10 +22,8 @@ import {
 import {
   DIMENSION_KEYS,
   buildFeaturesDescription,
-  validateOptionFeatures,
-  featureErrorRemedy,
-  type FeatureValidationError,
 } from "@/lib/decision/dimension-catalog";
+import { validateOptionInputs } from "@/lib/decision/option-input-contract";
 import {
   groundOptionsFromParams,
   buildScoredDecisionOptions,
@@ -53,8 +51,20 @@ const definitions: ToolDefinition[] = [
           items: {
             type: "object",
             properties: {
-              id: { type: "string", description: "Stable identifier for the option." },
-              description: { type: "string", description: "Short prose description." },
+              // Both are enforced at call time, not merely declared (BI-9889566B):
+              // an option with no id, or an id shared with another option,
+              // cannot be told apart in the scores, the recommendation or the
+              // evidence map, so the call is refused rather than scored.
+              id: {
+                type: "string",
+                description:
+                  "Stable identifier for the option. Required, non-empty, and DISTINCT across the option set — the scores, the recommendation and the `evidence` map are all keyed on it. A set with a missing or duplicated id is refused.",
+              },
+              description: {
+                type: "string",
+                description:
+                  "Short prose description. Required and non-empty — it is what the semantic path scores when an option carries no features.",
+              },
               features: {
                 type: "object",
                 description: buildFeaturesDescription(),
@@ -164,36 +174,11 @@ export async function runPrincipleDecision(
     };
   }
 
-  // BI-E0151DB2. Validate option features against the closed dimension
-  // registry, the same way ringScope is validated below. An unknown key is NOT
-  // harmless: computeStructuredAlignment iterates the PRINCIPLE's dimensions
-  // and reads option.features[dim], so a key that is not a real dimension is
-  // never read and the axis the caller thought they scored silently counts as
-  // zero. Silent skip on bad input is the failure mode
-  // `make-silent-failures-observable` forbids.
-  const featureErrors: FeatureValidationError[] = [];
-  for (const raw of optionsParam) {
-    if (typeof raw !== "object" || raw === null) continue;
-    const o = raw as Record<string, unknown>;
-    const f = o["features"];
-    if (typeof f !== "object" || f === null || Array.isArray(f)) continue;
-    featureErrors.push(
-      ...validateOptionFeatures(
-        String(o["id"] ?? "(unnamed option)"),
-        f as Record<string, unknown>,
-      ),
-    );
-  }
-  if (featureErrors.length > 0) {
-    return {
-      success: false,
-      message:
-        `principle_decide rejected ${featureErrors.length} option feature(s): ` +
-        featureErrors.map((e) => `[${e.optionId}] ${e.detail}`).join(" ") +
-        ` ${featureErrorRemedy()}`,
-      error: "Invalid option features",
-    };
-  }
+  // Option-set input contract (BI-9889566B / BI-E0151DB2): identity then
+  // features, both fail-fast. See option-input-contract.ts for why a silently
+  // accepted id-less option produced an option-invariant ranking.
+  const optionInputRejection = validateOptionInputs(optionsParam);
+  if (optionInputRejection) return { success: false, ...optionInputRejection };
 
   const { listPrinciplesByTier, prisma, PRINCIPLE_DECIDE_DEFAULTS } =
     await import("@dpf/db");
@@ -627,10 +612,10 @@ export async function runPrincipleDecision(
   // score to a cited source; when `requireEvidence` is set, drop features lacking
   // admissible evidence before scoring. Options are then embedded for the semantic
   // path (BI-3C1A6451). Both helpers live in evidence-grounding.ts (module-size).
-  const { groundedFeaturesById, ledgerArgs } = groundOptionsFromParams(params);
+  const { groundedFeaturesByIndex, ledgerArgs } = groundOptionsFromParams(params);
   const decisionOptions = await buildScoredDecisionOptions({
     optionsParam,
-    groundedFeaturesById,
+    groundedFeaturesByIndex,
     generateEmbedding,
   });
 

--- a/docs/architecture/principle-decide-mcda-identity.md
+++ b/docs/architecture/principle-decide-mcda-identity.md
@@ -18,6 +18,26 @@
 - **Not Saaty AHP eigendecomposition** at decide-time. AHP principal eigenvectors belong to **weight elicitation** from pairwise comparisons (BI-DF87F8D2), not option ranking.
 - **Not** TOPSIS / PROMETHEE / ELECTRE (intentionally deferred for inspectability — principles-as-wiki-kind Appendix B).
 
+## Option set input contract (BI-9889566B)
+
+The scorer discriminates between options only as far as their inputs let it, so the option set is validated before anything reads it. `principle_decide` **refuses** the call — it does not score and then warn — when any entry in `options`:
+
+- is not an object, or
+- has no non-empty `id`, or
+- reuses an `id` already used by an earlier option, or
+- has no non-empty `description`.
+
+`required` in an MCP tool inputSchema is documentation, not enforcement: nothing on the call path validates it. Before this refusal, an option that carried its identity under a different key (a caller writing `key` where the schema says `id`) arrived with `id: ""`, and every such option collapsed onto one entry of an id-keyed feature map. One feature map survived, **all options were scored with it**, every composite came back identical, `recommendation.optionId` echoed back empty and `margin` was `0.000`.
+
+The damage was that the result still read as governed: `signalQuality.usable` was `true` and `featureCoverage.minKeys` reported the surviving map's width, so the BI-E0151DB2 abstention never fired — it correctly saw that features had arrived, not that the rest had been discarded. `uncertain / low-margin` then reads as a genuine close call rather than as scoring that could not discriminate at all.
+
+Two things enforce this, and reviewers should expect both:
+
+1. **The refusal** (`apps/web/lib/decision/option-input-contract.ts`) — the caller hears about the typo, matching the fail-fast treatment `ringScope` and unknown feature keys already get.
+2. **A positional feature handoff** (`groundOptionsFromParams` in `evidence-grounding.ts`) — features travel to `decide()` by array position, never by caller-supplied id. Identity the caller controls cannot be assumed unique; a position always is. This holds even on a path that skips the refusal.
+
+Option `id`s stay meaningful for the ledger (`DecisionInteraction.options`, `scoredCriteria`) and for the `evidence` map, which is keyed by option id by design.
+
 ## Autonomy gate (BI-1D23EC26)
 
 Unattended proceed requires `signalQuality.autonomyEligible === true`, which means:


### PR DESCRIPTION
`principle_decide` returned an identical composite for every option and an empty `optionId` on each score entry, so it could not rank options at all. Fixes BI-9889566B.

## What was wrong

`required` in an MCP tool inputSchema is documentation, not enforcement — nothing on the call path validates it (`coerceMcpToolArgs` only reshapes values). An option that carried its identity under a different key — a caller writing `key` where the schema says `id` — arrived with `id: ""`, and every such option collapsed onto one entry of the id-keyed feature map in `groundOptionsFromParams`. One feature map survived, all options were scored with it, every composite came back byte-identical, `recommendation.optionId` echoed back empty and `margin` was `0.000`.

The damage is that the result still read as **governed**. `signalQuality.usable` was `true` and `featureCoverage.minKeys` reported the surviving map's width, so the BI-E0151DB2 abstention never fired — it correctly saw that features had arrived, not that the rest had been discarded. `uncertain / low-margin` then reads as a genuine close call rather than as scoring that could not discriminate at all.

Confirmed on this install: `DecisionInteraction` **DI-4A4EE8830A45** recorded `options: ["", "", "", ""]` with an empty `recommendedOptionId`. 3 of 1024 ledger rows carry that shape, the first on 2026-08-27.

## Not a regression of BI-E0151DB2

That guard hardened feature **keys** and is intact — its tests pass unchanged on both the pre-fix and post-fix tree. `id` never got the same treatment. Distinct defect, same failure class (`make-silent-failures-observable`), adjacent field.

## The fix

Two changes, each closing one half:

1. **`apps/web/lib/decision/option-input-contract.ts`** (new) refuses a missing, blank or duplicated `id` and a missing `description` — the same fail-fast posture `ringScope` and unknown feature keys already get. The existing feature-key validation moves behind the same entry point, so the pack holds one call and identity is reported first: an option with no identity cannot be *named* in a feature error.
2. **The feature handoff is positional.** `groundOptionsFromParams` hands features to `decide()` by array position, not by caller-supplied id. Identity the caller controls cannot be assumed unique; a position always is. This holds even on a path that skips the refusal.

Option `id`s stay meaningful for the ledger (`DecisionInteraction.options`, `scoredCriteria`) and for the `evidence` map, which is keyed by option id by design.

Also: the `id` / `description` schema descriptions now state that they are enforced and distinct — for an in-platform coworker who cannot read repo source, that schema text *is* the contract — and `docs/architecture/principle-decide-mcda-identity.md` carries the option-set input contract alongside the autonomy gate.

## Verification

- **Failing-then-passing proof.** The 7 new tests fail on the pre-fix tree and pass after. One pre-fix failure is worth naming: the id-less set did not merely come back uncertain, it came back `Recommends proceed (confidence: high…)`.
- `pnpm --filter web exec vitest run lib/decision lib/mcp` — 252 files, 2410 tests pass.
- `pnpm --filter web typecheck` and `typecheck:tests` — clean.
- `pnpm --filter web build` — exit 0.
- `pnpm pregate:preflight` — 67 guards clean.
- Local merged-CI gate — **PASS** for `ada2fa39f0f5`, evidence `cmtv6ddo50m9e01qnb1wlmnfu`.

The gate earned its keep here: the first run failed on the merge with `main` while passing locally, because BI-9C384562 (#5288) landed after this branch was cut and added a second lazy import to the pack's `caller-context` destructure that the new test's hand-listed mock did not carry. The second commit fixes that by spreading the real module, as the sibling test already does.

## Follow-ups spotted, not fixed here

Both are in the local-CI gate surface, unrelated to this diff, and were hit while gating it:

- A completed **passing** gate record was overwritten by a later starvation event on the same lease: `gatePassed` flipped true→false and the evidence id was cleared *after* the run had already exited 0.
- `pregate-status` reports `PENDING — "gate passed but evidence publication is pending"` off `evidencePending` alone, without checking `gatePassed`. On a blocked record that prints a pass which never happened, and routes you to a finalizer that correctly refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
