### PR TITLE
fix(readiness): let the merge signal use the runtime's own source root, and stop trusting a stale trunk

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts
+++ b/apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts
@@ -8,7 +8,7 @@ import {
   type ResolveCompletionEvidenceResult,
 } from "@/lib/backlog/completion-evidence-runtime";
 import { canonicalJson } from "@/lib/shared/canonical-json";
-import { isReachableFromTrunk, trunkHasMergedPullRequest, trunkRefExists } from "@/lib/work-capsules/git-scanner";
+import { isReachableFromTrunk, trunkHasMergedPullRequest, trunkRefCommittedAt, trunkRefExists } from "@/lib/work-capsules/git-scanner";
 
 import { projectBacklogItemReadiness, readinessShapeFromWorkShape, type InitiativeReadinessActivity } from "./entry-adapter";
 import { type InheritanceDb, loadInheritedInitiativeScope } from "./parent-scope-inheritance";
@@ -141,9 +141,38 @@ export type ResolveMergeDelivery = (args: { itemRowId: string; itemId: string })
  * real checkout.
  */
 export function mergeSignalRoots(): string[] {
-  const roots = [process.env.DPF_REPO_ROOT, process.env.DPF_HOST_SOURCE_ROOT, "/host-dpf", process.cwd()];
+  const roots = [
+    process.env.DPF_REPO_ROOT,
+    process.env.DPF_HOST_SOURCE_ROOT,
+    // The runtime's own source root. On a consumer install this is the Build
+    // Studio workspace volume (`/sandbox-workspace`), which docker-entrypoint.sh
+    // makes a real repo and `start_build` points at the upstream — so the signal
+    // works with NO operator configuration on exactly the installs that have no
+    // host checkout. It was simply never asked (BI-043946C5).
+    process.env.PROJECT_ROOT,
+    "/host-dpf",
+    process.cwd(),
+  ];
   return [...new Set(roots.filter((r): r is string => Boolean(r)))];
 }
+
+/**
+ * How stale a trunk ref may be before a NEGATIVE reachability answer stops
+ * counting as a measurement. Positives are unaffected: reachability is monotone,
+ * so a stale trunk can only ever miss a merge, never invent one.
+ *
+ * This exists because the roots above are not guaranteed to be fetched. The
+ * Build Studio workspace is refreshed at `start_build`, not on the completion
+ * path, and was observed ten days behind on a live install — old enough to
+ * report merged work as unmerged with total confidence, which is the exact
+ * failure BI-043946C5 set out to remove. Reading the ref is local and cheap;
+ * fetching here is deliberately NOT done, because the completion path must not
+ * depend on the network.
+ */
+const TRUNK_FRESHNESS_WINDOW_MS = (() => {
+  const raw = Number(process.env.DPF_MERGE_SIGNAL_MAX_TRUNK_AGE_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 24 * 60 * 60 * 1000;
+})();
 
 /**
  * The operator-facing sentence for an unavailable merge signal. It names the
@@ -196,8 +225,14 @@ export async function resolveMergeSignalFromRefs(input: {
   heads: readonly string[];
   pullRequests: readonly number[];
   roots: readonly string[];
+  /** Injectable for tests; defaults to the real clock. */
+  now?: Date;
+  /** Injectable for tests; defaults to reading the trunk tip's commit date. */
+  readTrunkCommittedAt?: (root: string) => Promise<Date | null>;
 }): Promise<MergeDeliverySignal> {
   const { heads, pullRequests, roots } = input;
+  const now = input.now ?? new Date();
+  const readTrunkCommittedAt = input.readTrunkCommittedAt ?? ((root: string) => trunkRefCommittedAt(root));
   // Nothing to look up: no room recorded a head and no PR is linked. That is a
   // real measurement about THIS item — there is no branch identity to find on
   // the trunk — not a broken probe, so it stays a negative.
@@ -219,7 +254,13 @@ export async function resolveMergeSignalFromRefs(input: {
       if (merged === true) return "merged";
       if (merged === false) sawDefiniteNegative = true;
     }
-    return sawDefiniteNegative ? "not-merged" : "signal-unavailable";
+    if (!sawDefiniteNegative) return "signal-unavailable";
+    // A negative is only a measurement if the trunk it was measured against is
+    // current. An unfetched trunk reports merged work as unmerged, confidently.
+    const trunkAt = await readTrunkCommittedAt(root);
+    if (!trunkAt) return "signal-unavailable";
+    const staleBy = now.getTime() - trunkAt.getTime();
+    return staleBy <= TRUNK_FRESHNESS_WINDOW_MS ? "not-merged" : "signal-unavailable";
   }
   // No candidate root is a readable repository.
   return "signal-unavailable";

--- a/apps/web/lib/backlog/initiative-readiness/merge-delivery-signal.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/merge-delivery-signal.test.ts
@@ -141,23 +141,85 @@ describe("merge-delivery signal against real repositories (BI-043946C5)", () => 
   });
 });
 
+describe("a negative is only trusted against a current trunk (BI-043946C5)", () => {
+  let repo: Fixture;
+
+  beforeAll(async () => { repo = await makeRepo(); });
+  afterAll(async () => { await rm(repo.root, { recursive: true, force: true }).catch(() => {}); });
+
+  const ELEVEN_DAYS_AGO = new Date(Date.now() + 11 * 24 * 60 * 60 * 1000);
+
+  it("downgrades a negative to signal-unavailable when the trunk ref is stale", async () => {
+    // The Build Studio workspace is fetched at start_build, not on the completion
+    // path; it was measured ten days behind on a live install. A trunk that old
+    // reports merged work as unmerged with total confidence — the same silent
+    // wrong answer this whole change exists to remove, one layer along.
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.unmergedSha],
+      pullRequests: [],
+      roots: [repo.root],
+      now: ELEVEN_DAYS_AGO,
+    })).resolves.toBe("signal-unavailable");
+  });
+
+  it("keeps a negative when the trunk ref is current", async () => {
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.unmergedSha],
+      pullRequests: [],
+      roots: [repo.root],
+    })).resolves.toBe("not-merged");
+  });
+
+  it("still reports merged from a stale trunk, because reachability is monotone", async () => {
+    // Staleness can only ever make the trunk MISS a merge, never invent one, so a
+    // positive needs no freshness check and must not be withheld by one.
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.mergedSha],
+      pullRequests: [],
+      roots: [repo.root],
+      now: ELEVEN_DAYS_AGO,
+    })).resolves.toBe("merged");
+  });
+
+  it("treats an unreadable trunk date as unavailable rather than as a negative", async () => {
+    await expect(resolveMergeSignalFromRefs({
+      heads: [repo.unmergedSha],
+      pullRequests: [],
+      roots: [repo.root],
+      readTrunkCommittedAt: async () => null,
+    })).resolves.toBe("signal-unavailable");
+  });
+});
+
 describe("mergeSignalRoots (BI-043946C5)", () => {
   it("puts the configured roots ahead of the built-in fallbacks", async () => {
     const { mergeSignalRoots } = await import("./backlog-terminal-transition");
-    const savedRepoRoot = process.env.DPF_REPO_ROOT;
-    const savedSourceRoot = process.env.DPF_HOST_SOURCE_ROOT;
+    const saved = {
+      repo: process.env.DPF_REPO_ROOT,
+      source: process.env.DPF_HOST_SOURCE_ROOT,
+      project: process.env.PROJECT_ROOT,
+    };
     try {
       process.env.DPF_REPO_ROOT = "/configured-a";
       process.env.DPF_HOST_SOURCE_ROOT = "/configured-b";
+      process.env.PROJECT_ROOT = "/sandbox-workspace";
       const roots = mergeSignalRoots();
       expect(roots[0]).toBe("/configured-a");
       expect(roots[1]).toBe("/configured-b");
+      // The runtime's own source root is probed ahead of the install-path guess,
+      // so a consumer install needs no operator configuration at all.
+      expect(roots[2]).toBe("/sandbox-workspace");
+      expect(roots.indexOf("/sandbox-workspace")).toBeLessThan(roots.indexOf("/host-dpf"));
       expect(roots).toContain("/host-dpf");
     } finally {
-      if (savedRepoRoot === undefined) delete process.env.DPF_REPO_ROOT;
-      else process.env.DPF_REPO_ROOT = savedRepoRoot;
-      if (savedSourceRoot === undefined) delete process.env.DPF_HOST_SOURCE_ROOT;
-      else process.env.DPF_HOST_SOURCE_ROOT = savedSourceRoot;
+      for (const [key, value] of [
+        ["DPF_REPO_ROOT", saved.repo],
+        ["DPF_HOST_SOURCE_ROOT", saved.source],
+        ["PROJECT_ROOT", saved.project],
+      ] as const) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
     }
   });
 });

--- a/apps/web/lib/work-capsules/git-scanner.ts
+++ b/apps/web/lib/work-capsules/git-scanner.ts
@@ -123,6 +123,30 @@ export async function trunkRefExists(repoRoot: string, trunkRef = "origin/main")
 }
 
 /**
+ * When the trunk ref's tip commit was authored, or null when it cannot be read.
+ *
+ * A reachability check is only as current as the trunk it is measured against.
+ * Reachability is monotone — once a commit is an ancestor it stays one — so a
+ * POSITIVE answer from a stale trunk is still true. A NEGATIVE is not: a trunk
+ * that has not been fetched since before the merge will report perfectly
+ * confidently that merged work never landed. Callers use this to decide whether
+ * a negative is a measurement or just an old ref (BI-043946C5).
+ */
+export async function trunkRefCommittedAt(repoRoot: string, trunkRef = "origin/main"): Promise<Date | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", repoRoot, "log", "-1", "--format=%cI", trunkRef],
+      { timeout: 5000, windowsHide: true },
+    );
+    const parsed = new Date(stdout.trim());
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * True when `headSha` is an ancestor of the trunk (`git merge-base --is-ancestor`
  * exits 0) — i.e. the branch's work has landed and the room is DELIVERED. This is
  * the workroom-closeout "done" signal, computed PROCEDURALLY from the LOCAL repo:

--- a/docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md
+++ b/docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md
@@ -51,6 +51,22 @@ Four instances, all measured on this platform within one working session:
 None of these errored. Each produced a plausible wrong answer, and each cost
 real time to a reader who had no way to tell it from a real one.
 
+A fifth, measured 2026-09-12, is worse than the other four because it was not a
+transient. The merge-through-gates **signal** asks git whether a branch reached
+the trunk, probing a list of candidate repository roots. On every install the
+first root was the *installed runtime directory*, not a checkout, so no root
+resolved and the signal returned a silent, unconditional "did not merge" — for
+as long as it had shipped. Two capabilities that depend on it were dead
+platform-wide with nothing anywhere saying so, and the suite stayed green
+because every test injected a stub in place of the probe.
+
+The lesson is not "add a third state to gates". It is that **anything a decision
+reads is a check** — a signal, a probe, a lookup — and inherits this obligation.
+An inconclusive branch that can never succeed in production is not a fail-safe,
+it is a blind spot wearing a fail-safe's clothes. If a code path's honest answer
+is always "I could not tell", someone has to be told that, once, loudly, rather
+than every caller being told "no" forever.
+
 ## What to do
 
 **Give "I could not tell" its own outcome.** A tri-state (`true` / `false` /
@@ -71,6 +87,15 @@ should report the ambiguity rather than pick.
 
 **Do not report a verdict about state you did not read.** A record from a
 previous run is evidence about that run, not this one.
+
+**Ask which direction of the answer needs fresh state — it is often only one.**
+Some properties are monotone: once a commit is an ancestor of the trunk it stays
+one, so a *positive* reachability answer read from a stale clone is still true,
+while a *negative* from the same clone is worthless — it cannot distinguish "not
+merged" from "not fetched since". Gating both answers on freshness costs
+availability for nothing; gating neither ships confident wrong negatives.
+Measured 2026-09-12: the workspace the merge signal reads is refreshed when a
+build starts, not when an item completes, and was found ten days behind.
 
 **An inconclusive result never withdraws a verdict already reached.** "I could
 not tell" is not evidence that the earlier answer was wrong -- it is the absence


### PR DESCRIPTION
## Summary

Follow-up to #5297, which made the merge-through-gates signal three-valued so an install that cannot answer says so instead of answering "no". This makes the signal able to answer on the installs that were reporting unavailable, and stops it giving a confident wrong answer once it can.

**Probe `PROJECT_ROOT`.** The portal already knows where its source is. On a consumer install `PROJECT_ROOT` is `/sandbox-workspace` — the Build Studio workspace volume, which `docker-entrypoint.sh` makes a real repository and which `start_build` points at the upstream. Verified on the live install:

```
$ docker exec dpf-portal-1 sh -c 'echo $PROJECT_ROOT; cd /sandbox-workspace && git rev-parse --is-inside-work-tree && git rev-parse --short origin/main'
/sandbox-workspace
true
7628b19c
```

Every root the probe used to try failed on that same host. So the signal now works with no operator configuration on exactly the installs that have no host checkout. It was simply never asked.

**A negative now requires a current trunk.** Reachability is monotone: once a commit is an ancestor of the trunk it stays one, so a positive read from a stale clone is still true. A negative is not — it cannot tell "not merged" from "not fetched since". That workspace is refreshed when a build starts, not when an item completes, and was measured **ten days behind** on the live install, which is easily enough to report merged work as unmerged with total confidence. That is the exact failure #5297 set out to remove, one layer along.

So a definite negative is downgraded to `signal-unavailable` when the trunk tip is older than the freshness window (24h default, `DPF_MERGE_SIGNAL_MAX_TRUNK_AGE_MS`). Reading the ref is local and cheap. Fetching is deliberately **not** done here, because the completion path must not depend on the network.

## Changes

- `apps/web/lib/backlog/initiative-readiness/backlog-terminal-transition.ts`: probe `PROJECT_ROOT`; freshness-gate a negative; `resolveMergeSignalFromRefs` gains injectable clock and trunk-date reader.
- `apps/web/lib/work-capsules/git-scanner.ts`: `trunkRefCommittedAt`.
- `docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md`: amended.

## The durable part

The kernel principle already said a check that cannot conclude must say so, and listed four measured instances — all transient. This adds a fifth that was **permanent**: a signal whose inconclusive branch could never succeed in production, shipped, silent, with a green suite because every test stubbed the probe. An inconclusive branch that can never succeed is not a fail-safe, it is a blind spot wearing a fail-safe's clothes.

It also generalises the rule from gates to **anything a decision reads**, and adds a refinement the principle was missing: *ask which direction of the answer needs fresh state, because it is often only one*. Gating both directions on freshness costs availability for nothing; gating neither ships confident wrong negatives.

## Test plan

- [x] `pnpm typecheck`
- [x] 299 initiative-readiness tests green, including new coverage for stale-trunk downgrade, fresh-trunk negative preserved, stale-trunk positive still reported (monotonicity), unreadable trunk date treated as unavailable, and `PROJECT_ROOT` probe ordering.
- [x] Exact-tree local-CI gate PASS

### Verification evidence

Local-CI-Evidence: cmtxumu4r1g8i01s0klyb8cm4 (fix/merge-signal-uses-project-root@9e0b8ace4e9d)

The first gate run on this SHA returned `blocked_control_plane_starvation` — infrastructure, not the diff, and recorded as inconclusive per AGENTS.md §4. Re-run on the same SHA passed.

Not yet proven: verified by test and by the gate, not yet exercised against a live install, which needs a release.

## Pre-PR readiness

- [x] `pnpm run pregate:preflight` passed (67 guards)
- [x] Exact-tree local-CI evidence captured — PASS at 9e0b8ace4e9d
- [x] `pnpm pr:ready` READY

## Related issues / Epic

Refs BI-043946C5. Found while tracing how a consumer install develops and contributes code (EP-INPLATFORM-PARITY).

## Overlap sweep

No open PR touches `initiative-readiness` or `work-capsules/git-scanner`.

## Notes for the reviewer

The freshness window only ever downgrades a NEGATIVE. A positive is never withheld by it, because staleness can make the trunk miss a merge but never invent one. That asymmetry is the load-bearing idea and is asserted directly in the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Seed-Fit-Decision: global-default
