### PR TITLE
fix(local-ci): a HEAD that already passed is not re-gated, and a launch failure is not a verdict (BI-1669E08A)

### DIFF
--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolveHostCommandInvocation } from "./host-command-invocation.mjs";
+import { EXIT_CHILD_SIGNAL_DEATH } from "./sandbox-freshness.mjs";
 
 export function integrationBranchName(candidateBranch, slotKey = "") {
   const prefix = slotKey ? `local-integration/${slotKey}` : "local-integration";
@@ -85,6 +86,31 @@ function redactCommandArgs(args) {
   });
 }
 
+/**
+ * BI-1669E08A. Did the HOST fail to start the process, rather than the process
+ * failing?
+ *
+ * `0xC0000142` (3221225794, STATUS_DLL_INIT_FAILED) is Windows reporting that
+ * process initialisation never completed. Nothing ran, so nothing was graded —
+ * yet the raw code used to travel out of here as an ordinary command failure,
+ * the gate recorded `failed`, and that superseded a real PASS for the same tree
+ * (observed 2026-09-10: the `git merge` step died 7 ms in with exactly this
+ * code). A gate that could not run is not a verdict.
+ *
+ * The runner already held this concept — `classifyTypecheckResult` calls status
+ * null/-1/4294967295 `runner-termination` — but it never covered the launch
+ * failure, and never reached the integration plan's own commands. Kept as one
+ * exported predicate so the two lanes cannot drift apart the way BI-C59AC8AF's
+ * four copies of a status set did.
+ */
+export function isHostProcessLaunchFailure(status) {
+  return status === null
+    || status === undefined
+    || status === -1
+    || status === 4294967295 // the wrapper-terminated sentinel
+    || status === 3221225794; // 0xC0000142 STATUS_DLL_INIT_FAILED
+}
+
 export function createCommandFailureDiagnostics({ invocation, result, elapsedMs }) {
   const error = result.error
     ? {
@@ -97,8 +123,11 @@ export function createCommandFailureDiagnostics({ invocation, result, elapsedMs 
     command: invocation.command,
     args: redactCommandArgs(invocation.args),
     elapsedMs,
+    // The RAW code is kept here on purpose: the diagnostics are the record of
+    // what the host actually said, even when the status we return is reclassified.
     status: result.status ?? null,
     signal: result.signal ?? null,
+    hostLaunchFailure: isHostProcessLaunchFailure(result.status),
     error,
   };
 }
@@ -138,7 +167,13 @@ export function executeLocalIntegrationPlan(plan, {
       });
       error(`[local-integration-ci] command-failure ${JSON.stringify(diagnostics)}`);
       return {
-        status: result.status ?? 1,
+        // BI-1669E08A: a host that could not START the command graded nothing.
+        // EXIT_CHILD_SIGNAL_DEATH is the code classifyGateOutcome already reads
+        // as infrastructure evidence rather than a product build failure, so the
+        // run is recorded inconclusive and the prior verdict stands.
+        status: diagnostics.hostLaunchFailure
+          ? EXIT_CHILD_SIGNAL_DEATH
+          : (result.status ?? 1),
         completedCommandCount,
         failedCommand: [...command],
         diagnostics,

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -11,6 +11,7 @@ import {
   executeLocalIntegrationPlan,
   resolveGitRevision,
   resolveCommandInvocation,
+  isHostProcessLaunchFailure,
 } from "./local-integration-ci.mjs";
 
 describe("createLocalIntegrationPlan", () => {
@@ -402,6 +403,9 @@ describe("createLocalIntegrationPlan", () => {
       elapsedMs: 1180,
       status: 1,
       signal: null,
+      // BI-1669E08A: the diagnostics now say whether the host could START the
+      // command. An exit 1 from a command that ran is a verdict, so: false.
+      hostLaunchFailure: false,
       error: null,
     });
   });
@@ -524,4 +528,65 @@ describe("resolveGitRevision", () => {
       spawnSyncImpl: () => ({ status: 128, stdout: "", stderr: "fatal: bad revision\n" }),
     }), /failed to resolve missing: fatal: bad revision/);
   });
+});
+
+// BI-1669E08A, second half. 0xC0000142 (3221225794) is STATUS_DLL_INIT_FAILED:
+// Windows could not START the process. Nothing ran, so nothing was graded — but
+// the runner passed the code straight through as a command failure, the gate
+// recorded `failed`, and a real PASS for that tree was superseded by it.
+// Observed 2026-09-10 on chore/retired-substrate-sweep: the git merge step died
+// 7 ms in with exactly this code.
+//
+// The runner already has this concept — classifyTypecheckResult calls
+// status null/-1/4294967295 "runner-termination" — it just never covered the
+// launch failure, and never reached the integration plan's own commands.
+describe("host launch failure is not a verdict (BI-1669E08A)", () => {
+it("a Windows process-initialisation failure is a launch failure, not a verdict", () => {
+  assert.equal(isHostProcessLaunchFailure(3221225794), true, "0xC0000142 STATUS_DLL_INIT_FAILED");
+  assert.equal(isHostProcessLaunchFailure(4294967295), true, "the wrapper-terminated sentinel");
+  assert.equal(isHostProcessLaunchFailure(null), true, "a killed spawn reports no status");
+  assert.equal(isHostProcessLaunchFailure(-1), true);
+});
+
+it("an ordinary non-zero status stays a verdict about the diff", () => {
+  for (const status of [1, 2, 86, 87, 130, 143]) {
+    assert.equal(isHostProcessLaunchFailure(status), false, String(status));
+  }
+  assert.equal(isHostProcessLaunchFailure(0), false);
+});
+
+it("a command that could not be started reports infrastructure death, not its raw code", () => {
+  const plan = { commands: [["git", "merge", "--no-ff", "--no-edit", "--signoff", "candidate"]] };
+  const errors = [];
+  const outcome = executeLocalIntegrationPlan(plan, {
+    spawnSyncImpl: () => ({ status: 3221225794, signal: null }),
+    baseEnv: {},
+    platform: "win32",
+    now: () => 0,
+    log: () => {},
+    error: (line) => errors.push(line),
+  });
+
+  // EXIT_CHILD_SIGNAL_DEATH is what classifyGateOutcome already reads as
+  // "infrastructure evidence, NOT a product build failure". Passing 3221225794
+  // through instead is what let a launch failure outrank a real pass.
+  assert.equal(outcome.status, 87);
+  assert.equal(outcome.diagnostics.status, 3221225794, "the raw code stays in the diagnostics");
+  assert.equal(outcome.diagnostics.hostLaunchFailure, true);
+  assert.match(errors.join("\n"), /command-failure/);
+});
+
+it("a genuine command failure still reports its own status", () => {
+  const plan = { commands: [["pnpm", "test"]] };
+  const outcome = executeLocalIntegrationPlan(plan, {
+    spawnSyncImpl: () => ({ status: 1, signal: null }),
+    baseEnv: {},
+    platform: "linux",
+    now: () => 0,
+    log: () => {},
+    error: () => {},
+  });
+  assert.equal(outcome.status, 1);
+  assert.equal(outcome.diagnostics.hostLaunchFailure, false);
+});
 });

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -66,6 +66,55 @@ export function isRecordExemptInvocation(args) {
   );
 }
 
+/** The flag that forces a re-gate of a HEAD that already passed (BI-1669E08A). */
+export const FORCE_RERUN_FLAG = "--force-rerun";
+
+/**
+ * BI-1669E08A. Should this invocation reuse the PASS already recorded for HEAD
+ * instead of starting a second run?
+ *
+ * A second run of an identical tree cannot add information — its verdict is
+ * either the same or wrong — but it can destroy some, because a run takes the
+ * record the moment it starts. Both observed erasures on this install ran that
+ * way: 2026-09-10 a waiting loop re-invoked pregate and a 0xC0000142 launch
+ * failure ate the PASS; 2026-09-12 nothing re-invoked anything at all — the
+ * durable-wait detached resumer gated to a PASS and the original queued claim
+ * was then also admitted, wrote `running` over it, and died on starvation.
+ *
+ * Deliberately keyed on the SAME reconciled verdict the exit-honesty rule uses,
+ * so "already passed" cannot mean one thing to the wrapper's entry and another
+ * to its exit. Anything but PASS runs the gate, and an unreadable record runs it
+ * too: corroboration that cannot be read is not corroboration (BI-A9CF0D69).
+ *
+ * @returns {{ reuse: boolean, reason: string }}
+ */
+export function shouldReuseExistingPass({ args = [], verdictAtHead = "" } = {}) {
+  if (isRecordExemptInvocation(args)) {
+    return { reuse: false, reason: "record-exempt invocation — it acts on the record rather than reading it" };
+  }
+  if (args.includes(FORCE_RERUN_FLAG)) {
+    return { reuse: false, reason: `${FORCE_RERUN_FLAG} was passed — re-gating a HEAD that already has a verdict` };
+  }
+  if (verdictAtHead !== "PASS") {
+    return {
+      reuse: false,
+      reason: verdictAtHead
+        ? `verdict at HEAD is ${verdictAtHead}, not PASS`
+        : "verdict at HEAD is unreadable",
+    };
+  }
+  return { reuse: true, reason: "a passing local-CI gate record already covers this HEAD" };
+}
+
+/**
+ * Drop the wrapper-only force flag before the gate sees it — gate-worktree.mjs
+ * dies on an unknown option, so forwarding it would turn a deliberate re-gate
+ * into a crash (BI-1669E08A).
+ */
+export function stripForceRerunFlag(args = []) {
+  return args.filter((arg) => arg !== FORCE_RERUN_FLAG);
+}
+
 // Pure exit-code policy so the honesty rules are unit-testable without a gate:
 // timedOut (admission window elapsed, nothing gated) and status-0-without-a-
 // corroborating-PASS both map to ABANDONED_OR_UNRECORDED_EXIT_CODE; a genuine
@@ -755,6 +804,19 @@ async function main() {
     process.exit(1);
   }
 
+  // BI-1669E08A: check BEFORE the preflight. A tree that already has a passing
+  // record for this exact HEAD needs neither the three-minute guard parity run
+  // nor a lease; starting either can only cost time and risk the record.
+  const reuse = shouldReuseExistingPass({ args, verdictAtHead: readReconciledVerdictAtHead() });
+  if (reuse.reuse) {
+    process.stdout.write(
+      `pregate: ${reuse.reason} — not starting a second run.\n`
+        + `pregate: a second run of an identical tree can only repeat or contradict that verdict, and it takes the record the moment it starts.\n`
+        + `pregate: read it with  pnpm run pregate:status  — re-gate anyway with  pnpm run pregate -- ${FORCE_RERUN_FLAG}\n`,
+    );
+    process.exit(0); // exit-0: a PASS record bound to current HEAD already exists; this run reused it and gated nothing
+  }
+
   if (shouldRunPreflight(args)) {
     // BI-B1065D41: the guard-parity preflight is loud and, on a passing run,
     // uninteresting — including a TOLERATED GuardRuntimeEnvironmentError that
@@ -794,7 +856,7 @@ async function main() {
   }
 
   const useShell = shouldUseShell();
-  const { result, timedOut } = await runGateWithQueuedRevival({ args, useShell });
+  const { result, timedOut } = await runGateWithQueuedRevival({ args: stripForceRerunFlag(args), useShell });
   if (result?.error) {
     process.stderr.write(`pregate: failed to launch gate: ${result.error.message}\n`);
     process.exit(1);

--- a/scripts/pregate.test.mjs
+++ b/scripts/pregate.test.mjs
@@ -13,7 +13,9 @@ import {
   recoverInterruptedGateState,
   resolvePregateGateContext,
   reviveInterruptedQueuedGateState,
+  shouldReuseExistingPass,
   shouldUseShell,
+  stripForceRerunFlag,
 } from "./pregate.mjs";
 
 test("pregate recovery uses the bare common directory as the canonical root", () => {
@@ -448,4 +450,60 @@ test("a clean exit is still not a recovery", async () => {
   });
 
   assert.equal(recovered.reason, "not-a-recoverable-invocation");
+});
+
+// BI-1669E08A. A claim for a HEAD that already carries a passing, non-stale gate
+// record must report that pass and stop. Re-running can only lose information:
+// the tree is identical, so a second verdict is either the same or wrong — and
+// the second run takes the record with it the moment it starts.
+//
+// Reproduced twice on this install. 2026-09-10 on chore/retired-substrate-sweep:
+// a waiting loop re-invoked pregate and a 0xC0000142 launch failure erased the
+// PASS. 2026-09-12 on fix/local-ci-runner-tests-run-on-windows: NOTHING
+// re-invoked pregate — the durable-wait detached resumer ran the gate to a PASS
+// and the original queued claim was then also admitted, wrote `running` over the
+// record, and died on blocked_control_plane_starvation. A two-step erasure.
+test("a PASS at HEAD is reused instead of starting a second run", () => {
+  assert.deepEqual(
+    shouldReuseExistingPass({ args: [], verdictAtHead: "PASS" }),
+    { reuse: true, reason: "a passing local-CI gate record already covers this HEAD" },
+  );
+});
+
+test("every non-PASS verdict still runs the gate, and names what it saw", () => {
+  for (const verdict of ["NO-RECORD", "STALE", "FAIL", "PENDING", "INCONCLUSIVE"]) {
+    const decision = shouldReuseExistingPass({ args: [], verdictAtHead: verdict });
+    assert.equal(decision.reuse, false, verdict);
+    assert.match(decision.reason, new RegExp(verdict));
+  }
+  // An unreadable record must fail OPEN into running the gate, never into reuse:
+  // corroboration that cannot be read is not corroboration (BI-A9CF0D69).
+  const unreadable = shouldReuseExistingPass({ args: [], verdictAtHead: "" });
+  assert.equal(unreadable.reuse, false);
+  assert.match(unreadable.reason, /unreadable/);
+});
+
+test("--force-rerun re-gates a passing HEAD, and record-exempt invocations never reuse", () => {
+  const forced = shouldReuseExistingPass({ args: ["--force-rerun"], verdictAtHead: "PASS" });
+  assert.equal(forced.reuse, false);
+  assert.match(forced.reason, /--force-rerun/);
+
+  // --finalize-evidence exists precisely to act on an existing record; short-
+  // circuiting it would make the reuse path eat its own recovery tool.
+  for (const exempt of ["--dry-run", "--finalize-evidence", "--help", "-h"]) {
+    const decision = shouldReuseExistingPass({ args: [exempt], verdictAtHead: "PASS" });
+    assert.equal(decision.reuse, false, exempt);
+    assert.match(decision.reason, /record-exempt/);
+  }
+});
+
+test("the force flag is consumed by the wrapper and never forwarded to the gate", () => {
+  // gate-worktree.mjs dies on an unknown option, so forwarding it would turn a
+  // deliberate re-gate into a crash.
+  assert.deepEqual(
+    stripForceRerunFlag(["--branch", "fix/x", "--force-rerun", "--no-push"]),
+    ["--branch", "fix/x", "--no-push"],
+  );
+  assert.deepEqual(stripForceRerunFlag([]), []);
+  assert.deepEqual(stripForceRerunFlag(["--no-push"]), ["--no-push"]);
 });


### PR DESCRIPTION
## What this fixes

**BI-1669E08A.** Two ways a real local-CI PASS was being destroyed, both observed on this install.

### 1. The gate was not idempotent

A claim for a HEAD that already carried a passing, non-stale record started a **second run of the identical tree**. A second run cannot add information — its verdict is either the same or wrong — but it destroys some, because a run takes the record the moment it starts.

`pregate` now reads the reconciled verdict at HEAD **before it does anything expensive**, and on `PASS` reports it and exits 0 with no preflight and no lease.

It reuses the same `readReconciledVerdictAtHead()` the exit-honesty rule already uses (BI-A9CF0D69), so "already passed" cannot mean one thing at the wrapper's entry and another at its exit. That also means exit 0 here still satisfies honesty rule #1 — *exit 0 means gated and passed* — because the corroborating PASS record is exactly what was checked.

Guard rails, each with a test:
- `--force-rerun` re-gates anyway, and is **stripped before the gate sees it** — `gate-worktree.mjs` dies on an unknown option, so forwarding it would turn a deliberate re-gate into a crash.
- Record-exempt invocations (`--dry-run`, `--finalize-evidence`, `--help`, `-h`) never reuse. `--finalize-evidence` exists to act on an existing record; short-circuiting it would make the reuse path eat its own recovery tool.
- An **unreadable** verdict runs the gate. Corroboration that cannot be read is not corroboration.
- A dirty tree is already refused upstream by `shouldRefuseDirtyTree`, so the short-circuit only ever fires on a clean tree whose HEAD carries the pass.

### 2. A launch failure outranked a real pass

`0xC0000142` (3221225794, `STATUS_DLL_INIT_FAILED`) is Windows reporting that process initialisation never completed — nothing ran, so nothing was graded. The runner passed that code straight through as an ordinary command failure, the gate recorded `failed`, and that superseded a real PASS for the same tree. Observed 2026-09-10 on `chore/retired-substrate-sweep`: the `git merge` step died 7 ms in with exactly this code.

`isHostProcessLaunchFailure()` now covers `null` / `-1` / `4294967295` / `3221225794` in **one** exported predicate, and a command the host could not start returns `EXIT_CHILD_SIGNAL_DEATH` — the code `classifyGateOutcome` already reads as *"infrastructure evidence, NOT a product build failure"*. The raw code stays in the diagnostics, which are the record of what the host actually said.

One predicate rather than a second copy of the idea: the runner already called `null`/`-1`/`4294967295` "runner-termination" in `classifyTypecheckResult`, and BI-C59AC8AF cost a permanently ungateable tree because four copies of one status set drifted apart.

## Why admission, and not another write-path guard

BI-FFCFCCE0 (merged `266631b0a4b`) stops an infrastructure-inconclusive write from withdrawing a terminal PASS, but deliberately still lets a non-terminal `queued`/`admitted`/`running` write take the record — because a stale PASS sitting beside a genuinely live run would lie.

On 2026-09-12 that exclusion was exercised end to end on `fix/local-ci-runner-tests-run-on-windows`: the record went `passed` → `running` → `blocked_control_plane_starvation`. **A two-step erasure walks straight through a guard that blocks the one-step version.** And nothing re-invoked `pregate` — the durable-wait detached resumer gated to a PASS and the original queued claim was *also* admitted. Admission is where this has to be stopped, which is what this item said from the start.

## Verification

- `node --test scripts/pregate.test.mjs scripts/pregate-exit-honesty.test.mjs` — 26 pass. The exit-honesty suite enumerates every `process.exit(0)` site in the wrapper/gate pair and fails on an unannotated one; the new reuse exit carries its `// exit-0:` annotation.
- `node --test scripts/lib/local-integration-ci.test.mjs` — 32 pass, including four new cases: the predicate on both sides, a launch failure reported as infrastructure with the raw code preserved in diagnostics, and a genuine failure keeping its own status.
- Whole local-CI surface (`gate-worktree-*`, `pregate*`, `local-ci-*`, `lib/local-ci-*`, `lib/local-integration-ci`, `lib/pregate-status`, `lib/documentation-evidence-lane`, `lib/sandbox-freshness`): **406 tests, 404 pass, 0 fail, 2 skipped** — the skips being the POSIX-only shim execution from BI-785B3253 and one pre-existing.
- New tests written first and confirmed failing before the implementation.
- `pnpm pregate:preflight` — **68 guards clean** in 142s.
- `pnpm pregate:status` — **PASS**, `fix/gate-is-idempotent-on-a-fresh-pass @ acc520b1437d`, slot-1, evidence `cmty8w3t70qrc01mbjj8n178m`.

### One existing test changed, deliberately

`reports secret-safe child-process failure diagnostics` asserts the diagnostics shape exactly. Adding `hostLaunchFailure` is a real contract change to that shape, so the expectation was updated rather than the field hidden.

### Not proven here

The reuse path has not been exercised against a live already-passing HEAD end to end — it is unit-proven on the pure policy. The gate run on this branch queued from `NO-RECORD`, which is the non-reuse path.

Also unfixed, and recorded on BI-D35B85BF rather than widened into this PR: while gating this branch, a queued row advertised `resumeOwner: "detached-resumer"` whose resumer process was **dead**, and the claim sat queued for 70 minutes. A caller honouring the resumer contract waits forever; re-invoking risks the duplicate claim this PR is about. Three `proven-dead queue observer` rows were also holding positions ahead of a live claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
