### PR TITLE
fix(readiness): a refusal names the shape that gated it and whether sensitivity raised it (BI-BD60DC91)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/evaluate.ts
+++ b/apps/web/lib/backlog/initiative-readiness/evaluate.ts
@@ -1,5 +1,5 @@
 import { requirementEvidenceLane, requirementNextAction } from "./readiness-guidance";
-import { shapeRequirements, type ShapeRequirement } from "./shape-requirements";
+import { effectiveShape, shapeRequirements, type ShapeRequirement } from "./shape-requirements";
 import type {
   InitiativeReadinessDecision,
   InitiativeReadinessFacts,
@@ -164,6 +164,25 @@ function result(
   };
 }
 
+/**
+ * Report the shape that actually gated this evaluation (BI-BD60DC91).
+ *
+ * Sensitivity raises the shape silently, so a one-file fix can owe a medium
+ * item's independent baseline because its body mentions a keyword while
+ * describing the blast radius. Naming the declared shape, the effective one and
+ * the sensitivity between them does not change a single verdict — it makes the
+ * raise legible to the operator and to the recovery packet.
+ */
+function shapeDecisionOf(facts: InitiativeReadinessFacts): NonNullable<InitiativeReadinessDecision["shapeDecision"]> {
+  const effective = effectiveShape(facts.shape!, facts.sensitivity);
+  return {
+    declared: facts.shape!,
+    effective,
+    sensitivity: facts.sensitivity ?? null,
+    raised: effective !== facts.shape,
+  };
+}
+
 /** Pure policy evaluation. All I/O, identity resolution, persistence, and rendering stay in adapters. */
 export function evaluateInitiativeReadiness(
   facts: InitiativeReadinessFacts,
@@ -208,6 +227,10 @@ export function evaluateInitiativeReadiness(
     subject: facts.subject,
     transitionObject: facts.transitionObject,
     profile: facts.profile,
+    // Omitted, not null, for an unshaped item: the decision object is compared
+    // by deep equality against replayed terminal decisions, so an always-present
+    // key would invalidate every decision persisted before this change.
+    ...(facts.shape ? { shapeDecision: shapeDecisionOf(facts) } : {}),
     target,
     verdict: blockers.length > 0 ? "denied" : unmet.length > 0 ? "input-required" : "allowed",
     satisfied,

--- a/apps/web/lib/backlog/initiative-readiness/shape-requirements.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/shape-requirements.test.ts
@@ -111,4 +111,34 @@ describe("initiative-readiness.v3 — gates keyed by (shape, sensitivity, target
     expect(xlarge.blockers.map((entry) => entry.code)).toContain("DECOMPOSITION_REQUIRED");
     expect(xlarge.blockers.find((entry) => entry.code === "DECOMPOSITION_REQUIRED")?.nextAction).toMatch(/Decompose/);
   });
+
+  // BI-BD60DC91: a delivery-small fix was gated as medium — owing an
+  // independent objective baseline it could never mint — because its body
+  // mentioned a keyword while describing the blast radius. The verdict was
+  // correct policy; the silence about WHY was the defect.
+  it("reports the shape that actually gated the evaluation, and whether sensitivity raised it", () => {
+    const plain = evaluateInitiativeReadiness(facts({ shape: "small" }), "completion");
+    expect(plain.shapeDecision).toEqual({ declared: "small", effective: "small", sensitivity: null, raised: false });
+    expect(codes(plain)).not.toContain("OBJECTIVE_BASELINE_REQUIRED");
+
+    const raised = evaluateInitiativeReadiness(facts({ shape: "small", sensitivity: "elevated" }), "completion");
+    expect(raised.shapeDecision).toEqual({ declared: "small", effective: "medium", sensitivity: "elevated", raised: true });
+    // The raise is what pulls in the medium-only baseline; naming it explains the refusal.
+    expect(codes(raised)).toContain("OBJECTIVE_BASELINE_REQUIRED");
+
+    const high = evaluateInitiativeReadiness(facts({ shape: "small", sensitivity: "high" }), "completion");
+    expect(high.shapeDecision).toMatchObject({ declared: "small", effective: "large", raised: true });
+
+    // An unshaped item is still gated by the v2 profile and claims no shape.
+    expect(evaluateInitiativeReadiness(facts(), "completion").shapeDecision).toBeUndefined();
+  });
+
+  it("does not change any verdict: the reported effective shape is the one the table used", () => {
+    for (const sensitivity of [null, "elevated", "high"] as const) {
+      for (const shape of ["break-fix", "small", "medium", "large"] as const) {
+        const decision = evaluateInitiativeReadiness(facts({ shape, sensitivity }), "completion");
+        expect(decision.shapeDecision?.effective).toBe(effectiveShape(shape, sensitivity));
+      }
+    }
+  });
 });

--- a/apps/web/lib/backlog/initiative-readiness/types.ts
+++ b/apps/web/lib/backlog/initiative-readiness/types.ts
@@ -165,6 +165,22 @@ export type InitiativeReadinessDecision = {
   subject: InitiativeSubject;
   transitionObject: InitiativeTransitionObject;
   profile: ReadinessProfile;
+  /**
+   * Which shape actually gated this evaluation, and why (BI-BD60DC91).
+   *
+   * `declared` is the shape bound on the item's live Workroom; `effective` is
+   * what `effectiveShape` gated on after sensitivity was applied. They differ
+   * whenever sensitivity raised the item, and until now nothing in the refusal
+   * said so: an author saw a small fix owing a medium item's independent
+   * baseline with no way to tell that a word in the body had raised it.
+   * Absent for an unshaped item, which is still gated by the v2 profile.
+   */
+  shapeDecision?: {
+    declared: ReadinessShape;
+    effective: ReadinessShape;
+    sensitivity: ReadinessSensitivity | null;
+    raised: boolean;
+  } | null;
   target: ReadinessTarget;
   verdict: ReadinessVerdict;
   satisfied: ReadinessRequirementResult[];


### PR DESCRIPTION
## Summary

A delivered one-file change to `scripts/promote.sh` could not be marked done. Its bound shape was `delivery-small`, and the `small()` table in `shape-requirements.ts` contains no `OBJECTIVE_BASELINE_REQUIRED` at all — yet the refusal demanded one, from an independent reviewer, for a promoter one-liner.

The cause is legitimate policy applied invisibly. `deriveDeliverableSensitivity` matched `federation` and `deploy` in the item body, where those words appear only to describe which peer calls broke while production was down. `effectiveShape` then raised `small` to `medium`. Nothing in the decision, the refusal, or the recovery packet said a raise had occurred, so the author reads a list of medium gates against an item they declared small with no way to learn why.

This PR makes the raise legible. It changes no verdict.

## What changes

`InitiativeReadinessDecision` gains `shapeDecision`: the `declared` shape, the `effective` shape the requirement table actually keyed on, the `sensitivity` between them, and a `raised` boolean.

The field is **omitted rather than null** for an unshaped item. Terminal decisions are replayed and compared by deep equality, so an always-present key would invalidate every decision persisted before this change — `entry-adapter.test.ts` catches exactly that, and did.

## Why this and not the derivation itself

Measured against the live backlog on 2026-09-12, over 1,514 open and in-progress items:

| bucket | items | share |
|---|---|---|
| low | 568 | 37% |
| elevated | 418 | 27% |
| high | 528 | 34% |

946 items (62%) are raised above `low`, and 528 (34%) reach `high`, which takes `small` and `medium` straight to the large gates. The most frequent triggers are `schema` (130), `kernel` (92) and `governance` (82) — this platform's own domain vocabulary, which appears in the prose of items that touch none of it. 199 small-size bugs are raised right now, and 17 open items whose own titles say SHIPPED or MERGED are among them.

Whether sensitivity should key off the paths a change actually touches rather than the item's prose is a governance decision. It is recorded on BI-BD60DC91 with this data and deliberately **not** taken here. Weakening a security-facing gate by 779 items is not a change to make as a side effect of a bug fix.

## Verification

- Two new cases in `shape-requirements.test.ts`, failing before and passing after. The second asserts across every `(shape, sensitivity)` pair that the reported effective shape is exactly what `effectiveShape` returns — the value the table was already keyed on — so the reporting cannot drift from the policy.
- `lib/backlog lib/mcp lib/tak` — **3,689 passed**, 1 skipped, 359/359 files.
- `pnpm --filter web typecheck` — clean.
- `pregate:preflight` — 69 guards clean.

**Honest note on one run.** The first whole-suite pass reported `work-capsules-pack.test.ts > imports mcp-tools without runtime error under the @dpf/db mock` as failed. That file passes standalone on this exact tree, passes on pristine `main`, and the full three-suite run is green on re-run. I could not reproduce it and am recording it rather than omitting it.

## Relationship to #5316

Independent and complementary. #5316 makes `RESEARCH_REQUIRED` author-reachable and stops the recovery packet offering a baseline the shape excludes. This PR explains the case where the baseline genuinely *is* required because sensitivity raised the shape. Neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
