### PR TITLE
fix(worktree): tell "no ignored builds" apart from "pnpm cannot say" (BI-5318366C)

### DIFF
--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -164,8 +164,22 @@ function run(cmd, args, cwd, opts = {}) {
 // three carry a deliberate `false`, and it left every worktree created off main
 // stuck at SOURCE-ONLY with no way to converge. Pass the policy-denied set in so
 // a recorded decision counts as classified wherever it was recorded.
+// BI-5318366C: pnpm prints this INSTEAD of a package list when it cannot answer
+// the question at all. `pnpm ignored-builds` reads the `ignoredBuilds` key from
+// node_modules/.modules.yaml, and pnpm writes that key only on an install that
+// actually reached its build phase — so an install that links nothing new
+// rewrites the manifest WITHOUT it, and every later call prints this line.
+//
+// It is a diagnostic, not a package. Read as one it invented an unclassified
+// dependency named "Cannot identify as no node_modules found", failed the cheap
+// gate, and took every worktree sharing that node_modules to SOURCE-ONLY at
+// once — with the fabricated name as the only clue. Observed 2026-09-12 across
+// the whole host, costing a long read through pnpm's own dist bundle to explain.
+const PNPM_UNREADABLE_BUILD_RECORD = /cannot identify as no node_modules found/i;
+
 export function classifyIgnoredBuilds(stdout, policyDenied = new Set()) {
   const packages = [];
+  let indeterminate = false;
   let inUnclassifiedSection = false;
   for (const raw of String(stdout ?? "").split(/\r?\n/)) {
     if (/^\s*$/.test(raw)) {
@@ -180,11 +194,18 @@ export function classifyIgnoredBuilds(stdout, policyDenied = new Set()) {
     if (!inUnclassifiedSection) continue;
     const entry = raw.trim().replace(/^[-*•]\s*/, "");
     if (!entry || /^none\.?$/i.test(entry) || /^hint:/i.test(entry)) continue;
+    if (PNPM_UNREADABLE_BUILD_RECORD.test(entry)) {
+      indeterminate = true;
+      continue;
+    }
     // pnpm prints bare names here; a policy decision is keyed by name too.
     if (policyDenied.has(entry.replace(/@[^@]*$/, "")) || policyDenied.has(entry)) continue;
     packages.push(entry);
   }
-  return { ok: packages.length === 0, packages };
+  // Still fails closed: nothing here proves no build script went unclassified.
+  // But `indeterminate` separates "pnpm answered, and the answer was none" from
+  // "pnpm could not answer", so the caller can say which one it hit.
+  return { ok: packages.length === 0 && !indeterminate, packages, indeterminate };
 }
 
 /**
@@ -334,6 +355,12 @@ export function probeWorktreeReadiness(worktreePath, opts = {}) {
     status: classifyReadiness({ hasNodeModules, depProbeOk, gateOk }),
     reason: !ignoredBuilds.ok && ignoredBuilds.packages.length > 0
       ? `ignored_builds_unclassified:${ignoredBuilds.packages.join(",")}`
+      // BI-5318366C: name the state and its remedy. This is not a dependency
+      // anyone must classify — the package manager has no build record to read,
+      // and a clean install writes one.
+      : ignoredBuilds.indeterminate
+      ? "build_record_unreadable:the package manager kept no build record for this node_modules; "
+        + "remove node_modules at the workspace root and install again to write one"
       : missing.length > 0 && hasNodeModules && depProbeOk && linkCheck.ok
       ? `missing_compile_artifacts:${missing.map((m) => m.path).join(",")}`
       : readinessReason({ hasNodeModules, depProbeOk, gateOk, staleWorkspaceLinks: linkCheck.stale }),

--- a/scripts/lib/bootstrap-worktree-deps.test.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.test.mjs
@@ -51,10 +51,12 @@ test("ignored-build readiness fails closed when pnpm reports an unclassified scr
   assert.deepEqual(classifyIgnoredBuilds("Automatically ignored builds during installation: None"), {
     ok: true,
     packages: [],
+    indeterminate: false,
   });
   assert.deepEqual(classifyIgnoredBuilds("Automatically ignored builds during installation:\n  sharp@1.2.3"), {
     ok: false,
     packages: ["sharp@1.2.3"],
+    indeterminate: false,
   });
 });
 
@@ -70,7 +72,7 @@ test("ignored-build parser ignores the Explicitly-ignored section and hint lines
     "Explicitly ignored package builds (via pnpm.ignoredBuiltDependencies):",
     "  @scarf/scarf",
   ].join("\n");
-  assert.deepEqual(classifyIgnoredBuilds(classified), { ok: true, packages: [] });
+  assert.deepEqual(classifyIgnoredBuilds(classified), { ok: true, packages: [], indeterminate: false });
 
   // Before classification: the build sits under "Automatically ignored" and pnpm
   // appends advisory "hint:" lines. Flag the package, never the hints.
@@ -80,7 +82,7 @@ test("ignored-build parser ignores the Explicitly-ignored section and hint lines
     "hint: To allow the execution of build scripts, add its name to \"pnpm.onlyBuiltDependencies\".",
     "hint: If you don't want to build a package, add it to the \"pnpm.ignoredBuiltDependencies\" list.",
   ].join("\n");
-  assert.deepEqual(classifyIgnoredBuilds(unclassified), { ok: false, packages: ["@scarf/scarf"] });
+  assert.deepEqual(classifyIgnoredBuilds(unclassified), { ok: false, packages: ["@scarf/scarf"], indeterminate: false });
 });
 
 test("a build denied by allowBuilds policy is classified, not unclassified (BI-6945BEEF)", () => {
@@ -100,16 +102,17 @@ test("a build denied by allowBuilds policy is classified, not unclassified (BI-6
   assert.deepEqual(classifyIgnoredBuilds(stdout), {
     ok: false,
     packages: ["puppeteer", "unrs-resolver", "protobufjs"],
+    indeterminate: false,
   });
 
   const denied = new Set(["puppeteer", "unrs-resolver", "protobufjs"]);
-  assert.deepEqual(classifyIgnoredBuilds(stdout, denied), { ok: true, packages: [] });
+  assert.deepEqual(classifyIgnoredBuilds(stdout, denied), { ok: true, packages: [], indeterminate: false });
 
   // A package with no recorded decision is still flagged even when siblings are
   // decided — the gate must not go blanket-permissive.
   assert.deepEqual(
     classifyIgnoredBuilds(`${stdout}\n  brand-new-dep`, denied),
-    { ok: false, packages: ["brand-new-dep"] },
+    { ok: false, packages: ["brand-new-dep"], indeterminate: false },
   );
 });
 
@@ -401,4 +404,72 @@ test("the install decision is driven by measured readiness, not by existsSync", 
     .filter((line) => !line.trimStart().startsWith("//") && !line.trimStart().startsWith("*"))
     .filter((line) => /if\s*\(\s*!exists\s*\(/.test(line));
   assert.deepEqual(offending, [], "bootstrapWorktreeDeps must gate its install on probeWorktreeReadiness, not existsSync");
+});
+
+test("pnpm saying it cannot answer is not a package nobody classified (BI-5318366C)", () => {
+  // pnpm prints this INSTEAD of a list when node_modules/.modules.yaml carries no
+  // `ignoredBuilds` key, which is what an install that links nothing new leaves
+  // behind. Read as a package name it invented a dependency called "Cannot
+  // identify as no node_modules found" and took every worktree sharing that
+  // node_modules to SOURCE-ONLY at once, with the fabricated name as the only clue.
+  const stdout = [
+    "Automatically ignored builds during installation:",
+    "  Cannot identify as no node_modules found",
+    "",
+    "Explicitly ignored package builds (via pnpm.ignoredBuiltDependencies):",
+    "  @scarf/scarf",
+    "  protobufjs",
+  ].join(String.fromCharCode(10));
+
+  const result = classifyIgnoredBuilds(stdout);
+
+  // Nothing to classify, and nobody to name.
+  assert.deepEqual(result.packages, []);
+  // Still fails closed: an unreadable record does not prove the tree is clean.
+  assert.equal(result.ok, false);
+  // But the caller can now say WHICH of the two it hit.
+  assert.equal(result.indeterminate, true);
+});
+
+test("an unreadable build record still flags a real unclassified build beside it", () => {
+  // Fail-closed must not become fail-blind: if pnpm manages to name a package,
+  // that package is still unclassified whatever else the section says.
+  const result = classifyIgnoredBuilds([
+    "Automatically ignored builds during installation:",
+    "  Cannot identify as no node_modules found",
+    "  brand-new-dep",
+  ].join(String.fromCharCode(10)));
+
+  assert.deepEqual(result.packages, ["brand-new-dep"]);
+  assert.equal(result.ok, false);
+  assert.equal(result.indeterminate, true);
+});
+
+test("readiness names an unreadable build record and its remedy, not a phantom package (BI-5318366C)", () => {
+  const sentinel = [
+    "Automatically ignored builds during installation:",
+    "  Cannot identify as no node_modules found",
+  ].join(String.fromCharCode(10));
+
+  const result = probeWorktreeReadiness("/wt", {
+    artifactDeps: { exists: () => true, readdir: () => ["something"] },
+    linkCheckDeps: { readdir: () => [], realpath: () => null },
+    execute: (cmd, args) => {
+      const arg = args?.[0] ?? "";
+      if (arg === "ignored-builds") return { ok: true, status: 0, stdout: sentinel, stderr: "" };
+      if (cmd === "git") return { ok: true, status: 0, stdout: "a".repeat(40), stderr: "" };
+      return { ok: true, status: 0, stdout: "10.33.2", stderr: "" };
+    },
+  });
+
+  // Fails closed, as it must: nothing here proves the tree is clean.
+  assert.equal(result.status, "source-only");
+  // But it names the state and the way out, instead of a dependency that does
+  // not exist. Reading the diagnostic as a package took a whole host to
+  // SOURCE-ONLY with a fabricated name as the only clue.
+  assert.match(result.reason, /^build_record_unreadable:/);
+  assert.match(result.reason, /install again/);
+  assert.deepEqual(result.checks.ignoredBuilds, []);
+  // And no dependency-policy review is raised for a decision nobody owes.
+  assert.deepEqual(result.checks.dependencyPolicyReviewKeys, []);
 });


### PR DESCRIPTION
Closes BI-5318366C. Epic EP-C00F61F4.

## The symptom

Every worktree on this development host reported SOURCE-ONLY, with the reason:

```
ignored_builds_unclassified:Cannot identify as no node_modules found
```

No worktree could be gated. The string being flagged as an unclassified dependency is not a package name. It is pnpm's own diagnostic sentence.

## The mechanism

`pnpm ignored-builds` reads the `ignoredBuilds` key from `node_modules/.modules.yaml`. pnpm writes that key only on an install that actually reaches its build phase, so an install that links nothing new (`reused N, added 0`) rewrites the manifest **without** it. From then on the command prints the sentence instead of a list, permanently, until a clean install.

`classifyIgnoredBuilds` already filtered `None`, bullet markers and `hint:` lines. It did not filter this one, so it parsed the sentence as a package and failed the cheap gate on a dependency that does not exist.

Worktrees junction their root `node_modules` at the root clone, so one manifest missing the key takes every worktree sharing it to SOURCE-ONLY at the same moment. Reproduced in the root clone and independently in a second worktree before the cause was found.

## Why it failed in the worst direction

The guard exists to force a dependency-policy decision on a build script nobody classified. Here there was no such package. The gate was not being strict about a real risk, it was being strict about a sentence, and the only clue it offered was an invented dependency name. That is where the time went: the answer was only visible by reading pnpm's own bundled `getAutomaticallyIgnoredBuilds`, which returns null when the key is absent and an array when it is present.

## The change

`classifyIgnoredBuilds` now returns `indeterminate` alongside `ok` and `packages`. The diagnostic sets it and contributes no package.

Readiness still **fails closed**, because an unreadable record does not prove the tree is clean. But it now answers with the state and the remedy in the same line, and raises no dependency-policy review for a decision nobody owes:

```
build_record_unreadable:the package manager kept no build record for this
node_modules; remove node_modules at the workspace root and install again to
write one
```

Fail-closed must not become fail-blind, so a real package named beside the diagnostic is still flagged. There is a test for exactly that.

## The remedy it names is the one that worked

Remove `node_modules` at the workspace root and install again. That runs the build phase, restores the key, and `pnpm ignored-builds` prints `None`. Every worktree on this host returned to `compile-ready`. It took 57 seconds with the local store warm.

Worth recording for whoever hits this next: `pnpm rebuild` does **not** repair it here. The lifecycle child shell on this host cannot resolve `node`, so the esbuild postinstall fails and the manifest is never rewritten. That is a separate problem and is not addressed in this change.

## Evidence

- 31 tests pass in the bootstrap readiness suite, covering both pnpm outputs, a real package named beside the diagnostic, and the readiness reason built from them.
- Local-CI gate PASS on `dfacd22be63e`, slot-0, evidence `cmtyaee7b0vbs01mb07h9igzq`.

## An unrelated failure seen on the way

Two earlier gate attempts failed on slot-1 at the web typecheck stage. Both printed `Types generated successfully` for both programs and then exited 1 with no diagnostics at all, in 36 seconds. The same command passes locally with exit 0, and this branch touches no TypeScript. `scripts/run-tsc.mjs` ends with `process.exit(result.status ?? 1)`, which turns a child killed by a signal into a bare exit 1 with nothing said. Filed separately rather than worked around here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
