### PR TITLE
feat(decision): a governed decision names its subject, and says whether anyone watched it (BI-01F8F06D)

### DIFF
--- a/apps/web/lib/decision-perspective/persistence.ts
+++ b/apps/web/lib/decision-perspective/persistence.ts
@@ -11,6 +11,7 @@ import {
   type DecisionEvaluationSource,
   type PerspectiveMaterialFreshness,
 } from "./types";
+import type { DecisionSubjectKind } from "@dpf/db";
 import { normalizeLocator } from "@/lib/deliberation/evidence";
 
 type DecisionInteractionClient = {
@@ -226,6 +227,19 @@ export async function persistDecisionInteraction(input: {
   /** True when doctrine fell back off the gate's own profile kind. */
   gateFallbackUsed?: boolean;
   /**
+   * What the decision is ABOUT (BI-01F8F06D). Without it a decision is an
+   * isolated event that no later outcome can be attributed to. Omit only when
+   * the caller genuinely governs nothing identifiable — a null subject is
+   * honest, a fabricated one is not.
+   */
+  subject?: { kind: DecisionSubjectKind; id: string } | null;
+  /**
+   * True when no human was in the loop. Not telemetry: an unattended decision
+   * has nobody to agree or disagree with, so it must be excluded from an
+   * agreement denominator by construction rather than filtered out later.
+   */
+  autonomous?: boolean;
+  /**
    * Trust-envelope immutability seal (BI-81CC5D8E). When present, the row is
    * written as the next append-only entry in a hash chain. Omitted for callers
    * that do not seal (behavior unchanged — all chain columns stay NULL).
@@ -270,6 +284,9 @@ export async function persistDecisionInteraction(input: {
       principleConflict: input.evaluation.principleConflict,
       gateKey: input.gateKey ?? null,
       gateFallbackUsed: input.gateFallbackUsed ?? false,
+      subjectKind: input.subject?.kind ?? null,
+      subjectRef: input.subject?.id ?? null,
+      autonomous: input.autonomous ?? false,
       chainId: input.chain?.chainId ?? null,
       prevHash: input.chain?.prevHash ?? null,
       chainEntryHash: input.chain?.chainEntryHash ?? null,

--- a/apps/web/lib/decision/kernel-consult-ledger.test.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.test.ts
@@ -176,6 +176,10 @@ describe("recordKernelConsultInteraction", () => {
     expect(row.domainClass).toBe("kernel-consult");
     // BI-FD7CBA06: external MCP consults must name their door for audit filters.
     expect(row.gateKey).toBe("kernel-consult");
+    // BI-01F8F06D: a consult with no human behind it is unattended, and must be
+    // excluded from an agreement denominator by construction. This fixture has
+    // no triggeredByUserId, so it is an agent asking the kernel.
+    expect(row.autonomous).toBe(true);
     expect(row.outcomeType).toBe("recommend");
     expect(row.question).toBe("Which storage approach should we take?");
     expect(row.options).toEqual(["option-a", "option-b"]);

--- a/apps/web/lib/decision/kernel-consult-ledger.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.ts
@@ -357,6 +357,11 @@ export async function recordKernelConsultInteraction(input: {
       // BI-FD7CBA06: name the door so WWMD audit can filter external MCP consults
       // separately from build-studio / backlog-triage (was always null before).
       gateKey: "kernel-consult",
+      // BI-01F8F06D: a consult is attended when a human triggered it and
+      // unattended when an agent did. Derived from the caller the request
+      // already declares rather than assumed, so the agreement denominator
+      // never silently absorbs a decision nobody reviewed.
+      autonomous: !input.triggeredByUserId,
       phaseFrom: null,
       phaseTo: null,
       chain,

--- a/apps/web/lib/operate/backlog-triage-ledger.test.ts
+++ b/apps/web/lib/operate/backlog-triage-ledger.test.ts
@@ -48,6 +48,17 @@ describe("recordTriageDecision", () => {
     // The drain applies the decision, so it arbitrates rather than advises.
     expect(data.outcomeType).toBe("arbitrate");
     expect(data.question).toContain("BI-XYZ");
+    // BI-01F8F06D: the item must be a COLUMN, not only prose in the question.
+    // It lived only in that prose and in the payload blob, so no outcome could
+    // ever be attributed back to the item the decision governed.
+    // The Prisma member, not the mapped DB value: a where/create clause takes
+    // `backlog_item` and Prisma writes `backlog-item` to Postgres.
+    expect(data.subjectKind).toBe("backlog_item");
+    expect(data.subjectRef).toBe("BI-XYZ");
+    // The drain is an hourly cron with nobody watching. Marking it keeps it out
+    // of any agreement denominator by construction rather than by a filter
+    // someone has to remember to apply.
+    expect(data.autonomous).toBe(true);
   });
 
   it("records the mutation it is about to authorise, so the row is auditable against the item", async () => {

--- a/apps/web/lib/operate/backlog-triage-ledger.ts
+++ b/apps/web/lib/operate/backlog-triage-ledger.ts
@@ -127,6 +127,13 @@ export async function recordTriageDecision(input: {
       phaseTo: null,
       gateKey: BACKLOG_TRIAGE_GATE_KEY,
       gateFallbackUsed: false,
+      // BI-01F8F06D: the item being triaged was only ever recorded inside the
+      // question prose and the payload blob, so no outcome could be attributed
+      // back to it. `autonomous` marks the hourly drain as unattended, which
+      // keeps it out of any agreement denominator by construction.
+      // The Prisma MEMBER name; Prisma maps it to `backlog-item` in Postgres.
+      subject: { kind: "backlog_item", id: input.item.itemId },
+      autonomous: true,
       outcomePayloadExtra: {
         // Names the unattended writer, so an operator scanning WWMD can tell
         // hourly cron triage from a human-initiated gate at a glance.

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -9,7 +9,7 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Count | Value | Source of truth |
 |---|---:|---|
 | Prisma models | 628 | `packages/db/prisma/schema/` |
-| Prisma enums | 93 | `packages/db/prisma/schema/` |
-| Migrations | 578 | `packages/db/prisma/migrations/` |
+| Prisma enums | 94 | `packages/db/prisma/schema/` |
+| Migrations | 579 | `packages/db/prisma/migrations/` |
 | Kernel principles | 109 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 661 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/data-impact/2026-09-12-decision-subject-and-autonomy.data-impact.json
+++ b/docs/data-impact/2026-09-12-decision-subject-and-autonomy.data-impact.json
@@ -1,0 +1,41 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [],
+  "migration": {
+    "name": "20260912070000_decision_subject_and_autonomy",
+    "backfill": "adds subjectKind, subjectId and autonomous to DecisionInteraction, then promotes values each row already recorded in its own outcomePayload JSON into those columns. Nothing is derived or inferred: subjectRef is copied from outcomePayload->>'backlogItemId' with subjectKind set to the constant 'backlog-item' that key implies, and autonomous is set only where the payload already says autonomous is true. Rows carrying neither key keep NULL / false, which is the honest state. Both statements touch only rows whose column is still unset, so re-running reports UPDATE 0. Measured on one operator install: 518 subjects and 518 unattended decisions recovered out of 1093 rows; the attended population carrying a recommendation became selectable at 151."
+  },
+  "tests": [
+    "apps/web/lib/operate/backlog-triage-ledger.test.ts",
+    "apps/web/lib/decision/kernel-consult-ledger.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:decision-interaction",
+      "prismaModel": "DecisionInteraction",
+      "lifecycleDisposition": "operational",
+      "fields": [
+        {
+          "fieldId": "data:decision-interaction#subjectKind",
+          "resolution": "inherited",
+          "reason": "a closed-vocabulary label naming what kind of thing a governed decision was about; not personal or customer data. Only the constant 'backlog-item' is written by the backfill, matching the one payload key that exists today.",
+          "provenance": "manual/platform-architecture"
+        },
+        {
+          "fieldId": "data:decision-interaction#subjectRef",
+          "resolution": "inherited",
+          "reason": "an internal platform record identifier such as a backlog item id, already present in the same row's outcomePayload and in the question text; carries no personal or customer data. Its absence is why no decision outcome could be attributed to the work it governed.",
+          "provenance": "manual/platform-architecture"
+        },
+        {
+          "fieldId": "data:decision-interaction#autonomous",
+          "resolution": "inherited",
+          "reason": "a boolean stating whether a human was in the loop, already recorded in outcomePayload for the unattended cron writer. It is a governance classifier rather than telemetry: it keeps unattended decisions out of any agreement denominator by construction, and carries no personal data.",
+          "provenance": "manual/platform-architecture"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260912070000_decision_subject_and_autonomy/migration.sql
+++ b/packages/db/prisma/migrations/20260912070000_decision_subject_and_autonomy/migration.sql
@@ -1,0 +1,42 @@
+-- BI-01F8F06D. Give a governed decision a subject, and say whether anyone watched it.
+--
+-- Without these a decision is an isolated event. Of the first 1,093 rows, one
+-- carried a buildId and twenty a taskRunId, while the backlog item id lived
+-- inside the question prose -- so nothing could join a decision to the work it
+-- governed, and no outcome could ever be attributed to it.
+--
+-- `autonomous` is not telemetry. 518 of those rows were an hourly cron drain
+-- with no human in the loop; an agreement rate computed over them would measure
+-- nothing while looking authoritative. Marking them keeps them out of any
+-- denominator by construction rather than by a filter someone must remember.
+--
+-- The backfill invents nothing. Both values were already recorded by the
+-- platform in the same row's outcomePayload and are moved into the columns that
+-- should have held them. A row whose payload carries neither stays NULL/false,
+-- which is the honest state. Idempotent: only NULL columns with a present key
+-- are touched, so a re-run reports UPDATE 0.
+
+-- `subjectKind` is a typed enum rather than TEXT (AGENTS.md section 8, BI-817ED2D4):
+-- it is a brand-new closed set, so it can be born correct instead of being
+-- retrofitted with a NOT VALID CHECK the way the long-lived TEXT columns were.
+CREATE TYPE "DecisionSubjectKind" AS ENUM ('backlog-item');
+ALTER TABLE "DecisionInteraction" ADD COLUMN "subjectKind" "DecisionSubjectKind";
+ALTER TABLE "DecisionInteraction" ADD COLUMN "subjectRef" TEXT;
+ALTER TABLE "DecisionInteraction" ADD COLUMN "autonomous" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX "DecisionInteraction_subjectKind_subjectRef_idx"
+  ON "DecisionInteraction" ("subjectKind", "subjectRef");
+CREATE INDEX "DecisionInteraction_autonomous_idx"
+  ON "DecisionInteraction" ("autonomous");
+
+UPDATE "DecisionInteraction"
+SET "subjectKind" = 'backlog-item'::"DecisionSubjectKind",
+    "subjectRef"  = "outcomePayload" ->> 'backlogItemId'
+WHERE "subjectRef" IS NULL
+  AND "outcomePayload" ->> 'backlogItemId' IS NOT NULL
+  AND length(trim("outcomePayload" ->> 'backlogItemId')) > 0;
+
+UPDATE "DecisionInteraction"
+SET "autonomous" = true
+WHERE "autonomous" = false
+  AND "outcomePayload" ->> 'autonomous' = 'true';

--- a/packages/db/prisma/schema/decision-governance.prisma
+++ b/packages/db/prisma/schema/decision-governance.prisma
@@ -370,6 +370,20 @@ model PerspectiveMaterial {
   @@index([sourceType])
 }
 
+// What a governed decision can be ABOUT (BI-01F8F06D).
+//
+// One member, deliberately. A subject kind is only legitimate once a writer
+// actually records it, and today the backlog triage drain is the only caller
+// that names one. Adding a kind is a migration, which is the point: the set is
+// closed so a new writer cannot invent a spelling nobody can query for.
+//
+// `build` and `taskRun` are NOT members. Those subjects already have their own
+// declared columns and relations on DecisionInteraction, so repeating them here
+// would give one fact two homes and two answers.
+enum DecisionSubjectKind {
+  backlog_item @map("backlog-item")
+}
+
 model DecisionInteraction {
   id                      String                            @id @default(cuid())
   interactionId           String                            @unique
@@ -419,6 +433,28 @@ model DecisionInteraction {
   // True when the gate ran but doctrine fell back off the gate's own profile
   // kind (e.g. profession gate resolving to MARK_DPF_PLATFORM_PROFILE).
   gateFallbackUsed        Boolean                           @default(false)
+  // BI-01F8F06D. What the decision was ABOUT, and whether anyone watched it.
+  //
+  // Without these a decision is an isolated event: of the first 1,093 rows, one
+  // carried a buildId and twenty a taskRunId, while the backlog item id lived
+  // inside the question prose. Nothing could join a decision to the work it
+  // governed, so no outcome could ever be attributed to it.
+  //
+  // `autonomous` is not telemetry. An unattended cron decision has no human to
+  // agree or disagree with, so it must be excluded from an agreement denominator
+  // BY CONSTRUCTION — 518 of those first rows were an hourly drain, and a rate
+  // computed over them would measure nothing while looking authoritative.
+  //
+  // Null subject is honest for a caller that genuinely governs nothing
+  // identifiable; a fabricated subject is not.
+  subjectKind             DecisionSubjectKind?
+  // Named `subjectRef`, not `subjectId`: the reference is POLYMORPHIC — the
+  // kind discriminates a backlog item from a build from a design doc — so it
+  // can never be a single declared relation. An `*Id` name would promise a
+  // foreign key the column cannot honour, which is what the FK index-coverage
+  // ratchet correctly objected to.
+  subjectRef              String?
+  autonomous              Boolean                           @default(false)
   // Trust-envelope immutability (BI-81CC5D8E, EP-VERIFICATION-INTEGRITY).
   // A recorded decision is sealed into an append-only per-(chainId) hash chain:
   // chainEntryHash = H(canonical{criteria, evidence-digests, weights, composite}
@@ -460,6 +496,8 @@ model DecisionInteraction {
   @@index([riskTier, createdAt])
   // Trust-envelope chain lookups (find the head of a chain to link the next entry).
   @@index([chainId, sealedAt])
+  @@index([subjectKind, subjectRef])
+  @@index([autonomous])
 }
 
 model EscalationCapture {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -35,6 +35,13 @@ export {
   DecisionProposalScope,
   DecisionProposalStatus,
 } from "../generated/client/client";
+// What a governed decision is ABOUT (BI-01F8F06D). Exported as a TYPE, not a
+// value: under vitest `@dpf/db` aliases to src/client.ts, which exports only
+// `prisma`, so a value import of a generated enum resolves to undefined there.
+// The type still closes the set at compile time, and Postgres closes it at
+// write time, so a writer spells the member as a literal and TS rejects any
+// member the schema does not define.
+export type { DecisionSubjectKind } from "../generated/client/client";
 export {
   WorkroomParticipantRole,
   WorkroomParticipantAssignmentSource,


### PR DESCRIPTION
## Why this is first

A decision was recorded as an isolated event. Of the first 1,093 rows, **one** carried a `buildId` and twenty a `taskRunId`, while the backlog item it governed lived inside the question prose — `Triage BI-XXXX: "..."`.

Nothing could join a decision to the work it decided, so **no outcome could ever be attributed to it**. That sits upstream of capturing any outcome, which is why it lands before the resolution capture.

## Both facts were already recorded, where nothing can query them

| Already in `outcomePayload` JSON | Rows |
|---|---|
| `backlogItemId` | 518 |
| `autonomous` | 518 |

Same shape as `recommendedOptionId`, which sat in that blob while its own column stayed `NULL` (PR #5310). Three values, one table, all written beside the columns that should hold them.

## What changed

`subjectKind` and `subjectId` give a decision the thing it was about.

**`autonomous` is not telemetry.** 518 rows are an hourly cron drain with no human in the loop. An agreement rate computed over them would measure nothing while looking authoritative. Marking them keeps them out of a denominator **by construction**, rather than by a filter someone has to remember. The kernel consult derives it from whether a human triggered the call, so an agent asking the kernel is never silently counted as a reviewed decision.

A caller with no identifiable subject records `NULL`. Null is honest; a fabricated subject is not.

## The number that matters

The population an agreement rate may legitimately use is now selectable:

| | |
|---|---|
| Attended, carrying a recommendation | **151** |
| Unattended (cron) | 518 |
| Carrying no recommendation at all | 435 |
| Total rows | 1,093 |

So the honest denominator is 151, not the 1,093 the table appears to offer.

## Verification

Applied against the live database: `UPDATE 518` and `UPDATE 518`, and a decision now joins to its backlog item — including items filed in this session. Re-running both statements reports `UPDATE 0`, so it is idempotent by construction; each touches only rows whose column is still unset.

16 tests pass across both wired callers, asserting the **columns** rather than the payload copies — asserting the copy is exactly what let the previous instance of this survive. Pre-commit typecheck passed. All 8 PR policy guards pass. Data-impact manifest committed alongside.

## Still absent

**`humanOutcome` remains 1 of 1,093.** We now know what the kernel recommended and what it was about; we still do not know what happened. **No agreement rate should be computed or shown until the resolution lands** in BI-F302B80E.

Convergence-Impact-Decision: auto-converges — the columns and their backfill are a forward-only Prisma migration applied by promote.sh step 3b on the next self-upgrade, and the writers ship with the same release; the backfill is idempotent and safe on an install that already ran it

Docs-Impact-Decision: no-docs-needed — no route, contract or operator-facing surface changes; the governance record for the schema change is the data-impact manifest committed alongside it

Refs: BI-01F8F06D EP-DECISION-OUTCOME-LOOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)
