### PR TITLE
fix(local-ci): a reused PASS keeps its own clock, so an unchanged tree converges (BI-03E1139A)

### DIFF
--- a/apps/web/lib/gates/gate-run-identity.test.ts
+++ b/apps/web/lib/gates/gate-run-identity.test.ts
@@ -152,6 +152,38 @@ describe("local-CI terminal evidence projection", () => {
       status: "reused",
       evidenceRecordId: "EXT-GATE",
       resultClass: "pass",
+      // BI-03E1139A: hand back the stamp this decision was made against. The
+      // caller records the verdict in its own state, and without the evidence's
+      // clock it reached for the lease's — minutes long — and stamped a PASS as
+      // already expired.
+      evidenceValidity: { issuedAt: null, expiresAt: "2026-08-25T12:01:00.000Z" },
+    });
+  });
+
+  it("carries the issue time through when the record has one", () => {
+    const projection = projectLocalCiTerminalEvidence({
+      claimKey: `gate:${gateKey}`,
+      evidence: {
+        id: "EXT-GATE",
+        operationType: "local_integration_ci",
+        details: {
+          gateKey,
+          status: "passed",
+          evidenceValidity: {
+            issuedAt: "2026-08-24T12:01:00.000Z",
+            expiresAt: "2026-08-25T12:01:00.000Z",
+          },
+        },
+      },
+      now: new Date("2026-08-25T12:00:00.000Z"),
+    });
+
+    expect(projection).toMatchObject({
+      status: "reused",
+      evidenceValidity: {
+        issuedAt: "2026-08-24T12:01:00.000Z",
+        expiresAt: "2026-08-25T12:01:00.000Z",
+      },
     });
   });
 

--- a/apps/web/lib/gates/gate-run-identity.ts
+++ b/apps/web/lib/gates/gate-run-identity.ts
@@ -26,8 +26,31 @@ export type GateRunIdentity = GateRunIdentityInput & {
   schemaVersion: typeof GATE_RUN_IDENTITY_SCHEMA_VERSION;
 };
 
+/**
+ * The freshness stamp a local-CI PASS carries, as recorded by the run that
+ * produced it. A reuse decision is made against this and nothing else, so the
+ * caller reusing the verdict must be told the same window rather than left to
+ * infer one (BI-03E1139A).
+ */
+export type LocalCiEvidenceValidity = {
+  /** Informational. Older records predate the field. */
+  issuedAt: string | null;
+  /** The instant this reuse decision was actually made against. */
+  expiresAt: string;
+};
+
 export type LocalCiTerminalEvidenceProjection =
-  | { status: "reused"; evidenceRecordId: string; resultClass: "pass" | "fail" }
+  | {
+    status: "reused";
+    evidenceRecordId: string;
+    resultClass: "pass" | "fail";
+    /**
+     * Present whenever the reuse was decided by a real stamp. Reuse of a record
+     * that reached a product verdict always carries one; the infrastructure
+     * records that skip validity are `rerunnable`, never `reused`.
+     */
+    evidenceValidity: LocalCiEvidenceValidity | null;
+  }
   | { status: "rerunnable" }
   | {
     status: "blocked";
@@ -163,10 +186,18 @@ export function projectLocalCiTerminalEvidence(input: {
   if (expiresAt <= input.now.getTime()) {
     return { status: "blocked", reason: "expired-evidence" };
   }
+  // Hand back the very stamp this decision was made against. The caller writes
+  // the verdict into its own state and needs the evidence's clock; left without
+  // one it reached for the lease's, which is minutes long, and stamped a PASS as
+  // already expired (BI-03E1139A).
   return {
     status: "reused",
     evidenceRecordId: input.evidence.id,
     resultClass: details.status === "passed" ? "pass" : "fail",
+    evidenceValidity: {
+      issuedAt: typeof validity?.issuedAt === "string" ? validity.issuedAt : null,
+      expiresAt: String(validity?.expiresAt),
+    },
   };
 }
 

--- a/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
+++ b/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
@@ -527,6 +527,9 @@ async function claimNonprodEnvironmentLeaseHandler(
           status: "reused",
           evidenceRecordId: result.evidenceRecordId,
           resultClass: result.resultClass,
+          // The caller records this verdict in its own state and must stamp it
+          // with the evidence's clock, not the lease's (BI-03E1139A).
+          evidenceValidity: result.evidenceValidity,
         },
         poolPolicy: result.poolPolicy,
         gateKey,

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -19,7 +19,7 @@ import { assertRenewalSlotBinding, type NonprodSlotBinding } from "./environment
 import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
 import { gateRunDispositionsTotal } from "@/lib/operate/metrics";
 import type { NonprodOwnerProvider } from "./nonprod-owner-provider";
-import { isImmutableGateClaimKey } from "@/lib/gates/gate-run-identity";
+import { isImmutableGateClaimKey, type LocalCiEvidenceValidity } from "@/lib/gates/gate-run-identity";
 import { settleTerminalGateLease } from "./environment-lease-terminal-evidence";
 import { admittedLeaseTtlMs, DEFAULT_LEASE_TTL_MS, requestedTtlMs } from "./environment-lease-timing";
 import { afterNonprodLeaseRelease, publishNonprodCapacityForHead } from "./durable-wait";
@@ -235,7 +235,7 @@ export type ClaimNonprodEnvironmentLeaseResult =
   | { status: "queued"; lease: LeaseRow; queuePosition: number; waitAgeMs: number; poolPolicy: ResolvedNonprodPoolPolicy }
   | { status: "terminal"; lease: LeaseRow; reason: "released" | "expired" | "cancelled"; poolPolicy: ResolvedNonprodPoolPolicy }
   | { status: "subscribed"; lease: LeaseRow; executionStatus: "admitted" | "queued"; poolPolicy: ResolvedNonprodPoolPolicy }
-  | { status: "reused"; lease: LeaseRow; evidenceRecordId: string; resultClass: "pass" | "fail"; poolPolicy: ResolvedNonprodPoolPolicy }
+  | { status: "reused"; lease: LeaseRow; evidenceRecordId: string; resultClass: "pass" | "fail"; evidenceValidity: LocalCiEvidenceValidity | null; poolPolicy: ResolvedNonprodPoolPolicy }
   | { status: "blocked"; lease: LeaseRow; reason: "missing-evidence" | "mismatched-evidence" | "expired-evidence"; poolPolicy: ResolvedNonprodPoolPolicy };
 
 type ResolvedNonprodPoolPolicy = ResolvedLocalCiPoolPolicy | ResolvedHostResourcePoolPolicy;

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -91,6 +91,14 @@ function isolatedFencePath() {
   return join(mkdtempSync(join(tmpdir(), "dpf-gate-fence-")), "owner.json");
 }
 
+// BI-03E1139A: the two clocks a reused PASS is dated by, kept far enough apart
+// that a record stamped with the wrong one is unmistakable. The lease expiry is
+// in the past exactly as it is in the field, where a pool lease outlives its run
+// by minutes while the evidence stays valid for a day.
+const LEASE_EXPIRED_AT = "2020-01-01T00:00:00.000Z";
+const EVIDENCE_ISSUED_AT = "2999-01-01T00:00:00.000Z";
+const EVIDENCE_EXPIRES_AT = "2999-01-02T00:00:00.000Z";
+
 function makeTempWorktree() {
   const dir = mkdtempSync(join(tmpdir(), "dpf-gate-worktree-"));
   const git = (args) => {
@@ -410,11 +418,18 @@ test("a subscriber observes the canonical run and reuses its terminal evidence w
             entityId: "EXT-WINNER",
             data: {
               gateKey: "a".repeat(64),
-              lease: { leaseId: "NPEL-WINNER" },
+              // The lease died minutes ago; the evidence it points at is good
+              // for another day. The gate must date its record by the second
+              // clock, not the first (BI-03E1139A).
+              lease: { leaseId: "NPEL-WINNER", expiresAt: LEASE_EXPIRED_AT },
               admission: {
                 status: "reused",
                 evidenceRecordId: "EXT-WINNER",
                 resultClass: "pass",
+                evidenceValidity: {
+                  issuedAt: EVIDENCE_ISSUED_AT,
+                  expiresAt: EVIDENCE_EXPIRES_AT,
+                },
               },
             },
           }
@@ -453,10 +468,86 @@ test("a subscriber observes the canonical run and reuses its terminal evidence w
     assert.equal(result.code, 0, result.output);
     assert.match(result.output, /owned by another caller/);
     assert.match(result.output, /reused canonical local-CI pass evidence: EXT-WINNER/);
+    // The record is dated by the evidence, and the lease's own expiry survives
+    // beside it rather than overwriting it. Stamped with the lease clock, this
+    // PASS would be born expired and pregate:status would answer STALE forever.
+    const reusedState = JSON.parse(readFileSync(join(worktree, ".git", "dpf-local-ci-gate.json"), "utf8"));
+    assert.equal(reusedState.expiresAt, EVIDENCE_EXPIRES_AT);
+    assert.equal(reusedState.leaseExpiresAt, LEASE_EXPIRED_AT);
+    assert.equal(reusedState.evidenceValidity.issuedAt, EVIDENCE_ISSUED_AT);
     assert.equal(calls.filter((tool) => tool === "claim_nonprod_environment_lease").length, 2);
     assert.equal(calls.includes("renew_nonprod_environment_lease"), false);
     assert.equal(calls.includes("release_nonprod_environment_lease"), false);
     assert.equal(calls.includes("record_local_integration_result"), false);
+  } finally {
+    rmSync(worktree, { recursive: true, force: true });
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("a reused PASS carrying no validity stamp is refused rather than dated by guesswork", async () => {
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const result = payload.params.name === "claim_nonprod_environment_lease"
+        ? {
+          success: true,
+          entityId: "EXT-UNSTAMPED",
+          data: {
+            gateKey: "b".repeat(64),
+            lease: { leaseId: "NPEL-UNSTAMPED", expiresAt: LEASE_EXPIRED_AT },
+            // No evidenceValidity: the server did not say how fresh this
+            // verdict is, and the gate must not invent a window for it.
+            admission: {
+              status: "reused",
+              evidenceRecordId: "EXT-UNSTAMPED",
+              resultClass: "pass",
+            },
+          },
+        }
+        : { success: true, data: { level: "normal" } };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const worktree = makeTempWorktree();
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/unstamped-reuse",
+      "--worktree", worktree,
+      "--poll-seconds", "0.01",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_GATE_RETRY_JITTER: "0",
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.notEqual(result.code, 0, result.output);
+    assert.match(result.output, /without a validity stamp/);
+    // And it must not have left a PASS behind that nobody can date.
+    const statePath = join(worktree, ".git", "dpf-local-ci-gate.json");
+    if (existsSync(statePath)) {
+      const state = JSON.parse(readFileSync(statePath, "utf8"));
+      assert.notEqual(state.status, "passed");
+    }
   } finally {
     rmSync(worktree, { recursive: true, force: true });
     server.closeAllConnections();

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -91,6 +91,7 @@ import {
   createLocalCiPassEvidenceValidity,
   projectReusedPassMetadata,
   readLocalCiGateState,
+  readReusedEvidenceValidity,
   supersedeLosingSlotRecords,
   writeLocalCiGateState,
 } from "./lib/local-ci-gate-state.mjs";
@@ -1397,6 +1398,21 @@ async function main() {
     if (claimResponse?.success === true && admission?.status === "reused") {
       const evidenceId = admission.evidenceRecordId || claimResponse.entityId || "";
       const passed = admission.resultClass === "pass";
+      // BI-03E1139A: a reused PASS is stamped with the EVIDENCE's clock, never
+      // the lease's. Evidence validity runs for a day; a pool lease runs for
+      // minutes. Writing the lease expiry into the evidence field produced a
+      // record born expired — pregate:status read it as STALE and the author was
+      // told to re-run a gate that could only ever reuse the same verdict again.
+      const reusedValidity = readReusedEvidenceValidity(admission.evidenceValidity);
+      // A reuse with no stamp is a server that did not tell us how fresh this
+      // verdict is. Absent evidence of freshness is not evidence of freshness,
+      // so do the work rather than inventing a window.
+      if (passed && !reusedValidity) {
+        die(
+          `local-CI admission reused evidence ${evidenceId} without a validity stamp; `
+            + "refusing to date a verdict this gate cannot vouch for — re-run the gate",
+        );
+      }
       if (queueObserverPath) {
         releaseLocalQueueObserver({
           path: queueObserverPath,
@@ -1411,7 +1427,11 @@ async function main() {
         leaseId: canonicalLeaseId,
         evidenceId,
         status: passed ? "passed" : "failed",
-        expiresAt: claimResponse?.data?.lease?.expiresAt || expiresAt,
+        expiresAt: reusedValidity?.expiresAt
+          || claimResponse?.data?.lease?.expiresAt
+          || expiresAt,
+        leaseExpiresAt: claimResponse?.data?.lease?.expiresAt || expiresAt,
+        evidenceValidity: reusedValidity,
         resilience: null,
         leaseEvents: [
           ...leaseEvents,

--- a/scripts/lib/local-ci-gate-state.mjs
+++ b/scripts/lib/local-ci-gate-state.mjs
@@ -50,6 +50,32 @@ export function createLocalCiPassEvidenceValidity(options) {
   return createCiEvidenceValidity(options);
 }
 
+/**
+ * The freshness stamp carried by a reused canonical PASS, or null when the
+ * admission carried none this gate can stand behind (BI-03E1139A).
+ *
+ * A gate that reuses someone else's verdict must date it by the evidence's own
+ * clock. The pool lease beside it lives for minutes, and writing that expiry
+ * into the evidence field stamped a PASS as expired before it was written — so
+ * `pregate:status` answered STALE and the author was told to re-run a gate whose
+ * only possible outcome was to reuse the same verdict again.
+ *
+ * Strict by intent. A malformed or partial stamp yields null, and the caller
+ * runs the gate rather than guessing a window: a verdict nobody can date is not
+ * a verdict this gate may publish.
+ */
+export function readReusedEvidenceValidity(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const { issuedAt, expiresAt } = value;
+  // The expiry is the whole decision. The issue time is informational, and
+  // records written before the field existed do not carry one.
+  if (typeof expiresAt !== "string" || !Number.isFinite(Date.parse(expiresAt))) return null;
+  const issued = typeof issuedAt === "string" && Number.isFinite(Date.parse(issuedAt))
+    ? issuedAt
+    : null;
+  return { schemaVersion: 1, issuedAt: issued, expiresAt };
+}
+
 export function readLocalCiGateState(stateFile) {
   if (!stateFile) return null;
   try {

--- a/scripts/lib/local-ci-gate-state.test.mjs
+++ b/scripts/lib/local-ci-gate-state.test.mjs
@@ -10,6 +10,7 @@ import {
   isRecoverableInterruptedGateState,
   projectReusedPassMetadata,
   readLocalCiGateState,
+  readReusedEvidenceValidity,
   supersedeLosingSlotRecords,
   writeLocalCiGateState,
 } from "./local-ci-gate-state.mjs";
@@ -358,4 +359,68 @@ test("a wrapper that exited before a terminal state cannot withdraw a PASS eithe
   });
 
   assert.equal(readLocalCiGateState(stateFile).status, "passed");
+});
+
+test("a reused PASS is dated by the stamp it arrives with", () => {
+  const validity = readReusedEvidenceValidity({
+    issuedAt: "2026-09-12T07:52:00.000Z",
+    expiresAt: "2026-09-13T07:52:00.000Z",
+  });
+
+  assert.equal(validity.issuedAt, "2026-09-12T07:52:00.000Z");
+  assert.equal(validity.expiresAt, "2026-09-13T07:52:00.000Z");
+  assert.equal(validity.schemaVersion, 1);
+});
+
+test("an older record without an issue time still carries the expiry that decides reuse", () => {
+  const validity = readReusedEvidenceValidity({ expiresAt: "2026-09-13T07:52:00.000Z" });
+
+  assert.equal(validity.expiresAt, "2026-09-13T07:52:00.000Z");
+  assert.equal(validity.issuedAt, null);
+});
+
+test("a stamp this gate cannot read yields nothing, so the caller runs instead of guessing", () => {
+  // Each of these once reached the state file as an expiry the gate then
+  // enforced against itself (BI-03E1139A). A verdict nobody can date is not a
+  // verdict this gate may publish.
+  for (const value of [
+    null,
+    undefined,
+    "2026-09-13T07:52:00.000Z",
+    [],
+    {},
+    { issuedAt: "2026-09-12T07:52:00.000Z" },
+    { issuedAt: "2026-09-12T07:52:00.000Z", expiresAt: "whenever" },
+  ]) {
+    assert.equal(readReusedEvidenceValidity(value), null, JSON.stringify(value ?? null));
+  }
+});
+
+test("the evidence clock and the lease clock are recorded as two separate fields", () => {
+  const stateFile = join(mkdtempSync(join(tmpdir(), "dpf-gate-reuse-clock-")), "gate.json");
+  const evidenceValidity = readReusedEvidenceValidity({
+    issuedAt: "2026-09-12T07:52:00.000Z",
+    expiresAt: "2026-09-13T07:52:00.000Z",
+  });
+
+  writeLocalCiGateState(stateFile, {
+    branch: "fix/x",
+    sha: "a".repeat(40),
+    gatePassed: true,
+    leaseId: "NPEL-1",
+    evidenceId: "E1",
+    status: "passed",
+    expiresAt: evidenceValidity.expiresAt,
+    // The lease died fourteen minutes before this record was written. Recorded
+    // in the evidence field it would have made the PASS unreadable.
+    leaseExpiresAt: "2026-09-12T08:08:05.061Z",
+    evidenceValidity,
+    resilience: null,
+    leaseEvents: [],
+  });
+
+  const state = readLocalCiGateState(stateFile);
+  assert.equal(state.expiresAt, "2026-09-13T07:52:00.000Z");
+  assert.equal(state.leaseExpiresAt, "2026-09-12T08:08:05.061Z");
+  assert.ok(Date.parse(state.expiresAt) > Date.parse(state.leaseExpiresAt));
 });


### PR DESCRIPTION
Closes BI-03E1139A. Epic EP-C00F61F4.

## The symptom

A branch that had genuinely passed could not be pushed. Every `pnpm run pregate` printed `reused canonical local-CI pass evidence: <id>` and exited 7, and `pregate:status` answered STALE with "gate record expired — re-run pregate". There was nothing the author could change: the tree is exactly what the reuse is keyed on, so re-running could only reuse the same verdict and produce the same refusal. Observed three times in a row on the same tree before the cause was found.

## The cause

Two clocks, one field.

| clock | lifetime | field |
| --- | --- | --- |
| evidence validity | 24 hours | `expiresAt` |
| pool lease | minutes | `leaseExpiresAt` |

The two write sites that publish a fresh PASS already keep them apart. The reuse branch wrote the lease expiry into the evidence field. The observed state file records a PASS written at `08:21:56.877Z` carrying `expiresAt: 2026-09-12T08:08:05.061Z` — fourteen minutes before the record existed. `pregate-status.mjs` read that field, correctly called it expired, and the BI-A9CF0D69 guard exited 7 on a record that really was invalid.

The client could not have done better. The server read the evidence's stamped validity to decide reuse was permitted at all — `projectLocalCiTerminalEvidence` refuses a lapsed stamp as `expired-evidence` — and then dropped it, returning only `evidenceRecordId` and `resultClass`. With no evidence clock in the payload, the lease clock was the only timestamp within reach.

## The change

- The reused projection returns the stamp the reuse decision was made against. It had already parsed it.
- The lease admission and its MCP response carry that stamp through.
- The reuse branch writes `expiresAt` from it, keeps the lease expiry in `leaseExpiresAt`, and records `evidenceValidity` — the same shape the fresh-PASS write sites already produce.
- A reused PASS arriving with no readable stamp is refused and the gate runs. Absent evidence of freshness is not evidence of freshness, and the one thing this gate must never do is invent an expiry for a verdict it cannot date.

Nothing changes about **when** reuse is allowed. That decision was settled by BI-C59AC8AF and BI-0F2E42D5 and is untouched here.

## Evidence

The end-to-end reuse test drives a dead lease (`2020-01-01`) beside live evidence (`2999-01-02`) and asserts the record is dated by the second. Reverted to the previous assignment it fails with:

```
actual: '2020-01-01T00:00:00.000Z',
expected: '2999-01-02T00:00:00.000Z',
```

which is the defect exactly as observed in the field. A second test proves an unstamped reuse is refused and leaves no PASS behind. Unit tests cover the stamp reader, including older records that carry no issue time, and the projection test covers both shapes the server can hold.

- `typecheck` and `typecheck:tests` clean.
- 132 tests pass across `lib/nonprod`, `lib/gates` and the nonprod lease pack.
- 27 pass in the gate lease suite.
- Local-CI gate PASS on `94c20b30aa71`, slot-1, evidence `cmty7a6jh0kpd01mbultorp4t`.

That gate run is itself a demonstration: its own record is dated `2026-09-13T09:46:18.952Z`, a full day out, rather than by a lease that had already died.

## Not yet proven

The fix is proven against the gate's own test harness and against a real gate run, but it has not yet been observed repairing the branch that surfaced it. `feat/no-work-stops-without-a-conclusion` is still blocked on the pre-fix behaviour and will be re-gated once this merges. Live acceptance stays on BI-03E1139A.

## Related, not overlapping

`fix/gate-is-idempotent-on-a-fresh-pass` (BI-1669E08A) is a sibling defect in the same area — a HEAD that already passed being re-gated. It touches `scripts/pregate.mjs` and `scripts/lib/local-integration-ci.mjs`; this branch touches `scripts/gate-worktree.mjs`, `scripts/lib/local-ci-gate-state.mjs` and three files under `apps/web/lib`. No file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
