### PR TITLE
fix(build-studio): verify before publishing, and never blindly overwrite a ref

### DIFF
--- a/apps/web/lib/build/github-api-commit-ref-guard.test.ts
+++ b/apps/web/lib/build/github-api-commit-ref-guard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * BI-9A405652 — publishing must not force-overwrite a ref it does not own.
+ *
+ * Branch names on this path are DERIVED (`dpf/<clientId>/<slug>`), so two builds
+ * described similarly on the same install collide. The previous behaviour
+ * force-updated the ref, which destroyed the earlier content unrecoverably, told
+ * nobody, and left the loser uncontactable because the identity is pseudonymous.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isAncestorCommit, readRefSha } from "./github-api-commit";
+
+const API = "https://api.github.com/repos/o/r";
+const TOKEN = "t";
+
+function mockFetch(handler: (url: string) => { ok: boolean; body?: unknown }) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url ?? String(input);
+    const { ok, body } = handler(url);
+    return {
+      ok,
+      status: ok ? 200 : 404,
+      json: async () => body,
+      text: async () => JSON.stringify(body ?? {}),
+    } as unknown as Response;
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("readRefSha", () => {
+  it("returns the commit a ref points at", async () => {
+    mockFetch(() => ({ ok: true, body: { object: { sha: "abc123" } } }));
+    await expect(readRefSha(API, "dpf/ab12/feature", TOKEN)).resolves.toBe("abc123");
+  });
+
+  it("returns null when the ref cannot be read", async () => {
+    mockFetch(() => ({ ok: false }));
+    await expect(readRefSha(API, "dpf/ab12/feature", TOKEN)).resolves.toBeNull();
+  });
+
+  it("returns null rather than a partial value when the payload has no sha", async () => {
+    mockFetch(() => ({ ok: true, body: { object: {} } }));
+    await expect(readRefSha(API, "b", TOKEN)).resolves.toBeNull();
+  });
+
+  it("encodes a branch name with slashes", async () => {
+    const spy = mockFetch(() => ({ ok: true, body: { object: { sha: "s" } } }));
+    await readRefSha(API, "dpf/ab12/my feature", TOKEN);
+    const called = String(spy.mock.calls[0]?.[0]);
+    expect(called).not.toContain(" ");
+  });
+});
+
+describe("isAncestorCommit", () => {
+  it("allows a fast-forward: the new commit is ahead", async () => {
+    mockFetch(() => ({ ok: true, body: { status: "ahead" } }));
+    await expect(isAncestorCommit(API, "old", "new", TOKEN)).resolves.toBe(true);
+  });
+
+  it("allows an identical commit", async () => {
+    mockFetch(() => ({ ok: true, body: { status: "identical" } }));
+    await expect(isAncestorCommit(API, "old", "new", TOKEN)).resolves.toBe(true);
+  });
+
+  it("short-circuits when the shas are the same", async () => {
+    const spy = mockFetch(() => ({ ok: true, body: { status: "ahead" } }));
+    await expect(isAncestorCommit(API, "same", "same", TOKEN)).resolves.toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("REFUSES a diverged ref", async () => {
+    // This is the case that used to silently destroy someone's branch.
+    mockFetch(() => ({ ok: true, body: { status: "diverged" } }));
+    await expect(isAncestorCommit(API, "old", "new", TOKEN)).resolves.toBe(false);
+  });
+
+  it("refuses a ref that is behind", async () => {
+    mockFetch(() => ({ ok: true, body: { status: "behind" } }));
+    await expect(isAncestorCommit(API, "old", "new", TOKEN)).resolves.toBe(false);
+  });
+
+  it("refuses when the comparison cannot be read", async () => {
+    // Unreadable is not permission. The cost of a wrong "yes" here is someone
+    // else's work, so the safe direction is to refuse.
+    mockFetch(() => ({ ok: false }));
+    await expect(isAncestorCommit(API, "old", "new", TOKEN)).resolves.toBe(false);
+  });
+});

--- a/apps/web/lib/build/github-api-commit.ts
+++ b/apps/web/lib/build/github-api-commit.ts
@@ -191,6 +191,55 @@ async function githubGet<T>(url: string, token: string): Promise<T> {
 }
 
 /**
+ * The commit a ref currently points at, or null when it cannot be read.
+ *
+ * Null is "I could not tell", not "nothing is there" — the caller must treat it
+ * as a reason to refuse rather than as permission to overwrite (BI-9A405652).
+ */
+export async function readRefSha(
+  apiBase: string,
+  branchName: string,
+  token: string,
+): Promise<string | null> {
+  try {
+    const ref = await githubGet<{ object?: { sha?: unknown } }>(
+      `${apiBase}/git/refs/heads/${encodeURIComponent(branchName)}`,
+      token,
+    );
+    const sha = ref.object?.sha;
+    return typeof sha === "string" && sha.length > 0 ? sha : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether `ancestor` is reachable from `descendant` — i.e. moving the ref to
+ * `descendant` would be a fast-forward and would discard nothing.
+ *
+ * Uses the compare API, whose `status` is `ahead` or `identical` exactly when
+ * nothing would be lost. Anything unreadable answers false, because the safe
+ * direction here is to refuse: the cost of a wrong "yes" is someone else's work.
+ */
+export async function isAncestorCommit(
+  apiBase: string,
+  ancestor: string,
+  descendant: string,
+  token: string,
+): Promise<boolean> {
+  if (ancestor === descendant) return true;
+  try {
+    const comparison = await githubGet<{ status?: unknown }>(
+      `${apiBase}/compare/${encodeURIComponent(ancestor)}...${encodeURIComponent(descendant)}`,
+      token,
+    );
+    return comparison.status === "ahead" || comparison.status === "identical";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build a specific error for a base-branch lookup failure.
  *
  * GitHub returns 404 for BOTH "repo doesn't exist" and "token can't see this
@@ -380,7 +429,8 @@ export async function publishBranchCommit(input: {
     token,
   );
 
-  // 6. Create the branch ref on the HEAD repo.
+  // 6. Create the branch ref on the HEAD repo. See the catch below for why an
+  // existing ref is not simply force-updated.
   try {
     await githubPost(
       `${headApiBase}/git/refs`,
@@ -388,11 +438,30 @@ export async function publishBranchCommit(input: {
       token,
     );
   } catch (err) {
-    // Branch might already exist — try updating it
+    // The ref already exists. It used to be force-updated here with no check of
+    // who wrote it or what it pointed at, which silently destroyed the previous
+    // content: branch names are derived (`dpf/<clientId>/<slug>`), so two builds
+    // described similarly on the SAME install collide, and the loser is
+    // unrecoverable from the remote. Nobody is told, and the pseudonymous
+    // identity means the loser cannot be contacted (BI-9A405652).
+    //
+    // A fast-forward is safe and still allowed — that is the same branch moving
+    // on. Anything else is refused, and the caller is told which ref stopped it.
+    const existingSha = await readRefSha(headApiBase, branchName, token);
+    const fastForward = existingSha
+      ? await isAncestorCommit(headApiBase, existingSha, commit.sha, token)
+      : false;
+    if (!fastForward) {
+      throw new Error(
+        `Refusing to overwrite ${branchName}: it already exists at ${existingSha ?? "an unreadable commit"} `
+        + `and the new commit ${commit.sha} does not descend from it. `
+        + "Publishing would discard whatever is there, unrecoverably.",
+      );
+    }
     const response = await fetch(`${headApiBase}/git/refs/heads/${branchName}`, {
       method: "PATCH",
       headers: getHeaders(token),
-      body: JSON.stringify({ sha: commit.sha, force: true }),
+      body: JSON.stringify({ sha: commit.sha, force: false }),
     });
     if (!response.ok) {
       throw new Error(`Failed to create/update branch: ${(err as Error).message}`);

--- a/apps/web/lib/mcp/build-ship-handlers.ts
+++ b/apps/web/lib/mcp/build-ship-handlers.ts
@@ -520,6 +520,45 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
   const labels = ["build-studio", "automated"];
   const { publishBranchCommit, openPullRequest } = await import("@/lib/build/github-api-commit");
 
+  const {
+    buildPublishedReadinessCommand,
+    evaluateBuildVerificationReadiness,
+    parsePublishedReadinessOutput,
+  } = await import("@/lib/build/build-studio-pr-readiness");
+
+  // Verify BEFORE publishing (BI-46E9AB38). This used to run after the branch
+  // was already on the target repository, so a build that failed its own
+  // readiness contract still left a ref behind — on a consumer install, upstream,
+  // authored pseudonymously, with nothing cleaning it up. The check withheld the
+  // pull request while the thing that actually costs something had already
+  // happened.
+  //
+  // Only the LOCAL half can move: the canonical check fetches and checks out the
+  // published commit, so it cannot run before one exists. That half stays where
+  // it is. This half needs nothing but the build's own recorded verification, and
+  // it is the half that catches a build which never passed its tests.
+  const verificationReadiness = evaluateBuildVerificationReadiness({
+    typecheckPassed,
+    testsFailed,
+    acceptanceMet: acMet,
+    acceptanceTotal: acTotal,
+  });
+  const prePublishBlockers = [...verificationReadiness.blockers];
+  if (prePublishBlockers.length > 0) {
+    logBuildActivity(
+      buildId,
+      "pr-readiness:blocked-before-publish",
+      `blockers=${prePublishBlockers.join(" | ").slice(0, 700)}`,
+    );
+    return {
+      success: false,
+      error: "Verification blocked publication.",
+      message: `Nothing was published for \`${branchName}\`, because this change has not passed verification.\n\n`
+        + prePublishBlockers.map((blocker) => `- ${blocker}`).join("\n"),
+      data: { branchName, blockers: prePublishBlockers, published: false },
+    };
+  }
+
   const published = await publishBranchCommit({
     headOwner: repoOwner,
     headRepo: repoName,
@@ -527,18 +566,6 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
     commitMessage,
     diff: shareableDiff,
     token,
-  });
-
-  const {
-    buildPublishedReadinessCommand,
-    evaluateBuildVerificationReadiness,
-    parsePublishedReadinessOutput,
-  } = await import("@/lib/build/build-studio-pr-readiness");
-  const verificationReadiness = evaluateBuildVerificationReadiness({
-    typecheckPassed,
-    testsFailed,
-    acceptanceMet: acMet,
-    acceptanceTotal: acTotal,
   });
   let canonicalReadiness = {
     ready: false,
@@ -567,7 +594,7 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
       };
     }
   }
-  const blockers = [...verificationReadiness.blockers, ...canonicalReadiness.blockers];
+  const blockers = [...canonicalReadiness.blockers];
   const contextState = readinessTrailers ? "context-present" : "context-missing";
   const verdictState = blockers.length === 0 ? "ready" : "blocked";
   logBuildActivity(


### PR DESCRIPTION
## Summary

Two publish-path defects under EP-INPLATFORM-PARITY. Both are the same concern: the in-platform path could put content on a shared repository that nothing had checked, and could destroy content that was already there.

**1. Verify before publishing (BI-46E9AB38).** `create_portal_pr` published the branch and only *then* ran readiness, so a build that failed its own contract still left a ref behind. On a consumer install that ref is upstream, authored pseudonymously, with nothing cleaning it up. The check withheld the pull request while the thing that actually costs something had already happened.

The local half of readiness now runs first and returns without publishing. Only that half can move: the canonical check fetches and checks out the published commit, so it cannot run before one exists, and it stays where it is.

**2. Never blindly overwrite a ref (BI-9A405652).** `publishBranchCommit` force-updated an existing ref with no authorship or ancestry check. Branch names here are derived — `dpf/<clientId>/<slug>` — so two builds described similarly on the **same** install collide, and the loser was unrecoverable from the remote, unannounced, and uncontactable because the identity is pseudonymous.

An existing ref is now only updated when the new commit descends from it. A fast-forward is still allowed, because that is the same branch moving on. Anything diverged, behind, or unreadable is refused with the ref and its current commit named.

**Unreadable is deliberately not treated as permission.** `readRefSha` and `isAncestorCommit` both answer false when GitHub cannot be read, because the cost of a wrong "yes" here is someone else's work.

## Changes

- `apps/web/lib/mcp/build-ship-handlers.ts` — local readiness runs before `publishBranchCommit` and returns without publishing on blockers.
- `apps/web/lib/build/github-api-commit.ts` — `readRefSha` and `isAncestorCommit`; the force fallback becomes an ancestry-checked fast-forward.

## Not in this PR

Slice 3 of the epic, requiring a passing gate record for the exact tree (BI-0700B79C), imports the guard-gauntlet modules from #5302. It could not build on a branch cut from main until that merged, and stacking would have tangled two PRs that need to merge in order. It is next, now unblocked.

## Test plan

- [x] `pnpm typecheck`
- [x] 10 new unit tests: fast-forward and identical allowed, diverged and behind refused, unreadable refused, branch names with slashes encoded
- [x] `pnpm run pregate:preflight` — 67 guards clean
- [x] Exact-tree local-CI gate PASS

### Verification evidence

Local-CI-Evidence: cmtyckx1210s101mbodcpmd75 (feat/publish-requires-verification@b78a5293a306)

This branch took seven gate attempts. **None of the six failures were this code**: the shared root's `node_modules/.modules.yaml` had lost its `ignoredBuilds` key (fixed, it affected every junctioned worktree on the host), the image build hit `ResourceExhausted` under another session's load, Docker's port forward dropped after a Docker Desktop restart and read as control-plane starvation, main advanced between refresh and gate start twice, and one lease expired mid-run leaving a record bound to a pre-rebase commit. Recorded here because the pattern is itself evidence for BI-96253639: a correct gate still becomes the binding constraint when its cycle time exceeds the merge rate around it.

**Not yet proven:** verified by test and by the gate, not exercised against a live build on the install — that needs a release. The failure mode if something is wrong is a refusal to publish, which fails safe.

## Pre-PR readiness

- [x] `pnpm run pregate:preflight` passed (67 guards)
- [x] Exact-tree local-CI evidence captured — PASS at b78a5293a306
- [x] `pnpm pr:ready` READY

## Related issues / Epic

EP-INPLATFORM-PARITY. Refs BI-46E9AB38 and BI-9A405652.

## Overlap sweep

No open PR touches `build-ship-handlers` or `github-api-commit`.

## Notes for the reviewer

The ordering change is the half with teeth. Before it, readiness was advisory: it withheld the pull request but the branch was already on the remote. After it, a build that has not passed its own verification produces no remote artefact at all.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
