### PR TITLE
fix(readiness): a signal that cannot run must say so, not answer "no" (BI-043946C5, BI-2FA5A874)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.test.ts
@@ -127,7 +127,7 @@ describe("completeBacklogItemTransition", () => {
       dependencies: {
         resolveCompletionEvidence: async () => ({ kind: "evaluated", item: { id: "row-1", itemId: "BI-1", status: "in-progress", workType: "feature" }, verdict: { allowed: true, noOp: false, normalizedManifest: null, blockers: [], nextAction: null } }),
         reconcileObjectives: () => ({ state: "missing", baselineId: "BASE-1", evidenceRefs: [], requiredStatementIds: ["OBJ-1"] }),
-        resolveMergeDelivery: async () => false,
+        resolveMergeDelivery: async () => "not-merged" as const,
         projectReadiness: () => projected("input-required"),
       },
     });
@@ -165,7 +165,7 @@ describe("completeBacklogItemTransition", () => {
           },
         }),
         reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
-        resolveMergeDelivery: async () => false,
+        resolveMergeDelivery: async () => "not-merged" as const,
         projectReadiness: ((input: { completion: { acceptanceEvidence: string; objectiveReconciliation: string; evidenceRefs: Record<string, string[]> } }) => {
           seen.push(input);
           return projected("allowed");
@@ -208,7 +208,7 @@ describe("completeBacklogItemTransition", () => {
           },
         }),
         reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
-        resolveMergeDelivery: async () => false,
+        resolveMergeDelivery: async () => "not-merged" as const,
         projectReadiness: ((input: { completion: { acceptanceEvidence: string } }) => {
           seen.push(input);
           return projected("input-required");
@@ -249,7 +249,7 @@ describe("completeBacklogItemTransition", () => {
           },
         }),
         reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
-        resolveMergeDelivery: async () => false,
+        resolveMergeDelivery: async () => "not-merged" as const,
         projectReadiness: ((input: { completion: { acceptanceEvidence: string; objectiveReconciliation: string; evidenceRefs: Record<string, string[]> } }) => {
           seen.push(input);
           return projected("allowed");
@@ -288,7 +288,7 @@ describe("completeBacklogItemTransition", () => {
           },
         }),
         reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
-        resolveMergeDelivery: async () => false,
+        resolveMergeDelivery: async () => "not-merged" as const,
         projectReadiness: ((input: { completion: { acceptanceEvidence: string } }) => { seen.push(input); return projected("input-required"); }) as never,
       },
     });
@@ -308,7 +308,7 @@ describe("completeBacklogItemTransition", () => {
       dependencies: {
         resolveCompletionEvidence: async () => ({ kind: "evaluated", item: { id: "row-1", itemId: "BI-1", status: "in-progress", workType: "feature" }, verdict: { allowed: true, noOp: false, normalizedManifest: { workClass: "implementation", evidenceActivityIds: ["E-1"], useActiveBuildEvidence: false }, blockers: [], nextAction: null } }),
         reconcileObjectives: () => ({ state: "pass", baselineId: "BASE-1", evidenceRefs: ["E-1"], requiredStatementIds: ["OBJ-1"] }),
-        resolveMergeDelivery: async () => false,
+        resolveMergeDelivery: async () => "not-merged" as const,
         projectReadiness: () => projected("allowed"),
       },
     });
@@ -338,7 +338,7 @@ describe("completeBacklogItemTransition", () => {
         // No hand-built manifest — delivery would otherwise read `missing`.
         resolveCompletionEvidence: async () => ({ kind: "not-found", itemId: "BI-1" }),
         reconcileObjectives: () => ({ state: "pass", baselineId: "BASE-1", evidenceRefs: ["E-1"], requiredStatementIds: ["OBJ-1"] }),
-        resolveMergeDelivery: async () => true,
+        resolveMergeDelivery: async () => "merged" as const,
         projectReadiness: ((input: { completion: { deliveryEvidence: string; requirementReasons?: Record<string, string[]> } }) => { seen.push(input.completion); return projected("allowed"); }) as never,
       },
     });
@@ -361,7 +361,7 @@ describe("completeBacklogItemTransition", () => {
       dependencies: {
         resolveCompletionEvidence: async () => ({ kind: "not-found", itemId: "BI-1" }),
         reconcileObjectives: () => ({ state: "missing", baselineId: "BASE-1", evidenceRefs: [], requiredStatementIds: ["OBJ-1"] }),
-        resolveMergeDelivery: async () => false,
+        resolveMergeDelivery: async () => "not-merged" as const,
         projectReadiness: ((input: { completion: { deliveryEvidence: string } }) => { seen.push(input.completion); return projected("input-required"); }) as never,
       },
     });
@@ -384,7 +384,7 @@ describe("completeBacklogItemTransition", () => {
         resolveCompletionEvidence: async () => ({ kind: "not-found", itemId: "BI-1" }),
         // No objective baseline to reconcile (the whole point — merged platform work).
         reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
-        resolveMergeDelivery: async () => true,
+        resolveMergeDelivery: async () => "merged" as const,
         resolveHasDesignSpec: async () => true,
         projectReadiness: ((input: { recognizeMergeThroughGates?: boolean; completion: { deliveryEvidence: string; acceptanceEvidence: string; objectiveReconciliation: string } }) => { seen.push(input); return projected("allowed"); }) as never,
       },
@@ -409,7 +409,7 @@ describe("completeBacklogItemTransition", () => {
       dependencies: {
         resolveCompletionEvidence: async () => ({ kind: "not-found", itemId: "BI-1" }),
         reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
-        resolveMergeDelivery: async () => true,
+        resolveMergeDelivery: async () => "merged" as const,
         resolveHasDesignSpec: async () => true,
         projectReadiness: ((input: { recognizeMergeThroughGates?: boolean; completion: { acceptanceEvidence: string } }) => { seen.push(input); return projected("input-required"); }) as never,
       },
@@ -417,6 +417,97 @@ describe("completeBacklogItemTransition", () => {
     expect(seen[0]?.recognizeMergeThroughGates).toBe(false);
     // Acceptance is NOT waved through for product work with no reconciliation.
     expect(seen[0]?.completion.acceptanceEvidence).toBe("missing");
+  });
+});
+
+describe("merge signal unavailability is reported, never disguised as a negative (BI-043946C5)", () => {
+  it("does NOT recognize direct-merge work when the signal could not run, and says so on every requirement it would have satisfied", async () => {
+    // Identical to the recognition case above in EVERY term except the signal:
+    // platform scope, no build, no product, no objective, design spec present.
+    // The only difference is that no runtime could answer whether it merged.
+    const fake = fakeDb(1, "feature", { scopeKind: "platform", digitalProductId: null, activeBuild: null, productObjectiveWork: [] });
+    const seen: Array<{
+      recognizeMergeThroughGates?: boolean;
+      completion: { requirementReasons?: Partial<Record<string, string[]>> };
+    }> = [];
+    await completeBacklogItemTransition({
+      db: fake.db,
+      itemId: "BI-1",
+      expectedStatus: "in-progress",
+      resolution: "Landed through the merge queue, but this runtime has no checkout to prove it.",
+      completionEvidence: {},
+      actor,
+      authority,
+      dependencies: {
+        resolveCompletionEvidence: async () => ({ kind: "not-found", itemId: "BI-1" }),
+        reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
+        resolveMergeDelivery: async () => "signal-unavailable" as const,
+        resolveHasDesignSpec: async () => true,
+        projectReadiness: ((input: {
+          recognizeMergeThroughGates?: boolean;
+          completion: { requirementReasons?: Partial<Record<string, string[]>> };
+        }) => { seen.push(input); return projected("input-required"); }) as never,
+      },
+    });
+    // Governance still fails safe: unknown is never treated as merged.
+    expect(seen[0]?.recognizeMergeThroughGates).toBe(false);
+    const reasons = seen[0]?.completion.requirementReasons;
+    for (const code of ["DELIVERY_EVIDENCE_REQUIRED", "ACCEPTANCE_EVIDENCE_REQUIRED", "OBJECTIVE_RECONCILIATION_REQUIRED"]) {
+      const text = (reasons?.[code] ?? []).join(" ");
+      expect(text, `${code} must carry the unavailability reason`).toContain("could not run on this runtime");
+      expect(text, `${code} must not be reported as a negative verdict`).toContain("UNKNOWN");
+      expect(text).toContain("DPF_HOST_SOURCE_ROOT");
+    }
+  });
+
+  it("stays silent about the signal when the item could never qualify anyway", async () => {
+    // Demand-driven product work keeps the full lifecycle regardless of the
+    // signal, so naming an unavailable merge probe would be noise pointing at
+    // a lever that would change nothing.
+    const fake = fakeDb(1, "feature", { scopeKind: "platform", digitalProductId: "DP-1" });
+    const seen: Array<{ completion: { requirementReasons?: Partial<Record<string, string[]>> } }> = [];
+    await completeBacklogItemTransition({
+      db: fake.db,
+      itemId: "BI-1",
+      expectedStatus: "in-progress",
+      resolution: "Product feature.",
+      completionEvidence: {},
+      actor,
+      authority,
+      dependencies: {
+        resolveCompletionEvidence: async () => ({ kind: "not-found", itemId: "BI-1" }),
+        reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
+        resolveMergeDelivery: async () => "signal-unavailable" as const,
+        resolveHasDesignSpec: async () => true,
+        projectReadiness: ((input: { completion: { requirementReasons?: Partial<Record<string, string[]>> } }) => { seen.push(input); return projected("input-required"); }) as never,
+      },
+    });
+    const reasons = seen[0]?.completion.requirementReasons;
+    expect((reasons?.ACCEPTANCE_EVIDENCE_REQUIRED ?? []).join(" ")).not.toContain("could not run");
+    expect((reasons?.OBJECTIVE_RECONCILIATION_REQUIRED ?? []).join(" ")).not.toContain("could not run");
+  });
+
+  it("a measured negative carries no unavailability text", async () => {
+    const fake = fakeDb(1, "feature", { scopeKind: "platform", digitalProductId: null, activeBuild: null, productObjectiveWork: [] });
+    const seen: Array<{ completion: { requirementReasons?: Partial<Record<string, string[]>> } }> = [];
+    await completeBacklogItemTransition({
+      db: fake.db,
+      itemId: "BI-1",
+      expectedStatus: "in-progress",
+      resolution: "Not merged.",
+      completionEvidence: {},
+      actor,
+      authority,
+      dependencies: {
+        resolveCompletionEvidence: async () => ({ kind: "not-found", itemId: "BI-1" }),
+        reconcileObjectives: () => ({ state: "missing", baselineId: null, evidenceRefs: [], requiredStatementIds: [] }),
+        resolveMergeDelivery: async () => "not-merged" as const,
+        resolveHasDesignSpec: async () => true,
+        projectReadiness: ((input: { completion: { requirementReasons?: Partial<Record<string, string[]>> } }) => { seen.push(input); return projected("input-required"); }) as never,
+      },
+    });
+    const reasons = seen[0]?.completion.requirementReasons;
+    expect((reasons?.DELIVERY_EVIDENCE_REQUIRED ?? []).join(" ")).not.toContain("could not run");
   });
 });
 

--- a/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts
+++ b/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts
@@ -108,22 +108,54 @@ function deliveryReasons(result: ResolveCompletionEvidenceResult): string[] {
  * whose branch landed does not need a hand-built delivery manifest. Detect it
  * PROCEDURALLY and LOCALLY: the item's Workroom head SHA reachable from origin/main
  * == merged, reusing the room-closeout reachability helper — no GitHub API, no LLM.
- * Best-effort: any failure (no bound room, no local trunk, git unavailable) returns
- * false so the caller falls back to the recorded completion-evidence manifest.
+ *
+ * BI-043946C5: this used to answer `boolean`, and every infrastructure failure —
+ * no candidate root is a git repository, the trunk ref does not resolve, the head
+ * was never fetched locally — collapsed into `false`, which the caller could not
+ * tell apart from a genuine "this never merged". Measured on a live install: the
+ * probe's first root `/host-dpf` is the INSTALLED runtime directory, not a source
+ * checkout, so `trunkRefExists` was false for every root and the signal was
+ * unconditionally and silently false. Two capabilities were dead as a result —
+ * merge-as-delivery-evidence (BI-B04A0203) and direct-merge recognition
+ * (EP-4614F35E) — with nothing anywhere saying so.
+ *
+ * So the signal is now three-valued. `not-merged` is a MEASUREMENT: some root
+ * answered and said no. `signal-unavailable` means nothing could answer, and the
+ * caller must say that out loud rather than report it as a negative.
  */
-export type ResolveMergeDelivery = (args: { itemRowId: string; itemId: string }) => Promise<boolean>;
+export type MergeDeliverySignal = "merged" | "not-merged" | "signal-unavailable";
+
+export type ResolveMergeDelivery = (args: { itemRowId: string; itemId: string }) => Promise<MergeDeliverySignal>;
 
 /**
- * Candidate source roots the merge signal probes, in order. The portal runtime has
- * no working checkout at cwd, but it DOES mount the host source tree the self-upgrade
- * pipeline runs git against (`/host-dpf`), so reachability stays LOCAL and procedural
- * — no GitHub API, no LLM (platform-function-never-depends-on-a-client). The first
- * root whose trunk ref resolves wins; if none does, the signal is false and the
- * caller falls back to the recorded manifest.
+ * Candidate source roots the merge signal probes, in order. Reachability stays
+ * LOCAL and procedural — no GitHub API, no LLM
+ * (platform-function-never-depends-on-a-client). The first root whose trunk ref
+ * resolves wins.
+ *
+ * `/host-dpf` is listed because a source install mounts its checkout there. A
+ * CONSUMER install legitimately has no checkout at all — there, `/host-dpf` is the
+ * runtime directory and no root resolves, which is precisely the case that must
+ * report `signal-unavailable` instead of a silent `false` (BI-043946C5). An
+ * operator who wants the signal on such a host points `DPF_HOST_SOURCE_ROOT` at a
+ * real checkout.
  */
-function mergeSignalRoots(): string[] {
+export function mergeSignalRoots(): string[] {
   const roots = [process.env.DPF_REPO_ROOT, process.env.DPF_HOST_SOURCE_ROOT, "/host-dpf", process.cwd()];
   return [...new Set(roots.filter((r): r is string => Boolean(r)))];
+}
+
+/**
+ * The operator-facing sentence for an unavailable merge signal. It names the
+ * measurement (nothing could answer), never a verdict, and the one lever that
+ * changes it. Surfaced through `requirementReasons`, which `requirementNextAction`
+ * puts at the FRONT of the next action.
+ */
+export function mergeSignalUnavailableReason(roots: readonly string[]): string {
+  const probed = roots.length > 0 ? roots.join(", ") : "no candidate roots";
+  return "The merge-through-gates signal could not run on this runtime, so whether this work "
+    + `landed on the trunk is UNKNOWN here, not answered "no" (probed: ${probed}). `
+    + "Point DPF_HOST_SOURCE_ROOT at a source checkout to enable it.";
 }
 
 /** Pull-request numbers named by an item's evidence links (`.../pull/123`). */
@@ -149,7 +181,53 @@ export function pullRequestNumbersFromActivities(
  * link — and look for its merge commit on the trunk. The manifest path stays
  * as the fallback the caller already has.
  */
-async function defaultResolveMergeDelivery({ itemRowId, itemId }: { itemRowId: string; itemId: string }): Promise<boolean> {
+/**
+ * The git half of the merge signal, with no database and no ambient
+ * configuration: given the branch identities to look for and the roots to look
+ * in, decide whether the work landed.
+ *
+ * Split out so it can be driven against REAL repositories in a test
+ * (BI-043946C5). The defect this function now encodes lived precisely in the
+ * boundary between this module and git, and every existing test stubbed the
+ * whole resolver, so the suite stayed green while the shipped code could not
+ * answer at all on a live install.
+ */
+export async function resolveMergeSignalFromRefs(input: {
+  heads: readonly string[];
+  pullRequests: readonly number[];
+  roots: readonly string[];
+}): Promise<MergeDeliverySignal> {
+  const { heads, pullRequests, roots } = input;
+  // Nothing to look up: no room recorded a head and no PR is linked. That is a
+  // real measurement about THIS item — there is no branch identity to find on
+  // the trunk — not a broken probe, so it stays a negative.
+  if (heads.length === 0 && pullRequests.length === 0) return "not-merged";
+  for (const root of roots) {
+    if (!(await trunkRefExists(root))) continue;
+    // A root answered. Distinguish "git said no" from "git could not say":
+    // isReachableFromTrunk / trunkHasMergedPullRequest already return null for
+    // the indeterminate case (sha never fetched, bad ref, git missing), and
+    // flattening those to false is the same silent-negative bug one level down.
+    let sawDefiniteNegative = false;
+    for (const sha of heads) {
+      const reachable = await isReachableFromTrunk(root, sha);
+      if (reachable === true) return "merged";
+      if (reachable === false) sawDefiniteNegative = true;
+    }
+    for (const prNumber of new Set(pullRequests)) {
+      const merged = await trunkHasMergedPullRequest(root, prNumber);
+      if (merged === true) return "merged";
+      if (merged === false) sawDefiniteNegative = true;
+    }
+    return sawDefiniteNegative ? "not-merged" : "signal-unavailable";
+  }
+  // No candidate root is a readable repository.
+  return "signal-unavailable";
+}
+
+async function defaultResolveMergeDelivery(
+  { itemRowId, itemId }: { itemRowId: string; itemId: string },
+): Promise<MergeDeliverySignal> {
   try {
     const db = prisma as unknown as {
       workroom: { findMany(args: unknown): Promise<{ headSha: string | null; pullRequestNumber: number | null }[]> };
@@ -170,20 +248,9 @@ async function defaultResolveMergeDelivery({ itemRowId, itemId }: { itemRowId: s
       ...rooms.map((room) => room.pullRequestNumber).filter((n): n is number => typeof n === "number"),
       ...pullRequestNumbersFromActivities(evidence),
     ];
-    if (heads.length === 0 && pullRequests.length === 0) return false;
-    for (const root of mergeSignalRoots()) {
-      if (!(await trunkRefExists(root))) continue;
-      for (const sha of heads) {
-        if ((await isReachableFromTrunk(root, sha)) === true) return true;
-      }
-      for (const prNumber of new Set(pullRequests)) {
-        if ((await trunkHasMergedPullRequest(root, prNumber)) === true) return true;
-      }
-      return false;
-    }
-    return false;
+    return await resolveMergeSignalFromRefs({ heads, pullRequests, roots: mergeSignalRoots() });
   } catch {
-    return false;
+    return "signal-unavailable";
   }
 }
 
@@ -320,10 +387,20 @@ export async function completeBacklogItemTransition(args: {
         itemId: lockedItem.itemId,
       });
       const recognizeMergeThroughGates =
-        mergedThroughGates && isDirectMergePlatformWork(lockedItem) && hasDesignSpec;
+        mergedThroughGates === "merged" && isDirectMergePlatformWork(lockedItem) && hasDesignSpec;
+      // BI-043946C5: the item clears every OTHER term of the direct-merge predicate,
+      // so the merge signal is the only thing standing between it and recognition —
+      // and the signal could not run. That is the difference between "this did not
+      // merge" and "this runtime cannot tell", and the operator has to be told which
+      // one they are looking at, on the requirements the signal would have satisfied.
+      const mergeSignalBlindSpot =
+        mergedThroughGates === "signal-unavailable" && isDirectMergePlatformWork(lockedItem) && hasDesignSpec;
+      const mergeSignalReasons = mergeSignalBlindSpot
+        ? [mergeSignalUnavailableReason(mergeSignalRoots())]
+        : [];
       // A merge through branch protection is authoritative delivery evidence and
       // supersedes a missing/hand-built manifest (BI-B04A0203).
-      const delivery = mergedThroughGates ? "pass" : deliveryState(completion);
+      const delivery = mergedThroughGates === "merged" ? "pass" : deliveryState(completion);
       const directDocumentationAcceptance = completion.kind === "evaluated"
         && completion.verdict.allowed
         && completion.verdict.normalizedManifest?.workClass === "documentation"
@@ -380,7 +457,13 @@ export async function completeBacklogItemTransition(args: {
               : reconciliation.evidenceRefs,
             OBJECTIVE_RECONCILIATION_REQUIRED: reconciliation.evidenceRefs,
           },
-          requirementReasons: { DELIVERY_EVIDENCE_REQUIRED: mergedThroughGates ? [] : deliveryReasons(completion) },
+          requirementReasons: {
+            DELIVERY_EVIDENCE_REQUIRED: mergedThroughGates === "merged"
+              ? []
+              : [...mergeSignalReasons, ...deliveryReasons(completion)],
+            ACCEPTANCE_EVIDENCE_REQUIRED: mergeSignalReasons,
+            OBJECTIVE_RECONCILIATION_REQUIRED: mergeSignalReasons,
+          },
         },
         evaluatedAt,
       });

--- a/apps/web/lib/backlog/initiative-readiness/merge-delivery-signal.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/merge-delivery-signal.test.ts
@@ -1,0 +1,163 @@
+/**
+ * BI-043946C5 — the merge-delivery signal driven against REAL git repositories.
+ *
+ * Every existing test of this path injects `resolveMergeDelivery`, so the shipped
+ * probe was never executed by the suite. It had been returning a silent,
+ * unconditional negative on the live install for as long as its candidate roots
+ * contained no checkout, and the suite stayed green throughout, because the only
+ * thing it ever exercised was the stub.
+ *
+ * So these tests create actual repositories with `git`. The defect lived in the
+ * boundary between this module and git, and a mock of that boundary is exactly
+ * what hid it.
+ */
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { resolveMergeSignalFromRefs } from "./backlog-terminal-transition";
+
+const execFileAsync = promisify(execFile);
+
+type Fixture = { root: string; mergedSha: string; unmergedSha: string };
+
+async function git(root: string, ...args: string[]) {
+  return execFileAsync("git", ["-C", root, ...args], { windowsHide: true });
+}
+
+/** A repository with one commit on the trunk and one commit that never landed. */
+async function makeRepo(): Promise<Fixture> {
+  const root = await mkdtemp(path.join(tmpdir(), "dpf-merge-signal-"));
+  await git(root, "init", "--initial-branch=main");
+  await git(root, "config", "user.email", "test@example.invalid");
+  await git(root, "config", "user.name", "Test");
+  await git(root, "config", "commit.gpgsign", "false");
+
+  await writeFile(path.join(root, "a.txt"), "one\n");
+  await git(root, "add", ".");
+  // The trunk subject carries the shape the merge queue writes, so the
+  // pull-request branch of the probe has something real to match.
+  await git(root, "commit", "-m", "feat: land the thing (#4242)");
+  const mergedSha = (await git(root, "rev-parse", "HEAD")).stdout.trim();
+  // origin/main is the ref the probe reads.
+  await git(root, "update-ref", "refs/remotes/origin/main", mergedSha);
+
+  await git(root, "checkout", "-q", "-b", "side");
+  await writeFile(path.join(root, "b.txt"), "two\n");
+  await git(root, "add", ".");
+  await git(root, "commit", "-m", "wip: never merged");
+  const unmergedSha = (await git(root, "rev-parse", "HEAD")).stdout.trim();
+
+  return { root, mergedSha, unmergedSha };
+}
+
+describe("merge-delivery signal against real repositories (BI-043946C5)", () => {
+  let repo: Fixture;
+  let notARepo: string;
+
+  beforeAll(async () => {
+    repo = await makeRepo();
+    notARepo = await mkdtemp(path.join(tmpdir(), "dpf-no-repo-"));
+    await writeFile(path.join(notARepo, ".env"), "PORT=3000\n");
+  });
+
+  afterAll(async () => {
+    await rm(repo.root, { recursive: true, force: true }).catch(() => {});
+    await rm(notARepo, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("reports signal-unavailable when the only root is a directory but not a repository", async () => {
+    // The live-install shape exactly: the probe's first root is the INSTALLED
+    // runtime directory, so it exists, is readable, and is not a checkout.
+    // Before the fix this answered false, indistinguishable from "never merged".
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.mergedSha],
+      pullRequests: [4242],
+      roots: [notARepo],
+    })).resolves.toBe("signal-unavailable");
+  });
+
+  it("reports signal-unavailable when there are no candidate roots at all", async () => {
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.mergedSha],
+      pullRequests: [],
+      roots: [],
+    })).resolves.toBe("signal-unavailable");
+  });
+
+  it("reports merged when a Workroom head is an ancestor of the trunk", async () => {
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.mergedSha],
+      pullRequests: [],
+      roots: [repo.root],
+    })).resolves.toBe("merged");
+  });
+
+  it("reports merged from a linked pull request when no room recorded a head", async () => {
+    await expect(resolveMergeSignalFromRefs({
+      heads: [],
+      pullRequests: [4242],
+      roots: [repo.root],
+    })).resolves.toBe("merged");
+  });
+
+  it("skips an unreadable root and still answers from a later readable one", async () => {
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.mergedSha],
+      pullRequests: [],
+      roots: [notARepo, repo.root],
+    })).resolves.toBe("merged");
+  });
+
+  it("reports not-merged when git answers definitively that the head never landed", async () => {
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.unmergedSha],
+      pullRequests: [],
+      roots: [repo.root],
+    })).resolves.toBe("not-merged");
+  });
+
+  it("reports signal-unavailable when the repository cannot resolve the head at all", async () => {
+    // A sha this clone has never fetched is indeterminate, not a negative: git
+    // cannot say whether it is an ancestor of a commit it does not have.
+    await expect(resolveMergeSignalFromRefs({
+      heads: ["0123456789012345678901234567890123456789"],
+      pullRequests: [],
+      roots: [repo.root],
+    })).resolves.toBe("signal-unavailable");
+  });
+
+  it("reports not-merged when the item has no branch identity to look for", async () => {
+    // No room head and no linked PR is a fact about the ITEM, not a broken probe.
+    await expect(resolveMergeSignalFromRefs({
+      heads: [],
+      pullRequests: [],
+      roots: [repo.root],
+    })).resolves.toBe("not-merged");
+  });
+});
+
+describe("mergeSignalRoots (BI-043946C5)", () => {
+  it("puts the configured roots ahead of the built-in fallbacks", async () => {
+    const { mergeSignalRoots } = await import("./backlog-terminal-transition");
+    const savedRepoRoot = process.env.DPF_REPO_ROOT;
+    const savedSourceRoot = process.env.DPF_HOST_SOURCE_ROOT;
+    try {
+      process.env.DPF_REPO_ROOT = "/configured-a";
+      process.env.DPF_HOST_SOURCE_ROOT = "/configured-b";
+      const roots = mergeSignalRoots();
+      expect(roots[0]).toBe("/configured-a");
+      expect(roots[1]).toBe("/configured-b");
+      expect(roots).toContain("/host-dpf");
+    } finally {
+      if (savedRepoRoot === undefined) delete process.env.DPF_REPO_ROOT;
+      else process.env.DPF_REPO_ROOT = savedRepoRoot;
+      if (savedSourceRoot === undefined) delete process.env.DPF_HOST_SOURCE_ROOT;
+      else process.env.DPF_HOST_SOURCE_ROOT = savedSourceRoot;
+    }
+  });
+});

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -71,6 +71,7 @@ import {
   type TerminalToolPolicy,
 } from "./terminal-tool-policy";
 import { rotateTerminalWriterRoute } from "./terminal-writer-route";
+import { shouldExitWithLocalToolCallDiagnostic } from "./local-tool-call-diagnostic";
 export { detectToolRefusedDespiteAvailability } from "./tool-refused-recovery";
 
 // Safety ceiling — the loop exits naturally when the model responds with text-only
@@ -1356,7 +1357,10 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
         `totalMs=${Date.now() - startTime} ` +
         `ctxPeakTokens=${ctxPeakTokens} ctxZone=${ctxPressure.zone} ` +
         `toolSurface=${surface.toolCount} estToolTokens=${surface.estDefinitionTokens} surfaceZone=${surface.zone} ` +
-        `toolAccuracy=${economyMetrics.toolSelectionAccuracy === null ? "na" : economyMetrics.toolSelectionAccuracy.toFixed(2)}`,
+        // toolAccuracy scores the calls a turn MADE, so a requireTools turn that
+        // made none still logged a clean 1.00 and read as healthy (BI-2FA5A874).
+        `toolAccuracy=${economyMetrics.toolSelectionAccuracy === null ? "na" : economyMetrics.toolSelectionAccuracy.toFixed(2)}` +
+        (requireTools ? ` requiredToolsMet=${executedTools.length > 0}` : ""),
       ),
     );
     // BI-47443B67: persist the same rollup durably so the regression detector
@@ -2104,19 +2108,13 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
         requireToolExecution: requireTools,
       });
 
-        // Local model produced text-only on iteration 0 of a tool-backed turn:
-        // exit with a diagnostic instead of nudging — nudging won't teach a
-        // small local model to use tools mid-turn, it just burns iterations.
-        // The previous Build-Studio carve-out (!BUILD_ROUTE_PATTERN) was the
-        // root cause of 200-iteration hangs on /build threads when the
-        // preferred provider was unavailable and routing fell back to local.
-        // See FB-71FB3A53 thread, 2026-05-22.
-        if (
-          shouldNudgeNow &&
-          iteration === 0 &&
-          executedTools.length === 0 &&
-          result.providerId === "local"
-        ) {
+        if (shouldExitWithLocalToolCallDiagnostic({
+          shouldNudgeNow,
+          iteration,
+          executedToolCount: executedTools.length,
+          providerId: result.providerId,
+          requireTools: Boolean(requireTools),
+        })) {
           console.warn(
             `[agentic-loop] local model produced text-only response for tool-backed turn; returning diagnostic instead of issuing a second nudge. agent=${JSON.stringify(agentId)} route=${JSON.stringify(routeContext)}`,
           );

--- a/apps/web/lib/tak/local-tool-call-diagnostic.test.ts
+++ b/apps/web/lib/tak/local-tool-call-diagnostic.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+import { shouldExitWithLocalToolCallDiagnostic } from "./local-tool-call-diagnostic";
+import { shouldNudge } from "./agentic-loop";
+
+describe("shouldExitWithLocalToolCallDiagnostic (BI-2FA5A874)", () => {
+  const base = {
+    shouldNudgeNow: true,
+    iteration: 0,
+    executedToolCount: 0,
+    providerId: "local",
+    requireTools: false,
+  };
+
+  it("exits with the diagnostic for an ordinary local text-only iteration-0 turn", () => {
+    // FB-71FB3A53: unchanged. Nudging a small local model here just burns
+    // iterations, and the diagnostic is a legitimate answer for the caller.
+    expect(shouldExitWithLocalToolCallDiagnostic(base)).toBe(true);
+  });
+
+  it("does NOT exit when the caller requires a tool call, so the one nudge is spent", () => {
+    // Text cannot satisfy the contract, so giving up without ever nudging makes
+    // the capability unreachable rather than merely degraded.
+    expect(shouldExitWithLocalToolCallDiagnostic({ ...base, requireTools: true })).toBe(false);
+  });
+
+  it("leaves every other guard condition intact", () => {
+    expect(shouldExitWithLocalToolCallDiagnostic({ ...base, shouldNudgeNow: false })).toBe(false);
+    expect(shouldExitWithLocalToolCallDiagnostic({ ...base, iteration: 1 })).toBe(false);
+    expect(shouldExitWithLocalToolCallDiagnostic({ ...base, executedToolCount: 2 })).toBe(false);
+    expect(shouldExitWithLocalToolCallDiagnostic({ ...base, providerId: "anthropic" })).toBe(false);
+    expect(shouldExitWithLocalToolCallDiagnostic({ ...base, providerId: null })).toBe(false);
+  });
+
+  it("agrees with shouldNudge that a requireTools text-only turn must be nudged", () => {
+    // The two decisions have to line up: shouldNudge says nudge, and this guard
+    // must not then throw that decision away. That disagreement was the defect.
+    const nudge = shouldNudge({
+      continuationNudges: 0,
+      iteration: 0,
+      maxIterations: 10,
+      hasTools: true,
+      executedToolCount: 0,
+      responseLength: 15_000,
+      responseText: "Let me think carefully about this task. ".repeat(200),
+      requireToolExecution: true,
+      isConversationalRoute: false,
+    });
+    expect(nudge).toBe(true);
+    expect(shouldExitWithLocalToolCallDiagnostic({ ...base, requireTools: true })).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/local-tool-call-diagnostic.ts
+++ b/apps/web/lib/tak/local-tool-call-diagnostic.ts
@@ -1,0 +1,37 @@
+/**
+ * When a local model answers a tool-backed turn with text alone, does the loop
+ * give up with a diagnostic, or spend its one corrective nudge?
+ *
+ * Lives in its own module so the condition is testable directly, rather than as
+ * an inline predicate inside the agentic loop's iteration body.
+ */
+
+/**
+ * Local model, iteration 0, text-only on a tool-backed turn: exit with a
+ * diagnostic rather than nudge. One nudge will not teach a small local model to
+ * use tools mid-turn, and the earlier carve-out here caused 200-iteration hangs
+ * on /build when routing fell back to local (FB-71FB3A53).
+ *
+ * `requireTools` is exempt: text cannot satisfy that contract at all, so giving
+ * up before nudging makes the capability unreachable rather than degraded, and
+ * throws away the decision `shouldNudge` already made
+ * (`permitsTextCompletion = !requireToolExecution`). Still bounded by
+ * `maxNudges = 1`, so such a turn gets one reminder and then takes this exit.
+ *
+ * Rationale and the measured failure: the capacity-deferral-is-not-a-writer-
+ * failure design, §8 (BI-2FA5A874).
+ */
+export function shouldExitWithLocalToolCallDiagnostic(params: {
+  shouldNudgeNow: boolean;
+  iteration: number;
+  executedToolCount: number;
+  providerId: string | null | undefined;
+  requireTools: boolean;
+}): boolean {
+  if (!params.shouldNudgeNow) return false;
+  if (params.iteration !== 0) return false;
+  if (params.executedToolCount !== 0) return false;
+  if (params.providerId !== "local") return false;
+  if (params.requireTools) return false;
+  return true;
+}

--- a/docs/superpowers/specs/2026-09-02-capacity-deferral-is-not-a-writer-failure-design.md
+++ b/docs/superpowers/specs/2026-09-02-capacity-deferral-is-not-a-writer-failure-design.md
@@ -267,3 +267,78 @@ check. It does not touch the plain-required path.
 - AC-C355-003 A plain required tool call on a CLI adapter still fails closed.
 - AC-C355-004 A bound writer without a governed MCP session still refuses
   before inference.
+
+## 8. Amendment (2026-09-11) — a third cause: the loop never asked
+
+### What happened
+
+Driving the `objective-mapping` gate for a delivered initiative on a fully-local
+install, the same bound writer failed five times across one resumable TaskRun.
+Every attempt recorded `missing-terminal-writer`, twice with
+`noncompliance: "prose-without-required-writer"`, and the platform eventually
+escalated `terminal_writer_retry_exhausted` with
+`action: "select-different-reviewer-provider"`.
+
+The turn log said what actually happened:
+
+```
+[agentic-loop] iter=0 provider=local model=...qwen3.8-27b...:Q4_K_M
+  toolCalls=0 contentLen=15091 nudges=0 executedTools=0
+[agentic-loop] iter=1 ... toolCalls=0 contentLen=16445 nudges=0 executedTools=0
+```
+
+`nudges=0`, every attempt. The model spent each turn on 15k+ characters of
+correct, on-topic reasoning about the gate and was never once told to convert it
+into the call.
+
+### Cause
+
+`agentic-loop.ts` short-circuits the corrective nudge when the provider is
+`local` at iteration 0 with no tools executed, returning a diagnostic instead
+(FB-71FB3A53 — the guard that stopped 200-iteration hangs on `/build` threads
+when routing fell back to local). Its premise is that the diagnostic is an
+acceptable answer.
+
+On a `requireTools` turn that premise is false: the caller has declared that text
+cannot satisfy the contract at all. `shouldNudge` already draws exactly this
+distinction (`permitsTextCompletion = !requireToolExecution`) and had returned
+true. The guard was discarding that decision.
+
+This is §1.1's rule at a third cause. §1.1 said a capacity deferral must not be
+reported as a writer no-show. §7 said a non-forcing adapter must not be. Here the
+loop's own decision not to ask is reported as one — and on a local-only install,
+where `local` is the normal path and not a degraded fallback, the effect is that
+a governed reviewer gate is reachable only if the model happens to call a reader
+before it starts reasoning. It was: the one attempt of the five that called
+`read_source_at_version` first bypassed the guard and ran on, failing later for
+an unrelated capacity reason.
+
+### Decision
+
+Exempt `requireTools` turns from the iteration-0 local diagnostic exit. The guard
+is extracted as `shouldExitWithLocalToolCallDiagnostic` so the condition is
+testable rather than inline, and every other term of it is unchanged.
+
+The hang FB-71FB3A53 addressed stays bounded: `maxNudges` is 1, so such a turn
+gets exactly one reminder and then takes the same exit.
+
+The turn log also gains `requiredToolsMet=<bool>` on `requireTools` turns.
+`toolAccuracy` measures whether the calls a turn MADE succeeded, so a turn that
+made none and failed its contract logged a clean `1.00` and read as healthy; the
+contract outcome now appears next to it.
+
+### What this does not do
+
+It does not weaken any receipt, approval, baseline or grant check, and it does not
+change what counts as a valid receipt. It does not alter routing or provider
+ranking. It does not raise `maxNudges` for any turn.
+
+### Acceptance
+
+- AC-C355-005 A `requireTools` turn on the local provider that returns text-only
+  at iteration 0 receives its one corrective nudge instead of exiting with the
+  diagnostic.
+- AC-C355-006 Every other condition of the local diagnostic exit is unchanged: a
+  non-`requireTools` local text-only iteration-0 turn still exits with it.
+- AC-C355-007 A `requireTools` turn's log line states whether the required tools
+  were met, independently of `toolAccuracy`.

--- a/docs/superpowers/specs/2026-09-06-merge-through-gates-completion-design.md
+++ b/docs/superpowers/specs/2026-09-06-merge-through-gates-completion-design.md
@@ -41,9 +41,26 @@ For a completing backlog item, recognize completion when **all** hold:
    trunk, computed by LOCAL git (`isReachableFromTrunk`) against the host source mount
    the portal already carries (`/host-dpf`, or `DPF_REPO_ROOT`/`DPF_HOST_SOURCE_ROOT`).
    No GitHub API, no LLM — procedural and local, per *platform-function-never-depends-on-
-   a-client*. Best-effort: any failure → not recognized (fails safe). Because `main`
-   advances **only** via the protected merge queue (AGENTS.md §3; deployment.md), a SHA on
-   the trunk provably passed CI + the merge queue + PR review.
+   a-client*. Because `main` advances **only** via the protected merge queue
+   (AGENTS.md §3; deployment.md), a SHA on the trunk provably passed CI + the merge queue
+   + PR review.
+
+   **The signal is three-valued** (amended 2026-09-11, BI-043946C5). It was originally
+   specified as best-effort with "any failure → not recognized (fails safe)", and that
+   collapsed two different facts into one answer: *git said this did not merge* and
+   *nothing here could ask git*. The second is not a fail-safe, it is a blind spot, and it
+   was the live state of every install — the probe's first root `/host-dpf` is the
+   INSTALLED runtime directory, not a checkout, so `trunkRefExists` was false everywhere
+   and the signal was unconditionally and silently negative. Both this recognition and
+   merge-as-delivery-evidence (BI-B04A0203) were dead platform-wide with nothing saying so.
+
+   So `resolveMergeDelivery` now answers `merged` | `not-merged` | `signal-unavailable`.
+   Recognition still requires `merged`, so governance is unchanged and still fails safe.
+   What changes is that `signal-unavailable` is REPORTED: when an item clears every other
+   term of the predicate and only the signal could not run, the readiness decision says so
+   on each requirement the signal would have satisfied, and names `DPF_HOST_SOURCE_ROOT`
+   as the lever. A consumer install with no checkout is a legitimate instance of this —
+   the answer there is an honest "unknown", never a silent "no".
 2. **Direct-merge platform predicate** (`isDirectMergePlatformWork`): `scopeKind` is
    `platform`/`common`, AND no Build Studio build, AND no linked `DigitalProduct`, AND no
    linked product objective. Demand-driven feature work fails this (it carries a build,
@@ -118,3 +135,13 @@ delivery + acceptance + reconciliation) and does NOT recognize demand-driven wor
 linked DigitalProduct. `entry-adapter.test.ts` — `recognizeMergeThroughGates` coerces the
 design/plan lanes to pass with zero receipts, and is inert without the flag. 346 backlog
 tests green; typecheck clean.
+
+Amended 2026-09-11 (BI-043946C5). Every test above injects `resolveMergeDelivery`, so the
+SHIPPED probe was never executed by the suite — which is exactly why a resolver that could
+not answer at all on any install kept a green suite. `merge-delivery-signal.test.ts` now
+drives the real probe against REAL git repositories built in a temp directory: a readable
+root distinguishes merged from not-merged, a directory that is not a repository reports
+`signal-unavailable` (the live-install shape), and a head the clone never fetched reports
+`signal-unavailable` rather than a negative. `backlog-terminal-transition.test.ts` asserts
+that an unavailable signal is named on every requirement it would have satisfied, and is
+silent for items that could never qualify anyway.


### PR DESCRIPTION
## Summary

Two silent failures on the initiative-readiness completion path. Together they made a delivered, merged, released and live-verified initiative (BI-4F7BB48B, the Mailroom) impossible to close, and neither showed up as a failure anywhere — no error, no log line, no red test.

**The merge-through-gates signal was dead platform-wide.** `defaultResolveMergeDelivery` proves delivery by asking git whether a Workroom head is reachable from the trunk, probing `DPF_REPO_ROOT`, `DPF_HOST_SOURCE_ROOT`, `/host-dpf` and cwd. On this install `/host-dpf` is the **installed runtime directory**, not a source checkout:

```
$ docker exec dpf-portal-1 sh -c 'echo $DPF_REPO_ROOT'
/host-dpf
$ docker exec dpf-portal-1 sh -c 'cd /host-dpf && git rev-parse --is-inside-work-tree'
fatal: not a git repository
```

So `trunkRefExists` was false for every root, the loop body never ran, and the resolver returned an unconditional `false` — swallowed, because the function is documented as best-effort. Two capabilities were unreachable as a result: merge-as-delivery-evidence (BI-B04A0203) and direct-merge recognition (EP-4614F35E). A consumer install legitimately has no checkout, so this is not a misconfiguration to be corrected; it is a case the signal has to be able to report.

The resolver is now three-valued: `merged` | `not-merged` | `signal-unavailable`. `not-merged` is a measurement — some root answered and said no. `signal-unavailable` means nothing could answer. Recognition still requires `merged`, so governance is unchanged and still fails safe. What changes is that when an item clears **every other term** of the direct-merge predicate and only the signal could not run, the readiness decision says so on each requirement the signal would have satisfied, and names `DPF_HOST_SOURCE_ROOT` as the lever.

The same flattening existed one level down and is fixed too: `isReachableFromTrunk` already returns `null` for "git cannot say" (a sha the clone never fetched), and that was being collapsed into a negative.

**A required-tool-call turn could never be nudged on a local-only install.** `agentic-loop.ts` exits with a diagnostic instead of nudging when the provider is `local` at iteration 0 with no tools run. That guard is sound where it came from (FB-71FB3A53 — it fixed real 200-iteration hangs on `/build` when routing fell back to local) and its premise is that a text answer is acceptable. On a `requireTools` turn it is not: the caller has declared that text cannot satisfy the contract at all, so giving up before nudging turns "the model needs one reminder" into "this capability is unreachable".

Measured driving a governed reviewer gate five times on one resumable TaskRun:

| Attempt | Tools run | Prose length | Nudges | Outcome |
|---|---|---|---|---|
| 1 | 1 | — | 0 | missing writer |
| 2 | 0 | — | 0 | prose, no writer |
| 3 | 3 | 15,771 | 0 | read the spec, then host capacity closed |
| 4 | 0 | 15,091 | 0 | prose, no writer |
| 5 | 0 | — | 0 | retries exhausted |

`nudges=0` every time. `shouldNudge` already draws the distinction (`permitsTextCompletion = !requireToolExecution`) and had returned `true`; the branch was discarding that decision. Attempt 3 is the counter-example that confirms it: there the model called a reader first, so `executedTools.length === 0` was false, the guard did not fire, and the loop kept going.

The exit is extracted as `shouldExitWithLocalToolCallDiagnostic` in its own module and exempts `requireTools`. The hang the guard exists to prevent stays bounded — `maxNudges` is 1, so such a turn gets one reminder and then takes the same exit.

**Why these ship together.** They are the same defect at two layers: a signal that cannot run reports a verdict instead of its own absence, and the caller then acts on a measurement that was never taken. Fixing either one alone unblocks the same item, which is precisely why splitting them would have left the second cause live and undiagnosed behind a green result.

## Changes

- `apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts`: `MergeDeliverySignal` tri-state; git probing split into the pure, injectable `resolveMergeSignalFromRefs`; unavailability surfaced through `requirementReasons` on the three affected requirements.
- `apps/web/lib/tak/local-tool-call-diagnostic.ts` (new): the extracted guard, with the `requireTools` exemption.
- `apps/web/lib/tak/agentic-loop.ts`: uses it; `requireTools` turns now log `requiredToolsMet`.
- Specs amended: merge-through-gates-completion (signal made three-valued), capacity-deferral-is-not-a-writer-failure §8 (a third cause that must not be reported as a writer no-show).

## Test plan

### Failure analysis and recovery

Every existing test of the merge path injects `resolveMergeDelivery`, so the **shipped** probe was never executed by the suite. That is exactly why a resolver that could not answer at all on any install kept a green suite for as long as it did — the only thing under test was the stub. The same shape of gap hid the two Mailroom defects found on 2026-09-09: the suite asserted the pipeline against fixtures it invented rather than against what the runtime produces.

- **Prevention:** `merge-delivery-signal.test.ts` drives the real probe against **real git repositories** created in a temp directory, including the exact live-install shape (a readable directory that is not a repository).
- **Detection:** an unavailable signal is now stated in the operator-facing next action instead of being silent; `requiredToolsMet` appears on the turn line.
- **Containment:** no schema change, no migration. Recognition still requires a positive `merged`, so nothing is waved through that was not before.
- **Residual risk:** a consumer install still has no checkout and so still cannot use the merge signal. That is now an honest, reported "unknown" with a named lever rather than a silent negative; mounting a checkout into the portal is a separate deployment decision, deliberately not taken here.

- [x] **Runtime-bound change** (readiness completion path, agentic loop)
  - [x] `pnpm typecheck`, targeted vitest, full suite, Next build and Docker image in the local-CI gate
  - [x] 765 tests green across the affected suites before gating

### Verification evidence

Local-CI-Evidence: cmtxps0s314ac01s00qs1jxgy (fix/readiness-completion-signals-fail-visibly@5bdf59447d51)

Not yet proven: the fixes are verified by test and by the gate, but not yet exercised against a live install — that needs a release, and is left on the backlog items rather than held open here.

## Pre-PR readiness

- [x] `pnpm run pregate:preflight` passed (67 guards)
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate` — PASS at 5bdf59447d51
- [x] `pnpm pr:ready` returned READY

## Related issues / Epic

Closes BI-043946C5 and BI-2FA5A874. Both were found while closing BI-4F7BB48B (Mailroom), which remains open and is unblocked by either fix.

## Overlap sweep

`gh pr list --state open`: no open PR touches `initiative-readiness` or `tak/agentic-loop`.

## Notes for the reviewer

The three-valued signal is the load-bearing change; the reporting is what makes it useful. Note that `not-merged` and `signal-unavailable` both leave recognition off, so this cannot loosen governance — the only behavioural difference for a passing item is that one of them now explains itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
