### PR TITLE
fix(local-ci): the resumer must not treat infrastructure as a verdict

### DIFF
--- a/scripts/lib/durable-wait-resumer.test.mjs
+++ b/scripts/lib/durable-wait-resumer.test.mjs
@@ -13,7 +13,18 @@ import {
   shouldSpawnResumer,
   spawnDurableWaitResumer,
 } from "./durable-wait-resumer.mjs";
-import { resumeUntilAdmitted } from "../local-ci-durable-wait-resumer.mjs";
+import {
+  EXIT_QUEUED,
+  INFRASTRUCTURE_BACKOFF_MS,
+  RETRYABLE_EXITS,
+  isRetryableExit,
+  resumeUntilAdmitted,
+} from "../local-ci-durable-wait-resumer.mjs";
+import {
+  EXIT_CONTROL_PLANE_STARVATION,
+  EXIT_SANDBOX_DRIFT,
+  classifyGateOutcome,
+} from "./sandbox-freshness.mjs";
 
 const GATE_ARGV = ["/usr/bin/node", "/repo/scripts/gate-worktree.mjs", "--branch", "fix/x"];
 
@@ -239,4 +250,90 @@ test("the resumer survives its sleep and re-claims more than once", async () => 
   );
   assert.ok(attempts.every((entry) => entry.code === 75));
   assert.equal(exitCode, 75, "still queued at its deadline is still queued, not a verdict");
+});
+
+// ── infrastructure is not a verdict (observed live 2026-09-12) ──────────────
+
+// RED for the field defect: attempt 7 returned exit 5, the resumer wrote
+// "finished", and the branch was left carrying a phantom FAIL that exact-tree
+// reuse replayed. A starved control plane is a host condition, not an answer.
+test("a control-plane starvation does not end the wait", async () => {
+  const codes = [EXIT_QUEUED, EXIT_CONTROL_PLANE_STARVATION, 0];
+  let i = 0;
+  const slept = [];
+  const { code, attempts, blockedAttempts } = await resumeUntilAdmitted({
+    gateArgv: ["/repo/scripts/gate-worktree.mjs"],
+    intervalMs: 20_000,
+    deadlineMs: 3_600_000,
+    env: {},
+    now: () => 0,
+    sleepFn: async (ms) => { slept.push(ms); },
+    spawnFn: () => {
+      const c = codes[i];
+      i += 1;
+      return { once(e, h) { if (e === "exit") queueMicrotask(() => h(c)); } };
+    },
+  });
+  assert.equal(code, 0, "the wait ends on the gate's real verdict, not on the starvation");
+  assert.equal(attempts, 3);
+  assert.equal(blockedAttempts, 1);
+  assert.equal(slept[1], INFRASTRUCTURE_BACKOFF_MS, "a host that just starved needs longer than the queue poll");
+});
+
+test("a killed build child does not end the wait either", async () => {
+  for (const infra of [87, 130, 143]) {
+    const codes = [infra, 1];
+    let i = 0;
+    const { code, attempts } = await resumeUntilAdmitted({
+      gateArgv: ["/repo/scripts/gate-worktree.mjs"],
+      intervalMs: 10,
+      deadlineMs: 3_600_000,
+      env: {},
+      now: () => 0,
+      sleepFn: async () => {},
+      spawnFn: () => {
+        const c = codes[i];
+        i += 1;
+        return { once(e, h) { if (e === "exit") queueMicrotask(() => h(c)); } };
+      },
+    });
+    assert.equal(code, 1, `exit ${infra} must be retried, then the real FAIL returned`);
+    assert.equal(attempts, 2);
+  }
+});
+
+test("a product FAIL ends the wait immediately - fail closed on safety", async () => {
+  const { code, attempts } = await resumeUntilAdmitted({
+    gateArgv: ["/repo/scripts/gate-worktree.mjs"],
+    intervalMs: 10,
+    deadlineMs: 3_600_000,
+    env: {},
+    now: () => 0,
+    sleepFn: async () => {},
+    spawnFn: () => ({ once(e, h) { if (e === "exit") queueMicrotask(() => h(1)); } }),
+  });
+  assert.equal(code, 1);
+  assert.equal(attempts, 1, "a real failure must not be retried into a green");
+});
+
+// Retrying a drifted sandbox cannot converge it; it would spin to the deadline.
+test("sandbox drift is not retried", () => {
+  assert.equal(isRetryableExit(EXIT_SANDBOX_DRIFT), false);
+});
+
+// The one rule that must never rot: this set is a SUBSET of what the canonical
+// classifier calls blocked. If someone reclassifies a code, this fails here
+// rather than silently turning an infrastructure blip into a verdict again.
+test("every retryable exit is one the canonical classifier calls blocked", () => {
+  for (const code of RETRYABLE_EXITS) {
+    const outcome = classifyGateOutcome({ freshnessVerdict: "green", gateExitCode: code });
+    assert.equal(
+      outcome.productEvidence, false,
+      `exit ${code} is treated as retryable but classifyGateOutcome calls it product evidence`,
+    );
+    assert.match(
+      outcome.status, /^blocked_/,
+      `exit ${code} is treated as retryable but classifies as "${outcome.status}"`,
+    );
+  }
 });

--- a/scripts/local-ci-durable-wait-resumer.mjs
+++ b/scripts/local-ci-durable-wait-resumer.mjs
@@ -10,6 +10,10 @@ import {
 } from "./lib/durable-wait-resumer.mjs";
 import { isEntryModule } from "./lib/entry-module.mjs";
 import {
+  EXIT_CHILD_SIGNAL_DEATH,
+  EXIT_CONTROL_PLANE_STARVATION,
+} from "./lib/sandbox-freshness.mjs";
+import {
   createGateObserverIdentity,
   registerLocalQueueObserver,
   releaseLocalQueueObserver,
@@ -24,7 +28,44 @@ import {
 // file exactly as it does on a first run, so `pregate:status` remains the
 // single source of the verdict and this file adds no second home for one.
 
-const EXIT_QUEUED = 75;
+export const EXIT_QUEUED = 75;
+
+/**
+ * Exit codes that are NOT a verdict, so the resumer keeps waiting.
+ *
+ * AGENTS.md 4: "A gate that could not run is not a verdict. Infrastructure
+ * failure is recorded as inconclusive and re-runs on the same SHA. Never a FAIL
+ * against the diff. Fail closed on safety; fail open on infrastructure."
+ *
+ * The first build of this resumer returned on ANY code other than 75, so a
+ * control-plane starvation (exit 5) - a transient condition this host produces
+ * regularly under concurrent gate load - ended the wait as though the gate had
+ * answered. Observed live 2026-09-12: attempt 7 returned 5, the resumer wrote
+ * "finished", and the branch was left carrying a phantom FAIL with no recorded
+ * reason that exact-tree reuse then replayed (BI-ED53E13A).
+ *
+ * `classifyGateOutcome` in lib/sandbox-freshness.mjs is the single source of
+ * truth for what each code means; this set is the subset it classifies as
+ * blocked AND transient, and a test asserts the two never drift apart.
+ *
+ * Deliberately NOT here: EXIT_SANDBOX_DRIFT (3). It is equally "not a verdict",
+ * but re-running cannot converge a drifted sandbox, so retrying it would spin
+ * until the deadline instead of surfacing the real work.
+ */
+export const RETRYABLE_EXITS = Object.freeze([
+  EXIT_QUEUED,
+  EXIT_CONTROL_PLANE_STARVATION,
+  EXIT_CHILD_SIGNAL_DEATH,
+  130, // 128 + SIGINT, stamped when the parent took the signal (BI-8392DA16)
+  143, // 128 + SIGTERM, likewise
+]);
+
+/** A host that just starved will starve again in 20s; back off before retrying. */
+export const INFRASTRUCTURE_BACKOFF_MS = 60_000;
+
+export function isRetryableExit(code) {
+  return RETRYABLE_EXITS.includes(code);
+}
 
 // A detached process with stdio "ignore" that leaves no trace is undiagnosable:
 // when the first field build of this resumer died on its second re-claim there
@@ -118,13 +159,18 @@ export async function resumeUntilAdmitted({
 }) {
   const giveUpAt = now() + deadlineMs;
   let attempts = 0;
+  let blockedAttempts = 0;
   for (;;) {
     attempts += 1;
     const code = await runGateOnce({ gateArgv, env, spawnFn });
-    log("gate-attempt", { attempts, code });
-    if (code !== EXIT_QUEUED && code !== null) return { code, attempts };
-    if (now() >= giveUpAt) return { code: EXIT_QUEUED, attempts };
-    await sleepFn(intervalMs);
+    const blocked = code !== null && code !== EXIT_QUEUED && isRetryableExit(code);
+    if (blocked) blockedAttempts += 1;
+    log("gate-attempt", { attempts, code, ...(blocked ? { blocked: true } : {}) });
+    // A real verdict - the gate passed or the product failed - ends the wait.
+    // Anything the classifier calls blocked-and-transient does not.
+    if (code !== null && !isRetryableExit(code)) return { code, attempts, blockedAttempts };
+    if (now() >= giveUpAt) return { code: EXIT_QUEUED, attempts, blockedAttempts };
+    await sleepFn(blocked ? Math.max(intervalMs, INFRASTRUCTURE_BACKOFF_MS) : intervalMs);
   }
 }
 
@@ -159,13 +205,13 @@ async function main() {
   const log = makeLogger(options.observerDirectory, identity.token);
   log("start", { pid: process.pid, gateArgv: options.gateArgv, intervalMs: options.intervalMs });
   try {
-    const { code, attempts } = await resumeUntilAdmitted({
+    const { code, attempts, blockedAttempts } = await resumeUntilAdmitted({
       gateArgv: options.gateArgv,
       intervalMs: options.intervalMs,
       deadlineMs: options.deadlineMs,
       log,
     });
-    log("finished", { code, attempts });
+    log("finished", { code, attempts, blockedAttempts });
     process.exitCode = code ?? EXIT_QUEUED;
   } catch (error) {
     log("crashed", { message: String(error?.message || error) });


### PR DESCRIPTION
## The defect

Found by running the resumer shipped in #5293 against the real queue, not by any test.

`resumeUntilAdmitted` returned on any exit other than 75. Exit 5 is `blocked_control_plane_starvation`, which the gate's own classifier describes as *"infrastructure evidence, NOT a product build failure"* — so a transient host condition ended the wait as though the gate had answered.

Observed live 2026-09-12 on this host: attempt 7 returned 5, the resumer wrote `finished`, and the branch was left carrying a phantom FAIL — `status: failed` with `failureReason`, `failureSummary` and `evidenceId` all null. Exact-tree reuse then replayed that FAIL on every later attempt (BI-ED53E13A). The slot log for that run ends mid-build at `Creating an optimized production build ...` followed by `terminated 3 descendant process(es)`, and names **no failing test at all**.

AGENTS.md §4 is explicit: *a gate that could not run is not a verdict … fail closed on safety; fail open on infrastructure.*

## What changed

- The resumer keeps waiting on the blocked-and-transient codes: `75` (queued or fenced), `5` (control-plane starvation), `87` (child signal death), and the conventional `130`/`143` the wrapper stamps when the parent took the signal (BI-8392DA16).
- It backs off to 60s after a blocked attempt. A host that just starved will starve again in 20s.
- A product FAIL still ends the wait on the first attempt. Retrying a real failure into a green is the one outcome worse than the defect being fixed.
- `EXIT_SANDBOX_DRIFT` (3) is deliberately **not** retried. It is equally "not a verdict", but re-running cannot converge a drifted sandbox, so retrying would spin to the deadline instead of surfacing the real work.

## The part that should not rot

The retryable set is a **subset** of what `classifyGateOutcome` in `lib/sandbox-freshness.mjs` already calls blocked, and a test asserts it for every member — both `productEvidence === false` and a `blocked_*` status. A future reclassification of any code breaks that test rather than silently turning an infrastructure blip back into a verdict.

That keeps one rule in one home rather than duplicating the exit-code taxonomy into the client.

## Verification

- `scripts/lib/durable-wait-resumer.test.mjs`: 17 passed.
- Both new behaviours fail against the previous rule (`code !== EXIT_QUEUED`) and pass against this one — confirmed by reverting the predicate and re-running.
- Local-CI gate: **PASS** on `d51f468692e5`, evidence `cmtxwdrqi1mge01s097ddm12l`.

## Related, not fixed here

The same live observation showed the resumer minting a **second** lease row rather than refreshing the first, orphaning the original until its 2h expiry — BI-D35B85BF Wanted item 2, now firing every ~30s instead of occasionally. The cause is a component of `deriveGateKey` changing between otherwise identical claims; which component is not yet proven, so it is deliberately not guessed at here. Recorded on BI-D35B85BF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
