### PR TITLE
fix(gate): pregate:status must not headline a pass for a gate that did not pass (BI-41C3E303)

### DIFF
--- a/docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md
+++ b/docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md
@@ -5,7 +5,7 @@ status: active
 # Change-delivery latency — tier by risk, fail open on infrastructure
 
 - **Epic:** EP-ABB3AC9D
-- **Backlog items:** BI-D908DA0A, BI-E58B57EC, BI-D088D06D, BI-8CDA7F95, BI-282AE0BC, BI-C09ECA63, BI-6332DD3D, BI-397EBDD6, BI-2C0A01CD
+- **Backlog items:** BI-D908DA0A, BI-E58B57EC, BI-D088D06D, BI-8CDA7F95, BI-282AE0BC, BI-C09ECA63, BI-6332DD3D, BI-397EBDD6, BI-2C0A01CD, BI-41C3E303
 - **Decision ledger:** DI-0DD38401DF9F (`principle_decide`, high stakes, no commandment conflict)
 - **Profile:** refactor
 - **Authored:** 2026-08-29
@@ -370,6 +370,50 @@ Stated as an invariant that a guard can enforce:
 Commandment-tier checks — auth, DCO, secret scanning, migration safety — are
 explicitly out of scope for every tiering, sampling and caching change in this
 spec. They run in every tier they run in today.
+
+#### Corollary: a qualifier on a PASS may never be read as a verdict (BI-41C3E303, 2026-09-10)
+
+The invariant above constrains what a gate may **write**. It said nothing about
+what the reader may **conclude**, and the reader found a way around it.
+
+`evidencePending` means *the gate passed and publication of that pass has not
+finished*. It is a qualifier on a PASS. But `gate-worktree.mjs` legitimately
+writes it alongside `gatePassed: false` for `blocked_control_plane_starvation`,
+because the local evidence is worth preserving across a control-plane outage even
+when the run never graded the diff. `classifySlotRecord` tested `evidencePending`
+**before** `gatePassed`, so such a record short-circuited into:
+
+```
+local-CI gate: PENDING
+  reason  gate passed but evidence publication is pending (tool_threw) — finish with: pnpm run pregate -- --finalize-evidence
+```
+
+Observed on `fix/principle-decide-requires-option-id` @ `04f681eae8d6`. The gate
+had not passed, and `--finalize-evidence` then refused with *no exact published
+PASS is available to finalize* — the authoritative verdict surface asserted a
+state its own record contradicted, and sent the operator to an action that cannot
+succeed. That is the failure `make-silent-failures-observable` forbids, arriving
+through the reader rather than the writer.
+
+So the invariant extends:
+
+> A field that qualifies a PASS is never evaluated before the record is known to
+> BE a pass. `classifySlotRecord` classifies `gatePassed !== true` first, and
+> reaches the PENDING branch only on a record that passed.
+
+Concretely: the unpassed-record classification is extracted into
+`classifyUnpassedRecord`, and the PENDING branch now sits after it, so no future
+qualifier can be inserted above the pass check by accident. A record whose gate
+did not pass and that still holds unpublished evidence reports its real verdict —
+`INCONCLUSIVE` for the infrastructure statuses, `FAIL` for a genuine failure — and
+its reason names the pending publication as *not* a pass, without naming
+`--finalize-evidence`, whose only correct next action is to re-gate the SHA.
+
+The two other consumers of these records were already correct and are unchanged:
+`.githooks/pre-push-gate` exits on `gatePassed !== true` before it ever looks at
+`evidencePending`, and `scripts/pr-health.mjs` tests
+`gatePassed !== true || evidencePending === true`. Only the reader disagreed with
+them.
 
 ## Scope — this change
 

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -717,7 +717,11 @@ the state branch, SHA, metadata candidate SHA, and evidence record ID all agree;
 an expired 24-hour window still requires a new pregate.
 
 The pre-push gate blocks `evidencePending=true` records until finalization
-succeeds. Failure evidence also carries `failureSummary`, a bounded list of
+succeeds. `evidencePending` qualifies a PASS; it never establishes one. A run
+blocked by control-plane starvation also preserves its local evidence and sets
+the flag while `gatePassed` stays `false`, so `pregate:status` reports that
+record as `INCONCLUSIVE` and the fix is to re-run pregate on the SHA —
+`--finalize-evidence` has no published PASS to finalize and refuses (BI-41C3E303). Failure evidence also carries `failureSummary`, a bounded list of
 failed tests/checks and omitted counts, plus an explicit pointer to
 BI-A4EC0EA6 for code-graph impacted-test recommendations. The complete output
 from the most recent run is retained outside the working tree at the git-private

--- a/scripts/lib/pregate-status.mjs
+++ b/scripts/lib/pregate-status.mjs
@@ -185,6 +185,87 @@ function metadataDescribesAnotherRun(state, metadata) {
   return true;
 }
 
+/**
+ * BI-41C3E303. Everything a record whose gate did NOT pass can be: infrastructure
+ * that never graded the diff, bookkeeping from a slot that lost the race, a record
+ * about another commit, or a real failure.
+ *
+ * Extracted so the ONE thing it must never be — a pass — cannot be reached around
+ * it. `evidencePending` is a qualifier on a PASS, not a verdict of its own, and the
+ * old ordering tested it first, so any of these outcomes carrying pending evidence
+ * short-circuited into a PENDING headlined "gate passed".
+ */
+function classifyUnpassedRecord({ state, metadata, base, headSha, candidateSha }) {
+  // BI-51353470: a metadata candidateSha that is not HEAD is STALE in the
+  // headline, not FAIL with a buried metadata line. Observed: FAIL quoting
+  // a previous run's vitest command while gated claimed the current HEAD.
+  if (candidateSha && headSha && candidateSha !== headSha) {
+    return {
+      ...base,
+      verdict: "STALE",
+      reason: `metadata record gated ${candidateSha.slice(0, 12)}, not HEAD ${headSha.slice(0, 12)} — re-run pregate`,
+      staleness: "metadata-mismatch",
+    };
+  }
+  const status = String(state.status || "");
+  // BI-5529B5AC: another slot PASSED this branch+SHA and the gate rewrote this
+  // losing record to say so. Bookkeeping, not a verdict on the diff.
+  if (status === "superseded" || state.supersededBy) {
+    const winner = state.supersededBy?.slotKey || "another slot";
+    return {
+      ...base,
+      verdict: "INCONCLUSIVE",
+      reason: `gate record superseded — ${winner} passed this SHA; this slot's ${state.supersededStatus || "prior"} record is not a verdict`,
+    };
+  }
+  if (UNFINISHED_GATE_STATUSES.has(status)) {
+    // BI-D908DA0A: a claim parked because the pool had NO admissible slot is
+    // host pressure, not a queue. Say so, or the operator waits behind nobody.
+    const closed = poolClosedReasonFromState(state);
+    if (closed) {
+      return {
+        ...base,
+        verdict: "INCONCLUSIVE",
+        reason: `gate record status ${status} — the local-CI pool was CLOSED (${closed}) when this claim was parked: no slot could admit anyone, so this is host pressure, not a queue and not a failure of the diff. Free host memory or wait for the pressure to pass, then re-run pregate.`,
+      };
+    }
+    return {
+      ...base,
+      verdict: "INCONCLUSIVE",
+      reason: `gate record status ${status} — the gate did not run. This is not a failure of the diff. Re-run pregate.`,
+    };
+  }
+  if (BLOCKED_GATE_STATUSES.has(status) || status.startsWith("blocked_")) {
+    const stated = state?.failureReason || state?.error || "";
+    return {
+      ...base,
+      verdict: "INCONCLUSIVE",
+      reason: stated
+        ? `gate record status ${status} — infrastructure, not a product verdict. ${stated}`
+        : `gate record status ${status} — infrastructure, not a product verdict. The run was blocked before it could grade the diff. Re-run when the host is quieter; do not treat this as a failure of the code.`,
+    };
+  }
+  return {
+    ...base,
+    verdict: "FAIL",
+    reason: describeFailure(state, metadata),
+    staleness: metadataDescribesAnotherRun(state, metadata) ? "metadata-describes-another-run" : "",
+  };
+}
+
+/**
+ * A run whose gate did not pass can still hold local evidence waiting to be
+ * published — `gate-worktree.mjs` preserves it across a control-plane outage on
+ * purpose. Say so, because the pending-evidence file is on disk and visible, but
+ * never let it read as a pass: --finalize-evidence has no published PASS to
+ * finalize and refuses, so it is deliberately not named here — the only real next
+ * action is to re-gate the SHA.
+ */
+function unpublishedEvidenceNote(state) {
+  const reason = state?.evidencePendingReason || "unknown";
+  return ` Local evidence from this run is preserved on disk and still unpublished (${reason}) — that is a pending PUBLICATION, not a pass, and publishing it cannot produce one. Re-run pregate on this SHA.`;
+}
+
 export function classifySlotRecord({ state, metadata, headSha, headBranch = "", now = Date.now() }) {
   const boundSha = String(state?.sha || "");
   const boundBranch = String(state?.branch || "");
@@ -218,69 +299,19 @@ export function classifySlotRecord({ state, metadata, headSha, headBranch = "", 
     };
   }
 
+  // The gate did not pass. Classify what actually happened FIRST — `evidencePending`
+  // qualifies a PASS and can never manufacture one (BI-41C3E303).
+  if (state.gatePassed !== true) {
+    const unpassed = classifyUnpassedRecord({ state, metadata, base, headSha, candidateSha });
+    if (state.evidencePending !== true) return unpassed;
+    return { ...unpassed, reason: `${unpassed.reason}${unpublishedEvidenceNote(state)}` };
+  }
+
   if (state.evidencePending === true) {
     return {
       ...base,
       verdict: "PENDING",
       reason: `gate passed but evidence publication is pending (${state.evidencePendingReason || "unknown"}) — finish with: pnpm run pregate -- --finalize-evidence`,
-    };
-  }
-
-  if (state.gatePassed !== true) {
-    // BI-51353470: a metadata candidateSha that is not HEAD is STALE in the
-    // headline, not FAIL with a buried metadata line. Observed: FAIL quoting
-    // a previous run's vitest command while gated claimed the current HEAD.
-    if (candidateSha && headSha && candidateSha !== headSha) {
-      return {
-        ...base,
-        verdict: "STALE",
-        reason: `metadata record gated ${candidateSha.slice(0, 12)}, not HEAD ${headSha.slice(0, 12)} — re-run pregate`,
-        staleness: "metadata-mismatch",
-      };
-    }
-    const status = String(state.status || "");
-    // BI-5529B5AC: another slot PASSED this branch+SHA and the gate rewrote this
-    // losing record to say so. Bookkeeping, not a verdict on the diff.
-    if (status === "superseded" || state.supersededBy) {
-      const winner = state.supersededBy?.slotKey || "another slot";
-      return {
-        ...base,
-        verdict: "INCONCLUSIVE",
-        reason: `gate record superseded — ${winner} passed this SHA; this slot's ${state.supersededStatus || "prior"} record is not a verdict`,
-      };
-    }
-    if (UNFINISHED_GATE_STATUSES.has(status)) {
-      // BI-D908DA0A: a claim parked because the pool had NO admissible slot is
-      // host pressure, not a queue. Say so, or the operator waits behind nobody.
-      const closed = poolClosedReasonFromState(state);
-      if (closed) {
-        return {
-          ...base,
-          verdict: "INCONCLUSIVE",
-          reason: `gate record status ${status} — the local-CI pool was CLOSED (${closed}) when this claim was parked: no slot could admit anyone, so this is host pressure, not a queue and not a failure of the diff. Free host memory or wait for the pressure to pass, then re-run pregate.`,
-        };
-      }
-      return {
-        ...base,
-        verdict: "INCONCLUSIVE",
-        reason: `gate record status ${status} — the gate did not run. This is not a failure of the diff. Re-run pregate.`,
-      };
-    }
-    if (BLOCKED_GATE_STATUSES.has(status) || status.startsWith("blocked_")) {
-      const stated = state?.failureReason || state?.error || "";
-      return {
-        ...base,
-        verdict: "INCONCLUSIVE",
-        reason: stated
-          ? `gate record status ${status} — infrastructure, not a product verdict. ${stated}`
-          : `gate record status ${status} — infrastructure, not a product verdict. The run was blocked before it could grade the diff. Re-run when the host is quieter; do not treat this as a failure of the code.`,
-      };
-    }
-    return {
-      ...base,
-      verdict: "FAIL",
-      reason: describeFailure(state, metadata),
-      staleness: metadataDescribesAnotherRun(state, metadata) ? "metadata-describes-another-run" : "",
     };
   }
 

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -220,6 +220,69 @@ test("PENDING when the gate passed but evidence publication is unfinished", () =
   assert.equal(exitCodeForVerdict(r.verdict), 1, "pending evidence is not a green light to push");
 });
 
+test("PENDING requires the gate to have PASSED — a blocked run carrying stale pending evidence is INCONCLUSIVE", () => {
+  // Observed 2026-09-10 on fix/principle-decide-requires-option-id @ 04f681eae8d6.
+  // gate-worktree.mjs writes gatePassed:false WITH evidencePending:true for
+  // blocked_control_plane_starvation — the local evidence is preserved for later
+  // publication even though the run never graded the diff. Reading evidencePending
+  // as a verdict of its own headlined "gate passed" over a record that says it did not.
+  const r = classifySlotRecord({
+    state: passingState({
+      gatePassed: false,
+      status: "blocked_control_plane_starvation",
+      evidenceRecordId: "",
+      evidencePending: true,
+      evidencePendingReason: "tool_threw",
+    }),
+    metadata: null,
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.doesNotMatch(r.reason, /gate passed/, "must not assert a pass the record contradicts");
+  assert.doesNotMatch(
+    r.reason,
+    /finalize-evidence/,
+    "must not send the operator to a finalizer that refuses without a published PASS",
+  );
+  assert.match(r.reason, /blocked_control_plane_starvation/);
+});
+
+test("a failing record carrying pending evidence is still FAIL, not PENDING", () => {
+  const r = classifySlotRecord({
+    state: passingState({
+      gatePassed: false,
+      status: "failed",
+      evidenceRecordId: "",
+      evidencePending: true,
+      evidencePendingReason: "tool_threw",
+      failureReason: "vitest exited 1",
+    }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "FAIL");
+  assert.doesNotMatch(r.reason, /gate passed/);
+});
+
+test("a queued record carrying pending evidence is INCONCLUSIVE, not PENDING", () => {
+  const r = classifySlotRecord({
+    state: passingState({
+      gatePassed: false,
+      status: "queued",
+      evidenceRecordId: "",
+      evidencePending: true,
+      evidencePendingReason: "control_plane_unavailable",
+    }),
+    metadata: null,
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.doesNotMatch(r.reason, /gate passed/);
+});
+
 test("reconcile takes the best slot so a sibling's stale record cannot fake a failure", () => {
   const best = reconcileSlots([
     { slotKey: "slot-0", verdict: "STALE", reason: "old" },


### PR DESCRIPTION
## What

`pnpm run pregate:status` reported

```
local-CI gate: PENDING
  reason  gate passed but evidence publication is pending (tool_threw) — finish with: pnpm run pregate -- --finalize-evidence
```

for a slot record that said `gatePassed: false`, `status: "blocked_control_plane_starvation"`, `evidenceRecordId: ""`. Observed 2026-09-10 on `fix/principle-decide-requires-option-id` @ `04f681eae8d6` (Arcamanus DEV). The finalizer the headline names then correctly refuses with *no exact published PASS is available to finalize*, so the authoritative verdict surface asserted a state its own record contradicts and pointed the operator at an action that cannot succeed.

## Why it matters

`pregate:status` is documented as **the** verdict — "reads the record, not this text". The pre-push gate consumes it, `pnpm pr:health` consumes it, and AGENTS.md §4 treats it as authoritative. A false *gate passed* from that surface is exactly what `make-silent-failures-observable` forbids, and it inverts this epic's own invariant — `docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md` §"Fail-closed on safety, fail-open on infrastructure": an infrastructure block reports `INCONCLUSIVE` and stays re-runnable, it does not borrow a PASS headline.

## Root cause

`evidencePending` means *the gate passed and publication of that pass has not finished*. It is a qualifier on a PASS. `classifySlotRecord` tested it **before** `gatePassed`:

```js
if (state.evidencePending === true) { return { verdict: "PENDING", reason: `gate passed but …` }; }
if (state.gatePassed !== true) { /* INCONCLUSIVE / STALE / FAIL */ }
```

so every record carrying the flag short-circuited past the whole classification below it.

The writer produces that shape on purpose. `scripts/gate-worktree.mjs:2042-2056` writes `gatePassed: false` **with** `evidencePending: true` for `blocked_control_plane_starvation` — the local evidence is preserved across a control-plane outage even though the run never graded the diff. Separately it writes `gatePassed: true, evidencePending: true` for `portal_quiescing`. Only the second is a PENDING; the reader could not tell them apart.

## Change

Classify the unpassed record first. The whole `gatePassed !== true` arm is extracted into `classifyUnpassedRecord`, and the PENDING branch now sits after it, so no future qualifier can be inserted above the pass check by accident.

A record whose gate did not pass and still holds unpublished evidence now reports its real verdict — `INCONCLUSIVE` for the infrastructure statuses, `FAIL` for a genuine failure — and its reason names the pending publication as *not* a pass, without naming `--finalize-evidence`, whose only correct next action is to re-gate the SHA.

No verdict string in `PREGATE_VERDICTS` changes, and no exit-code mapping changes.

**The other two consumers were already correct and are untouched.** `.githooks/pre-push-gate:310-322` exits on `gatePassed !== true` before it ever reads `evidencePending`; `scripts/pr-health.mjs:70` tests `gatePassed !== true || evidencePending === true`. Only the reader disagreed with them, which is why this surfaced as a status-line contradiction rather than a bad push.

## Design grounding

Extends the canonical design that owns this reducer and this invariant — `docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md`, §"Fail-closed on safety, fail-open on infrastructure" — with a corollary rather than adding a second home for the rule:

> A field that qualifies a PASS is never evaluated before the record is known to BE a pass.

The existing invariant constrained what a gate may **write**. It said nothing about what the reader may **conclude**, and the reader found a way around it. `BI-41C3E303` is added to that spec's backlog-item list.

## Verification

- `node --test scripts/lib/pregate-status.test.mjs` — **39 pass, 0 fail**. Three tests added, each red before the fix and green after: `blocked_control_plane_starvation`, `failed`, and `queued` records carrying `evidencePending: true`. The pre-existing `gatePassed: true` PENDING test is unchanged and still green, so the PASS-qualifier path is preserved.
- `node --test scripts/lib/local-ci-gate-state.test.mjs scripts/pregate.test.mjs` — 22 pass, 0 fail.
- `pnpm pregate:preflight` — 67 guards clean (run before the first commit and again after it).
- Local-CI gate: see the gate evidence recorded on `BI-41C3E303`.

## Docs impact

`docs/testing/pre-pr-gate.md` documented `evidencePending` only in the gate-passed quiescing case — the same misreading this defect encodes. It now states that the flag qualifies a PASS and never establishes one, and that such a record re-gates rather than finalizes.

## Backlog

`BI-41C3E303` under `EP-ABB3AC9D` (Change-delivery latency: tier by risk, fail open on infrastructure). Workroom `WC-214B5597`.

Related: `BI-D088D06D` (the INCONCLUSIVE vocabulary this record should have used), `BI-51353470` (`blocked_*` is INCONCLUSIVE, not FAIL), `BI-0DFE2CFE` (slot reconciliation order), `BI-B1065D41` (the one-authoritative-verdict-artifact rule this file implements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
