### PR TITLE
fix(local-ci): a late starvation event must not withdraw a PASS the gate already reached (BI-FFCFCCE0)

### DIFF
--- a/docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md
+++ b/docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md
@@ -72,6 +72,17 @@ should report the ambiguity rather than pick.
 **Do not report a verdict about state you did not read.** A record from a
 previous run is evidence about that run, not this one.
 
+**An inconclusive result never withdraws a verdict already reached.** "I could
+not tell" is not evidence that the earlier answer was wrong -- it is the absence
+of evidence, and absence cannot overturn a measurement. When an infrastructure
+event lands after a check has already concluded, record it beside the verdict,
+not on top of it. Measured 2026-09-10: a local-CI gate PASSED, published its
+result, and twenty minutes later the same record was rewritten to
+`blocked_control_plane_starvation` with the verdict and its evidence id erased --
+one lease, one run, and nothing had re-examined the tree. Whoever writes the
+result record owns this: a downgrade guard belongs at the write, because every
+caller that could clobber a verdict is a caller who did not mean to.
+
 ## The consequence clause
 
 A check that reports verdicts it did not reach **gets disabled** — by a switch,

--- a/scripts/gate-worktree-finalize-slot.test.mjs
+++ b/scripts/gate-worktree-finalize-slot.test.mjs
@@ -1,0 +1,93 @@
+// BI-FFCFCCE0 — `pregate -- --finalize-evidence` resolved its record before
+// admission, so it always read slot-0's UNSLOTTED `dpf-local-ci-gate.json`
+// while `pregate:status` reconciles across every `dpf-local-ci-gate-slot-*.json`.
+// A real pending PASS recorded on slot-1 was therefore unfinalizable, and the
+// two commands disagreed about which record was authoritative.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { resolveFinalizeSlot } from "./gate-worktree.mjs";
+import { createLocalCiSlotManifest } from "./lib/local-ci-slot-manifest.mjs";
+import { writeLocalCiGateState } from "./lib/local-ci-gate-state.mjs";
+
+const BRANCH = "fix/principle-decide-requires-option-id";
+const SHA = "04f681eae8d6c3f19a0d3d6e5c9c9b1f2a3b4c5d";
+
+function fixture() {
+  const rootClone = mkdtempSync(join(tmpdir(), "dpf-finalize-slot-"));
+  const gitCommonDir = join(rootClone, ".git");
+  const candidateGitDir = join(gitCommonDir, "worktrees", "candidate");
+  mkdirSync(candidateGitDir, { recursive: true });
+  return { rootClone, gitCommonDir, candidateGitDir };
+}
+
+function manifestFor(slotKey, paths) {
+  return createLocalCiSlotManifest({ slotKey, ...paths });
+}
+
+test("a pending PASS on slot-1 is found, not refused because slot-0 is empty", () => {
+  const paths = fixture();
+  const slot1 = manifestFor("slot-1", paths);
+  writeFileSync(
+    slot1.evidence.pending,
+    `${JSON.stringify({ branch: BRANCH, sha: SHA, recordArgs: {} }, null, 2)}\n`,
+  );
+
+  const resolved = resolveFinalizeSlot({ branch: BRANCH, sha: SHA, ...paths, defaultSlotKey: "slot-0" });
+
+  assert.equal(resolved.manifest.slotKey, "slot-1");
+  assert.equal(resolved.matchedBy, "pending");
+});
+
+test("a published PASS on slot-1 is found when no pending record exists", () => {
+  const paths = fixture();
+  const slot1 = manifestFor("slot-1", paths);
+  writeLocalCiGateState(slot1.evidence.state, {
+    branch: BRANCH,
+    sha: SHA,
+    gatePassed: true,
+    leaseId: "NPEL-50DF305E6C",
+    evidenceId: "cmtv4u0220h4301qn5r8le9ev",
+    status: "passed",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+    resilience: null,
+    leaseEvents: [],
+  });
+
+  const resolved = resolveFinalizeSlot({ branch: BRANCH, sha: SHA, ...paths, defaultSlotKey: "slot-0" });
+
+  assert.equal(resolved.manifest.slotKey, "slot-1");
+  assert.equal(resolved.matchedBy, "published-pass");
+});
+
+test("a record for another candidate does not claim the finalize, and the refusal can name every path searched", () => {
+  const paths = fixture();
+  const slot1 = manifestFor("slot-1", paths);
+  writeLocalCiGateState(slot1.evidence.state, {
+    branch: BRANCH,
+    sha: "f".repeat(40),
+    gatePassed: true,
+    leaseId: "NPEL-OTHER",
+    evidenceId: "E-other",
+    status: "passed",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+    resilience: null,
+    leaseEvents: [],
+  });
+
+  const resolved = resolveFinalizeSlot({ branch: BRANCH, sha: SHA, ...paths, defaultSlotKey: "slot-0" });
+
+  assert.equal(resolved.matchedBy, "none");
+  assert.equal(resolved.manifest.slotKey, "slot-0");
+  // Both slots' pending AND state paths are reported, so an operator reading the
+  // refusal can tell a missing record from one the gate failed to look for.
+  for (const slotKey of ["slot-0", "slot-1"]) {
+    const manifest = manifestFor(slotKey, paths);
+    assert.ok(resolved.searched.includes(manifest.evidence.pending), `${slotKey} pending`);
+    assert.ok(resolved.searched.includes(manifest.evidence.state), `${slotKey} state`);
+  }
+});

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -218,6 +218,56 @@ function siblingSlotStateFiles({ currentSlotKey, rootClone, gitCommonDir, candid
     }).evidence.state);
 }
 
+/**
+ * BI-FFCFCCE0. `--finalize-evidence` runs BEFORE admission, so `currentSlotKey`
+ * is still the `slot-0` default and slot-0's evidence files carry no suffix.
+ * The finalize path therefore read the UNSLOTTED `dpf-local-ci-gate.json` while
+ * `pregate:status` reconciles across every `dpf-local-ci-gate-slot-*.json`, and
+ * the two disagreed about which record was authoritative: a genuine PASS
+ * recorded on slot-1 could not be finalized at all, only refused with
+ * `no exact published PASS is available to finalize at ...dpf-local-ci-gate.json`.
+ *
+ * Resolve the same way the reader does. A pending record wins over a published
+ * one: it names the exact run whose publication was deferred.
+ *
+ * @returns {{ manifest: object, searched: string[], matchedBy: "pending"|"published-pass"|"none" }}
+ */
+export function resolveFinalizeSlot({ branch, sha, rootClone, gitCommonDir, candidateGitDir, defaultSlotKey }) {
+  const manifests = LOCAL_CI_SLOT_KEYS.map((slotKey) => createLocalCiSlotManifest({
+    slotKey,
+    rootClone,
+    gitCommonDir,
+    candidateGitDir,
+  }));
+  const searched = [];
+  for (const manifest of manifests) {
+    searched.push(manifest.evidence.pending);
+    let pending = null;
+    try {
+      pending = JSON.parse(readFileSync(manifest.evidence.pending, "utf8"));
+    } catch {
+      // An absent or unreadable pending file simply means this slot is not it.
+    }
+    if (pending?.branch === branch && pending?.sha === sha) {
+      return { manifest, searched, matchedBy: "pending" };
+    }
+  }
+  for (const manifest of manifests) {
+    searched.push(manifest.evidence.state);
+    const state = readLocalCiGateState(manifest.evidence.state);
+    if (
+      state?.branch === branch
+      && state?.sha === sha
+      && state?.gatePassed === true
+      && state?.status === "passed"
+    ) {
+      return { manifest, searched, matchedBy: "published-pass" };
+    }
+  }
+  const fallback = manifests.find((manifest) => manifest.slotKey === defaultSlotKey) ?? manifests[0];
+  return { manifest: fallback, searched, matchedBy: "none" };
+}
+
 function retryDelayMs({ attempt, pollSeconds, retryAfterSeconds = 0 }) {
   const floorMs = Math.max(10, pollSeconds * 1000);
   const requestedMs = Math.max(0, Number(retryAfterSeconds) * 1000);
@@ -1046,6 +1096,19 @@ async function main() {
   }
 
   if (options.finalizeEvidence) {
+    const finalizeSlot = resolveFinalizeSlot({
+      branch,
+      sha,
+      rootClone,
+      gitCommonDir,
+      candidateGitDir,
+      defaultSlotKey: currentSlotKey,
+    });
+    slotManifest = finalizeSlot.manifest;
+    currentSlotKey = slotManifest.slotKey;
+    stateFile = slotManifest.evidence.state;
+    metadataFile = slotManifest.evidence.metadata;
+    pendingEvidenceFile = slotManifest.evidence.pending;
     if (!existsSync(pendingEvidenceFile)) {
       const state = readLocalCiGateState(stateFile);
       let metadata = null;
@@ -1063,7 +1126,10 @@ async function main() {
         || !state?.evidenceRecordId
         || metadata?.candidateSha !== sha
       ) {
-        die(`no exact published PASS is available to finalize at ${stateFile}`);
+        die(
+          `no exact published PASS is available to finalize for ${branch} @ ${sha}; searched `
+            + finalizeSlot.searched.join(", "),
+        );
       }
       const evidenceValidity = createLocalCiPassEvidenceValidity({
         issuedAt: state.evidenceValidity?.issuedAt || state.recordedAt,
@@ -2040,7 +2106,7 @@ async function main() {
         retryAfterSeconds: 30,
         recordArgs: evidenceArgs,
       });
-      writeState(stateFile, {
+      const starvationWrite = writeState(stateFile, {
         branch,
         sha,
         gatePassed: false,
@@ -2054,6 +2120,14 @@ async function main() {
         evidencePendingReason: evidenceError || "control_plane_unavailable",
       });
       process.stderr.write("gate-worktree: control-plane starvation evidence is preserved locally and pending portal recovery.\n");
+      // BI-FFCFCCE0: the record already held a PASS this gate reached for the
+      // same tree, so the starvation was appended as an observation and the
+      // verdict stands. Say so, or the exit code reads as a lost pass.
+      if (starvationWrite?.preservedPass) {
+        process.stderr.write(
+          `gate-worktree: the PASS already recorded for ${sha} still stands; this starvation is logged on it as an inconclusive observation, not a verdict.\n`,
+        );
+      }
       process.exit(5);
     }
     if (outcome.gatePassed && evidenceError === "portal_quiescing") {
@@ -2193,7 +2267,7 @@ function writeState(stateFile, {
   childExitCode = null,
   onPassWritten = null,
 }) {
-  writeLocalCiGateState(stateFile, {
+  const result = writeLocalCiGateState(stateFile, {
     branch,
     sha,
     gatePassed,
@@ -2224,6 +2298,7 @@ function writeState(stateFile, {
 `);
     }
   }
+  return result;
 }
 
 // A gate that silently skips main() exits 0 — a false "pass" — so the entry

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -108,6 +108,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       // BI-D908DA0A: a parked claim says whether it waits behind work or behind
       // a closed pool; the two used to print identically.
       node("--test", "scripts/gate-worktree-pool-closed.test.mjs"),
+      // BI-FFCFCCE0: --finalize-evidence resolved its record before admission
+      // and so always read slot-0, while pregate:status reconciles every slot.
+      // A real pending PASS on slot-1 was unfinalizable. Registered here for the
+      // same reason as the tests above: in the allowlist it would never run.
+      node("--test", "scripts/gate-worktree-finalize-slot.test.mjs"),
       // BI-24D5D7C2: the control-plane watchdog aborts a 13-minute build after
       // two consecutive probe failures, and an inner mcpCall deadline was
       // classified as "request-failed" — an operator reads that as a broken

--- a/scripts/lib/local-ci-gate-state.mjs
+++ b/scripts/lib/local-ci-gate-state.mjs
@@ -17,6 +17,35 @@ export const NONTERMINAL_LOCAL_CI_GATE_STATUSES = Object.freeze(new Set([
   "running",
 ]));
 
+/**
+ * BI-FFCFCCE0. Is `status` an infrastructure observation rather than a verdict
+ * about the diff?
+ *
+ * A `blocked_*` status is INFRASTRUCTURE evidence, never a product verdict -
+ * local-integration-status.mjs and pregate-status.mjs both already say so in
+ * those words. Encode that rule by its prefix rather than as a fourth copy of a
+ * status list: BI-C59AC8AF cost a permanently ungateable tree precisely because
+ * four copies of one status set drifted apart, and this predicate must stay
+ * right for a `blocked_*` status nobody has written yet.
+ *
+ * `failed` and `conflict` are verdicts about the tree and stay free to replace a
+ * stale PASS.
+ */
+export function isInconclusiveLocalCiGateStatus(status) {
+  return typeof status === "string" && status.startsWith("blocked_");
+}
+
+/** The most inconclusive observations one record keeps before dropping the oldest. */
+const MAX_INCONCLUSIVE_OBSERVATIONS = 20;
+
+/** True when `state` is a PASS this gate actually reached, pending evidence or not. */
+export function isTerminalPassRecord(state) {
+  return Boolean(state)
+    && typeof state === "object"
+    && state.gatePassed === true
+    && state.status === "passed";
+}
+
 export function createLocalCiPassEvidenceValidity(options) {
   return createCiEvidenceValidity(options);
 }
@@ -62,6 +91,40 @@ export function writeLocalCiGateState(stateFile, {
   childExitCode = null,
 }) {
   const previous = readLocalCiGateState(stateFile);
+  // BI-FFCFCCE0. A verdict that was reached and reported must not be erased by
+  // an infrastructure event that arrives after the run finished. Observed
+  // 2026-09-10 on fix/principle-decide-requires-option-id: the gate PASSED at
+  // 05:55Z on lease NPEL-50DF305E6C, and at 06:15Z the same slot record was
+  // rewritten to blocked_control_plane_starvation with gatePassed:false and an
+  // empty evidenceRecordId. One lease, one run - nothing re-tested the tree, so
+  // nothing had the standing to withdraw the PASS.
+  //
+  // The event is still recorded, as its own inconclusive observation on the
+  // surviving record rather than as the record's status. This mirrors the guards
+  // supersedeLosingSlotRecords already applies to a SIBLING slot's pass
+  // (BI-5529B5AC): until now a sibling's PASS was protected and the record's own
+  // was not.
+  if (
+    isInconclusiveLocalCiGateStatus(status)
+    && isTerminalPassRecord(previous)
+    && previous.branch === branch
+    && previous.sha === sha
+  ) {
+    const observations = [
+      ...(Array.isArray(previous.inconclusiveObservations) ? previous.inconclusiveObservations : []),
+      {
+        status,
+        at: new Date().toISOString(),
+        leaseId: leaseId || null,
+        reason: failureReason || evidencePendingReason || null,
+      },
+    ].slice(-MAX_INCONCLUSIVE_OBSERVATIONS);
+    writeGateStateAtomically(
+      stateFile,
+      serializeGateState({ ...previous, inconclusiveObservations: observations }),
+    );
+    return { written: false, preservedPass: true, status: previous.status };
+  }
   const retainedAdmission = admission ?? (
     previous?.branch === branch && previous?.sha === sha
       ? previous.admission ?? null
@@ -94,7 +157,8 @@ export function writeLocalCiGateState(stateFile, {
   if (failureReason) payload.failureReason = failureReason;
   if (failureSummary) payload.failureSummary = failureSummary;
   if (childExitCode !== null && childExitCode !== undefined) payload.childExitCode = childExitCode;
-  writeGateStateAtomically(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+  writeGateStateAtomically(stateFile, serializeGateState(payload));
+  return { written: true, preservedPass: false, status };
 }
 
 /**
@@ -166,6 +230,11 @@ export function projectReusedPassMetadata(prior, { sha, branch, evidenceId, leas
       failedCommand: null,
     },
   };
+}
+
+function serializeGateState(payload) {
+  return `${JSON.stringify(payload, null, 2)}
+`;
 }
 
 function writeGateStateAtomically(stateFile, contents) {

--- a/scripts/lib/local-ci-gate-state.test.mjs
+++ b/scripts/lib/local-ci-gate-state.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   createLocalCiPassEvidenceValidity,
+  isInconclusiveLocalCiGateStatus,
   isRecoverableInterruptedGateState,
   projectReusedPassMetadata,
   readLocalCiGateState,
@@ -222,4 +223,139 @@ test("supersession leaves other SHAs, other branches, passes, and pending eviden
   for (const file of [otherSha, otherBranch, realPass, pending]) {
     assert.notEqual(readLocalCiGateState(file).status, "superseded", file);
   }
+});
+
+// BI-FFCFCCE0: a starvation event that arrives AFTER a terminal PASS is a
+// separate inconclusive observation, not a re-verdict. Observed 2026-09-10 on
+// fix/principle-decide-requires-option-id: the gate passed and reported PASS at
+// 05:55Z, and at 06:15Z the same slot record was rewritten to
+// blocked_control_plane_starvation with gatePassed:false and an empty
+// evidenceRecordId. One lease, one run — the verdict was reached, then erased.
+test("an infrastructure-blocked write cannot downgrade a terminal PASS for the same branch+SHA", () => {
+  const stateFile = join(mkdtempSync(join(tmpdir(), "dpf-gate-pass-guard-")), "gate.json");
+  const shared = { branch: "fix/x", sha: "d".repeat(40), leaseId: "NPEL-1", resilience: null, leaseEvents: [] };
+
+  writeLocalCiGateState(stateFile, {
+    ...shared,
+    gatePassed: true,
+    evidenceId: "cmtv4u0220h4301qn5r8le9ev",
+    status: "passed",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+  });
+  const result = writeLocalCiGateState(stateFile, {
+    ...shared,
+    gatePassed: false,
+    evidenceId: "",
+    status: "blocked_control_plane_starvation",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+    evidencePending: true,
+    evidencePendingReason: "control_plane_unavailable",
+    failureReason: "control plane unreachable for two sustained rounds",
+  });
+
+  const state = readLocalCiGateState(stateFile);
+  assert.equal(state.gatePassed, true, "the reached verdict must stand");
+  assert.equal(state.status, "passed");
+  assert.equal(state.evidenceRecordId, "cmtv4u0220h4301qn5r8le9ev");
+  assert.equal(result.preservedPass, true);
+  // The event is not swallowed: it is recorded as its own inconclusive observation.
+  assert.equal(state.inconclusiveObservations.length, 1);
+  assert.equal(state.inconclusiveObservations[0].status, "blocked_control_plane_starvation");
+  assert.equal(
+    state.inconclusiveObservations[0].reason,
+    "control plane unreachable for two sustained rounds",
+  );
+});
+
+test("a PASS whose evidence is still pending is protected the same way", () => {
+  const stateFile = join(mkdtempSync(join(tmpdir(), "dpf-gate-pass-pending-")), "gate.json");
+  const shared = { branch: "fix/x", sha: "e".repeat(40), leaseId: "NPEL-2", resilience: null, leaseEvents: [] };
+
+  writeLocalCiGateState(stateFile, {
+    ...shared,
+    gatePassed: true,
+    evidenceId: "",
+    status: "passed",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+    evidencePending: true,
+    evidencePendingReason: "tool_threw",
+  });
+  writeLocalCiGateState(stateFile, {
+    ...shared,
+    gatePassed: false,
+    evidenceId: "",
+    status: "blocked_child_signal_death",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+  });
+
+  const state = readLocalCiGateState(stateFile);
+  assert.equal(state.gatePassed, true);
+  assert.equal(state.evidencePending, true);
+  assert.equal(state.evidencePendingReason, "tool_threw");
+});
+
+test("a real verdict, a different candidate, and a re-run in flight still overwrite a PASS", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-gate-pass-overwrite-"));
+  const base = { leaseId: "L", evidenceId: "", resilience: null, leaseEvents: [], expiresAt: "2026-09-11T06:00:00.000Z" };
+  const pass = { ...base, gatePassed: true, status: "passed", evidenceId: "E1" };
+
+  // A FAIL for the same tree is a claim about the diff, not infrastructure.
+  const verdict = join(dir, "verdict.json");
+  writeLocalCiGateState(verdict, { ...pass, branch: "fix/x", sha: "abc" });
+  writeLocalCiGateState(verdict, { ...base, branch: "fix/x", sha: "abc", gatePassed: false, status: "failed" });
+  assert.equal(readLocalCiGateState(verdict).status, "failed");
+
+  // A blocked write for a DIFFERENT sha describes a different candidate.
+  const other = join(dir, "other.json");
+  writeLocalCiGateState(other, { ...pass, branch: "fix/x", sha: "abc" });
+  writeLocalCiGateState(other, {
+    ...base, branch: "fix/x", sha: "def", gatePassed: false, status: "blocked_control_plane_starvation",
+  });
+  assert.equal(readLocalCiGateState(other).sha, "def");
+
+  // A re-run in flight must own the record; a stale PASS beside a live run lies.
+  const rerun = join(dir, "rerun.json");
+  writeLocalCiGateState(rerun, { ...pass, branch: "fix/x", sha: "abc" });
+  writeLocalCiGateState(rerun, { ...base, branch: "fix/x", sha: "abc", gatePassed: false, status: "running" });
+  assert.equal(readLocalCiGateState(rerun).status, "running");
+});
+
+test("every blocked_* status counts as infrastructure, including ones added later", () => {
+  for (const status of [
+    "blocked_control_plane_starvation",
+    "blocked_child_signal_death",
+    "blocked_sandbox_drift",
+    "blocked_quiescence",
+    "blocked_wrapper_exited",
+    "blocked_something_nobody_has_written_yet",
+  ]) {
+    assert.equal(isInconclusiveLocalCiGateStatus(status), true, status);
+  }
+  // Verdicts about the tree are not infrastructure and must stay able to
+  // replace a stale PASS.
+  for (const status of ["passed", "failed", "conflict", "superseded", "running", "queued", null, undefined]) {
+    assert.equal(isInconclusiveLocalCiGateStatus(status), false, String(status));
+  }
+});
+
+test("a wrapper that exited before a terminal state cannot withdraw a PASS either", () => {
+  const stateFile = join(mkdtempSync(join(tmpdir(), "dpf-gate-wrapper-")), "gate.json");
+  const shared = { branch: "fix/x", sha: "a".repeat(40), leaseId: "NPEL-3", resilience: null, leaseEvents: [] };
+
+  writeLocalCiGateState(stateFile, {
+    ...shared,
+    gatePassed: true,
+    evidenceId: "E9",
+    status: "passed",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+  });
+  writeLocalCiGateState(stateFile, {
+    ...shared,
+    gatePassed: false,
+    evidenceId: "",
+    status: "blocked_wrapper_exited",
+    expiresAt: "2026-09-11T06:00:00.000Z",
+  });
+
+  assert.equal(readLocalCiGateState(stateFile).status, "passed");
 });

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -578,8 +578,14 @@ export async function recoverInterruptedGate({
       const releaseText = recovered.releaseSucceeded
         ? "released the lease"
         : `could not release the lease (${recovered.releaseError || "unknown error"})`;
+      // BI-FFCFCCE0: the record this path writes is `blocked_wrapper_exited`,
+      // which BI-D088D06D introduced precisely so an interrupted wrapper stops
+      // reading as a grade on the diff. This line kept the pre-BI-D088D06D
+      // wording and said "failed" anyway — the record told the truth while the
+      // one sentence an operator actually reads did not.
       stderr.write(
-        `pregate: recovered interrupted local-CI gate for ${context.branch} @ ${context.sha}; ${releaseText}; marked the local gate state failed.\n`,
+        `pregate: recovered interrupted local-CI gate for ${context.branch} @ ${context.sha}; ${releaseText}; `
+          + "recorded blocked_wrapper_exited: the run was interrupted before it could grade the diff, so this is NOT a verdict on your changes. Re-run pregate on the same SHA.\n",
       );
       return recovered;
     }


### PR DESCRIPTION
## What this fixes

**BI-FFCFCCE0.** A local-CI gate PASS that was already reached and reported was destroyed by an infrastructure event that arrived after the run finished.

Observed 2026-09-10 on `fix/principle-decide-requires-option-id` @ `04f681eae8d6`, lease `NPEL-50DF305E6C`, from that worktree's own `dpf-local-ci-gate-slot-1.json`:

1. Admitted 05:55:51Z (`admission.waitAgeMs` 1015575). The gate ran, `pnpm run pregate` exited 0, and `pnpm pregate:status` printed `local-CI gate: PASS ... evidence cmtv4u0220h4301qn5r8le9ev`.
2. Evidence publication threw — `evidencePending: true`, `evidencePendingReason: "tool_threw"`.
3. At 06:15:17Z the **same** slot record was rewritten to `status: "blocked_control_plane_starvation"`, `gatePassed: false`, `evidenceRecordId: ""`.

One lease, one run. Nothing re-examined the tree, so nothing had the standing to withdraw the verdict.

Same class as BI-1669E08A (an infrastructure failure outranking a real pass), different mechanism: BI-1669E08A is a *second run* superseding the first, and remains open.

## Root cause

`writeLocalCiGateState` (`scripts/lib/local-ci-gate-state.mjs`) had **no** guard on the record's current terminal state. It read the previous record only to retain `admission`, then overwrote unconditionally — so every `writeState` caller in `scripts/gate-worktree.mjs`, including the starvation branch, clobbers whatever the record holds.

The asymmetry sat inside the same module. `supersedeLosingSlotRecords` (BI-5529B5AC) already refuses to touch a **sibling** slot's record that `is-a-pass` or has `evidence-pending`. A sibling's PASS was protected; the record's own was not.

## Design grounding

Grounded in the kernel principle [`report-only-the-verdict-you-reached`](docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md) and AGENTS.md §4 — *a gate that could not run is not a verdict; fail closed on safety, fail open on infrastructure*. The principle is extended in this branch with the clause this defect proves: **an inconclusive result never withdraws a verdict already reached** — absence of evidence cannot overturn a measurement, and the guard belongs at the write, because every caller that could clobber a verdict is one that did not mean to.

The guard shape reuses what BI-5529B5AC established for sibling records rather than introducing a new mechanism.

## What changed

**1. An infrastructure-inconclusive write cannot downgrade a terminal PASS for the same branch+SHA.** The PASS stands and the event is appended to an `inconclusiveObservations` array on the surviving record, capped at 20 — nothing is swallowed. `writeLocalCiGateState` now returns `{ written, preservedPass, status }`, and the gate's starvation branch says on stderr that the earlier PASS still stands, so exit 5 does not read as a lost pass.

"Infrastructure" is the `blocked_*` **prefix**, not a fourth copy of a status list. `local-integration-status.mjs` and `pregate-status.mjs` both already state that rule in those words, and BI-C59AC8AF cost a permanently ungateable tree precisely because four copies of one status set drifted apart. The prefix also covers `blocked_wrapper_exited`, which `pregate.mjs` writes and which no list assembled from the recorder's enum would have caught.

Deliberately still overwrite: a `failed` or `conflict` verdict for the same SHA (that IS a claim about the diff), a record for a different SHA or branch, and a re-run in flight (`queued`/`admitted`/`running` — a stale PASS beside a live run lies). Each is a regression test.

**2. `--finalize-evidence` and `pregate:status` now resolve the same record.** Finalize runs before admission, so `currentSlotKey` was still the `slot-0` default and slot-0's evidence files carry no suffix: it read the **unslotted** `dpf-local-ci-gate.json` while `pregate:status` reconciles across every `dpf-local-ci-gate-slot-*.json`. A genuine pending PASS on slot-1 was unfinalizable, refused with `no exact published PASS is available to finalize at ...dpf-local-ci-gate.json`. `resolveFinalizeSlot` now searches every slot the way the reader does (a pending record wins — it names the exact run whose publication was deferred), and the refusal lists every path it searched.

**3. The interrupted-wrapper line said "failed" while its own record said `blocked_wrapper_exited`.** Found by this branch's own gating, in the second commit: the gate died on `ECONNRESET` to a starved portal, wrote `blocked_wrapper_exited` (correct, per BI-D088D06D), and printed `marked the local gate state failed`. BI-D088D06D changed the status for exactly this reason and left the sentence behind — the record told the truth while the one line an operator reads did not.

## Verification

- `node --test scripts/lib/local-ci-gate-state.test.mjs` — 13 pass. The two new PASS-preservation tests were written first and **fail on the parent commit** (`assert.equal(state.gatePassed, true)` → `false !== true`); the three regression tests pass before and after, which is the point.
- `node --test scripts/gate-worktree-finalize-slot.test.mjs` — 3 pass; each asserts `slot-1`, which is exactly what the old path got wrong.
- Whole affected surface — `scripts/gate-worktree-*.test.mjs scripts/pregate*.test.mjs scripts/local-ci-*.test.mjs scripts/lib/local-ci-*.test.mjs scripts/lib/documentation-evidence-lane.test.mjs scripts/lib/pregate-status.test.mjs`: **323 tests, 320 pass, 2 fail**, both pre-existing (below).
- `pnpm pregate:preflight` — **67 guards clean** in 86.7s.
- `pnpm pregate:status` — **PASS**, `fix/gate-pass-survives-late-starvation @ 9d16038d1b69`, slot-0, evidence `cmtw2tj8y03kl01qn500nsi7b`, 11:23 run.

### The gate took five attempts, and the four inconclusive ones are this PR's subject matter

Docker Desktop's engine was wedged on the host — `GET /containers/json` returned 500, `docker version` and `docker info` hung past 20s, the portal answered `000` after 30s. The control-plane watchdog reported `docker:invalid-response,postgres:invalid-response` and the gate exited 5 four times.

`.wslconfig` was untouched (mtime Sep 6), and no container was restarted: two other sessions held live local-CI leases and a restart would have fenced their gates. Each attempt waited for the portal to answer 200 before spending a lease. None of the four was a verdict on the diff — and under this change, none of them could have withdrawn one either.

### Pre-existing failures, not introduced here

`scripts/local-ci-runner.test.mjs:187` and `:244` fail on this Windows host with `local CI could not inspect host pnpm: unknown error`. Confirmed pre-existing by stashing every change and re-running on clean `origin/main` @ `0f25ef57161` — the same two failures. They write a `#!/bin/sh` fake pnpm and spawn it, which Windows cannot execute; they are green in CI, so nothing catches it. Same class as the `new URL(...).pathname` Windows defect. Not fixed here — outside this PR's one concern, and tracked separately.

### Not proven here

Live acceptance on the running install. The behaviour is unit-proven and the branch's own gate exercised the starvation path repeatedly, but no run on this branch reached a PASS *and then* took a late starvation write, so the preservation path has not been observed end-to-end on real evidence. That belongs on the BI, not in this PR.

Seed-Fit-Decision: global-default

The clause added to `report-only-the-verdict-you-reached` — an inconclusive result never withdraws a verdict already reached — is universal doctrine, not archetype, vertical, or install-specific. It is a property of what a measurement is, so every install inherits it unchanged and there is nothing to parameterize.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
