### PR TITLE
fix(readiness): let an author satisfy RESEARCH_REQUIRED, so a small item can close (BI-7876699F)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/terminal-recovery.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/terminal-recovery.test.ts
@@ -428,6 +428,39 @@ describe("terminal initiative recovery", () => {
     expect(result.escalations).toMatchObject([{ reason: "objective-mapping-identity-conflict" }]);
   });
 
+  // BI-7876699F: when the only unmet lane is RESEARCH_REQUIRED the packet used to
+  // fall through to the workroom/baseline chain and answer "baseline-not-found —
+  // complete independent spec approval". A delivery-small shape owes no
+  // OBJECTIVE_BASELINE_REQUIRED at all, so that route can never be taken: the
+  // item was unclosable by anyone. Research is author-satisfiable; say so.
+  it("routes an unmet research lane to the author's own writer, never to a baseline", async () => {
+    const ports = deps();
+    const researchOnly: InitiativeReadinessDecision = {
+      ...decision,
+      unmet: [readinessRequirement({
+        code: "RESEARCH_REQUIRED",
+        state: "missing",
+        accountableRole: "design-author",
+      })],
+    };
+
+    const result = await resolveTerminalInitiativeRecovery({
+      decision: researchOnly,
+      currentAgentId: "AGT-CALLER",
+      refusedWorkroomId: null,
+      ports,
+    });
+
+    expect(result.escalations).toMatchObject([{
+      reason: "research-evidence-required",
+      toolName: "record_initiative_evidence",
+      accountableRole: "design-author",
+    }]);
+    // It must not consult the baseline machinery at all for this lane.
+    expect(ports.loadBaselinePayloads).not.toHaveBeenCalled();
+    expect(ports.resolveRecovery).not.toHaveBeenCalled();
+  });
+
   it("fails closed when the current baseline has no eligible post-baseline passing evidence", async () => {
     const ports = deps();
     ports.loadEligibleEvidenceActivityIds.mockResolvedValue(ok({ activityIds: [] }));

--- a/apps/web/lib/backlog/initiative-readiness/terminal-recovery.ts
+++ b/apps/web/lib/backlog/initiative-readiness/terminal-recovery.ts
@@ -36,6 +36,7 @@ export type TerminalRecoveryRoom = {
 
 export type TerminalRecoveryEscalationReason =
   | "acceptance-evidence-required"
+  | "research-evidence-required"
   | "workroom-not-found"
   | "workroom-ambiguous"
   | "workroom-identity-incomplete"
@@ -50,7 +51,10 @@ export type TerminalRecoveryEscalationReason =
   | "canonical-artifact-unavailable";
 
 type TerminalEscalation = {
-  accountableRole: "acceptance-reviewer" | "delivery-coordinator";
+  // design-author owns RESEARCH_REQUIRED on every shape that carries it
+  // (shape-requirements.ts small() and medium()), so the research lane's
+  // escalation is addressed to the author, not to a reviewer (BI-7876699F).
+  accountableRole: "acceptance-reviewer" | "delivery-coordinator" | "design-author";
   toolName: "record_initiative_evidence" | "record_execution_evidence";
   grant: "initiative_evidence_write" | "backlog_write";
   reason: TerminalRecoveryEscalationReason;
@@ -75,6 +79,34 @@ function smallShapeAcceptanceEscalation(): TerminalInitiativeRecovery {
       grant: "backlog_write",
       reason: "acceptance-evidence-required",
       nextAction: "This delivery shape is accepted by the runtime check on the live install or by the failing-to-passing test, not by objective mapping. Record it with record_execution_evidence (kind manual_check or ux_verified) inside the current completion window, then cite that activity id in completionEvidence.evidenceActivityIds. Do not re-claim the item to refresh readiness; a re-claim does not reopen the window.",
+    }],
+  };
+}
+
+/**
+ * BI-7876699F: research is satisfied by the AUTHOR, never by objective mapping.
+ *
+ * When RESEARCH_REQUIRED was the only unmet lane this function did not exist, so
+ * the packet fell through to the workroom/baseline chain and answered
+ * "baseline-not-found — complete independent spec approval". A delivery-small
+ * shape's requirement set contains no OBJECTIVE_BASELINE_REQUIRED at all, so that
+ * route could never legally be taken: the item was unclosable by anyone, and the
+ * packet was pointing at a gate its own policy said did not apply.
+ *
+ * Same principle as smallShapeAcceptanceEscalation above (BI-05F8860A): name the
+ * writer the accountable role can actually reach, and do not consult machinery
+ * this lane does not use.
+ */
+function researchLaneEscalation(): TerminalInitiativeRecovery {
+  return {
+    reviewerRoutes: [],
+    unroutable: [],
+    escalations: [{
+      accountableRole: "design-author",
+      toolName: "record_initiative_evidence",
+      grant: "initiative_evidence_write",
+      reason: "research-evidence-required",
+      nextAction: "Research is the reproduction, and its author records it: call record_initiative_evidence with gate \"research\", citing the defect on a named ref (commit or branch + file + line) and the failing-to-passing proof. This lane needs no objective baseline and no independent spec approval — the delivery shape does not require one.",
     }],
   };
 }
@@ -555,6 +587,15 @@ export async function resolveTerminalInitiativeRecovery(args: {
     .find((entry) => entry.code === "ACCEPTANCE_EVIDENCE_REQUIRED");
   if (acceptanceLane && acceptanceLane.accountableRole === "delivery-coordinator") {
     return smallShapeAcceptanceEscalation();
+  }
+  // BI-7876699F: an unmet research lane is author-satisfiable on every shape.
+  // Checked after acceptance so the existing small-shape hint keeps precedence
+  // when both are open, and before the room/baseline chain because research
+  // does not use it.
+  const researchLane = [...args.decision.blockers, ...args.decision.unmet]
+    .find((entry) => entry.code === "RESEARCH_REQUIRED");
+  if (researchLane) {
+    return researchLaneEscalation();
   }
   const rooms = await ports.loadLiveRooms({
     itemId: args.decision.subject.id,

--- a/apps/web/lib/mcp/load-tools.test.ts
+++ b/apps/web/lib/mcp/load-tools.test.ts
@@ -72,6 +72,41 @@ describe("MCP progressive-disclosure bootstrap contract", () => {
     });
   });
 
+  // BI-7876699F: the author-satisfiable writer must not be classified as
+  // reviewer-routed. `record_initiative_evidence` is the ONLY record_initiative_*
+  // lane declared `independent: false`, with design-author among its accountable
+  // roles — so a name-prefix test is wrong for exactly the tool an author needs
+  // to close a delivery-small item, and it also masks the real reason by sitting
+  // above the not-granted branch.
+  it("does NOT call the author-satisfiable evidence writer reviewer-routed", () => {
+    const known = new Set(["get_backlog_item", "record_initiative_evidence"]);
+    const granted = new Set(["get_backlog_item", "record_initiative_evidence"]);
+    const res = classifyLoadToolsNoMatch(
+      { names: ["record_initiative_evidence"] }, known, granted, 0,
+    );
+    expect(res?.reason).not.toBe("reviewer-route-required");
+  });
+
+  it("reports not-granted, not reviewer-route-required, when the author lacks the evidence grant", () => {
+    const known = new Set(["get_backlog_item", "record_initiative_evidence"]);
+    const granted = new Set(["get_backlog_item"]);
+    const res = classifyLoadToolsNoMatch(
+      { names: ["record_initiative_evidence"] }, known, granted, 0,
+    );
+    // The operator must be told the truth: the grant is missing. Saying
+    // "reviewer-route-required" sends them to a packet that issues no route.
+    expect(res?.reason).toBe("not-granted");
+  });
+
+  it("still calls a genuinely independent reviewer writer reviewer-routed", () => {
+    const known = new Set(["get_backlog_item", "record_initiative_design_review"]);
+    const granted = new Set(["get_backlog_item"]);
+    const res = classifyLoadToolsNoMatch(
+      { names: ["record_initiative_design_review"] }, known, granted, 0,
+    );
+    expect(res?.reason).toBe("reviewer-route-required");
+  });
+
   it("returns no no-match reason when discovery selected a tool", () => {
     expect(classifyLoadToolsNoMatch(
       { names: ["get_backlog_item"] }, new Set(["get_backlog_item"]), new Set(["get_backlog_item"]), 1,

--- a/apps/web/lib/mcp/load-tools.ts
+++ b/apps/web/lib/mcp/load-tools.ts
@@ -7,11 +7,32 @@
 // write stay in the route/store — this module is presentation + payload shaping.
 
 import { LOAD_TOOLS_TOOL_NAME } from "@/lib/tak/tool-intent";
+import { INITIATIVE_READINESS_LANES } from "@/lib/tak/initiative-readiness-tool-grants";
 import { MCP_ROUTE_TOOL_RESULT_CHAR_CAP } from "@/lib/tak/tool-result-budget";
 
 type JsonRpcId = string | number | null;
 type NoMatchReason = "unknown-tool-name" | "reviewer-route-required" | "not-granted" | "intent-no-match" | "missing-query";
 type LoadToolsNoMatch = { reason: NoMatchReason; requestedNames?: string[] };
+
+/**
+ * A writer the author must NOT invoke directly — the registry decides, not the
+ * tool's name (BI-7876699F).
+ *
+ * `record_initiative_*` used to be matched by prefix, which is right for nine of
+ * the ten lanes and wrong for the only one that matters to an author:
+ * `record_initiative_evidence` is declared `independent: false` with
+ * `design-author` among its accountableRoles. Prefix-matching it meant a
+ * delivery-small item could never satisfy RESEARCH_REQUIRED — its own shape owes
+ * no baseline and no plan, so the author had no reachable writer at all and the
+ * item could not be closed by anyone.
+ *
+ * The prefix test also sat ABOVE the not-granted branch, so a missing grant was
+ * reported as "reviewer-route-required" and sent the operator to a recovery
+ * packet that issues no route. One registry, one answer.
+ */
+function isReviewerOnlyWriter(name: string): boolean {
+  return INITIATIVE_READINESS_LANES[name]?.independent === true;
+}
 
 export function classifyLoadToolsNoMatch(
   args: Record<string, unknown>,
@@ -26,7 +47,7 @@ export function classifyLoadToolsNoMatch(
   if (requestedNames.length > 0) {
     const reason = requestedNames.some((name) => !knownNames.has(name))
       ? "unknown-tool-name"
-      : requestedNames.some((name) => name.startsWith("record_initiative_"))
+      : requestedNames.some(isReviewerOnlyWriter)
         ? "reviewer-route-required"
         : requestedNames.some((name) => !grantedNames.has(name))
           ? "not-granted"


### PR DESCRIPTION
Work that had shipped, merged and been verified on the live install could not be marked done. `RESEARCH_REQUIRED` had no author-reachable writer, and the only route the recovery packet offered was an objective baseline the governing shape does not require. Fixes BI-7876699F.

## Two independent defects

### 1. The reviewer-only refusal was a name-prefix match

`classifyLoadToolsNoMatch` classified any requested tool whose name began with `record_initiative_` as `reviewer-route-required`. That is correct for nine of the ten lanes and wrong for the only one an author needs: `record_initiative_evidence` is declared **`independent: false`** in `INITIATIVE_READINESS_LANES`, with `design-author` among its `accountableRoles`. It is the single non-independent writer in the family, so the heuristic misfired on exactly the tool that closes a `delivery-small` item.

The prefix test also sat **above** the `not-granted` branch, so a caller who simply lacked `initiative_evidence_write` was told the tool was reviewer-routed and sent to a packet that issues no route. The registry now decides, not the name.

### 2. The recovery packet offered a gate its own policy excluded

With research the only unmet lane, `resolveTerminalInitiativeRecovery` fell through to the workroom/baseline chain and answered *"baseline-not-found — complete independent spec approval"*. A `delivery-small` requirement set contains no `OBJECTIVE_BASELINE_REQUIRED` at all (`shape-requirements.ts` `small()`), so that route could never legally be taken and the item was unclosable by anyone.

`researchLaneEscalation()` follows the pattern BI-05F8860A already established for the acceptance lane: name the writer the accountable role can actually reach, and do not consult machinery the lane does not use. It is checked **after** the acceptance short-circuit, so the existing small-shape hint keeps precedence when both lanes are open, and **before** the baseline chain, which research never needs.

`TerminalEscalation.accountableRole` gains `design-author` — research is owned by `design-author` on every shape that carries it.

Note what is *not* changed: the shape table. It was already correct. This restores the reachability its own comment assumes — *"A small fix owes a reproduction, the PR gate, a merged SHA and a runtime check — nothing it would not produce anyway."* No gate is added or removed.

## Verification

- **Failing-then-passing proof.** 3 new tests fail on the pre-fix tree and pass after. The recovery test failed with `test expected a complete objective-mapping recovery input`, which is itself the diagnosis — the research lane was being forced through objective mapping.
- `vitest run lib/backlog lib/mcp lib/tak` — **3,689 passed**, 1 skipped, 358/359 files.
- `pnpm --filter web typecheck` and `typecheck:tests` — clean.
- `pnpm pregate:preflight` — 68 guards clean.
- Local merged-CI gate — **PASS** for `f111aaf9925b`, evidence `cmty7w7la0mvl01mb8nekba0v`.

`typecheck` caught an error the tests could not: the new escalation object silently matched the wrong union member while vitest stayed green, because `TerminalEscalation` did not admit `design-author`. Running both web programs is what surfaced it.

## Why this matters beyond one item

The backlog is growing, not shrinking — ~1,998 items created against ~543 closed in the last six weeks. Part of that gap is measurement rather than delivery: **24 open items describe themselves as SHIPPED / MERGED / FIXED in their own titles**, because a `delivery-small` fix that ships without a design doc — which is most of them, by definition of the shape — lands in this trap. Three items delivered in the last two days are in it right now.

This PR unblocks the mechanism. It does **not** retroactively close anything: each stuck item still needs its author to record a research receipt and re-attempt completion, and evidence must be inside its completion window.

## Out of scope, deliberately

The smaller adjacent defect the item notes: the delivery gate names one missing evidence kind per rejected attempt rather than the full required set, so satisfying it takes four round trips. Worth its own change.

## Gate note

The first `pregate` run reported 68 guards failed and claimed no lease. The underlying guard loop reported `16/40 FAILED`, and that 16 was **alphabetically contiguous** (`check-no-provider-local-connector-lifecycle` → `check-no-url-pathname-fs`, mostly guard self-tests) — an aborted loop, not 16 violations. Two of the named guards pass standalone on this exact tree. The host was still settling after a Docker restart. Re-run was clean; recorded here because an aborted loop surfacing as a deterministic verdict is the same class of problem as the kernel's "a gate that could not run is not a verdict".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
