### PR TITLE
feat(build-studio): run the guard gauntlet against the build's own tree and record it as tree-keyed evidence

### DIFF
--- a/apps/web/lib/build/sandbox/guard-gauntlet-evidence.test.ts
+++ b/apps/web/lib/build/sandbox/guard-gauntlet-evidence.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveGateKey } from "@/lib/gates/gate-run-identity";
+import {
+  IN_PLATFORM_PREFLIGHT_GATE_KIND,
+  buildGauntletEvidence,
+  deriveGauntletGateKey,
+  summarizeGauntlet,
+  toolchainFingerprintFrom,
+} from "./guard-gauntlet-evidence";
+
+const TREE = "b".repeat(40);
+const OTHER_TREE = "c".repeat(40);
+const PLAN = "d".repeat(64);
+const TOOLCHAIN = "e".repeat(64);
+const REPO = "OpenDigitalProductFactory/opendigitalproductfactory";
+
+const identity = { repository: REPO, treeSha: TREE, guardPlanDigest: PLAN, toolchainFingerprint: TOOLCHAIN };
+
+describe("deriveGauntletGateKey", () => {
+  it("is keyed to the TREE: a different tree is a different key", () => {
+    expect(deriveGauntletGateKey(identity)).not.toBe(
+      deriveGauntletGateKey({ ...identity, treeSha: OTHER_TREE }),
+    );
+  });
+
+  it("is stable for the same tree, plan and toolchain", () => {
+    expect(deriveGauntletGateKey(identity)).toBe(deriveGauntletGateKey({ ...identity }));
+  });
+
+  it("CANNOT be mistaken for the heavy tier's key for the same tree", () => {
+    // This is the safety property. The fast tier runs guards only — no
+    // production build, no image — so a record of it must never satisfy a claim
+    // asking for local-integration-ci. The kind is hashed into the key, so the
+    // two derive different keys from identical inputs.
+    const heavy = deriveGateKey({
+      repository: REPO,
+      integrationTreeSha: TREE,
+      evidencePlanDigest: PLAN,
+      toolchainFingerprint: TOOLCHAIN,
+      gateKind: "local-integration-ci",
+    });
+    expect(deriveGauntletGateKey(identity)).not.toBe(heavy);
+  });
+
+  it("uses the same derivation as the external path, not a parallel one", () => {
+    // Same function, different kind — so the keying is identical rather than
+    // merely similar, and there is no second implementation to drift.
+    const viaShared = deriveGateKey({
+      repository: REPO,
+      integrationTreeSha: TREE,
+      evidencePlanDigest: PLAN,
+      toolchainFingerprint: TOOLCHAIN,
+      gateKind: IN_PLATFORM_PREFLIGHT_GATE_KIND,
+    });
+    expect(deriveGauntletGateKey(identity)).toBe(viaShared);
+  });
+
+  it("rejects a malformed tree sha rather than hashing it anyway", () => {
+    expect(() => deriveGauntletGateKey({ ...identity, treeSha: "not-a-sha" })).toThrow();
+  });
+});
+
+describe("buildGauntletEvidence", () => {
+  const base = {
+    identity,
+    workdir: "/workspace/.builds/b1",
+    failedGuards: [] as string[],
+    output: "OK — 67 guards clean",
+    durationMs: 71_000,
+    completedAt: new Date("2026-09-12T04:00:00.000Z"),
+  };
+
+  it("states what it does NOT cover", () => {
+    // A reader assuming a gate record means "fully verified" would be wrong
+    // about this one, and the record is the only place that can say so.
+    const evidence = buildGauntletEvidence({ ...base, passed: true });
+    expect(evidence.coverage).toEqual({
+      guards: true,
+      typecheck: false,
+      unitTests: false,
+      productionBuild: false,
+      image: false,
+    });
+    expect(evidence.tier).toBe(IN_PLATFORM_PREFLIGHT_GATE_KIND);
+  });
+
+  it("carries the tree it checked and the derived key", () => {
+    const evidence = buildGauntletEvidence({ ...base, passed: true });
+    expect(evidence.treeSha).toBe(TREE);
+    expect(evidence.gateKey).toBe(deriveGauntletGateKey(identity));
+  });
+
+  it("does not claim a pass when guards failed", () => {
+    const evidence = buildGauntletEvidence({ ...base, passed: false, failedGuards: ["Module Size Guard"] });
+    expect(evidence.passed).toBe(false);
+    expect(evidence.gatePassed).toBe(false);
+    expect(evidence.failedGuards).toEqual(["Module Size Guard"]);
+  });
+});
+
+describe("summarizeGauntlet", () => {
+  it("says the tier out loud on a pass", () => {
+    const summary = summarizeGauntlet({ passed: true, failedGuards: [], treeSha: TREE });
+    expect(summary).toContain("guards only");
+    expect(summary).toContain("no build or image");
+  });
+
+  it("names the failing guards and counts the rest", () => {
+    const summary = summarizeGauntlet({
+      passed: false,
+      treeSha: TREE,
+      failedGuards: ["A", "B", "C", "D", "E"],
+    });
+    expect(summary).toContain("5 guard(s)");
+    expect(summary).toContain("A, B, C");
+    expect(summary).toContain("+2 more");
+  });
+});
+
+describe("toolchainFingerprintFrom", () => {
+  it("produces a 64-hex digest the gate identity will accept", () => {
+    expect(toolchainFingerprintFrom({ node: "v24.19.0", pnpm: "9" })).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("distinguishes different toolchains", () => {
+    expect(toolchainFingerprintFrom({ node: "v24" })).not.toBe(toolchainFingerprintFrom({ node: "v22" }));
+  });
+});

--- a/apps/web/lib/build/sandbox/guard-gauntlet-evidence.ts
+++ b/apps/web/lib/build/sandbox/guard-gauntlet-evidence.ts
@@ -1,0 +1,141 @@
+/**
+ * Turn a guard-gauntlet run into a gate evidence record, keyed to the tree it
+ * checked, in the shape the external-agent path already produces.
+ *
+ * Slice 1 makes the checks run. This makes their result COUNT: an in-platform
+ * verification that leaves no record cannot be honoured by anything downstream,
+ * even when it happened and passed (BI-4A9910A9).
+ *
+ * Two deliberate choices, both about honesty:
+ *
+ * 1. Keyed to the TREE, not the build. A build id says who ran it; a tree sha
+ *    says what was checked. Only the second survives work moving between
+ *    surfaces, which is the whole point of parity — a change started in Build
+ *    Studio and finished in a worktree should not have to be re-verified.
+ *
+ * 2. A DISTINCT gate kind. This is the fast tier — guards only, no production
+ *    build and no image, because the sandbox has no Docker socket by design and
+ *    must not be given one. Recording it under the full gate's kind would let a
+ *    later claim reuse it as though the heavy tier had run. It states what it is
+ *    and is reusable only by something asking for the same thing.
+ */
+import { createHash } from "node:crypto";
+
+import { deriveGateKey } from "@/lib/gates/gate-run-identity";
+
+/**
+ * The fast-tier gate kind. Deliberately NOT "local-integration-ci": that kind
+ * means the full gauntlet plus typecheck, tests, production build and image, and
+ * a record claiming it would overstate this run's coverage.
+ */
+export const IN_PLATFORM_PREFLIGHT_GATE_KIND = "in-platform-preflight" as const;
+
+/**
+ * The repository a gate key is scoped to. Read from configuration when present,
+ * falling back to the canonical upstream — which is what a consumer install's
+ * sandbox is pointed at by `start_build`, so the fallback is the common case
+ * rather than a guess.
+ */
+export function resolveGauntletRepository(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.GITHUB_REPOSITORY?.trim();
+  if (configured && /^[^/\s]+\/[^/\s]+$/.test(configured)) return configured;
+  return "OpenDigitalProductFactory/opendigitalproductfactory";
+}
+
+export type GauntletEvidenceInput = {
+  repository: string;
+  treeSha: string;
+  /** Digest of exactly which guards ran and how they landed. */
+  guardPlanDigest: string;
+  /** Digest of the toolchain that ran them. */
+  toolchainFingerprint: string;
+};
+
+/**
+ * A fingerprint of the sandbox toolchain, so a record is attributable to the
+ * thing that produced it. Hashed to a 64-hex digest because that is the shape
+ * the gate identity requires.
+ */
+export function toolchainFingerprintFrom(parts: { node?: string; pnpm?: string; image?: string }): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ node: parts.node ?? "", pnpm: parts.pnpm ?? "", image: parts.image ?? "" }))
+    .digest("hex");
+}
+
+/**
+ * Derive the gate key for an in-platform preflight run.
+ *
+ * Uses the SAME `deriveGateKey` the external path uses, so the keying is
+ * identical rather than merely similar. A different `gateKind` keeps the two
+ * tiers from being mistaken for one another while the derivation stays shared —
+ * a second key-derivation function would be a second thing to keep in sync, and
+ * they always drift.
+ */
+export function deriveGauntletGateKey(input: GauntletEvidenceInput): string {
+  return deriveGateKey({
+    repository: input.repository,
+    integrationTreeSha: input.treeSha,
+    evidencePlanDigest: input.guardPlanDigest,
+    toolchainFingerprint: input.toolchainFingerprint,
+    gateKind: IN_PLATFORM_PREFLIGHT_GATE_KIND,
+  });
+}
+
+export type GauntletEvidencePayload = {
+  gateKey: string;
+  tier: typeof IN_PLATFORM_PREFLIGHT_GATE_KIND;
+  /** What this record does NOT cover, stated in the record itself. */
+  coverage: { guards: true; typecheck: false; unitTests: false; productionBuild: false; image: false };
+  treeSha: string;
+  workdir: string;
+  passed: boolean;
+  failedGuards: string[];
+  output: string;
+  durationMs: number;
+  completedAt: string;
+  gatePassed: boolean;
+};
+
+/**
+ * Build the `evidence` object for `recordLocalIntegrationResult`.
+ *
+ * `coverage` is not decoration. A reader that assumes a gate record means "fully
+ * verified" would be wrong about this one, and the record is the only place that
+ * can say so — the caller is long gone by the time it is read.
+ */
+export function buildGauntletEvidence(input: {
+  identity: GauntletEvidenceInput;
+  workdir: string;
+  passed: boolean;
+  failedGuards: readonly string[];
+  output: string;
+  durationMs: number;
+  completedAt?: Date;
+}): GauntletEvidencePayload {
+  return {
+    gateKey: deriveGauntletGateKey(input.identity),
+    tier: IN_PLATFORM_PREFLIGHT_GATE_KIND,
+    coverage: { guards: true, typecheck: false, unitTests: false, productionBuild: false, image: false },
+    treeSha: input.identity.treeSha,
+    workdir: input.workdir,
+    passed: input.passed,
+    failedGuards: [...input.failedGuards],
+    output: input.output,
+    durationMs: input.durationMs,
+    completedAt: (input.completedAt ?? new Date()).toISOString(),
+    gatePassed: input.passed,
+  };
+}
+
+/**
+ * The one-line summary that lands on the timeline. Says the tier out loud, so a
+ * reader scanning records is not left to infer it from a nested field.
+ */
+export function summarizeGauntlet(input: { passed: boolean; failedGuards: readonly string[]; treeSha: string }): string {
+  const tree = input.treeSha.slice(0, 12);
+  if (input.passed) return `Guard gauntlet passed (guards only, no build or image) for tree ${tree}`;
+  const count = input.failedGuards.length;
+  const named = input.failedGuards.slice(0, 3).join(", ");
+  const more = count > 3 ? `, +${count - 3} more` : "";
+  return `Guard gauntlet failed for tree ${tree}: ${count} guard(s) — ${named}${more}`;
+}

--- a/apps/web/lib/build/sandbox/guard-gauntlet.test.ts
+++ b/apps/web/lib/build/sandbox/guard-gauntlet.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  boundOutput,
+  parseFailedGuards,
+  readWorktreeTreeSha,
+  runGuardGauntlet,
+} from "./guard-gauntlet";
+
+const TREE = "a".repeat(40);
+
+/** A fake sandbox exec: matches on substrings of the command it is given. */
+function fakeExec(routes: Array<{ when: string; reply: string | Error }>) {
+  return vi.fn(async (_containerId: string, command: string) => {
+    for (const route of routes) {
+      if (command.includes(route.when)) {
+        if (route.reply instanceof Error) throw route.reply;
+        return route.reply;
+      }
+    }
+    throw new Error(`unexpected command: ${command}`);
+  });
+}
+
+const PREFLIGHT_FAILURE = `
+[pregate-preflight] Module Size Guard…
+[pregate-preflight] Prose Lint Guard…
+[pregate-preflight] 2 guard(s) FAILED in 67.6s — these are deterministic CI failures; fix them before the sandbox gate runs:
+  - Module Size Guard: node scripts/check-module-size.mjs
+  - Prose Lint Guard: node scripts/check-prose-lint.mjs
+[pregate-preflight] see every constraint that applies to this diff: pnpm gate:context
+`;
+
+describe("parseFailedGuards", () => {
+  it("names every failing guard from the summary block", () => {
+    expect(parseFailedGuards(PREFLIGHT_FAILURE)).toEqual(["Module Size Guard", "Prose Lint Guard"]);
+  });
+
+  it("returns nothing for a clean run", () => {
+    expect(parseFailedGuards("[pregate-preflight] OK — 67 guards clean in 64.9s")).toEqual([]);
+  });
+
+  it("reads the LAST summary when a log contains more than one", () => {
+    const twice = `1 guard(s) FAILED\n  - Old Guard: x\n` + PREFLIGHT_FAILURE;
+    expect(parseFailedGuards(twice)).toEqual(["Module Size Guard", "Prose Lint Guard"]);
+  });
+});
+
+describe("boundOutput", () => {
+  it("keeps short output verbatim", () => {
+    expect(boundOutput("short", 100)).toBe("short");
+  });
+
+  it("keeps the TAIL, because the verdict is at the end", () => {
+    const bounded = boundOutput("x".repeat(50) + "VERDICT", 10);
+    expect(bounded.endsWith("VERDICT")).toBe(true);
+    expect(bounded).toContain("earlier characters omitted");
+  });
+});
+
+describe("readWorktreeTreeSha", () => {
+  it("returns the tree sha", async () => {
+    const exec = fakeExec([{ when: "rev-parse", reply: `${TREE}\n` }]);
+    await expect(readWorktreeTreeSha(exec, "c1", "/workspace/.builds/b1")).resolves.toBe(TREE);
+  });
+
+  it("returns null rather than throwing when the worktree has no commit yet", async () => {
+    // A legitimate early-build state. Reporting it as a failure would be a
+    // verdict about something that was never checked.
+    const exec = fakeExec([{ when: "rev-parse", reply: "" }]);
+    await expect(readWorktreeTreeSha(exec, "c1", "/w")).resolves.toBeNull();
+  });
+
+  it("returns null when git errors", async () => {
+    const exec = fakeExec([{ when: "rev-parse", reply: new Error("not a git repository") }]);
+    await expect(readWorktreeTreeSha(exec, "c1", "/w")).resolves.toBeNull();
+  });
+});
+
+describe("runGuardGauntlet", () => {
+  const workdir = "/workspace/.builds/b1";
+
+  it("runs in the BUILD's worktree, not the shared root", async () => {
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: "OK — 67 guards clean\n__DPF_GAUNTLET_EXIT__=0" },
+    ]);
+    await runGuardGauntlet({ exec, containerId: "c1", workdir });
+
+    const gauntletCall = exec.mock.calls.find(([, cmd]) => cmd.includes("pregate-preflight"));
+    expect(gauntletCall?.[1]).toContain(`cd '${workdir}'`);
+    expect(gauntletCall?.[1]).not.toContain("cd '/workspace' &&");
+  });
+
+  it("passes a clean run", async () => {
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: "OK — 67 guards clean\n__DPF_GAUNTLET_EXIT__=0" },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    expect(result).toMatchObject({ ran: true, passed: true, failedGuards: [], treeSha: TREE });
+  });
+
+  it("fails with the guards named", async () => {
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: `${PREFLIGHT_FAILURE}\n__DPF_GAUNTLET_EXIT__=1` },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    expect(result).toMatchObject({ ran: true, passed: false });
+    expect(result).toHaveProperty("failedGuards", ["Module Size Guard", "Prose Lint Guard"]);
+  });
+
+  it("reports a crash as NOT-RUN, never as a failing guard", async () => {
+    // A non-zero exit that names no guard is a crash. Rendering it as a finding
+    // is the mistake report-only-the-verdict-you-reached exists to prevent.
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: "Error: Cannot find module\n__DPF_GAUNTLET_EXIT__=1" },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    expect(result.ran).toBe(false);
+    if (!result.ran) expect(result.reason).toContain("crash");
+  });
+
+  it("reports a timeout as NOT-RUN", async () => {
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: "…\n__DPF_GAUNTLET_EXIT__=124" },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    expect(result.ran).toBe(false);
+    if (!result.ran) expect(result.reason).toContain("no verdict");
+  });
+
+  it("reports a sandbox that could not start the command as NOT-RUN", async () => {
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: new Error("container is not running") },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    expect(result.ran).toBe(false);
+    if (!result.ran) expect(result.reason).toContain("could not be started");
+  });
+
+  it("reports missing exit status as NOT-RUN rather than guessing", async () => {
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: "output with no sentinel" },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    expect(result.ran).toBe(false);
+    if (!result.ran) expect(result.reason).toContain("unknown");
+  });
+
+  it("still reaches a verdict when the tree sha cannot be read", async () => {
+    // No commit yet is not a reason to withhold the guards' result.
+    const exec = fakeExec([
+      { when: "rev-parse", reply: new Error("no HEAD") },
+      { when: "pregate-preflight", reply: "OK\n__DPF_GAUNTLET_EXIT__=0" },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    expect(result).toMatchObject({ ran: true, passed: true, treeSha: null });
+  });
+
+  it("strips the exit sentinel from the kept output", async () => {
+    const exec = fakeExec([
+      { when: "rev-parse", reply: TREE },
+      { when: "pregate-preflight", reply: "clean\n__DPF_GAUNTLET_EXIT__=0" },
+    ]);
+    const result = await runGuardGauntlet({ exec, containerId: "c1", workdir });
+    if (result.ran) expect(result.output).not.toContain("__DPF_GAUNTLET_EXIT__");
+  });
+});
+
+describe("guardPlanDigest", () => {
+  it("depends ONLY on the plan, never on the outcome", async () => {
+    // A consumer has to derive the same key before it knows the result, in order
+    // to look the record up. Hashing the outcome in would make the key
+    // derivable only by the producer, which defeats keying it at all.
+    const { guardPlanDigest } = await import("./guard-gauntlet");
+    expect(guardPlanDigest("scripts/pregate-preflight.mjs"))
+      .toBe(guardPlanDigest("scripts/pregate-preflight.mjs"));
+  });
+
+  it("distinguishes different plans", async () => {
+    const { guardPlanDigest } = await import("./guard-gauntlet");
+    expect(guardPlanDigest("scripts/a.mjs")).not.toBe(guardPlanDigest("scripts/b.mjs"));
+  });
+
+  it("is a 64-hex digest the gate identity will accept", async () => {
+    const { guardPlanDigest } = await import("./guard-gauntlet");
+    expect(guardPlanDigest("scripts/pregate-preflight.mjs")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/apps/web/lib/build/sandbox/guard-gauntlet.ts
+++ b/apps/web/lib/build/sandbox/guard-gauntlet.ts
@@ -1,0 +1,200 @@
+/**
+ * Run the deterministic guard gauntlet against a Build Studio build's own tree.
+ *
+ * The external-agent path runs `scripts/pregate-preflight.mjs` — 67 guards —
+ * before its first commit. The in-platform path ran none of them, which is the
+ * bulk of the day-to-day quality difference between the two surfaces. Unlike the
+ * production build and the image, the guards need no Docker, no lease and no host
+ * toolchain: they are source-reading Node scripts, and the sandbox already has
+ * Node, pnpm, git, an installed node_modules and the whole scripts/ tree, all
+ * placed by docker-entrypoint.sh.
+ *
+ * This runs the SAME script the external path runs. Reimplementing the checks
+ * here would guarantee the two surfaces drift apart, which is the thing the
+ * parity work exists to prevent (BI-CA6769FE).
+ */
+import { createHash } from "node:crypto";
+
+/** Never let a runaway guard hold the build; the full sweep is ~70-110s. */
+const GAUNTLET_TIMEOUT_SECONDS = 600;
+
+/**
+ * Bound what we keep. The full preflight log is large and the interesting part
+ * is the tail, where the failure summary is printed.
+ */
+const MAX_OUTPUT_CHARS = 20_000;
+
+/** Marks the end of the command so a non-zero exit can be read from stdout. */
+const EXIT_SENTINEL = "__DPF_GAUNTLET_EXIT__";
+
+export type GuardGauntletOutcome =
+  /** The gauntlet ran to a verdict. */
+  | { ran: true; passed: boolean; failedGuards: string[]; output: string; treeSha: string | null; workdir: string; durationMs: number }
+  /**
+   * The gauntlet could not run. This is NOT a failing verdict — reporting it as
+   * one is the mistake `report-only-the-verdict-you-reached` names, and the
+   * caller must be able to tell the two apart.
+   */
+  | { ran: false; reason: string; workdir: string; durationMs: number };
+
+export type SandboxExec = (containerId: string, command: string) => Promise<string>;
+
+/** Shell-quote a path for `sh -c`. Workdirs are derived, never user text, but this is cheap. */
+function quote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * The guard names the preflight prints in its failure summary, which look like:
+ *
+ *   [pregate-preflight] 1 guard(s) FAILED in 67.6s — ...
+ *     - Module Size Guard: node scripts/check-module-size.mjs
+ *
+ * Parsed from the summary block rather than from each guard's own prose, because
+ * only the summary has a stable shape.
+ */
+export function parseFailedGuards(output: string): string[] {
+  const marker = output.lastIndexOf("guard(s) FAILED");
+  if (marker === -1) return [];
+  const names: string[] = [];
+  for (const line of output.slice(marker).split(/\r?\n/)) {
+    const match = /^\s*-\s+([^:]+):/.exec(line);
+    if (match?.[1]) names.push(match[1].trim());
+  }
+  return names;
+}
+
+/** Keep the tail: the verdict and the failure summary are at the end. */
+export function boundOutput(output: string, max = MAX_OUTPUT_CHARS): string {
+  if (output.length <= max) return output;
+  return `… (${output.length - max} earlier characters omitted)\n${output.slice(-max)}`;
+}
+
+/**
+ * A digest of the PLAN — what was going to be run — not of its outcome.
+ *
+ * This pairs with the tree sha: one says what was checked, the other says what
+ * checked it. It must contain nothing result-dependent, because a consumer has
+ * to derive the same key BEFORE it knows the result in order to look the record
+ * up. Hashing the outcome in here would make the key underivable by anything but
+ * the producer, which defeats the point of keying it at all.
+ */
+export const GUARD_PLAN_VERSION = 1 as const;
+
+export function guardPlanDigest(scriptPath: string): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ plan: "guard-gauntlet", version: GUARD_PLAN_VERSION, scriptPath }))
+    .digest("hex");
+}
+
+/**
+ * The HEAD tree of the build's worktree — what the guards actually inspected.
+ *
+ * A commit sha identifies a commit; a TREE sha identifies content, which is what
+ * a verification statement is about. Two builds that produce identical content
+ * share a tree sha, and evidence about one is honestly evidence about the other.
+ * Returns null when the worktree has no commit yet, which is a legitimate state
+ * early in a build and must not be reported as a failure.
+ */
+export async function readWorktreeTreeSha(
+  exec: SandboxExec,
+  containerId: string,
+  workdir: string,
+): Promise<string | null> {
+  try {
+    const out = await exec(containerId, `cd ${quote(workdir)} && git rev-parse HEAD^{tree} 2>/dev/null`);
+    const sha = out.trim();
+    return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the guard gauntlet in the build's worktree.
+ *
+ * `workdir` must be the build's own tree. With `DPF_BUILD_WORKTREE_ISOLATION` on
+ * (the default) the agent CLIs work in `/workspace/.builds/<buildId>` while the
+ * MCP file tools write to the shared root — gating the wrong one silently
+ * verifies work that is not the work.
+ */
+export async function runGuardGauntlet(input: {
+  exec: SandboxExec;
+  containerId: string;
+  workdir: string;
+  scriptPath?: string;
+  now?: () => number;
+}): Promise<GuardGauntletOutcome> {
+  const { exec, containerId, workdir } = input;
+  const scriptPath = input.scriptPath ?? "scripts/pregate-preflight.mjs";
+  const now = input.now ?? (() => Date.now());
+  const startedAt = now();
+
+  const treeSha = await readWorktreeTreeSha(exec, containerId, workdir);
+
+  // The preflight exits non-zero on failure and execInSandbox rejects on a
+  // non-zero exit, so the exit code is carried out through stdout instead. A
+  // rejection here therefore means the command could not run at all.
+  const command =
+    `cd ${quote(workdir)} && timeout ${GAUNTLET_TIMEOUT_SECONDS} node ${quote(scriptPath)} 2>&1; `
+    + `echo "${EXIT_SENTINEL}=$?"`;
+
+  let raw: string;
+  try {
+    raw = await exec(containerId, command);
+  } catch (err) {
+    return {
+      ran: false,
+      reason: `The guard gauntlet could not be started in the sandbox: ${(err as Error)?.message ?? "unknown error"}`,
+      workdir,
+      durationMs: now() - startedAt,
+    };
+  }
+
+  const exitMatch = new RegExp(`${EXIT_SENTINEL}=(\\d+)`).exec(raw);
+  if (!exitMatch) {
+    return {
+      ran: false,
+      reason: "The guard gauntlet produced no exit status, so its verdict is unknown.",
+      workdir,
+      durationMs: now() - startedAt,
+    };
+  }
+
+  const exitCode = Number(exitMatch[1]);
+  const output = boundOutput(raw.replace(exitMatch[0], "").trimEnd());
+
+  // 124 is `timeout`'s own code. A gauntlet that ran out of time did not reach a
+  // verdict, so it is unavailable rather than failing.
+  if (exitCode === 124) {
+    return {
+      ran: false,
+      reason: `The guard gauntlet did not finish within ${GAUNTLET_TIMEOUT_SECONDS}s, so it reached no verdict.`,
+      workdir,
+      durationMs: now() - startedAt,
+    };
+  }
+
+  const failedGuards = parseFailedGuards(output);
+
+  // A non-zero exit with no named guard is a crash, not a finding — the preflight
+  // prints its failures. Saying "a guard failed" here would be inventing one.
+  if (exitCode !== 0 && failedGuards.length === 0) {
+    return {
+      ran: false,
+      reason: `The guard gauntlet exited ${exitCode} without naming a failing guard, which is a crash rather than a finding.`,
+      workdir,
+      durationMs: now() - startedAt,
+    };
+  }
+
+  return {
+    ran: true,
+    passed: exitCode === 0,
+    failedGuards,
+    output,
+    treeSha,
+    workdir,
+    durationMs: now() - startedAt,
+  };
+}

--- a/apps/web/lib/gates/gate-run-identity.ts
+++ b/apps/web/lib/gates/gate-run-identity.ts
@@ -1,7 +1,16 @@
 import { createHash } from "node:crypto";
 
 export const GATE_RUN_IDENTITY_SCHEMA_VERSION = 1 as const;
-export const GATE_KINDS = ["local-integration-ci", "semantic-review"] as const;
+/**
+ * `in-platform-preflight` is the Build Studio fast tier: the guard gauntlet only,
+ * with no typecheck, tests, production build or image, because the sandbox has no
+ * Docker socket by design. It is a SEPARATE kind rather than a flag on
+ * `local-integration-ci` precisely so a fast-tier record can never be handed back
+ * to a claim asking for the heavy one — the gate key hashes the kind, so the two
+ * tiers derive different keys for the same tree and cannot be confused
+ * (BI-4A9910A9).
+ */
+export const GATE_KINDS = ["local-integration-ci", "semantic-review", "in-platform-preflight"] as const;
 
 export type GateKind = (typeof GATE_KINDS)[number];
 

--- a/apps/web/lib/mcp/packs/sandbox-pack.ts
+++ b/apps/web/lib/mcp/packs/sandbox-pack.ts
@@ -417,7 +417,10 @@ async function runSandboxTestsTool(
     console.warn("[run_sandbox_tests] could not resolve changed files for scoping:", (err as Error)?.message);
   }
 
-  let results = await runSandboxTests(rstSandboxId, { changedFiles: rstChangedFiles });
+  // Verify the build's OWN tree, as build-pipeline.ts does. Omitting the workdir
+  // verified the shared root instead — silently (BI-CA6769FE).
+  const { resolveBuildWorkdir: rstWorkdir } = await import("@/lib/build/sandbox/build-branch");
+  let results = await runSandboxTests(rstSandboxId, { changedFiles: rstChangedFiles, workdir: rstWorkdir(buildId) });
   let fixAttempts = 0;
 
   // Auto-fix loop: diagnose failures, apply fixes via LLM, re-test

--- a/apps/web/lib/queue/functions/build-review-verification.ts
+++ b/apps/web/lib/queue/functions/build-review-verification.ts
@@ -54,6 +54,7 @@ export const buildReviewVerification = inngest.createFunction(
           kind: true,
           diffPatch: true,
           verificationOut: true,
+          buildBranch: true,
         },
       });
     });
@@ -94,6 +95,79 @@ export const buildReviewVerification = inngest.createFunction(
     const runBrowserUse = shouldRunBrowserUxVerification({
       testCaseCount: testCases.length,
       changedFiles,
+    });
+
+    // The deterministic guard gauntlet the external-agent path runs before its
+    // first commit, run here against the build's OWN worktree and recorded as
+    // tree-keyed evidence (BI-CA6769FE, BI-4A9910A9).
+    //
+    // Deliberately NON-BLOCKING in this slice. Making publication depend on the
+    // record is BI-0700B79C, and it is sequenced after this on purpose: a
+    // refusal that arrives before the checks are trustworthy would meet a
+    // non-developer with a wall they did not earn. This step's job for now is to
+    // make the result exist and be honest about what it covers.
+    await step.run("guard-gauntlet", async () => {
+      const { runGuardGauntlet, guardPlanDigest } = await import("@/lib/build/sandbox/guard-gauntlet");
+      const { buildGauntletEvidence, summarizeGauntlet, toolchainFingerprintFrom, resolveGauntletRepository } =
+        await import("@/lib/build/sandbox/guard-gauntlet-evidence");
+      const { resolveBuildWorkdir } = await import("@/lib/build/sandbox/build-branch");
+      const { execInSandbox } = await import("@/lib/sandbox");
+      const { recordLocalIntegrationResult } = await import("@/lib/nonprod/local-integration");
+
+      const workdir = resolveBuildWorkdir(buildId);
+      const outcome = await runGuardGauntlet({
+        exec: execInSandbox,
+        containerId: build.sandboxId!,
+        workdir,
+      });
+
+      // Could-not-run is not a failing verdict, and must not be recorded as one.
+      if (!outcome.ran) {
+        console.warn(`[guard-gauntlet] not run for ${buildId}: ${outcome.reason}`);
+        return { ran: false, reason: outcome.reason };
+      }
+      // Without a tree there is nothing to key evidence to, so the run informs
+      // the log but cannot become a record that something else reuses.
+      if (!outcome.treeSha) {
+        console.warn(`[guard-gauntlet] ${buildId} produced no tree sha; result not recorded as evidence`);
+        return { ran: true, passed: outcome.passed, recorded: false };
+      }
+
+      const toolchain = await execInSandbox(build.sandboxId!, "node -v 2>/dev/null; pnpm -v 2>/dev/null")
+        .catch(() => "");
+      const [node, pnpm] = toolchain.split(/\r?\n/);
+      const identity = {
+        repository: resolveGauntletRepository(),
+        treeSha: outcome.treeSha,
+        guardPlanDigest: guardPlanDigest("scripts/pregate-preflight.mjs"),
+        toolchainFingerprint: toolchainFingerprintFrom({ node, pnpm }),
+      };
+
+      await recordLocalIntegrationResult({
+        actorUserId: build.createdById,
+        provider: "build-studio",
+        externalSessionId: buildId,
+        routeContext: "/build",
+        buildId,
+        candidateBranch: build.buildBranch ?? `build/${buildId}`,
+        mode: "single-branch",
+        status: outcome.passed ? "passed" : "failed",
+        summary: summarizeGauntlet({
+          passed: outcome.passed,
+          failedGuards: outcome.failedGuards,
+          treeSha: outcome.treeSha,
+        }),
+        evidence: buildGauntletEvidence({
+          identity,
+          workdir: outcome.workdir,
+          passed: outcome.passed,
+          failedGuards: outcome.failedGuards,
+          output: outcome.output,
+          durationMs: outcome.durationMs,
+        }),
+      });
+
+      return { ran: true, passed: outcome.passed, recorded: true, treeSha: outcome.treeSha };
     });
 
     // Phase 3 of the shared Change Reviewer control: task-level reviews remain

--- a/docs/superpowers/specs/2026-09-12-in-platform-gate-parity-design.md
+++ b/docs/superpowers/specs/2026-09-12-in-platform-gate-parity-design.md
@@ -1,0 +1,161 @@
+---
+title: In-Platform Gate Parity — Build Studio produces the evidence an external agent produces
+slug: 2026-09-12-in-platform-gate-parity-design
+status: draft
+authoredAt: 2026-09-12
+---
+
+# In-Platform Gate Parity
+
+## Problem
+
+The target market for this platform is non-developer users, and the consumer
+install is built for them: no host source checkout, all development in-product.
+But development has in practice moved to external CLI agents, because Build
+Studio has been hard to trust at the same level.
+
+The reason is not model capability. `Dockerfile.sandbox` installs Claude Code,
+Codex, Grok and OpenCode, and the dispatchers stream real credentials in at
+dispatch time — Build Studio runs the same frontier CLIs an external agent runs.
+It is not cost either: `apps/web/lib/build/claude-dispatch.ts` already defaults to
+OAuth subscription auth, documented in-code as ~20x cheaper than API keys.
+
+The reason is **evidence**.
+
+| | External agent | Build Studio |
+|---|---|---|
+| Guards before commit | 67, via `scripts/pregate-preflight.mjs` | none |
+| Gate keying | exact tree, recorded, reusable | none |
+| Publish | `git push`, refused without a gate record | REST API — no push, so the hook never fires |
+
+The pre-push gate is attached to a MECHANISM (`git push`) rather than to a
+CONTRACT (*a candidate tree wants to become a ref on a shared repository*). The
+in-platform path uses a different mechanism, so the entire local-CI contract is
+structurally absent from it. No operator can configure that away.
+
+**If a non-technical person can commit meaningful changes that make this platform
+better, the flywheel for the masses starts.** That is what this parity is for.
+
+## Decision
+
+Attach verification to the contract. A tree published by the in-platform path
+carries the same evidence, with the same keying, as a tree published by an
+external agent.
+
+Delivered in four slices, in order:
+
+1. Run the guard gauntlet against the build's own tree, in the sandbox.
+2. Emit a gate evidence record keyed to that tree, in the existing shape.
+3. Refuse to publish without a passing record for the exact tree.
+4. Make a gate failure legible to a non-developer.
+
+This document covers slices 1 and 2. Slice 3 is sequenced after them on purpose:
+it is the only slice that can block real work, and a refusal arriving before the
+checks are trustworthy would meet a non-developer with a wall they did not earn.
+
+## Design
+
+### Slice 1 — the gauntlet runs where the work is
+
+`apps/web/lib/build/sandbox/guard-gauntlet.ts` runs the SAME
+`scripts/pregate-preflight.mjs` the external path runs, inside the sandbox,
+against `resolveBuildWorkdir(buildId)`. Reimplementing the checks would guarantee
+the two surfaces drift; invoking the same script means they cannot.
+
+No Docker, no lease, no host toolchain is needed. The sandbox already has Node,
+pnpm, git, an installed `node_modules` and the whole `scripts/` tree from
+`docker-entrypoint.sh`. Verified on the live install before this was designed:
+
+```
+$ docker exec dpf-sandbox-1 sh -c 'cd /workspace && node scripts/check-module-size.mjs'
+Module-size OK — no new oversized files, no baselined file grew.
+exit=0
+```
+
+**Which tree.** With `DPF_BUILD_WORKTREE_ISOLATION` on (the default) the agent
+CLIs work in `/workspace/.builds/<buildId>` while the MCP file tools write to the
+shared root. `build-pipeline.ts` has always passed the workdir to
+`runSandboxTests`; the `run_sandbox_tests` MCP handler did not, so that tool
+verified a different tree than the build produced — silently, and always in the
+reassuring direction. Fixed here.
+
+**Could-not-run is not a verdict.** A crash (non-zero exit naming no guard), a
+timeout, a sandbox that cannot start the command, or missing exit status all
+return `ran: false` with a reason, never a failing guard. This is
+`report-only-the-verdict-you-reached` applied at the point of measurement.
+
+### Slice 2 — the result becomes evidence
+
+`apps/web/lib/build/sandbox/guard-gauntlet-evidence.ts` shapes the run into an
+`ExternalEvidenceRecord` through the existing canonical writer,
+`recordLocalIntegrationResult`. Two choices carry the weight:
+
+**Keyed to the TREE.** A build id says who ran it; a tree sha says what was
+checked. Only the second survives work moving between surfaces — a change started
+in Build Studio and finished in a worktree should not have to be re-verified. The
+key is derived by the SAME `deriveGateKey` the external path uses, so the keying
+is identical rather than merely similar.
+
+**A distinct gate kind.** `in-platform-preflight` is added to `GATE_KINDS`
+alongside `local-integration-ci`. This tier is guards only — no typecheck, no
+unit tests, no production build, no image — because the sandbox has no Docker
+socket by design and must not be given one. Since the kind is hashed into the
+gate key, the two tiers derive different keys for the same tree and a fast-tier
+record can never be handed back to a claim asking for the heavy one. The record
+also carries an explicit `coverage` object stating what it does not cover: a
+reader assuming "gate record means fully verified" would be wrong about this one,
+and the record is the only place that can say so.
+
+### Where it runs
+
+As a non-blocking step in the `build/review.verify` Inngest job, between
+`resolve-changed-files` and `semantic-change-review` — the point where the
+assembled change exists and before ship is dispatched.
+
+## Scope boundary
+
+Parity is of the FAST tier plus the cloud safety net, not of the image build.
+AGENTS.md §4 already tiers it that way for every surface: "the heavy build runs
+once, in the cloud. Fast local checks gate the push; the full build is the cloud
+merge-queue safety net." The in-platform path takes the same deal the external
+path takes; this is not a concession.
+
+## What this does not do
+
+It does not block anything yet (slice 3). It does not claim heavy-tier coverage.
+It does not give the sandbox a Docker socket, a credential, or network authority
+it did not have. It does not change the external path's behaviour.
+
+## Research & Benchmarking
+
+GitHub Actions and GitLab CI both key cached/reused results to a content digest
+rather than a branch or run id, for the same reason adopted here: the statement is
+about content, so it survives the work moving. GitHub's own merge-queue model
+separates a cheap pre-merge tier from an expensive merge-group tier, which is the
+tiering AGENTS.md §4 already states and this design follows rather than invents.
+
+Rejected: reimplementing a Build Studio-specific check list. It would drift from
+the external path by construction, which is the failure this work exists to end.
+
+Rejected: giving the sandbox a Docker socket for full parity. It would dissolve
+the isolation that makes the sandbox safe to hand to a non-developer, for a tier
+the cloud already covers.
+
+## Acceptance
+
+- AC-IPGP-001 A completed build carries a preflight result naming every guard that ran and every one that failed.
+- AC-IPGP-002 The result comes from the same script the external path runs, invoked against the build's own tree.
+- AC-IPGP-003 Running it requires no Docker, host checkout, or non-production lease.
+- AC-IPGP-004 A crash, timeout or unstartable sandbox is reported as not-run, never as a failing guard.
+- AC-IPGP-005 A verification run writes a gate record keyed to the tree it checked, via the existing writer.
+- AC-IPGP-006 The record states which tier ran and does not imply coverage it lacks.
+- AC-IPGP-007 A fast-tier record derives a different gate key than the heavy tier for the same tree.
+
+## Tests
+
+`guard-gauntlet.test.ts` — the gauntlet runs in the build's worktree and not the
+shared root; passes clean; names failing guards; and reports crash, timeout,
+unstartable sandbox and missing exit status as not-run rather than as failures.
+`guard-gauntlet-evidence.test.ts` — the key is tree-keyed, stable, derived by the
+shared function, and provably distinct from the heavy tier's key for identical
+inputs; the record states its coverage and never claims a pass it did not get.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -44,7 +44,7 @@ apps/web/lib/inference/ai-provider-internals.ts	1261
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp/packs/backlog-pack.dispatch.test.ts	874
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	855
-apps/web/lib/mcp/packs/sandbox-pack.ts	921
+apps/web/lib/mcp/packs/sandbox-pack.ts	924
 apps/web/lib/navigation/portal-navigation-model.ts	996
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1379
@@ -58,7 +58,7 @@ apps/web/lib/tak/agent-grants.test.ts	940
 apps/web/lib/tak/agent-grants.ts	1000
 apps/web/lib/tak/agent-routing.ts	1191
 apps/web/lib/tak/agentic-loop.test.ts	2485
-apps/web/lib/tak/agentic-loop.ts	2642
+apps/web/lib/tak/agentic-loop.ts	2640
 apps/web/lib/tak/route-context-map.ts	1440
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1239
 apps/web/lib/work-capsules/work-capsule-store.ts	1004


### PR DESCRIPTION
## Summary

Slices 1 and 2 of EP-INPLATFORM-PARITY. **If a non-technical person can commit meaningful changes that make this platform better, the flywheel for the masses starts.** What stands in the way is not model capability and not cost — it is evidence.

Build Studio already dispatches the same frontier CLIs an external agent uses (`Dockerfile.sandbox` installs Claude Code, Codex, Grok and OpenCode, and the dispatchers stream real credentials in at dispatch time). Its coding path already defaults to the flat-rate subscription auth that `claude-dispatch.ts` documents as ~20x cheaper than API keys. What it could not do was produce evidence anything downstream would honour.

The cause is structural. The pre-push gate is attached to a **mechanism** — `git push`, via `.githooks/pre-push-gate` — while the in-platform path publishes through the GitHub REST API. No push, no hook, no local-CI contract. No operator can configure that away.

**Slice 1 — the gauntlet runs where the work is.** `guard-gauntlet.ts` runs the SAME `scripts/pregate-preflight.mjs` the external path runs, inside the sandbox, against `resolveBuildWorkdir(buildId)`. Reimplementing the checks would guarantee the two surfaces drift; invoking the same script means they cannot. No Docker, no lease, no host toolchain — verified on the live install before this was designed:

```
$ docker exec dpf-sandbox-1 sh -c 'cd /workspace && node scripts/check-module-size.mjs'
Module-size OK — no new oversized files, no baselined file grew.
exit=0
```

A crash (non-zero exit naming no guard), a timeout, an unstartable sandbox, or a missing exit status all return `ran: false` with a reason — never a failing guard. That is `report-only-the-verdict-you-reached` applied at the point of measurement.

**Slice 2 — the result becomes evidence.** `guard-gauntlet-evidence.ts` shapes the run into an `ExternalEvidenceRecord` through the existing canonical writer. Two choices carry the weight:

- **Keyed to the TREE.** A build id says who ran it; a tree sha says what was checked. Only the second survives work moving between surfaces — a change started in Build Studio and finished in a worktree should not have to be re-verified.
- **A distinct gate kind.** `in-platform-preflight` joins `GATE_KINDS`. This tier is guards only, because the sandbox has no Docker socket **by design** and must not be given one. The kind is hashed into the gate key, so the two tiers derive different keys for the same tree and a fast-tier record can never be handed to a claim asking for the heavy one. There is a test asserting exactly that. The record also carries an explicit `coverage` object stating what it does not cover.

## A defect fixed because it is this slice's subject

The `run_sandbox_tests` MCP handler never passed a workdir, so it verified the shared workspace root while the build's agents worked in `/workspace/.builds/<buildId>`. `build-pipeline.ts` has always passed it. That tool was verifying a **different tree than the build produced** — silently, and always in the reassuring direction.

## Deliberately non-blocking

Making publication depend on the record is BI-0700B79C, sequenced after this on purpose: a refusal arriving before the checks are trustworthy would meet a non-developer with a wall they did not earn. This slice's job is to make the result exist and be honest about what it covers.

## Scope boundary

Parity is of the FAST tier plus the cloud safety net, not the image build. AGENTS.md §4 already tiers it that way for every surface: "the heavy build runs once, in the cloud." The in-platform path takes the same deal the external path takes. Giving the sandbox a Docker socket would dissolve the isolation that makes it safe to hand to a non-developer, for a tier the cloud already covers.

## Changes

- `apps/web/lib/build/sandbox/guard-gauntlet.ts` (new) — runs the gauntlet in the build's worktree; tri-states could-not-run.
- `apps/web/lib/build/sandbox/guard-gauntlet-evidence.ts` (new) — tree-keyed record shaping, coverage statement, summary.
- `apps/web/lib/gates/gate-run-identity.ts` — `in-platform-preflight` added to `GATE_KINDS`.
- `apps/web/lib/queue/functions/build-review-verification.ts` — non-blocking `guard-gauntlet` step.
- `apps/web/lib/mcp/packs/sandbox-pack.ts` — pass the build's workdir.
- `docs/superpowers/specs/2026-09-12-in-platform-gate-parity-design.md` (new).

## Test plan

- [x] `pnpm typecheck`
- [x] 32 new unit tests green
- [x] `pnpm run pregate:preflight` — 67 guards clean
- [x] Exact-tree local-CI gate PASS

### Verification evidence

Local-CI-Evidence: cmtxwlqy61n5o01s0kgmmsiyq (feat/in-platform-gate-parity@dac59493cab5)

**Not yet proven:** the gauntlet step has not been exercised against a real build on a live install — that needs a release. It is non-blocking, so the failure mode if something is wrong is a logged warning and a missing record, not a stalled build.

### Module-size baseline

`sandbox-pack.ts` grows 921→924. Those three lines are an import, a call restructure and a two-line comment for a correctness fix in an already-oversized file — the ratchet's own "unavoidable and intentional" case. The same `--update` tightens `agentic-loop.ts` 2642→2640 from merged #5297; the diff is those two lines and nothing else.

## Pre-PR readiness

- [x] `pnpm run pregate:preflight` passed (67 guards)
- [x] Exact-tree local-CI evidence captured — PASS at dac59493cab5
- [x] `pnpm pr:ready` READY

## Related issues / Epic

EP-INPLATFORM-PARITY. Refs BI-CA6769FE (slice 1) and BI-4A9910A9 (slice 2). Next: BI-0700B79C with BI-46E9AB38 and BI-9A405652.

## Overlap sweep

No open PR touches `build/sandbox`, `gates/gate-run-identity` or `queue/functions/build-review-verification`.

## Correction made before merge

`guardPlanDigest` originally hashed the run's OUTCOME — the failing guard names and the pass flag. That makes the key derivable only by the producer, and slice 3 has to compute the same key *before* it knows the result in order to look the record up. So the keying would have made the thing it exists for impossible. Caught while building the consumer; the digest now hashes only the plan and a version, with a test asserting it does not depend on the outcome.

## Notes for the reviewer

The load-bearing safety property is that a fast-tier record cannot be reused as the heavy tier. It holds because `deriveGateKey` hashes `gateKind`, so identical repository, tree, plan and toolchain still produce different keys. If you change how the key is derived, that test is the one to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
