### PR TITLE
fix(data-model): COMMENT ON cannot take a bind parameter — the metadata catalog has been empty on every install (BI-EA61F512)

### DIFF
--- a/packages/db/scripts/apply-model-metadata-comments.ts
+++ b/packages/db/scripts/apply-model-metadata-comments.ts
@@ -29,6 +29,44 @@ const dryRun = process.argv.includes("--dry-run");
 
 type CatalogRow = { table: string; comment: string | null };
 
+/**
+ * `COMMENT ON` is a PostgreSQL UTILITY statement: it cannot be prepared, so it
+ * cannot take a bind parameter (BI-EA61F512). `COMMENT ON TABLE "x" IS $1`
+ * fails with `syntax error at or near "COMMENT"` at execution time — and the
+ * first cut of this script shipped exactly that, because `--dry-run` never
+ * executed the statement and so could not fail the way the real run failed.
+ * Every install therefore booted with an empty catalog while the dry-run
+ * reported 198 comments ready.
+ *
+ * The payload must be inlined as a quoted literal instead. Both helpers below
+ * quote defensively even though their inputs are constrained (table names come
+ * from pg_catalog, payloads are machine-generated JSON): an identifier or a
+ * literal built by string concatenation is exactly where an injection lives, so
+ * the escaping is explicit rather than assumed.
+ */
+export function quoteSqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function quoteSqlIdentifier(value: string): string {
+  if (value.includes(String.fromCharCode(0))) throw new Error(`Refusing to quote an identifier containing a NUL byte: ${JSON.stringify(value)}`);
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/** Sentinel that unwinds a dry-run probe transaction; never escapes the applier. */
+class DryRunRollback extends Error {
+  constructor() {
+    super("dry-run rollback");
+    this.name = "DryRunRollback";
+  }
+}
+
+/** The exact statement the applier runs. Exported so a test can assert its shape without a database. */
+export function commentOnTableStatement(table: string, payload: string | null): string {
+  const target = quoteSqlIdentifier(table);
+  return `COMMENT ON TABLE ${target} IS ${payload === null ? "NULL" : quoteSqlLiteral(payload)}`;
+}
+
 export async function applyModelMetadataComments(opts: { dryRun?: boolean } = {}): Promise<{
   applied: number;
   unchanged: number;
@@ -41,6 +79,23 @@ export async function applyModelMetadataComments(opts: { dryRun?: boolean } = {}
   for (const issue of parsed.issues) {
     console.error(`[model-metadata] ${issue.file}:${issue.line} ${issue.model ?? ""} ${issue.message}`);
   }
+
+  const runCommentStatement = async (statement: string, rollback: boolean): Promise<void> => {
+    if (!rollback) {
+      await prisma.$executeRawUnsafe(statement);
+      return;
+    }
+    // Prove the statement really runs, then undo it: an interactive transaction
+    // whose callback throws is rolled back by Prisma.
+    await prisma
+      .$transaction(async (tx) => {
+        await tx.$executeRawUnsafe(statement);
+        throw new DryRunRollback();
+      })
+      .catch((err: unknown) => {
+        if (!(err instanceof DryRunRollback)) throw err;
+      });
+  };
 
   const rows = await prisma.$queryRawUnsafe<CatalogRow[]>(
     `SELECT c.relname AS "table", obj_description(c.oid, 'pg_class') AS "comment"
@@ -66,9 +121,10 @@ export async function applyModelMetadataComments(opts: { dryRun?: boolean } = {}
       unchanged += 1;
       continue;
     }
-    if (!opts.dryRun) {
-      await prisma.$executeRawUnsafe(`COMMENT ON TABLE "${entry.table}" IS $1`, want);
-    }
+    // The dry-run EXECUTES the statement and rolls it back, so a syntax or
+    // permission error fails the dry-run too (BI-EA61F512: the previous
+    // dry-run skipped the write and could not fail the way the real run did).
+    await runCommentStatement(commentOnTableStatement(entry.table, want), opts.dryRun === true);
     applied += 1;
   }
 
@@ -77,7 +133,7 @@ export async function applyModelMetadataComments(opts: { dryRun?: boolean } = {}
     if (!comment || !comment.startsWith(MODEL_METADATA_COMMENT_PREFIX)) continue;
     if (declaredTables.has(table)) continue;
     if (parseCatalogComment(comment) === null && !comment.startsWith(MODEL_METADATA_COMMENT_PREFIX)) continue;
-    if (!opts.dryRun) await prisma.$executeRawUnsafe(`COMMENT ON TABLE "${table}" IS NULL`);
+    await runCommentStatement(commentOnTableStatement(table, null), opts.dryRun === true);
     removed += 1;
   }
 

--- a/packages/db/src/model-metadata-comment-statement.test.ts
+++ b/packages/db/src/model-metadata-comment-statement.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  commentOnTableStatement,
+  quoteSqlIdentifier,
+  quoteSqlLiteral,
+} from "../scripts/apply-model-metadata-comments";
+
+// BI-EA61F512. The first cut emitted `COMMENT ON TABLE "x" IS $1` with a bind
+// parameter. COMMENT ON is a PostgreSQL utility statement: it cannot be
+// prepared, so that form fails at execution with `syntax error at or near
+// "COMMENT"`. It shipped because --dry-run skipped the write entirely, so the
+// only verification that ran was the path that could not fail. These tests pin
+// the statement SHAPE without a database; the applier's dry-run now also
+// executes and rolls back, so the real statement is exercised too.
+
+describe("COMMENT ON statement construction (BI-EA61F512)", () => {
+  it("inlines the payload as a quoted literal and never uses a bind parameter", () => {
+    const sql = commentOnTableStatement("ToolExecution", 'dpf:{"lifecycle":"telemetry-bounded"}');
+    expect(sql).toBe(`COMMENT ON TABLE "ToolExecution" IS 'dpf:{"lifecycle":"telemetry-bounded"}'`);
+    expect(sql).not.toContain("$1");
+  });
+
+  it("writes NULL unquoted when clearing a stale comment", () => {
+    expect(commentOnTableStatement("Widget", null)).toBe(`COMMENT ON TABLE "Widget" IS NULL`);
+  });
+
+  it("doubles single quotes in the payload so an apostrophe cannot terminate the literal", () => {
+    expect(quoteSqlLiteral("it's fine")).toBe("'it''s fine'");
+    const sql = commentOnTableStatement("T", `dpf:{"basis":"the operator's rule"}`);
+    expect(sql).toBe(`COMMENT ON TABLE "T" IS 'dpf:{"basis":"the operator''s rule"}'`);
+    // One opening and one closing quote only: the literal is not terminated early.
+    expect(sql.split("'").length - 1).toBe(4);
+  });
+
+  it("doubles double quotes in the identifier", () => {
+    expect(quoteSqlIdentifier('we"ird')).toBe('"we""ird"');
+  });
+
+  it("refuses an identifier carrying a NUL byte rather than truncating the statement", () => {
+    expect(() => quoteSqlIdentifier(`bad${String.fromCharCode(0)}name`)).toThrow(/NUL byte/);
+  });
+});


### PR DESCRIPTION
## Summary
Since #5273 merged, **every install has booted with an empty metadata catalog**. Live dev install, portal v2026.09.11:

```
SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
 WHERE n.nspname='public' AND obj_description(c.oid,'pg_class') LIKE 'dpf:%';
-> 0
```

Boot log, every start: `[model-metadata] failed:` then `Command failed with exit code 1`.

**Cause.** The applier ran `COMMENT ON TABLE "x" IS $1`. `COMMENT ON` is a PostgreSQL *utility* statement: it cannot be prepared, so it cannot take a bind parameter. Proven on the live database:

```
PREPARE t AS COMMENT ON TABLE "ToolExecution" IS $1;   -- ERROR: syntax error at or near "COMMENT"
COMMENT ON TABLE "ToolExecution" IS 'dpf:{"probe":1}'; -- COMMENT (works)
```

**Why it shipped.** `--dry-run` skipped the write entirely, so the only verification that ran was the path that could not fail. It reported `comments applied=198` while none of them could be written. Slice 4's carrier — metadata living in Postgres, next to the data — has never existed on any install. Readers silently fall back to parsing the schema files in the image, which is why nothing looked broken from outside; external catalog tools, the reason for using `COMMENT ON` at all, saw nothing.

## Fix
- `commentOnTableStatement()` inlines the payload as a quoted literal (single quotes doubled) and the relname as a quoted identifier (double quotes doubled, NUL refused). Exported so its shape is asserted without a database.
- **The dry-run now executes each statement inside a transaction and rolls it back**, so a syntax or permission error fails the dry-run exactly as it fails the real run. A dry-run that cannot fail the way the real run fails is not verification.
- `model-metadata-comment-statement.test.ts` pins the shape: no bind parameter, unquoted `NULL` when clearing, quote doubling in both literal and identifier, NUL refused.

## Verification
- `vitest run packages/db/src/model-metadata-comment-statement.test.ts`: 5/5.
- **Against the live install**: the fixed applier's dry-run executed all 198 `COMMENT ON` statements and exited 0; the catalog remained empty afterwards because every probe rolled back. The same path under the merged code throws on the first statement. Probe files removed.
- `check-model-metadata-tags.mjs`: 198 tagged, 430 grandfathered. Pre-commit scoped typecheck: ok.

## Unproven
- The real (non-dry-run) write lands at the next portal boot after this deploys; the acceptance check is that the count query above returns 198 instead of 0.

Docs-Impact-Decision: no user-facing route change; the runbook already documents the convention, which is unchanged — only its execution was broken.
Convergence-Impact-Decision: auto-converges — the applier ships in the portal image and runs from scripts/portal-migrate-boot.sh at every start, so each install converges at its next self-upgrade with no operator step.
Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)