### PR TITLE
fix(local-ci): reap an abandoned queue row, and record the identity behind each queued claim

### DIFF
--- a/apps/web/lib/nonprod/environment-lease-abandoned-waiter.test.ts
+++ b/apps/web/lib/nonprod/environment-lease-abandoned-waiter.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+// BI-D35B85BF Wanted 3 — a queued row whose owner stopped beating is reaped
+// now, instead of holding its reservation until its two-hour wait deadline.
+
+import {
+  ABANDONED_QUEUE_ROW_AFTER_MS,
+  planEnvironmentAdmission,
+  queueRowIsAbandoned,
+  type AdmissionLease,
+} from "./environment-lease-admission";
+
+const NOW = new Date("2026-09-12T04:00:00.000Z");
+const WAIT_DEADLINE = new Date(NOW.getTime() + 2 * 60 * 60_000);
+
+function queued(overrides: Partial<AdmissionLease> = {}): AdmissionLease {
+  return {
+    id: "row-queued",
+    status: "queued",
+    slotKey: null,
+    queuedAt: new Date(NOW.getTime() - 60_000),
+    heartbeatAt: new Date(NOW.getTime() - 60_000),
+    expiresAt: WAIT_DEADLINE,
+    ...overrides,
+  };
+}
+
+const minutesAgo = (n: number) => new Date(NOW.getTime() - n * 60_000);
+
+describe("abandoned queue rows", () => {
+  it("reaps a queued row whose owner stopped beating", () => {
+    const lease = queued({ heartbeatAt: minutesAgo(55) });
+    expect(queueRowIsAbandoned(lease, NOW, ABANDONED_QUEUE_ROW_AFTER_MS)).toBe(true);
+  });
+
+  it("keeps a waiter that merely missed a few re-claims on a busy host", () => {
+    const lease = queued({ heartbeatAt: minutesAgo(3) });
+    expect(queueRowIsAbandoned(lease, NOW, ABANDONED_QUEUE_ROW_AFTER_MS)).toBe(false);
+  });
+
+  it("falls back to queuedAt when no beat was ever recorded", () => {
+    const lease = queued({ heartbeatAt: null, queuedAt: minutesAgo(55) });
+    expect(queueRowIsAbandoned(lease, NOW, ABANDONED_QUEUE_ROW_AFTER_MS)).toBe(true);
+  });
+
+  it("never reaps an ACTIVE row - its TTL governs it, not this rule", () => {
+    const lease = queued({ status: "active", slotKey: "slot-0", heartbeatAt: minutesAgo(55) });
+    expect(queueRowIsAbandoned(lease, NOW, ABANDONED_QUEUE_ROW_AFTER_MS)).toBe(false);
+  });
+
+  it("does nothing at all for an environment that does not opt in", () => {
+    const lease = queued({ heartbeatAt: minutesAgo(55) });
+    expect(queueRowIsAbandoned(lease, NOW, undefined)).toBe(false);
+  });
+
+  // The window has to clear the cadence it is judging, or a live waiter is
+  // reaped mid-wait - a far worse failure than the reservation it reclaims.
+  it("leaves generous headroom over the resumer's re-claim cadence", () => {
+    expect(ABANDONED_QUEUE_ROW_AFTER_MS).toBeGreaterThanOrEqual(10 * 60_000);
+  });
+});
+
+describe("admission with abandoned rows", () => {
+  const plan = (leases: AdmissionLease[], abandonedWaiterAfterMs?: number) =>
+    planEnvironmentAdmission({
+      leases,
+      now: NOW,
+      slotKeys: ["slot-0", "slot-1"],
+      abandonedWaiterAfterMs,
+    });
+
+  it("expires the abandoned row and leaves the live one queued", () => {
+    const abandoned = queued({ id: "row-abandoned", heartbeatAt: minutesAgo(55) });
+    const live = queued({ id: "row-live", queuedAt: minutesAgo(5), heartbeatAt: minutesAgo(1) });
+
+    const result = plan([abandoned, live], ABANDONED_QUEUE_ROW_AFTER_MS);
+
+    expect(result.expiredLeaseIds).toContain("row-abandoned");
+    expect(result.expiredLeaseIds).not.toContain("row-live");
+  });
+
+  it("an expired row does not keep its place in the queue", () => {
+    const abandoned = queued({ id: "row-abandoned", queuedAt: minutesAgo(60), heartbeatAt: minutesAgo(55) });
+    const live = queued({ id: "row-live", queuedAt: minutesAgo(5), heartbeatAt: minutesAgo(1) });
+
+    const positions = plan([abandoned, live], ABANDONED_QUEUE_ROW_AFTER_MS).queuePositions;
+
+    expect(positions.some((entry) => entry.leaseId === "row-abandoned")).toBe(false);
+  });
+
+  // Back-compat: every existing caller passes no window, and must be unchanged.
+  it("reaps nothing when no window is supplied", () => {
+    const abandoned = queued({ id: "row-abandoned", heartbeatAt: minutesAgo(55) });
+    expect(plan([abandoned]).expiredLeaseIds).toEqual([]);
+  });
+
+  it("still expires on the wait deadline regardless of the window", () => {
+    const past = queued({ id: "row-past-deadline", expiresAt: minutesAgo(1) });
+    expect(plan([past]).expiredLeaseIds).toContain("row-past-deadline");
+  });
+});

--- a/apps/web/lib/nonprod/environment-lease-admission.ts
+++ b/apps/web/lib/nonprod/environment-lease-admission.ts
@@ -34,6 +34,44 @@ function compareQueued(left: AdmissionLease, right: AdmissionLease): number {
  * waiter keeps its FIFO position (it is not expired) but may neither take a
  * slot nor block a younger waiter that is provably alive.
  */
+/**
+ * How long a queued row may go without a beat before it is treated as
+ * abandoned and reaped, rather than holding its reservation to `expiresAt`.
+ *
+ * BI-D35B85BF Wanted 3. A queued row's wait deadline is two hours, so a waiter
+ * whose owner walked away kept a reservation for two hours after the last sign
+ * of life. Measured 2026-09-10: seven queued rows, several with beats frozen
+ * over an hour earlier, against a two-slot pool - the queue looked deep while
+ * most of its depth was abandoned.
+ *
+ * Ten minutes is ~20x the detached resumer's ~30s re-claim cadence and 5x the
+ * 120s admitted TTL, so a live waiter can lose several consecutive re-claims to
+ * a busy host and still keep its place. It only ever applies to environments
+ * that pass it, so an environment whose waiters legitimately beat slowly is
+ * unaffected.
+ */
+export const ABANDONED_QUEUE_ROW_AFTER_MS = 10 * 60_000;
+
+/**
+ * Has this queued row gone silent long enough to be reaped?
+ *
+ * Distinct from `waiterProvesLiveness`, which decides whether a waiter may take
+ * a slot RIGHT NOW: a waiter can fail that check for a few seconds and recover.
+ * This one decides whether the row should exist at all.
+ */
+export function queueRowIsAbandoned(
+  lease: AdmissionLease,
+  now: Date,
+  abandonedAfterMs: number | undefined,
+): boolean {
+  if (abandonedAfterMs === undefined) return false;
+  if (lease.status !== "queued") return false;
+  const lastBeat = lease.heartbeatAt ?? lease.queuedAt ?? null;
+  // No beat recorded at all is not evidence of abandonment; the TTL still bounds it.
+  if (!lastBeat) return false;
+  return now.getTime() - lastBeat.getTime() > abandonedAfterMs;
+}
+
 export function waiterProvesLiveness(
   lease: AdmissionLease,
   now: Date,
@@ -65,14 +103,19 @@ export function planEnvironmentAdmission(input: {
   now: Date;
   slotKeys: string[];
   livenessWindowMs?: number;
+  /** Reap a queued row silent for longer than this (BI-D35B85BF Wanted 3). */
+  abandonedWaiterAfterMs?: number;
   admissibleLeaseIds?: string[];
 }): EnvironmentAdmissionPlan {
   const slotKeys = [...new Set(input.slotKeys)].sort((left, right) =>
     left.localeCompare(right));
   const expiredLeaseIds = input.leases
     .filter((lease) =>
-      (lease.status === "active" || lease.status === "queued")
-      && lease.expiresAt.getTime() <= input.now.getTime())
+      ((lease.status === "active" || lease.status === "queued")
+        && lease.expiresAt.getTime() <= input.now.getTime())
+      // A queued row whose owner stopped beating is reaped now rather than
+      // holding a reservation until its two-hour wait deadline.
+      || queueRowIsAbandoned(lease, input.now, input.abandonedWaiterAfterMs))
     .map((lease) => lease.id)
     .sort((left, right) => left.localeCompare(right));
   const expired = new Set(expiredLeaseIds);

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "@dpf/db";
-import { planEnvironmentAdmission, type AdmissionLease } from "./environment-lease-admission";
+import {
+  ABANDONED_QUEUE_ROW_AFTER_MS,
+  planEnvironmentAdmission,
+  type AdmissionLease,
+} from "./environment-lease-admission";
 import { type LocalCiHostPressure, type ResolvedLocalCiPoolPolicy } from "./local-ci-pool-policy";
 import type { LocalCiCapacityBroker } from "./local-ci-capacity-broker";
 import {
@@ -153,6 +157,7 @@ async function reconcileEnvironmentInTransaction(input: {
   /** BI-B1CB7EC3: only these rows may take a slot on this pass. */
   admissibleLeaseIds?: string[];
   livenessWindowMs?: number;
+  abandonedWaiterAfterMs?: number;
 }): Promise<{
   expiredLeaseIds: string[];
   admittedLeaseIds: string[];
@@ -178,6 +183,7 @@ async function reconcileEnvironmentInTransaction(input: {
     slotKeys: input.slotKeys,
     admissibleLeaseIds: input.admissibleLeaseIds,
     livenessWindowMs: input.livenessWindowMs,
+    abandonedWaiterAfterMs: input.abandonedWaiterAfterMs,
   });
 
   if (plan.expiredLeaseIds.length > 0) {
@@ -452,6 +458,9 @@ export async function claimNonprodEnvironmentLease(input: {
       livenessWindowMs: selfAdmitting
         ? admittedLeaseTtlMs(input.environmentKey, ttlMs)
         : undefined,
+      // Only a self-admitting environment has a known re-claim cadence, so it is
+      // the only one where silence is evidence of abandonment (BI-D35B85BF).
+      abandonedWaiterAfterMs: selfAdmitting ? ABANDONED_QUEUE_ROW_AFTER_MS : undefined,
     });
     admittedNow = reconciliation.admittedLeaseIds.includes(lease.id);
     queueDepth = reconciliation.queueDepth;

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -109,6 +109,34 @@ import {
 import { isEntryModule } from "./lib/entry-module.mjs";
 import { spawnDurableWaitResumer } from "./lib/durable-wait-resumer.mjs";
 
+/**
+ * Append the gate identity behind one queued claim, for BI-D35B85BF Wanted 2.
+ *
+ * One JSONL line per queued claim, beside the queue observer records so the
+ * same reap clears both. Two lines for one wait with two different claimKeys
+ * name the component that moved; a single line is equally informative.
+ *
+ * Never throws: this is diagnostics, and a gate must not fail because a
+ * diagnostic file could not be written.
+ */
+function recordQueuedClaimIdentity({ directory, branch, sha, claimKey, leaseId, identity }) {
+  if (!directory) return;
+  try {
+    mkdirSync(directory, { recursive: true });
+    appendFileSync(
+      resolvePath(directory, "queued-claim-identity.jsonl"),
+      `${JSON.stringify({
+        at: new Date().toISOString(),
+        branch,
+        sha,
+        leaseId,
+        claimKey,
+        identity: identity ?? null,
+      })}\n`,
+    );
+  } catch { /* diagnostics must never take the gate down */ }
+}
+
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
 const LOCAL_CI_ACTIVE_LEASE_TTL_MS = 2 * 60_000;
@@ -1551,12 +1579,32 @@ async function main() {
           releaseLocalQueueObserver({ path: queueObserverPath, token: gateObserverIdentity.token });
           queueObserverPath = "";
         }
+        // BI-D35B85BF Wanted 2. A resumed wait was observed minting a SECOND
+        // queue row with a different server-derived gate:<hash>, orphaning the
+        // first for its full two-hour deadline. The server derives that hash
+        // from repository + integrationTreeSha + evidencePlanDigest +
+        // toolchainFingerprint, and the two claims are gone by the time anyone
+        // looks, so which component moved has never been established.
+        //
+        // This is deliberately observation, not a fix: if the integration tree
+        // genuinely changed, a new key is CORRECT and only the orphaned row is
+        // the defect. Appending the identity behind every queued claim makes the
+        // next real wait answer the question instead of inviting a guess.
+        recordQueuedClaimIdentity({
+          directory: queueObserverDirectory,
+          branch,
+          sha,
+          claimKey,
+          leaseId,
+          identity: preAdmissionGateIdentity,
+        });
         process.stderr.write(JSON.stringify({
           status: "queued",
           code: "local_ci_durable_wait",
           leaseId,
           taskRunId: admission.taskRunId,
           claimKey,
+          gateIdentity: preAdmissionGateIdentity ?? null,
           queuePosition: admission.queuePosition ?? null,
           resumeMode: "durable-task",
           // Name the owner of the resume outright. A caller reading "caller"


### PR DESCRIPTION
BI-D35B85BF Wanted item 3, plus the observation Wanted item 2 needs before it can be fixed honestly.

## Reap an abandoned queue row (Wanted 3)

A queued row's wait deadline is two hours, so a waiter whose owner walked away held its reservation for two hours after its last sign of life. Measured 2026-09-10: seven queued rows against a two-slot pool, several with beats frozen over an hour earlier — the queue *looked* deep while most of its depth was abandoned.

The detached resumer that landed in #5293 makes this worse rather than better: it re-claims every ~30s, so any wait that mints a new row leaves the old one parked for the full two hours.

`planEnvironmentAdmission` now reaps a queued row silent for longer than `ABANDONED_QUEUE_ROW_AFTER_MS` (10 minutes) — about 20× the resumer's re-claim cadence and 5× the 120s admitted TTL, so a live waiter can lose several consecutive re-claims on a busy host and still keep its place.

Deliberately narrow:

- **Active rows are untouched.** Their TTL already governs them; this rule is only about rows that exist but are attached to nobody.
- **A row with no beat recorded at all is not reaped.** Absence of a beat is not evidence of abandonment, and the wait deadline still bounds it.
- **The window is opt-in per environment** and passed only for the self-admitting `local-integration-ci` pool, because that is the only environment whose re-claim cadence is known. Every other caller passes nothing and behaves exactly as before — covered by a back-compat test.
- Reaping is distinct from `waiterProvesLiveness`, which decides whether a waiter may take a slot *right now*; a waiter can fail that for a few seconds and recover. This decides whether the row should exist at all.

## Record the identity behind each queued claim (observation for Wanted 2)

A resumed wait was observed minting a **second** queue row with a different server-derived `gate:<hash>`, orphaning the first. The server derives that hash from `repository + integrationTreeSha + evidencePlanDigest + toolchainFingerprint`, and both claims are gone by the time anyone looks, so which component moved has never been established.

**This PR does not guess at it.** If the integration tree genuinely changed then a new key is *correct*, and only the orphaned row is the defect — which the reap above already covers. Fixing a hypothesis here risked "fixing" correct behaviour.

The gate now appends one JSONL line per queued claim to `queued-claim-identity.jsonl`, beside the queue observer records so the same reap clears it, carrying the claimKey and all four identity components; the queued payload also reports `gateIdentity`. Two lines from one wait will name the component that moved, and the next real queued wait settles the question with evidence instead of inference.

## Verification

- `apps/web` `lib/nonprod`: 93 passed, 1 skipped — 10 new, covering the reap, the active-row exclusion, the no-beat case, back-compat with no window, and that the wait deadline still applies.
- `pnpm --filter web typecheck:all` exits 0 on both programs.
- `scripts/gate-worktree-lease.test.mjs`: 26 passed.
- Local-CI gate: **PASS** on `c96f4bbb67e8`, evidence `cmty2bncq02ze01mbt5bw17fz`.

An earlier gate attempt on this SHA exited 5 (`lease fenced (portal_quiescing)`) because the install was self-upgrading to `8d1d1835de9` — the merged #5293 commit — mid-run. Zero named failing tests in either slot log; recorded as inconclusive and re-run on the same SHA per AGENTS.md §4.

Note for whoever hits it next: `canonical local-CI claims request no more than the admitted-owner recovery TTL` is timing-flaky on this host (~2.0–2.2s). Observed failing once on unmodified `main` and once here, passing on re-run both times. Not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
