### PR TITLE
fix(pregate): refuse to take the fence from a live gate, or to key a record to the wrong commit (BI-1281A164)

### DIFF
--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -264,6 +264,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       conformanceTest(
         "scripts/lib/dev-preview-migrate-converge.test.mjs",
         "scripts/pregate-exit-honesty.test.mjs",
+        "scripts/pregate-fence-safety.test.mjs",
         "scripts/pre-push-gate-slot-contract.test.mjs",
         "scripts/lib/gate-context-runtime-contract.test.mjs",
         "packages/dpf-skill-pack/hooks/code-intelligence-guidance.test.mjs",

--- a/scripts/pregate-fence-safety.test.mjs
+++ b/scripts/pregate-fence-safety.test.mjs
@@ -1,0 +1,98 @@
+// scripts/pregate-fence-safety.test.mjs
+//
+// BI-1281A164. Two operating rules that lived only in one AI client's local
+// memory, encoded here so nobody has to remember either one.
+//
+// Both were learned by destroying something. The first killed a gate that was
+// exporting its image, because every pregate entry point claims the same
+// worktree fence and a stale status line said it was safe to finalize. The
+// second burned a full lease and Docker build on a record the pre-push hook
+// then refused, because the record keys to the SHA at lease claim rather than
+// to the code the build compiled.
+//
+// The guards are pure so the policy is testable without a git tree or a lease.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldRefuseWhileGateRunning, shouldRefuseDirtyTree } from "./pregate.mjs";
+
+test("refuses any fence-taking invocation while a gate runs in this worktree", () => {
+  const record = { status: "running", slot: "slot-0", sha: "abcdef0123456789" };
+
+  for (const args of [[], ["--finalize-evidence"], ["--resume"], ["--dry-run"]]) {
+    const verdict = shouldRefuseWhileGateRunning({ args, buildRecord: record });
+    assert.equal(verdict.refuse, true, `expected refusal for ${JSON.stringify(args)}`);
+  }
+});
+
+test("names the running slot and commit so the caller can find the live gate", () => {
+  const verdict = shouldRefuseWhileGateRunning({
+    args: ["--finalize-evidence"],
+    buildRecord: { status: "running", slot: "slot-0", sha: "abcdef0123456789" },
+  });
+
+  assert.match(verdict.reason, /slot-0/);
+  assert.match(verdict.reason, /abcdef012345/);
+  // The caller's next move has to be in the message, or they reach for the
+  // thing that caused the incident.
+  assert.match(verdict.reason, /read-only/);
+  assert.match(verdict.reason, /finalize-evidence/);
+});
+
+test("lets help through, and lets every invocation through when no gate is running", () => {
+  assert.equal(
+    shouldRefuseWhileGateRunning({
+      args: ["--help"],
+      buildRecord: { status: "running", slot: "slot-0" },
+    }).refuse,
+    false,
+  );
+
+  for (const status of ["passed", "failed", "queued", undefined]) {
+    assert.equal(
+      shouldRefuseWhileGateRunning({ args: [], buildRecord: { status } }).refuse,
+      false,
+      `expected no refusal for status=${status}`,
+    );
+  }
+});
+
+test("fails open when the build record cannot be measured", () => {
+  // A guard that cannot measure must not block a legitimate gate.
+  assert.equal(shouldRefuseWhileGateRunning({ args: [] }).refuse, false);
+  assert.equal(shouldRefuseWhileGateRunning({ args: [], buildRecord: null }).refuse, false);
+});
+
+test("refuses a real gate run on a dirty tree, because the record would key to the base commit", () => {
+  const verdict = shouldRefuseDirtyTree({
+    args: [],
+    porcelain: " M apps/web/lib/a.ts\n?? scripts/new.mjs\n",
+  });
+
+  assert.equal(verdict.refuse, true);
+  assert.match(verdict.reason, /2 uncommitted change/);
+  // The failure is a stale record key, not a bad build — say so, or the reader
+  // concludes the gate is broken and reaches for the push override.
+  assert.match(verdict.reason, /lease claim/);
+  assert.match(verdict.reason, /Commit first/);
+  assert.match(verdict.reason, /override/);
+});
+
+test("does not refuse invocations that build nothing", () => {
+  const porcelain = " M apps/web/lib/a.ts\n";
+
+  for (const args of [["--finalize-evidence"], ["--dry-run"], ["--help"], ["-h"]]) {
+    assert.equal(
+      shouldRefuseDirtyTree({ args, porcelain }).refuse,
+      false,
+      `expected no refusal for ${JSON.stringify(args)}`,
+    );
+  }
+});
+
+test("treats a clean or unmeasurable tree as nothing to refuse on", () => {
+  assert.equal(shouldRefuseDirtyTree({ args: [], porcelain: "" }).refuse, false);
+  assert.equal(shouldRefuseDirtyTree({ args: [], porcelain: "   \n  \n" }).refuse, false);
+  assert.equal(shouldRefuseDirtyTree({ args: [] }).refuse, false);
+});

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -15,6 +15,7 @@
 // focused debugging. This keeps lease/fence safety in one implementation.
 
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mcpCall } from "./lib/mcp-client.mjs";
@@ -75,6 +76,57 @@ export function resolveWrapperExitCode({ status, timedOut, recordExempt, verdict
   if (recordExempt) return 0;
   return verdictAtHead === "PASS" ? 0 : ABANDONED_OR_UNRECORDED_EXIT_CODE;
 }
+// A gate is single-tenant per worktree: run, resume and --finalize-evidence all
+// claim the same fence. Taking it while one is mid-flight kills the running
+// gate — observed 2026-09-05, where a --finalize-evidence issued on a stale
+// pregate:status line (that line had read an OLDER slot's record) killed a gate
+// that was exporting its image. The record became blocked_wrapper_exited and
+// the lease release failed as nonprod_lease_not_owner.
+//
+// pregate:status text is not scoped to the slot currently running, so it cannot
+// be the thing a caller checks. The build record can: its own metadata says
+// whether THIS worktree has a gate in flight. Refuse on that, not on prose.
+export function shouldRefuseWhileGateRunning({ args = [], buildRecord = null } = {}) {
+  if (args.includes("--help") || args.includes("-h")) return { refuse: false };
+  if (buildRecord?.status !== "running") return { refuse: false };
+  const slot = buildRecord.slot ? ` in ${buildRecord.slot}` : "";
+  const sha = buildRecord.sha ? ` @ ${String(buildRecord.sha).slice(0, 12)}` : "";
+  return {
+    refuse: true,
+    reason:
+      `a gate is already running in this worktree${slot}${sha}. Every pregate entry point — run, `
+      + "resume and --finalize-evidence — claims the same fence, so this invocation would kill it. "
+      + "While a gate runs here the only safe commands are read-only: git, ls, and reading "
+      + "dpf-local-ci-output*.log / dpf-local-ci-gate*.json under .git/worktrees/<name>/. "
+      + "Use --finalize-evidence only after the running gate prints its own "
+      + "\"rerun --finalize-evidence after quiescence clears\" line.",
+  };
+}
+
+// The gate record is keyed to the SHA captured when the LEASE is claimed, not to
+// the code the build actually compiled. Start a gate on a dirty tree and the
+// record keys to the base commit while the build gates your uncommitted code;
+// the pre-push hook then compares HEAD against that stale key and refuses, so a
+// full lease plus Docker build is burned on a record nothing will accept.
+// Confirmed 2026-07-29. The hook is right; the fix is to commit first.
+export function shouldRefuseDirtyTree({ args = [], porcelain = "" } = {}) {
+  if (isRecordExemptInvocation(args)) return { refuse: false };
+  const dirty = String(porcelain)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (dirty.length === 0) return { refuse: false };
+  return {
+    refuse: true,
+    reason:
+      `the working tree has ${dirty.length} uncommitted change(s). The gate record is keyed to the `
+      + "SHA at lease claim, so a gate started now records the BASE commit and the pre-push hook "
+      + "will refuse the push even though the build gated your code. Commit first, then run pregate "
+      + "— a second run is a full lease and Docker build, and a contended slot can queue for 20 "
+      + "minutes. Do not reach for the push override; the hook is correct.",
+  };
+}
+
 const DEFAULT_LEASE_WAIT_SECONDS = 7200;
 
 // Host-side guard parity preflight (BI-D35433FB): run the deterministic CI
@@ -649,6 +701,30 @@ export async function runGateWithQueuedRevival({
   }
 }
 
+// Thin, failure-tolerant readers for the two safety guards above. Both fail
+// OPEN by returning a shape the guard treats as "nothing to refuse on": a guard
+// that cannot measure must not block a legitimate gate. The guards themselves
+// stay pure so the policy is unit-testable without a git tree.
+function readWorktreeBuildRecord() {
+  try {
+    const path = gitText(["rev-parse", "--git-path", ".build.json"]);
+    if (!path) return null;
+    return JSON.parse(readFileSync(resolvePath(process.cwd(), path), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readWorkingTreePorcelain() {
+  try {
+    const result = spawnSync("git", ["status", "--porcelain"], { encoding: "utf8" });
+    if (result.error || result.status !== 0) return "";
+    return String(result.stdout || "");
+  } catch {
+    return "";
+  }
+}
+
 async function main() {
   // BI-B1065D41: `pnpm run pregate | head -5` must survive head exiting. Both
   // this wrapper and the gate it spawns need the tolerance — the gate inherits
@@ -659,6 +735,23 @@ async function main() {
   const diskCheck = checkHostDiskSpace();
   if (!diskCheck.ok) {
     process.stderr.write(`pregate: ${diskCheck.message}\n`);
+    process.exit(1);
+  }
+
+  const fenceSafety = shouldRefuseWhileGateRunning({
+    args,
+    buildRecord: readWorktreeBuildRecord(),
+  });
+  if (fenceSafety.refuse) {
+    process.stderr.write(`pregate: ${fenceSafety.reason}
+`);
+    process.exit(1);
+  }
+
+  const treeSafety = shouldRefuseDirtyTree({ args, porcelain: readWorkingTreePorcelain() });
+  if (treeSafety.refuse) {
+    process.stderr.write(`pregate: ${treeSafety.reason}
+`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## What

Two operating rules that lived only in one AI client's local memory become guards in `scripts/pregate.mjs`. Both were learned by destroying something, and both are checkable, so neither needs to be remembered any more.

Part of BI-1281A164 under EP-HIVE-HARVEST. The triage rubric prefers encoding a rule over writing it down; these are the two entries in the `feedback_*` corpus that supported it.

## The two incidents

**A gate is single-tenant per worktree.** Run, resume and `--finalize-evidence` all claim the same fence. On 2026-09-05 a `--finalize-evidence` issued on a stale `pregate:status` line — that line had read an *older* slot's record — killed a gate that was mid-flight exporting its image. The record became `blocked_wrapper_exited` and the lease release failed as `nonprod_lease_not_owner`.

Status text is not scoped to the slot currently running, so it cannot be the thing a caller checks. The worktree's own build record can, and now is.

**The gate record is keyed to the SHA at lease claim, not to the code the build compiled.** Start a gate on a dirty tree and the record keys to the base commit while the build gates your uncommitted work. The pre-push hook then compares HEAD against that stale key and refuses. A full lease and Docker build are burned on a record nothing will accept, and a contended slot can queue twenty minutes before that happens. Confirmed 2026-07-29.

## Shape

Both are pure functions beside the existing exit-code policy, so the rules are unit-testable without a git tree or a lease. Both **fail open**: a guard that cannot measure must never block a legitimate gate.

The messages carry the caller's next move, not just a refusal.

- The fence message names the running slot and commit, and lists what is safe to run meanwhile.
- The dirty-tree message says the build was fine and the *record key* was stale. A reader who concludes the gate is broken reaches for the push override, which is the one thing that must not happen here. The hook is right.

## Verification

End to end on a real dirty tree, refusing before any lease is claimed:

```
pregate: the working tree has 3 uncommitted change(s). The gate record is keyed to
the SHA at lease claim, so a gate started now records the BASE commit and the
pre-push hook will refuse the push even though the build gated your code. Commit
first, then run pregate ... Do not reach for the push override; the hook is correct.
```

Exit 1, no lease claimed.

Seven unit tests cover both guards, including the fail-open paths and the closed set of invocations that build nothing. The test is registered in `scripts/lib/ci-policy-guards.mjs`, **not** the allowlist, so it actually runs — the inventory guard now reads 328 discovered, 180 listed.

Worth noting for whoever touches this next: `scripts/pregate.test.mjs` is in the allowlist, so tests added there never run in CI. That is why this is a new file.

## Local copy removed

The two memory files and their index entries are deleted in the same change, so the local copy cannot remain a rival source of truth.

Convergence-Impact-Decision: auto-converges — the guards live in scripts/pregate.mjs, which ships in the repo and is what every contributor and worktree invokes directly; an install picks them up with the source it already pulls, and nothing needs seeding or an operator step

Docs-Impact-Decision: no-docs-needed — the rules are now enforced at the moment of action with the reasoning in the refusal message itself, which is the surface a caller actually reads; adding prose elsewhere would create the second home this change exists to remove

Refs: BI-1281A164 EP-HIVE-HARVEST

🤖 Generated with [Claude Code](https://claude.com/claude-code)
