### PR TITLE
fix(prisma): guard two runtime traps that mocked tests cannot catch, and fix the live instance

### DIFF
--- a/apps/web/lib/federation/demand-read-model.ts
+++ b/apps/web/lib/federation/demand-read-model.ts
@@ -179,10 +179,20 @@ export const getDemandShareContext = cache(async (): Promise<DemandShareContext>
     prisma.backlogItem.findMany({
       where: {
         status: { in: ["open", "in-progress"] },
-        NOT: [
-          { body: { contains: "[origin:federatedDemand:" } },
-          // A work-sync mirror is not local demand to share (BI-FF8A57EF).
-          { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } },
+        // `body` is nullable, and NOT (body LIKE '...') is NULL - not TRUE - for
+        // a NULL body, so the bare NOT silently dropped every demand item nobody
+        // wrote prose for. Same defect, same column, same feature as the one that
+        // cost 29 epics their sync (#5007); the null companion is the fix, and
+        // check-no-unguarded-not-contains.mjs now holds the shape.
+        OR: [
+          { body: null },
+          {
+            NOT: [
+              { body: { contains: "[origin:federatedDemand:" } },
+              // A work-sync mirror is not local demand to share (BI-FF8A57EF).
+              { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } },
+            ],
+          },
         ],
       },
       select: { itemId: true, title: true, status: true },

--- a/scripts/check-no-mapped-enum-database-value.mjs
+++ b/scripts/check-no-mapped-enum-database-value.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+// scripts/check-no-mapped-enum-database-value.mjs — a Prisma query must spell a
+// @map'd enum with its MEMBER, never with the database value.
+//
+// THE FAILURE THIS PREVENTS
+//
+// Every DPF enum whose values contain hyphens declares members with underscores
+// and @maps them to the hyphenated database value:
+//
+//   post_implementation_review @map("post-implementation-review")
+//
+// Prisma accepts only the MEMBER in a query. The database spelling throws
+// `Invalid value for argument 'gateKey'. Expected InitiativeGateKey.` at
+// runtime — and rows read back carry the member too, so `row.gateKey ===
+// "post-implementation-review"` silently never matches.
+//
+// Unit tests cannot catch either shape, because they mock Prisma and a mock
+// does not enforce the enum. `structural-verification-is-not-functional`
+// applies exactly here: the defect only appears on a live install.
+//
+// It has already shipped a feature completely broken: `declare_break_fix` in
+// v2026.09.07-work-shape-taxonomy.1 (BI-D36E2916, fixed in PR #5185). Every
+// unit test passed.
+//
+// THE RULE
+//
+// Inside a Prisma query block, a string literal assigned to a field whose type
+// is a @map'd enum on THAT model must be a member, not a mapped database value.
+//
+// Scoped that tightly on purpose. The hyphenated spelling is the legitimate
+// wire key nearly everywhere else — receipt schemas, tool grants, readiness
+// codes, GATE_NAMES — so the same gate genuinely has two spellings in one file.
+// Matching the bare string anywhere would be unusable noise. Only a literal
+// standing where Prisma will parse it as an enum is a finding.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+import { isEntryModule } from "./lib/entry-module.mjs";
+
+const QUERY_METHODS = [
+  "findMany", "findFirst", "findFirstOrThrow", "findUnique", "findUniqueOrThrow",
+  "count", "aggregate", "groupBy", "updateMany", "deleteMany", "create", "createMany",
+  "update", "upsert", "delete",
+];
+
+const ACCESSOR_RE = new RegExp(
+  String.raw`\.\s*([a-z][A-Za-z0-9_]*)\s*\.\s*(${QUERY_METHODS.join("|")})\s*\(`,
+  "g",
+);
+
+const SOURCE_FILE = /\.(?:[cm]?ts|[cm]?js)x?$/;
+const SKIP_DIRS = new Set([
+  "node_modules", ".git", "dist", ".next", "build", "coverage", ".turbo",
+  "generated", ".pnpm-store", "prisma",
+]);
+
+export const ALLOWLIST = Object.freeze([
+  "scripts/check-no-mapped-enum-database-value.mjs",
+  "scripts/check-no-mapped-enum-database-value.test.mjs",
+]);
+
+export function toRepoPath(value) {
+  return String(value).split(/[\\/]+/).join("/");
+}
+
+/**
+ * Parse enums and model fields out of the split Prisma schema.
+ *
+ * Returns `enums`: enum name -> Map(databaseValue -> member), holding ONLY
+ * members whose @map differs from the member itself; and `fields`: model name
+ * -> Map(field -> enum name), for fields typed by one of those enums.
+ */
+export function parseSchema(schemaSources) {
+  const enums = new Map();
+  const fieldTypes = new Map();
+  for (const source of schemaSources) {
+    let block = null;
+    let kind = null;
+    for (const raw of String(source).split("\n")) {
+      const line = raw.replace(/\/\/.*$/, "").trim();
+      const open = line.match(/^(model|enum)\s+([A-Za-z0-9_]+)\s*\{/);
+      if (open) {
+        kind = open[1];
+        block = open[2];
+        if (kind === "enum" && !enums.has(block)) enums.set(block, new Map());
+        if (kind === "model" && !fieldTypes.has(block)) fieldTypes.set(block, new Map());
+        continue;
+      }
+      if (line === "}") { block = null; kind = null; continue; }
+      if (!block) continue;
+      if (kind === "enum") {
+        const member = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*(?:@map\("([^"]+)"\))?/);
+        if (!member) continue;
+        const mapped = member[2];
+        // A member that maps to itself can never be spelled wrong.
+        if (mapped && mapped !== member[1]) enums.get(block).set(mapped, member[1]);
+        continue;
+      }
+      const field = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z0-9_]+)/);
+      if (field) fieldTypes.get(block).set(field[1], field[2]);
+    }
+  }
+  // Keep only fields whose type is an enum that has at least one mapped value.
+  const fields = new Map();
+  for (const [model, typed] of fieldTypes) {
+    const mapped = new Map();
+    for (const [field, type] of typed) {
+      if (enums.has(type) && enums.get(type).size > 0) mapped.set(field, type);
+    }
+    if (mapped.size > 0) fields.set(model, mapped);
+  }
+  return { enums, fields };
+}
+
+export function accessorToModel(accessor) {
+  return String(accessor).charAt(0).toUpperCase() + String(accessor).slice(1);
+}
+
+export function extractCallBlock(source, openIndex) {
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIndex, i + 1);
+    }
+  }
+  return source.slice(openIndex);
+}
+
+/**
+ * String literals assigned to `field` inside this block, covering the direct
+ * form (`gateKey: "x"`), the filter forms (`gateKey: { equals: "x" }`) and the
+ * list forms (`gateKey: { in: ["x", "y"] }`).
+ */
+export function literalsAssignedTo(block, field) {
+  const found = [];
+  const re = new RegExp(String.raw`\b${field}\s*:\s*(\{[^{}]*\}|"[^"]*"|'[^']*')`, "g");
+  let match;
+  while ((match = re.exec(String(block))) !== null) {
+    const value = match[1];
+    const strings = value.match(/["']([^"']+)["']/g) || [];
+    for (const raw of strings) found.push(raw.slice(1, -1));
+  }
+  return found;
+}
+
+export function findMappedEnumDatabaseValues(source, schema) {
+  const findings = [];
+  const text = String(source);
+  ACCESSOR_RE.lastIndex = 0;
+  let call;
+  while ((call = ACCESSOR_RE.exec(text)) !== null) {
+    const model = accessorToModel(call[1]);
+    const enumFields = schema.fields.get(model);
+    if (!enumFields) continue;
+    const block = extractCallBlock(text, call.index + call[0].length - 1);
+    const line = text.slice(0, call.index).split("\n").length;
+    for (const [field, enumName] of enumFields) {
+      const mapped = schema.enums.get(enumName);
+      for (const literal of literalsAssignedTo(block, field)) {
+        const member = mapped.get(literal);
+        if (!member) continue;
+        findings.push({ line, model, field, enumName, used: literal, expected: member });
+      }
+    }
+  }
+  return findings;
+}
+
+export function listSourceFiles(root) {
+  const acc = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(join(dir, entry.name));
+        continue;
+      }
+      if (entry.isFile() && SOURCE_FILE.test(entry.name)) {
+        acc.push(toRepoPath(relative(root, join(dir, entry.name))));
+      }
+    }
+  };
+  walk(root);
+  return acc.sort();
+}
+
+export function readSchemaSources(root) {
+  const dir = join(root, "packages", "db", "prisma", "schema");
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".prisma"))
+      .map((name) => readFileSync(join(dir, name), "utf8"));
+  } catch {
+    return [];
+  }
+}
+
+export function scanRepository(root, { allowlist = ALLOWLIST } = {}) {
+  const schema = parseSchema(readSchemaSources(root));
+  const offenders = [];
+  if (schema.enums.size === 0) return { offenders, mappedEnums: 0 };
+  const base = join(root, "apps");
+  for (const file of listSourceFiles(base)) {
+    const repoPath = `apps/${file}`;
+    if (allowlist.includes(repoPath)) continue;
+    const source = readFileSync(join(base, file), "utf8");
+    if (!source.includes("-")) continue;
+    const findings = findMappedEnumDatabaseValues(source, schema);
+    if (findings.length) offenders.push({ file: repoPath, findings });
+  }
+  return { offenders, mappedEnums: schema.enums.size };
+}
+
+function main() {
+  const root = resolve(process.cwd());
+  const { offenders, mappedEnums } = scanRepository(root);
+  if (mappedEnums === 0) {
+    console.error("✗ No Prisma schema found under packages/db/prisma/schema — cannot judge enum spellings.");
+    process.exitCode = 1;
+    return;
+  }
+  if (offenders.length === 0) {
+    console.log(`✓ Every Prisma query spells a @map'd enum with its member (${mappedEnums} enums).`);
+    return;
+  }
+  const total = offenders.reduce((n, o) => n + o.findings.length, 0);
+  console.error(
+    `✗ ${total} Prisma query value(s) using a mapped DATABASE spelling instead of the enum member, ` +
+    `in ${offenders.length} file(s).\n` +
+    "  Prisma accepts only the member; the database spelling throws at runtime, and a\n" +
+    "  mocked Prisma in a unit test will not catch it (BI-D36E2916 shipped broken).\n",
+  );
+  for (const o of offenders) {
+    console.error(`  ${o.file}`);
+    for (const f of o.findings) {
+      console.error(`    L${f.line}  ${f.model}.${f.field} (${f.enumName}): "${f.used}" -> ${f.expected}`);
+    }
+  }
+  console.error("\n  Rows read back carry the member too, so normalise for display:");
+  console.error("  value?.replaceAll(\"_\", \"-\") — see entry-adapter.ts normalizeGate.");
+  process.exitCode = 1;
+}
+
+if (isEntryModule(import.meta.url)) main();

--- a/scripts/check-no-mapped-enum-database-value.test.mjs
+++ b/scripts/check-no-mapped-enum-database-value.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  findMappedEnumDatabaseValues,
+  literalsAssignedTo,
+  parseSchema,
+} from "./check-no-mapped-enum-database-value.mjs";
+
+// The real shape, from work-coordination.prisma.
+const SCHEMA = `
+enum InitiativeGateKey {
+  classification
+  research
+  design_spec                @map("design-spec")
+  post_implementation_review @map("post-implementation-review")
+}
+
+enum PlainEnum {
+  alpha
+  beta
+}
+
+model InitiativeGateReceipt {
+  id      String             @id
+  gateKey InitiativeGateKey?
+  label   String
+}
+
+model Unrelated {
+  id     String @id
+  status PlainEnum
+}
+`;
+
+const schema = () => parseSchema([SCHEMA]);
+
+test("only members whose @map differs are recorded, keyed by database value", () => {
+  const { enums } = schema();
+  const gate = enums.get("InitiativeGateKey");
+  assert.equal(gate.get("post-implementation-review"), "post_implementation_review");
+  assert.equal(gate.get("design-spec"), "design_spec");
+  assert.equal(gate.get("classification"), undefined, "a member that maps to itself cannot be spelled wrong");
+  assert.equal(enums.get("PlainEnum").size, 0);
+});
+
+test("only fields typed by a mapped enum are tracked", () => {
+  const { fields } = schema();
+  assert.equal(fields.get("InitiativeGateReceipt").get("gateKey"), "InitiativeGateKey");
+  assert.equal(fields.get("InitiativeGateReceipt").get("label"), undefined, "a String field is not an enum");
+  assert.equal(fields.get("Unrelated"), undefined, "PlainEnum maps nothing, so the model is not tracked");
+});
+
+// RED: the shape that shipped declare_break_fix completely broken (BI-D36E2916).
+test("a query using the database spelling is a finding", () => {
+  const source = `
+    await prisma.initiativeGateReceipt.findMany({
+      where: { gateKey: "post-implementation-review" },
+    });
+  `;
+  const findings = findMappedEnumDatabaseValues(source, schema());
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].used, "post-implementation-review");
+  assert.equal(findings[0].expected, "post_implementation_review");
+  assert.equal(findings[0].field, "gateKey");
+});
+
+test("the member spelling passes", () => {
+  const source = `
+    await prisma.initiativeGateReceipt.findMany({
+      where: { gateKey: "post_implementation_review" },
+    });
+  `;
+  assert.deepEqual(findMappedEnumDatabaseValues(source, schema()), []);
+});
+
+test("the filter and list forms are covered, not just the direct one", () => {
+  const equals = `await prisma.initiativeGateReceipt.findFirst({ where: { gateKey: { equals: "design-spec" } } });`;
+  assert.equal(findMappedEnumDatabaseValues(equals, schema()).length, 1);
+
+  const list = `await prisma.initiativeGateReceipt.count({ where: { gateKey: { in: ["design-spec", "research"] } } });`;
+  assert.equal(findMappedEnumDatabaseValues(list, schema()).length, 1, "only the mapped value is a finding");
+});
+
+// PRECISION. The hyphenated spelling is the legitimate wire key nearly
+// everywhere - receipt schemas, tool grants, GATE_NAMES - so a guard that
+// matched the bare string anywhere would be unusable noise.
+test("the same string is untouched outside a Prisma query", () => {
+  const source = `
+    const GATE_NAMES = ["post-implementation-review", "design-spec"];
+    if (receipt.gate === "post-implementation-review") return true;
+  `;
+  assert.deepEqual(findMappedEnumDatabaseValues(source, schema()), []);
+});
+
+test("the same string is untouched on a field that is not that enum", () => {
+  const source = `
+    await prisma.initiativeGateReceipt.findMany({
+      where: { label: "post-implementation-review" },
+    });
+  `;
+  assert.deepEqual(findMappedEnumDatabaseValues(source, schema()), [], "label is a String, not the enum");
+});
+
+test("a model that is not in the schema is ignored", () => {
+  const source = `await prisma.somethingElse.findMany({ where: { gateKey: "design-spec" } });`;
+  assert.deepEqual(findMappedEnumDatabaseValues(source, schema()), []);
+});
+
+test("a write path is covered too, not only reads", () => {
+  const source = `await prisma.initiativeGateReceipt.create({ data: { gateKey: "design-spec" } });`;
+  assert.equal(findMappedEnumDatabaseValues(source, schema()).length, 1);
+});
+
+test("literalsAssignedTo reads each supported value shape", () => {
+  assert.deepEqual(literalsAssignedTo(`{ gateKey: "a" }`, "gateKey"), ["a"]);
+  assert.deepEqual(literalsAssignedTo(`{ gateKey: { equals: "a" } }`, "gateKey"), ["a"]);
+  assert.deepEqual(literalsAssignedTo(`{ gateKey: { in: ["a", "b"] } }`, "gateKey"), ["a", "b"]);
+  assert.deepEqual(literalsAssignedTo(`{ other: "a" }`, "gateKey"), []);
+});

--- a/scripts/check-no-unguarded-not-contains.mjs
+++ b/scripts/check-no-unguarded-not-contains.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// scripts/check-no-unguarded-not-contains.mjs — a Prisma `NOT … contains` on a
+// NULLABLE column must carry its `{ column: null }` companion.
+//
+// THE FAILURE THIS PREVENTS
+//
+// SQL is three-valued. `NOT (body LIKE '%marker%')` is NULL — not TRUE — when
+// `body` IS NULL, and Prisma passes that straight through, so every row whose
+// column is NULL silently disappears from the result. Nothing errors. The query
+// looks obviously correct, and the rows it drops are exactly the ones nobody
+// wrote prose for.
+//
+// It has already cost a production incident: 29 epics never synced because a
+// federation read model filtered `NOT: { description: { contains: marker } }`
+// on a nullable column (#5007). The fix shipped as the OR-with-null form and is
+// visible in apps/web/lib/federation/work-page.ts:
+//
+//   OR: [{ body: null }, { NOT: { body: { contains: MARKER } } }]
+//
+// That fix was applied file by file, so the SHAPE was never guarded — and this
+// guard's first run found the same defect still live in the sibling module
+// apps/web/lib/federation/demand-read-model.ts, on the same nullable column,
+// in the same federation feature.
+//
+// THE RULE
+//
+// Inside a Prisma query block, a `contains` that sits under a `NOT` is a
+// finding when the column is nullable in the model that block queries, unless
+// the same block also matches that column against null.
+//
+// Nullability comes from packages/db/prisma/schema/*.prisma, so the guard
+// tracks the schema instead of a hand-maintained list: make a column nullable
+// tomorrow and the guard starts protecting it. A block whose model cannot be
+// resolved lexically is reported as unresolved and does NOT fail the run —
+// `report-only-the-verdict-you-reached` applies to guards too, and a guard that
+// guesses is worse than one that says it could not tell.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+import { isEntryModule } from "./lib/entry-module.mjs";
+
+/** Query methods whose first argument carries a `where`. */
+const QUERY_METHODS = [
+  "findMany", "findFirst", "findFirstOrThrow", "findUnique", "findUniqueOrThrow",
+  "count", "aggregate", "groupBy", "updateMany", "deleteMany",
+];
+
+/** `<receiver>.<model>.<method>(` — receiver is prisma/db/tx/store/client/etc. */
+const ACCESSOR_RE = new RegExp(
+  String.raw`\.\s*([a-z][A-Za-z0-9_]*)\s*\.\s*(${QUERY_METHODS.join("|")})\s*\(`,
+  "g",
+);
+
+const SOURCE_FILE = /\.(?:[cm]?ts|[cm]?js)x?$/;
+const SKIP_DIRS = new Set([
+  "node_modules", ".git", "dist", ".next", "build", "coverage", ".turbo",
+  "generated", ".pnpm-store", "prisma",
+]);
+
+/** Files allowed to carry the shape; each names the trap in prose, not in code. */
+export const ALLOWLIST = Object.freeze([
+  "scripts/check-no-unguarded-not-contains.mjs",
+  "scripts/check-no-unguarded-not-contains.test.mjs",
+]);
+
+export function toRepoPath(value) {
+  return String(value).split(/[\\/]+/).join("/");
+}
+
+/**
+ * Nullable scalar fields per model, read from the split Prisma schema.
+ *
+ * Only `Type?` counts. A list (`String[]`) is never NULL in Postgres and a
+ * relation has no LIKE to be NOT-ed, so neither can produce this defect.
+ */
+export function parseNullableFields(schemaSources) {
+  const models = new Map();
+  for (const source of schemaSources) {
+    let model = null;
+    for (const raw of String(source).split("\n")) {
+      const line = raw.replace(/\/\/.*$/, "").trim();
+      const open = line.match(/^model\s+([A-Za-z0-9_]+)\s*\{/);
+      if (open) {
+        model = open[1];
+        if (!models.has(model)) models.set(model, new Set());
+        continue;
+      }
+      if (line === "}") { model = null; continue; }
+      if (!model) continue;
+      const field = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z0-9_]+)(\?)?/);
+      if (field && field[3] === "?") models.get(model).add(field[1]);
+    }
+  }
+  return models;
+}
+
+/** `discoveredModel` -> `DiscoveredModel`, the accessor-to-model convention. */
+export function accessorToModel(accessor) {
+  return String(accessor).charAt(0).toUpperCase() + String(accessor).slice(1);
+}
+
+/**
+ * The argument block of the call whose `(` sits at `openIndex`, by brace
+ * matching. Bounded so a malformed file cannot walk the whole source.
+ */
+export function extractCallBlock(source, openIndex) {
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIndex, i + 1);
+    }
+  }
+  return source.slice(openIndex);
+}
+
+/**
+ * Columns compared with `contains` underneath a `NOT` in this block.
+ *
+ * Deliberately lexical: it looks for `NOT` and then reads the `column: {`
+ * headers that precede a `contains` within the NOT's own braces. Both the
+ * object form (`NOT: { body: { contains } }`) and the array form
+ * (`NOT: [{ body: { contains } }]`) are covered, because the array form is what
+ * the live defect used.
+ */
+export function notContainsColumns(block) {
+  const columns = [];
+  const text = String(block);
+  const notRe = /\bNOT\s*:\s*([[{])/g;
+  let match;
+  while ((match = notRe.exec(text)) !== null) {
+    const openChar = match[1];
+    const closeChar = openChar === "[" ? "]" : "}";
+    let depth = 0;
+    let end = text.length;
+    for (let i = match.index + match[0].length - 1; i < text.length; i += 1) {
+      const ch = text[i];
+      if (ch === openChar) depth += 1;
+      else if (ch === closeChar) {
+        depth -= 1;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    const body = text.slice(match.index, end);
+    const columnRe = /([A-Za-z_][A-Za-z0-9_]*)\s*:\s*\{[^{}]*\bcontains\b/g;
+    let column;
+    while ((column = columnRe.exec(body)) !== null) columns.push(column[1]);
+  }
+  return [...new Set(columns)];
+}
+
+/** Does the block match this column against null anywhere (the companion)? */
+export function hasNullCompanion(block, column) {
+  return new RegExp(String.raw`\b${column}\s*:\s*null\b`).test(String(block));
+}
+
+/**
+ * Every finding in one file. `unresolved` entries are reported but never fail
+ * the run: the model could not be read lexically, so the guard cannot know
+ * whether the column is nullable.
+ */
+export function findUnguardedNotContains(source, nullableByModel) {
+  const findings = [];
+  const unresolved = [];
+  const text = String(source);
+  ACCESSOR_RE.lastIndex = 0;
+  let call;
+  while ((call = ACCESSOR_RE.exec(text)) !== null) {
+    const accessor = call[1];
+    const block = extractCallBlock(text, call.index + call[0].length - 1);
+    const columns = notContainsColumns(block);
+    if (columns.length === 0) continue;
+    const model = accessorToModel(accessor);
+    const line = text.slice(0, call.index).split("\n").length;
+    const nullable = nullableByModel.get(model);
+    if (!nullable) {
+      unresolved.push({ line, model, columns });
+      continue;
+    }
+    for (const column of columns) {
+      if (!nullable.has(column)) continue;
+      if (hasNullCompanion(block, column)) continue;
+      findings.push({ line, model, column });
+    }
+  }
+  return { findings, unresolved };
+}
+
+export function listSourceFiles(root) {
+  const acc = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(join(dir, entry.name));
+        continue;
+      }
+      if (entry.isFile() && SOURCE_FILE.test(entry.name)) {
+        acc.push(toRepoPath(relative(root, join(dir, entry.name))));
+      }
+    }
+  };
+  walk(root);
+  return acc.sort();
+}
+
+export function readSchemaSources(root) {
+  const dir = join(root, "packages", "db", "prisma", "schema");
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((name) => name.endsWith(".prisma"))
+    .map((name) => readFileSync(join(dir, name), "utf8"));
+}
+
+export function scanRepository(root, { allowlist = ALLOWLIST } = {}) {
+  const schemaSources = readSchemaSources(root);
+  const nullableByModel = parseNullableFields(schemaSources);
+  const offenders = [];
+  const unresolved = [];
+  if (nullableByModel.size === 0) {
+    return { offenders, unresolved, schemaModels: 0 };
+  }
+  for (const file of listSourceFiles(join(root, "apps"))) {
+    const repoPath = `apps/${file}`;
+    if (allowlist.includes(repoPath)) continue;
+    const source = readFileSync(join(root, "apps", file), "utf8");
+    if (!source.includes("NOT")) continue;
+    const result = findUnguardedNotContains(source, nullableByModel);
+    if (result.findings.length) offenders.push({ file: repoPath, findings: result.findings });
+    if (result.unresolved.length) unresolved.push({ file: repoPath, entries: result.unresolved });
+  }
+  return { offenders, unresolved, schemaModels: nullableByModel.size };
+}
+
+function main() {
+  const root = resolve(process.cwd());
+  const { offenders, schemaModels } = scanRepository(root);
+  if (schemaModels === 0) {
+    console.error("✗ No Prisma schema found under packages/db/prisma/schema — cannot judge nullability.");
+    process.exitCode = 1;
+    return;
+  }
+  if (offenders.length === 0) {
+    console.log(`✓ Every Prisma NOT-contains on a nullable column carries its null companion (${schemaModels} models).`);
+    return;
+  }
+  const total = offenders.reduce((n, o) => n + o.findings.length, 0);
+  console.error(
+    `✗ ${total} NOT-contains on a nullable column without a null companion, in ${offenders.length} file(s).\n` +
+    "  NOT (col LIKE '%x%') is NULL, not TRUE, when col IS NULL, so every row with a\n" +
+    "  NULL in that column is silently dropped. This cost 29 epics never syncing (#5007).\n",
+  );
+  for (const o of offenders) {
+    console.error(`  ${o.file}`);
+    for (const f of o.findings) console.error(`    L${f.line}  ${f.model}.${f.column}`);
+  }
+  console.error("\n  Fix: OR: [{ col: null }, { NOT: { col: { contains: X } } }]");
+  console.error("  See apps/web/lib/federation/work-page.ts for the shape.");
+  process.exitCode = 1;
+}
+
+if (isEntryModule(import.meta.url)) main();

--- a/scripts/check-no-unguarded-not-contains.test.mjs
+++ b/scripts/check-no-unguarded-not-contains.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  accessorToModel,
+  findUnguardedNotContains,
+  hasNullCompanion,
+  notContainsColumns,
+  parseNullableFields,
+} from "./check-no-unguarded-not-contains.mjs";
+
+const SCHEMA = `
+model BacklogItem {
+  id        String  @id
+  itemId    String  @unique
+  body      String?
+  title     String
+  tags      String[]
+  epic      Epic?   @relation(fields: [epicId], references: [id])
+}
+
+model DiscoveredModel {
+  id      String @id
+  modelId String
+}
+`;
+
+const nullable = () => parseNullableFields([SCHEMA]);
+
+test("only `Type?` scalars count as nullable", () => {
+  const models = nullable();
+  assert.ok(models.get("BacklogItem").has("body"));
+  assert.ok(!models.get("BacklogItem").has("title"), "a required column cannot be NULL");
+  assert.ok(!models.get("BacklogItem").has("tags"), "a list is never NULL in Postgres");
+  assert.ok(!models.get("DiscoveredModel").has("modelId"));
+});
+
+test("a relation marked optional is not a LIKE-able column", () => {
+  // `epic Epic?` parses as optional, but there is no NOT-contains to write
+  // against a relation, so its presence in the set is harmless. What must NOT
+  // happen is a required scalar leaking in.
+  assert.ok(!nullable().get("BacklogItem").has("title"));
+});
+
+test("accessor maps to the model by the Prisma camelCase convention", () => {
+  assert.equal(accessorToModel("backlogItem"), "BacklogItem");
+  assert.equal(accessorToModel("discoveredModel"), "DiscoveredModel");
+});
+
+// The live defect used the ARRAY form. A guard that only understood
+// `NOT: { col: {...} }` would have reported the repository clean.
+test("NOT columns are found in both the object and the array form", () => {
+  assert.deepEqual(
+    notContainsColumns(`{ where: { NOT: { body: { contains: "x" } } } }`),
+    ["body"],
+  );
+  assert.deepEqual(
+    notContainsColumns(`{ where: { NOT: [{ body: { contains: "x" } }, { body: { contains: "y" } }] } }`),
+    ["body"],
+  );
+});
+
+test("a contains that is not under a NOT is not a finding", () => {
+  assert.deepEqual(notContainsColumns(`{ where: { body: { contains: "x" } } }`), []);
+});
+
+test("the null companion is recognised wherever it sits in the block", () => {
+  assert.ok(hasNullCompanion(`OR: [{ body: null }, { NOT: { body: { contains: "x" } } }]`, "body"));
+  assert.ok(!hasNullCompanion(`NOT: { body: { contains: "x" } }`, "body"));
+  assert.ok(!hasNullCompanion(`OR: [{ title: null }]`, "body"), "a different column is not the companion");
+});
+
+// RED: this is the exact shape found live in demand-read-model.ts.
+test("a bare NOT-contains on a nullable column is a finding", () => {
+  const source = `
+    await prisma.backlogItem.findMany({
+      where: {
+        status: { in: ["open"] },
+        NOT: [
+          { body: { contains: "[origin:federatedDemand:" } },
+        ],
+      },
+    });
+  `;
+  const { findings } = findUnguardedNotContains(source, nullable());
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].model, "BacklogItem");
+  assert.equal(findings[0].column, "body");
+});
+
+// GREEN: the shape the #5007 fix shipped, in work-page.ts.
+test("the OR-with-null form passes", () => {
+  const source = `
+    await prisma.backlogItem.findMany({
+      where: { OR: [{ body: null }, { NOT: { body: { contains: MARKER } } }] },
+    });
+  `;
+  assert.equal(findUnguardedNotContains(source, nullable()).findings.length, 0);
+});
+
+test("a NOT-contains on a required column is not a finding", () => {
+  const source = `
+    await prisma.discoveredModel.findFirst({
+      where: { NOT: { modelId: { contains: "embed" } } },
+    });
+  `;
+  assert.equal(findUnguardedNotContains(source, nullable()).findings.length, 0);
+});
+
+// A guard that guesses is worse than one that says it could not tell.
+test("an unknown model is reported as unresolved, never as a failure", () => {
+  const source = `
+    await prisma.somethingNotInTheSchema.findMany({
+      where: { NOT: { body: { contains: "x" } } },
+    });
+  `;
+  const { findings, unresolved } = findUnguardedNotContains(source, nullable());
+  assert.equal(findings.length, 0);
+  assert.equal(unresolved.length, 1);
+  assert.equal(unresolved[0].model, "SomethingNotInTheSchema");
+});
+
+test("each query block is judged on its own null companion", () => {
+  const source = `
+    await prisma.backlogItem.findMany({
+      where: { OR: [{ body: null }, { NOT: { body: { contains: "a" } } }] },
+    });
+    await prisma.backlogItem.count({
+      where: { NOT: { body: { contains: "b" } } },
+    });
+  `;
+  const { findings } = findUnguardedNotContains(source, nullable());
+  assert.equal(findings.length, 1, "the guarded block must not launder the unguarded one");
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -63,6 +63,7 @@ const EXPECTED_LEGACY_JOBS = [
   "package-boundary-guard",
   "platform-composition-single-home",
   "pr-health-test",
+  "prisma-runtime-traps",
   "prose-lint-guard",
   "published-image-freshness",
   "release-asset-contract",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -153,6 +153,15 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       conformanceTest("scripts/check-release-asset-contract.test.mjs"),
       node("--test", "scripts/installer/local-model-policy-contract.test.mjs"),
     ]),
+    // BI-1281A164 drain: a Prisma NOT-contains on a nullable column silently
+    // drops every NULL row (SQL three-valued logic). It cost 29 epics their
+    // sync (#5007), was fixed file-by-file, and the SHAPE was never guarded -
+    // so the same defect was still live in a sibling federation module when
+    // this guard first ran.
+    guard("prisma-null-contains", "Prisma Null-Contains Semantics", [
+      node("scripts/check-no-unguarded-not-contains.mjs"),
+      node("--test", "scripts/check-no-unguarded-not-contains.test.mjs"),
+    ]),
     guard("db-commandment-coverage", "DB Commandment Coverage", [
       // The never-wipe-db commandment guarded two spellings and allowed three
       // equivalents, including `docker system prune -a --volumes` and every

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -158,7 +158,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     // sync (#5007), was fixed file-by-file, and the SHAPE was never guarded -
     // so the same defect was still live in a sibling federation module when
     // this guard first ran.
-    guard("prisma-null-contains", "Prisma Null-Contains Semantics", [
+    guard("prisma-runtime-traps", "Prisma Runtime Traps", [
       node("scripts/check-no-unguarded-not-contains.mjs"),
       node("--test", "scripts/check-no-unguarded-not-contains.test.mjs"),
       // BI-1281A164 drain: every DPF enum whose values carry hyphens declares

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -161,6 +161,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("prisma-null-contains", "Prisma Null-Contains Semantics", [
       node("scripts/check-no-unguarded-not-contains.mjs"),
       node("--test", "scripts/check-no-unguarded-not-contains.test.mjs"),
+      // BI-1281A164 drain: every DPF enum whose values carry hyphens declares
+      // members with underscores and @maps them. Prisma accepts only the
+      // MEMBER; the database spelling throws at runtime, and a mocked Prisma in
+      // a unit test does not enforce the enum - which is why declare_break_fix
+      // shipped completely broken with every test green (BI-D36E2916, #5185).
+      node("scripts/check-no-mapped-enum-database-value.mjs"),
+      node("--test", "scripts/check-no-mapped-enum-database-value.test.mjs"),
     ]),
     guard("db-commandment-coverage", "DB Commandment Coverage", [
       // The never-wipe-db commandment guarded two spellings and allowed three


### PR DESCRIPTION
First hardening batch of **BI-1281A164** — draining client-local agent memory into the tree. Two notes that lived on one laptop, unreachable by any other install or client, become guards that nobody has to remember.

Both traps share a root cause: **unit tests mock Prisma, and a mock enforces neither SQL's three-valued logic nor an enum**. `structural-verification-is-not-functional` applies to both, and both have already shipped broken.

## 1. `NOT … contains` on a nullable column — and one still live

`NOT (body LIKE '%marker%')` is NULL, not TRUE, when `body` IS NULL, so every row with a NULL in that column silently disappears. Nothing errors.

It cost 29 epics their sync (#5007). That fix was applied **file by file**, so the shape was never guarded — and this guard's first run found the same defect **still live** in the sibling module `apps/web/lib/federation/demand-read-model.ts`, on the same nullable column (`BacklogItem.body`), in the same federation feature. Every demand item with no prose was being dropped from the federated demand read model. Fixed here with the OR-with-null companion that `work-page.ts` already used.

`check-no-unguarded-not-contains.mjs` reads nullability from `packages/db/prisma/schema/*.prisma`, so a column that becomes nullable tomorrow is protected without touching the guard. It understands the **array** form of `NOT` as well as the object form — the live defect used the array form, and an object-only guard would have reported the repository clean.

## 2. A `@map`'d enum spelled with the database value

Every DPF enum whose values carry hyphens declares members with underscores and `@map`s them. Prisma accepts only the member; the database spelling throws at runtime, and rows read back carry the member too, so `row.gateKey === "post-implementation-review"` silently never matches. 93 enums here carry at least one mapped value.

This shipped `declare_break_fix` completely broken in `v2026.09.07-work-shape-taxonomy.1` with every unit test green (BI-D36E2916, #5185).

`check-no-mapped-enum-database-value.mjs` is scoped tightly on purpose: only a literal standing where Prisma will parse it as an enum is a finding. The hyphenated spelling is the legitimate wire key nearly everywhere else — receipt schemas, tool grants, `GATE_NAMES` — so matching the bare string anywhere would be unusable noise. It resolves the model from the query accessor and the field's enum type from the schema, ignores a model it cannot resolve, and covers the direct, `equals`, `in` and write-path forms.

The repository is clean across all 93 enums, so this one is regression prevention.

## Verification

- `check-no-unguarded-not-contains.test.mjs`: 11 passed. Guard clean across 628 models after the fix; reported exactly the one finding before it, with no false positives across `apps/`.
- `check-no-mapped-enum-database-value.test.mjs`: 10 passed.
- `apps/web` `lib/federation`: 442 passed (59 files).
- Local-CI gate: **PASS** on `6809bf3b41f`.

**Both guards were proven against reality, not just fixtures.** For the enum guard I injected a real violation into `backlog-terminal-transition.ts` and confirmed it reported `L126 BacklogItemActivity.gateKey (InitiativeGateKey): "design-spec" -> design_spec`, then went clean on revert. Worth stating because my first probe used a model name that does not exist and the guard reported clean — which would have looked like success while detecting nothing.

## Note for the next person

An earlier SHA of this branch hit `BI-ED53E13A`: a gate FAIL with no recorded reason was replayed by exact-tree reuse on every subsequent attempt, with a byte-identical `elapsedMs`, so "re-run on the same SHA" never actually re-ran. The only escape was changing the tree. That makes `BI-ED53E13A` more load-bearing than its title suggests — AGENTS.md §4 tells you to re-run an inconclusive gate, and for a recorded FAIL that instruction currently cannot be followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
