### PR TITLE
fix(guards): a seed-fit decision travels in the commit, so the pre-push gate can refuse before a PR exists (BI-4F1E9249)

### DIFF
--- a/scripts/check-seed-fit-decision.mjs
+++ b/scripts/check-seed-fit-decision.mjs
@@ -45,8 +45,12 @@ try {
   process.exit(1);
 }
 
+// BI-4F1E9249: read the decision from the outgoing commits as well as the PR
+// body, so the gate gives a truthful answer before a pull request exists and
+// `pregate-preflight` can refuse the push instead of CI refusing the PR.
 const result = evaluateSeedFitGate({
   changedFiles,
+  commitMessages: git("log", `${base}..HEAD`, "--format=%B"),
   prBody: process.env.PR_BODY || "",
   labels,
 });
@@ -64,7 +68,14 @@ if (result.ok) {
 console.error(`[seed-fit-gate] FAILED: ${result.reason}.`);
 for (const path of result.seedPaths) console.error(`  - ${path}`);
 if (result.reason === "missing-decision") {
-  console.error("Add exactly one reviewed `Seed-Fit-Decision: <value>` PR-body trailer or `seed-fit:<value>` label.");
+  console.error(
+    "Add exactly one reviewed `Seed-Fit-Decision: <value>` trailer to a commit message "
+      + "in this range or to the PR body, or a `seed-fit:<value>` label.",
+  );
+  console.error(
+    "Putting it in the commit is preferred: the decision then travels with the change, "
+      + "and the pre-push gate can refuse before a pull request exists.",
+  );
 }
 if (result.reason === "contradictory-decisions") {
   console.error(`Conflicting decisions: ${result.decisions.join(", ")}`);

--- a/scripts/check-seed-fit-decision.test.mjs
+++ b/scripts/check-seed-fit-decision.test.mjs
@@ -113,3 +113,72 @@ describe("seed-fit PR gate", () => {
     }
   });
 });
+
+// BI-4F1E9249 - the decision may travel in the commit, so the gate can answer
+// before a pull request exists and the pre-push gate can refuse the push.
+describe("seed-fit decision in the commit range", () => {
+  const SEED = ["prompts/reviewer/code-review.prompt.md"];
+  const COMMIT_WITH_DECISION = `feat(prompts): sharpen the reviewer prompt
+
+Seed-Fit-Decision: global-default
+`;
+
+  it("accepts a decision stated only in a commit message", () => {
+    const result = evaluateSeedFitGate({
+      changedFiles: SEED,
+      commitMessages: COMMIT_WITH_DECISION,
+      prBody: "",
+      labels: [],
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, "eligible-decision");
+    assert.equal(result.decision, "global-default");
+    assert.deepEqual(result.seedPaths, SEED);
+  });
+
+  it("still accepts a decision stated only in the PR body", () => {
+    const fromBody = evaluateSeedFitGate({
+      changedFiles: SEED,
+      prBody: "Seed-Fit-Decision: global-default",
+      labels: [],
+    });
+    assert.equal(fromBody.ok, true);
+    assert.equal(fromBody.decision, "global-default");
+  });
+
+  it("treats the same decision in both sources as one decision, not a contradiction", () => {
+    const result = evaluateSeedFitGate({
+      changedFiles: SEED,
+      commitMessages: "Seed-Fit-Decision: global-default",
+      prBody: "Seed-Fit-Decision: global-default",
+      labels: [],
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.decision, "global-default");
+  });
+
+  it("refuses a commit and a PR body that disagree", () => {
+    const result = evaluateSeedFitGate({
+      changedFiles: SEED,
+      commitMessages: "Seed-Fit-Decision: global-default",
+      prBody: "Seed-Fit-Decision: install-local-only",
+      labels: [],
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "contradictory-decisions");
+  });
+
+  it("reads a scoped decision's enforcement mechanism from the commit too", () => {
+    const result = evaluateSeedFitGate({
+      changedFiles: SEED,
+      commitMessages: "Seed-Fit-Decision: vertical-scoped mechanism=seed-gate symbol=nothingReferencesThis",
+      prBody: "",
+      labels: [],
+      readFile: () => "",
+    });
+    // Parsed from the commit, then refused on evidence. That is the mechanism
+    // check doing its job, not the commit source being ignored.
+    assert.equal(result.ok, false);
+    assert.notEqual(result.reason, "missing-decision");
+  });
+});

--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -54,8 +54,14 @@ export const PREFLIGHT_SKIP_ENV = "DPF_SKIP_PREGATE_PREFLIGHT_REASON";
 // a full CI round trip on #4558, where Docs Impact failed in CI on an edge the
 // preflight had just declared clean.
 //
-// Two gates stay excluded, and these reasons do NOT expire:
-//   - seed-fit-gate reads the PR body, which does not exist before push;
+// seed-fit-gate joined this list on 2026-09-11 (BI-4F1E9249). Its exclusion
+// reason — "reads the PR body, which does not exist before push" — was removed
+// rather than waived: the gate now reads `git log <base>..HEAD` for its
+// decision, as its four sibling decision gates already did. It cost a full CI
+// round trip on #5291, where a kernel principle was pushed without a seed-fit
+// decision and the fix needed an amended commit plus a fresh local-CI gate.
+//
+// ONE gate stays excluded, and that reason does NOT expire:
 //   - decision-baseline MERGES origin/main into the branch — a tree mutation
 //     the preflight must never perform.
 export const LOCAL_SAFE_PR_GUARD_IDS = Object.freeze([
@@ -65,6 +71,7 @@ export const LOCAL_SAFE_PR_GUARD_IDS = Object.freeze([
   "data-impact-gate",
   "convergence-impact-gate",
   "spec-plan-doc-gate",
+  "seed-fit-gate",
 ]);
 
 // Exit-output signatures that mean "this host cannot run the guard", not

--- a/scripts/lib/seed-fit-gate.mjs
+++ b/scripts/lib/seed-fit-gate.mjs
@@ -47,23 +47,45 @@ export function normalizeGithubLabels(value) {
     .filter((label) => typeof label === "string");
 }
 
-function collectDecisionTokens(prBody, labels) {
-  const bodyMatches = [...String(prBody).matchAll(/Seed-Fit-Decision:\s*([^\s`]+)/gi)]
+function collectDecisionTokens(decisionText, labels) {
+  const textMatches = [...String(decisionText).matchAll(/Seed-Fit-Decision:\s*([^\s`]+)/gi)]
     .map((match) => match[1].toLowerCase());
   const labelMatches = labels
     .map((label) => String(label).toLowerCase())
     .filter((label) => label.startsWith("seed-fit:"))
     .map((label) => label.slice("seed-fit:".length));
-  return [...bodyMatches, ...labelMatches];
+  return [...textMatches, ...labelMatches];
 }
 
-export function evaluateSeedFitGate({ changedFiles, prBody = "", labels = [], readFile } = {}) {
+/**
+ * BI-4F1E9249: the decision may travel in the COMMIT as well as the PR body.
+ *
+ * This gate used to read the PR body and labels only, which made it the one
+ * decision guard that could not run before a pull request existed — so
+ * `pregate-preflight` excluded it, and a missing line was discoverable only
+ * after a push, costing an amended commit and a fresh local-CI gate for the
+ * new SHA. Its four siblings (docs-impact, convergence-impact, design-grounding,
+ * spec-plan-doc) already read `git log <base>..HEAD`; this brings seed-fit into
+ * line with them rather than inventing a mechanism.
+ *
+ * Both sources are read and merged. The PR body stays valid, because a decision
+ * reviewed on the pull request is still a reviewed decision; the commit is
+ * simply the source that exists early enough to refuse the push.
+ */
+export function evaluateSeedFitGate({
+  changedFiles,
+  commitMessages = "",
+  prBody = "",
+  labels = [],
+  readFile,
+} = {}) {
+  const decisionText = [commitMessages, prBody].filter(Boolean).join("\n");
   const seedPaths = findCanonicalSeedContentPaths(changedFiles);
   if (seedPaths.length === 0) {
     return { ok: true, reason: "no-seed-content", seedPaths, decision: null };
   }
 
-  const tokens = collectDecisionTokens(prBody, labels);
+  const tokens = collectDecisionTokens(decisionText, labels);
   const invalid = tokens.filter((decision) => !DECISION_SET.has(decision));
   if (invalid.length > 0) {
     return { ok: false, reason: "invalid-decision", seedPaths, decision: null, invalid };
@@ -89,6 +111,7 @@ export function evaluateSeedFitGate({ changedFiles, prBody = "", labels = [], re
   // shipped and the read half did not (BI-B507DBD1, kernel DI-D17CAA32468F).
   const mechanism = evaluateScopeMechanism({
     decision,
+    commitMessages,
     prBody,
     changedFiles,
     readFile: readFile ?? ((file) => readFileSync(file, "utf8")),

--- a/scripts/lib/seed-fit-mechanism.mjs
+++ b/scripts/lib/seed-fit-mechanism.mjs
@@ -108,12 +108,25 @@ export function findMechanismEvidence({ symbol, changedFiles, readFile }) {
  * machine-readable code; the caller renders the sentence, so this stays pure and
  * testable and the gate output stays in one place.
  */
-export function evaluateScopeMechanism({ decision, prBody = "", changedFiles = [], readFile }) {
+/**
+ * BI-4F1E9249: a scoped decision states its enforcement mechanism wherever the
+ * decision itself is stated, so this reads the commit range and the PR body
+ * together, exactly as evaluateSeedFitGate does.
+ */
+export function evaluateScopeMechanism({
+  decision,
+  commitMessages = "",
+  prBody = "",
+  changedFiles = [],
+  readFile,
+}) {
   if (!isScopedSeedFitDecision(decision)) {
     return { ok: true, reason: "not-a-scoped-decision", mechanism: null, symbol: null, evidenceFiles: [] };
   }
 
-  const { mechanism, symbol } = parseSeedFitMechanism(prBody);
+  const { mechanism, symbol } = parseSeedFitMechanism(
+    [commitMessages, prBody].filter(Boolean).join("\n"),
+  );
 
   if (!mechanism) {
     return { ok: false, reason: "missing-mechanism", mechanism: null, symbol, evidenceFiles: [] };

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -131,18 +131,40 @@ test("buildPreflightPlan includes only commit-range-safe pull-request gates", ()
   for (const id of LOCAL_SAFE_PR_GUARD_IDS) {
     assert.ok(ids.has(id), `expected local-safe gate ${id} in the plan`);
   }
-  // PR-body-dependent and tree-mutating gates must never run host-side.
-  assert.ok(!ids.has("seed-fit-gate"), "seed-fit-gate reads the PR body");
+  // BI-4F1E9249: seed-fit-gate now reads the commit range like its sibling
+  // decision gates, so it CAN answer host-side and must be planned. Its former
+  // exclusion cost a full CI round trip on #5291.
+  assert.ok(ids.has("seed-fit-gate"), "seed-fit-gate reads the commit range");
+  // Tree-mutating gates must never run host-side. This reason does not expire.
   assert.ok(!ids.has("decision-baseline"), "decision-baseline merges origin/main");
+});
+
+test("a decision guard that can read the commit range is not excluded from the preflight", () => {
+  // The generalisation of BI-4F1E9249. A gate excluded for "needs the PR body"
+  // is excluded for a removable reason: the decision can travel in the commit.
+  // Only a gate that MUTATES the tree has a reason that does not expire.
+  const CANNOT_ANSWER_HOST_SIDE = new Set(["decision-baseline"]);
+  const planned = new Set(buildPreflightPlan().map((entry) => entry.id));
+  const excluded = POLICY_GUARD_PROFILES["pull-request"]
+    .map((entry) => entry.id)
+    .filter((id) => !planned.has(id));
+  assert.deepEqual(
+    excluded.filter((id) => !CANNOT_ANSWER_HOST_SIDE.has(id)),
+    [],
+    "A pull-request gate is excluded from the preflight for a reason that can expire. "
+      + "If it needs the PR body, teach it to read the commit range instead (BI-4F1E9249).",
+  );
 });
 
 test("buildPreflightPlan runs every pull-request gate that can answer host-side", () => {
   // Parity with CI's pull-request profile is the point of the preflight. A gate
   // omitted here is one a push can only discover in CI — which is what happened
-  // to Docs Impact on #4558. Only the two gates that CANNOT answer before a push
-  // may be missing; anything else added to the profile must be triaged into or
-  // out of LOCAL_SAFE_PR_GUARD_IDS deliberately, and this test is the prompt.
-  const CANNOT_ANSWER_HOST_SIDE = new Set(["seed-fit-gate", "decision-baseline"]);
+  // to Docs Impact on #4558, and to Seed Contribution Fit on #5291. Only a gate
+  // that CANNOT answer before a push may be missing, and after BI-4F1E9249 that
+  // is one gate: the tree-mutating decision-baseline. Anything else added to the
+  // profile must be triaged into or out of LOCAL_SAFE_PR_GUARD_IDS deliberately,
+  // and this test is the prompt.
+  const CANNOT_ANSWER_HOST_SIDE = new Set(["decision-baseline"]);
   const planned = new Set(buildPreflightPlan().map((entry) => entry.id));
   const missing = POLICY_GUARD_PROFILES["pull-request"]
     .map((entry) => entry.id)


### PR DESCRIPTION
## What

A seed-fit decision may now travel in the commit, so the pre-push gate can refuse before a pull request exists. First child of EP-C00F61F4, and the cheapest: it already cost a full CI round trip on #5291.

## The gap, measured rather than assumed

Four of the five decision guards already read `git log <base>..HEAD`: docs-impact, convergence-impact, design-grounding and spec-plan-doc. All four are in `LOCAL_SAFE_PR_GUARD_IDS` and run pre-push. `seed-fit-gate` alone read `process.env.PR_BODY` and labels, and it was the only gate excluded from the preflight for that reason, carrying a comment that the reason does not expire. It does expire, by letting the decision travel in the commit exactly as its siblings do.

On #5291 a kernel principle was pushed without a seed-fit decision. Because the gate is only discoverable after the push, the fix needed an amended commit plus a fresh local-CI gate for the new SHA, which then queued behind other sessions on a two-slot pool. One missing line became hours. The runbook's answer is a manual command a contributor has to remember at the moment they are thinking about something else, which is the failure mode the epic exists to remove.

## The change

`evaluateSeedFitGate` and `evaluateScopeMechanism` take `commitMessages` alongside `prBody` and read both. `check-seed-fit-decision.mjs` supplies the commit range. `seed-fit-gate` joins `LOCAL_SAFE_PR_GUARD_IDS`, so the preflight refuses the push instead of CI refusing the PR.

The PR body stays a valid source, because a decision reviewed on the pull request is still a reviewed decision. The commit is simply the source that exists early enough to refuse. CI stays authoritative and the pre-push run is the early, cheap copy, so a divergence is a bug in the local copy rather than a bypass.

## Verified on real history, not only in unit tests

Against the range `d7020166b2..HEAD`, which contains commit `ba7eb2ba21`'s seeded-content change and its `Seed-Fit-Decision: global-default` commit trailer, with `PR_BODY` empty:

- baseline code: `[seed-fit-gate] FAILED: missing-decision`
- this change: `[seed-fit-gate] Seeded-content decision is global-default. OK.`

Same inputs, opposite verdicts. The preflight itself now reports `Seed Contribution Fit Gate` among its guards, 68 clean.

## The generalisation is pinned

A new preflight test refuses any pull-request gate excluded for a reason that can expire. Only a tree-mutating gate may stay out, which today is `decision-baseline`, because it merges `origin/main` into the branch. That reason does not expire.

## Verification

- 27 seed-fit tests pass: the existing PR-body cases unchanged, plus a commit-only decision, agreement across both sources, disagreement across both sources, and a scoped decision whose enforcement mechanism is parsed from the commit.
- 29 preflight tests pass.
- Pre-push preflight: 68 guards clean, including the newly included gate.
- Local-CI gate PASSED on 967aa6e45d10.

Seed-Fit-Decision: global-default
Design-Grounding-Decision: extends the commit-range decision pattern already used by check-convergence-impact.mjs; code substrate reviewed under scripts/ and scripts/lib/.
Docs-Impact-Decision: not-applicable — no documented user-facing route changed; guard behaviour only.
Convergence-Impact-Decision: auto-converges — scripts/ is copied wholesale into the promoter image, so the guard ships with the next image build; nothing reads it at runtime and no install needs any action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
