### PR TITLE
fix(review): unblock refreshed failure evidence

### DIFF
--- a/apps/web/lib/change-review/semantic-review-background.test.ts
+++ b/apps/web/lib/change-review/semantic-review-background.test.ts
@@ -204,6 +204,22 @@ describe("durable semantic review worker", () => {
     expect(row.status).toBe("auth-required");
     expect(mocks.dispatch).not.toHaveBeenCalled();
   });
+  it("terminalizes an immutable request whose failure evidence changed so a refreshed request is not stranded", async () => {
+    mocks.resolveFailureEvidence.mockResolvedValue([]);
+
+    expect(await executePersistedSemanticReview("TR-1")).toMatchObject({
+      taskRunId: "TR-1",
+      status: "failed",
+      changed: true,
+    });
+    expect(row.status).toBe("failed");
+    expect(row.progressPayload).toMatchObject({ semanticReview: {
+      state: "failed",
+      reason: "failure-analysis-evidence-changed",
+      action: "Submit a refreshed immutable review request with current failure evidence.",
+    } });
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+  });
   it("reports cancellation when it wins against an admission failure", async () => {
     mocks.db.taskArtifact.findUnique.mockImplementation(async () => { row.status = "canceled"; return null; });
     expect(await executePersistedSemanticReview("TR-1")).toMatchObject({ status: "canceled" });

--- a/apps/web/lib/change-review/semantic-review-background.ts
+++ b/apps/web/lib/change-review/semantic-review-background.ts
@@ -35,10 +35,11 @@ async function assertFence(db: Prisma.TransactionClient, taskRunId: string, gene
   const owned = await db.taskRun.updateMany({ where: fence(taskRunId, generation), data: { lastHeartbeatAt: new Date() } });
   if (owned.count !== 1) throw new Error("semantic-review-generation-no-longer-owned");
 }
-async function settle(row: Run, status: "failed" | "auth-required" | "input-required", reason: string) {
+async function settle(row: Run, status: "failed" | "auth-required" | "input-required", reason: string,
+  details: Record<string, unknown> = {}) {
   const changed = await prisma.taskRun.updateMany({ where: { taskRunId: row.taskRunId, status: row.status, updatedAt: row.updatedAt },
     data: { status, ...(status === "failed" ? { completedAt: new Date() } : {}),
-      progressPayload: progress(row, { state: status, reason }) } });
+      progressPayload: progress(row, { state: status, reason, ...details }) } });
   const current = changed.count === 1 ? status
     : (await prisma.taskRun.findUnique({ where: { taskRunId: row.taskRunId }, select: { status: true } }))?.status ?? "unknown";
   return { taskRunId: row.taskRunId, status: current, changed: changed.count === 1 };
@@ -176,7 +177,13 @@ export async function executePersistedSemanticReview(taskRunId: string) {
   const currentEvidence = reviewRoom ? await resolveFailureAnalysisEvidence(packet.input.failureAnalysis, reviewRoom.id) : [];
   const currentAnalysis = validateFailureAnalysis(packet.input.failureAnalysis, packet.input.identity, currentEvidence);
   if (!currentAnalysis.valid || currentAnalysis.digest !== packet.input.identity.failureAnalysisDigest) {
-    return settle(row, "input-required", "failure-analysis-evidence-changed; internal author must refresh evidence and review");
+    // The persisted packet is immutable, so changed evidence cannot be repaired
+    // by resuming this TaskRun. Terminalize the stale attempt: the next
+    // submission resolves current evidence into a new gate identity instead of
+    // subscribing forever to an unrecoverable input-required run.
+    return settle(row, "failed", "failure-analysis-evidence-changed", {
+      action: "Submit a refreshed immutable review request with current failure evidence.",
+    });
   }
   const generation = randomUUID();
   const owned = await reserveSubmittedTaskRunWorking({ taskRunId, updatedAt: row.updatedAt,

--- a/docs/superpowers/plans/2026-09-12-failure-analysis-closeout-recovery.md
+++ b/docs/superpowers/plans/2026-09-12-failure-analysis-closeout-recovery.md
@@ -1,0 +1,20 @@
+---
+status: active
+---
+
+# Failure-analysis closeout recovery plan
+
+Implements [failure-analysis closeout recovery](../specs/2026-09-12-failure-analysis-closeout-recovery.md) for `BI-6B311DC8`.
+
+## Ordered sequence
+
+1. Reproduce the live failure: resolved evidence differs from the immutable packet and the worker parks the TaskRun as `input-required` without dispatch.
+2. Terminalize only this immutable evidence-drift case as failed and publish a precise action to submit a refreshed immutable request.
+3. Prove the worker does not dispatch a reviewer for stale evidence and retain the existing single-flight test proving terminal stale evidence permits one new attempt.
+4. Run focused and adjacent review tests, web typecheck, source guards, DCO, and all protected PR checks. If a local leased gate is unavailable, record it as inconclusive; do not infer PASS.
+5. Deploy through the canonical release path, resubmit the corrected failure review, verify a genuine receipt, then complete the original Workroom.
+
+## Atomic backlog coverage
+
+`BI-6B311DC8` maps OBJ-CLOSEOUT-001 through OBJ-CLOSEOUT-003 to this single repair. The worker regression proves AC-CLOSEOUT-001; the existing terminal-attempt single-flight regression proves AC-CLOSEOUT-002; the adjacent durable-worker suite proves AC-CLOSEOUT-003.
+

--- a/docs/superpowers/specs/2026-09-12-failure-analysis-closeout-recovery.md
+++ b/docs/superpowers/specs/2026-09-12-failure-analysis-closeout-recovery.md
@@ -1,0 +1,31 @@
+---
+title: Failure-analysis closeout recovery
+status: binding
+date: 2026-09-12
+owner: platform
+---
+
+# Failure-analysis closeout recovery
+
+## Problem
+
+An immutable semantic-review request can become stale when its governed failure evidence changes before the background worker starts. The worker currently parks that immutable request as `input-required`, while semantic-review single-flight treats the parked run as active. A corrected submission therefore subscribes to a request that cannot become valid, permanently blocking Workroom completion.
+
+## Objectives
+
+- **OBJ-CLOSEOUT-001:** A stale immutable failure-analysis request must reach a truthful terminal state.
+- **OBJ-CLOSEOUT-002:** A refreshed request for the same change must be admitted without rerunning or rewriting the stale request.
+- **OBJ-CLOSEOUT-003:** Preserve immutable identity, authority, evidence, and exactly-once receipt guarantees.
+
+## Acceptance criteria
+
+| ID | Objectives | Observable proof |
+| --- | --- | --- |
+| AC-CLOSEOUT-001 | OBJ-CLOSEOUT-001 | Evidence drift before dispatch terminalizes the old TaskRun as failed with a refresh action and performs no reviewer dispatch. |
+| AC-CLOSEOUT-002 | OBJ-CLOSEOUT-002 | A later request resolved from current evidence is not subscribed to the terminal stale attempt. |
+| AC-CLOSEOUT-003 | OBJ-CLOSEOUT-003 | Revoked authority, uncertain provider outcomes, malformed counters, and concurrent delivery retain their existing fail-closed behavior. |
+
+## Boundary and recovery
+
+The repair does not mutate an admitted packet, refresh evidence inside it, or infer a review result. The stale request remains auditable. The author submits a new immutable request whose evidence digest contributes to a new gate identity. Existing bounded dispatch, recovery, and receipt publication remain unchanged.
+


### PR DESCRIPTION
## Outcome

Prevents failure-analysis evidence drift from permanently stranding Workroom closeout. An immutable stale review request now terminates fail-closed with an explicit refresh action; a corrected submission can receive a new deterministic single-flight attempt.

## Evidence

- TDD red reproduced `input-required` subscription to an unrecoverable immutable request.
- Focused/adjacent review suite: 4 files, 56 tests passed.
- Style drift and diff checks passed; pre-commit secret scan passed.
- Linked-worktree broad typecheck was unavailable because workspace packages such as `@dpf/db` were unresolved. This is recorded as inconclusive under the operator's broken-local-gate boundary; protected CI remains mandatory.

## Governance

- Backlog: BI-6B311DC8
- Workroom: WC-0E886DDF
- DCO Signed-off-by present.
- No stale request is mutated, retried, or treated as a passing review.
