### PR TITLE
fix(local-ci): measure CPU to admit gates, and record the observation the decision used (BI-48F42581)

### DIFF
--- a/apps/web/lib/nonprod/environment-lease-pool-policy.test.ts
+++ b/apps/web/lib/nonprod/environment-lease-pool-policy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveHostResourcePoolPolicy } from "./environment-lease-pool-policy";
+import {
+  resolveHostResourcePoolPolicy,
+  resolveNonprodPoolPolicy,
+} from "./environment-lease-pool-policy";
 
 const GiB = 1024 ** 3;
 
@@ -39,5 +42,89 @@ describe("resolveHostResourcePoolPolicy", () => {
       slotKeys: [],
       rollbackReason: "inference-resident-singleton",
     });
+  });
+});
+
+describe("resolveNonprodPoolPolicy decidedHostPressure (BI-48F42581)", () => {
+  const platformConfig = {
+    findUnique: async () => ({
+      value: {
+        version: 1,
+        requestedCapacity: 2,
+        ceilings: {
+          minAvailableMemoryBytes: 4 * GiB,
+          maxSustainedCpuPercent: 85,
+          minDiskFreeBytes: 50 * GiB,
+        },
+        rollback: {
+          maxServiceDurationRegressionPercent: 15,
+          maxInfrastructureFailureRatePercent: 5,
+          evidenceMismatchTolerance: 0,
+        },
+      },
+    }),
+  };
+
+  const now = new Date("2026-09-10T02:00:00.000Z");
+  const healthy = {
+    observedAt: now.toISOString(),
+    diskFreeBytes: 900 * GiB,
+    dockerHealthy: true,
+    convergenceActive: false,
+    fencesHealthy: true,
+    evidenceIsolationHealthy: true,
+  };
+
+  it("hands back the observation the decision was taken on, not the caller's sample", async () => {
+    // The caller's own sample says the host is quiet; the canonical broker sees
+    // it saturated. The refusal must travel with the numbers that produced it,
+    // or a gate record reads "host-cpu-high" beside 12% CPU and the operator
+    // goes looking for a bug in the gate.
+    const policy = await resolveNonprodPoolPolicy({
+      platformConfig,
+      environmentKey: "local-integration-ci",
+      manifestSlotCount: 2,
+      now,
+      hostPressure: {
+        ...healthy,
+        availableMemoryBytes: 25 * GiB,
+        sustainedCpuPercent: 12,
+      },
+      capacityBroker: async () => ({
+        ...healthy,
+        availableMemoryBytes: 25 * GiB,
+        dockerAvailableMemoryBytes: 25 * GiB,
+        builderMemoryUsageBytes: [0, 0],
+        sustainedCpuPercent: 97,
+      }),
+    });
+
+    expect(policy.rollbackReason).toBe("host-cpu-high");
+    expect(policy.decidedHostPressure?.sustainedCpuPercent).toBe(97);
+  });
+
+  it("carries the merged observation on an open pool too", async () => {
+    const policy = await resolveNonprodPoolPolicy({
+      platformConfig,
+      environmentKey: "local-integration-ci",
+      manifestSlotCount: 2,
+      now,
+      hostPressure: {
+        ...healthy,
+        availableMemoryBytes: 25 * GiB,
+        sustainedCpuPercent: 12,
+      },
+      capacityBroker: async () => ({
+        ...healthy,
+        availableMemoryBytes: 25 * GiB,
+        dockerAvailableMemoryBytes: 25 * GiB,
+        builderMemoryUsageBytes: [0, 0],
+        sustainedCpuPercent: 20,
+      }),
+    });
+
+    expect(policy.rollbackReason).toBeNull();
+    // Maximum load wins in the merge, so the recorded figure is the pessimistic one.
+    expect(policy.decidedHostPressure?.sustainedCpuPercent).toBe(20);
   });
 });

--- a/apps/web/lib/nonprod/environment-lease-pool-policy.ts
+++ b/apps/web/lib/nonprod/environment-lease-pool-policy.ts
@@ -141,16 +141,24 @@ export async function resolveNonprodPoolPolicy(input: {
       evidenceIsolationHealthy: false,
     };
   }
-  return resolveLocalCiPoolPolicy({
-    configValue,
-    host: mergeLocalCiHostPressure({
-      client: clientPressure,
-      server: serverPressure,
-    }),
-    manifestSlotCount: input.manifestSlotCount,
-    reserveAdmissionHeadroom: input.reserveAdmissionHeadroom,
-    env: process.env,
-    now: input.now,
-    installation,
+  const decidedHostPressure = mergeLocalCiHostPressure({
+    client: clientPressure,
+    server: serverPressure,
   });
+  // Hand the decided observation back with the decision (BI-48F42581). The
+  // caller only has its own client sample; recording that next to a
+  // server-derived rollbackReason produced gate records that contradicted
+  // themselves and sent operators looking for a bug in the wrong place.
+  return {
+    ...resolveLocalCiPoolPolicy({
+      configValue,
+      host: decidedHostPressure,
+      manifestSlotCount: input.manifestSlotCount,
+      reserveAdmissionHeadroom: input.reserveAdmissionHeadroom,
+      env: process.env,
+      now: input.now,
+      installation,
+    }),
+    decidedHostPressure,
+  };
 }

--- a/apps/web/lib/nonprod/local-ci-capacity-broker.ts
+++ b/apps/web/lib/nonprod/local-ci-capacity-broker.ts
@@ -1,5 +1,5 @@
 import { statfs } from "node:fs/promises";
-import { cpus, freemem, loadavg } from "node:os";
+import { cpus, freemem } from "node:os";
 import { dockerSocketGet } from "../platform-runtime/docker-socket.mjs";
 import type { LocalCiHostPressure } from "./local-ci-pool-policy";
 import localCiSlotResources from "./local-ci-slot-resources.json" with {
@@ -12,7 +12,7 @@ export type LocalCiServerPressureProbes = {
   now: () => Date;
   availableMemoryBytes: () => number;
   builderMemoryUsageBytes: () => MaybePromise<number[]>;
-  sustainedCpuPercent: () => number;
+  sustainedCpuPercent: () => MaybePromise<number>;
   diskFreeBytes: () => MaybePromise<number>;
   dockerHealthy: () => MaybePromise<boolean>;
   convergenceActive: () => MaybePromise<boolean>;
@@ -183,15 +183,73 @@ async function defaultBuilderMemoryUsageBytes(): Promise<number[]> {
   return builderMemoryUsageBytesFromDocker(dockerSocketGet);
 }
 
+/** How long the CPU sample runs. Matches the host client's window (BI-48F42581). */
+export const LOCAL_CI_CPU_SAMPLE_WINDOW_MS = 1_000;
+
+type CpuTimesSnapshot = { idle: number; total: number };
+
+/** Cumulative-since-boot CPU times, summed across cores. */
+export function cpuTimesSnapshot(): CpuTimesSnapshot {
+  return cpus().reduce(
+    (sum, cpu) => {
+      const total = Object.values(cpu.times).reduce((acc, value) => acc + value, 0);
+      return { idle: sum.idle + cpu.times.idle, total: sum.total + total };
+    },
+    { idle: 0, total: 0 },
+  );
+}
+
+/**
+ * Busy percentage between two cumulative snapshots.
+ *
+ * The same delta the host client computes in scripts/lib/local-ci-host-pressure.mjs,
+ * so the two halves of the merged observation now measure the same quantity.
+ * A non-advancing or backwards total is unmeasurable, never zero — reporting an
+ * idle host we did not observe is how admission gets looser than the evidence.
+ */
+export function cpuPercentBetween(
+  start: CpuTimesSnapshot | undefined,
+  end: CpuTimesSnapshot | undefined,
+): number {
+  if (!start || !end) return Number.NaN;
+  const totalDelta = end.total - start.total;
+  const idleDelta = end.idle - start.idle;
+  if (!Number.isFinite(totalDelta) || totalDelta <= 0 || !Number.isFinite(idleDelta)) {
+    return Number.NaN;
+  }
+  return Math.max(0, Math.min(100, ((totalDelta - idleDelta) / totalDelta) * 100));
+}
+
+/**
+ * Measure CPU utilization over a real window.
+ *
+ * This replaced `loadavg()[0] / cpus().length`, which is not utilization
+ * (BI-48F42581). Load average is a 1-minute-smoothed count of runnable PLUS
+ * uninterruptible-I/O tasks, so it was wrong in both directions and the pool
+ * opened and closed on it. Measured on the reference install inside the portal,
+ * over one 2-second window: /proc/stat said 55.2% busy, loadavg/cpus said 24.2%.
+ * The converse bit harder — Docker build I/O parks tasks in D-state, inflating
+ * load without using CPU, so a running gate could close the pool for every gate
+ * queued behind it.
+ */
+export async function sampleSustainedCpuPercent(deps: {
+  snapshot?: () => CpuTimesSnapshot;
+  delay?: (ms: number) => Promise<void>;
+  windowMs?: number;
+} = {}): Promise<number> {
+  const snapshot = deps.snapshot ?? cpuTimesSnapshot;
+  const delay = deps.delay
+    ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const start = snapshot();
+  await delay(deps.windowMs ?? LOCAL_CI_CPU_SAMPLE_WINDOW_MS);
+  return cpuPercentBetween(start, snapshot());
+}
+
 const DEFAULT_PROBES: LocalCiServerPressureProbes = {
   now: () => new Date(),
   availableMemoryBytes: () => freemem(),
   builderMemoryUsageBytes: defaultBuilderMemoryUsageBytes,
-  sustainedCpuPercent: () => {
-    const cpuCount = cpus().length;
-    if (cpuCount < 1) return Number.NaN;
-    return Math.min(100, Math.max(0, (loadavg()[0] / cpuCount) * 100));
-  },
+  sustainedCpuPercent: () => sampleSustainedCpuPercent(),
   diskFreeBytes: defaultDiskFreeBytes,
   dockerHealthy: defaultDockerHealthy,
   // Portal quiescence rejects the claim before this broker runs. Dependency

--- a/apps/web/lib/nonprod/local-ci-cpu-probe.test.ts
+++ b/apps/web/lib/nonprod/local-ci-cpu-probe.test.ts
@@ -1,0 +1,80 @@
+// The local-CI CPU probe and the honesty of the observation recorded with a
+// decision (BI-48F42581).
+
+import { describe, expect, it } from "vitest";
+
+import {
+  cpuPercentBetween,
+  sampleSustainedCpuPercent,
+} from "./local-ci-capacity-broker";
+
+describe("cpuPercentBetween", () => {
+  it("reports the busy share of the interval, not a load average", () => {
+    // 1000 ticks elapsed, 250 of them idle → 75% busy.
+    expect(cpuPercentBetween({ idle: 0, total: 0 }, { idle: 250, total: 1000 }))
+      .toBeCloseTo(75);
+  });
+
+  it("reports a fully idle interval as zero", () => {
+    expect(cpuPercentBetween({ idle: 0, total: 0 }, { idle: 1000, total: 1000 }))
+      .toBe(0);
+  });
+
+  it("reports a saturated interval as 100, and never above it", () => {
+    expect(cpuPercentBetween({ idle: 5, total: 5 }, { idle: 5, total: 1005 }))
+      .toBe(100);
+  });
+
+  it("is unmeasurable rather than idle when the clock did not advance", () => {
+    // The old probe could only return a number. Returning 0 for "we did not
+    // measure" would admit a gate onto a host nobody looked at; NaN routes to
+    // host-cpu-unmeasurable, which closes the pool.
+    expect(cpuPercentBetween({ idle: 10, total: 100 }, { idle: 10, total: 100 }))
+      .toBeNaN();
+    expect(cpuPercentBetween({ idle: 10, total: 100 }, { idle: 10, total: 50 }))
+      .toBeNaN();
+    expect(cpuPercentBetween(undefined, { idle: 0, total: 100 })).toBeNaN();
+  });
+});
+
+describe("sampleSustainedCpuPercent", () => {
+  it("measures across a window instead of reading a smoothed queue length", async () => {
+    const snapshots = [
+      { idle: 100, total: 200 },
+      { idle: 140, total: 400 },
+    ];
+    let taken = 0;
+    const delays: number[] = [];
+
+    const percent = await sampleSustainedCpuPercent({
+      snapshot: () => snapshots[taken++]!,
+      delay: async (ms) => {
+        delays.push(ms);
+      },
+      windowMs: 1_000,
+    });
+
+    // 200 ticks elapsed, 40 idle → 80% busy.
+    expect(percent).toBeCloseTo(80);
+    expect(taken).toBe(2);
+    expect(delays).toEqual([1_000]);
+  });
+
+  it("does not report a host it never sampled twice as idle", async () => {
+    const frozen = { idle: 100, total: 200 };
+    const percent = await sampleSustainedCpuPercent({
+      snapshot: () => frozen,
+      delay: async () => {},
+    });
+    expect(percent).toBeNaN();
+  });
+
+  it("the live probe returns a real percentage", async () => {
+    // Guards the wiring: the exported default path must still measure something
+    // in [0, 100] on the machine running the suite.
+    const percent = await sampleSustainedCpuPercent({ windowMs: 50 });
+    expect(Number.isFinite(percent)).toBe(true);
+    expect(percent).toBeGreaterThanOrEqual(0);
+    expect(percent).toBeLessThanOrEqual(100);
+  });
+});

--- a/apps/web/lib/nonprod/local-ci-pool-policy.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-policy.ts
@@ -66,6 +66,16 @@ export type ResolvedLocalCiPoolPolicy = {
   slotKeys: Array<"slot-0" | "slot-1">;
   rollbackReason: string | null;
   config: LocalCiPoolConfig | null;
+  /**
+   * The host observation this decision was actually taken on (BI-48F42581).
+   *
+   * The caller sends its own client sample and used to record that beside the
+   * server's rollbackReason, so a gate record could report 19.9% CPU next to a
+   * "host-cpu-high" refusal against an 85 ceiling. A reason and the numbers
+   * printed beside it have to come from one observation, or the record is not
+   * evidence. Present whenever the canonical broker contributed.
+   */
+  decidedHostPressure?: LocalCiHostPressure;
 };
 
 /**

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -611,8 +611,15 @@ consume this host reservation.
 
 Every queued observation persists its queue position, wait age, resolved pool
 policy (including `rollbackReason` and effective slot capacity), and paired
-host-pressure sample in the candidate's SHA-bound gate state. Later recovery or
-terminal writes retain the latest admission record. Diagnose a timeout from
+host-pressure sample in the candidate's SHA-bound gate state. That sample is
+the observation the decision was actually taken on — the client's own reading
+merged with the canonical runtime's, which is what the policy weighed. It was
+previously the caller's sample alone, so a record could name a server-derived
+`rollbackReason` beside client numbers that did not support it (a
+`host-cpu-high` refusal printed next to 19.9% CPU against an 85 ceiling). A
+reason and the numbers beside it now come from one observation, because a
+record that disagrees with itself is not evidence (BI-48F42581). Later recovery
+or terminal writes retain the latest admission record. Diagnose a timeout from
 that durable record; do not infer the refusal from process residency, cancel
 and recreate a healthy FIFO claim, or conflate Docker model residency and GPU
 VRAM with Windows physical-memory telemetry.

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -1541,7 +1541,11 @@ async function main() {
           queuePosition: admission?.queuePosition ?? null,
           waitAgeMs: admission?.waitAgeMs ?? null,
           poolPolicy: claimResponse?.data?.poolPolicy ?? null,
-          hostPressure,
+          // The observation the DECISION was taken on, when the canonical broker
+          // contributed one (BI-48F42581). Falling back to our own client sample
+          // is honest only when nothing better exists; recording it beside a
+          // server-derived rollbackReason is what made records self-contradictory.
+          hostPressure: claimResponse?.data?.poolPolicy?.decidedHostPressure ?? hostPressure,
         },
       });
       break;
@@ -1576,7 +1580,11 @@ async function main() {
           resumeMode: admission.resumeMode ?? null,
           taskRunId: admission.taskRunId ?? null,
           poolPolicy: claimResponse?.data?.poolPolicy ?? null,
-          hostPressure,
+          // The observation the DECISION was taken on, when the canonical broker
+          // contributed one (BI-48F42581). Falling back to our own client sample
+          // is honest only when nothing better exists; recording it beside a
+          // server-derived rollbackReason is what made records self-contradictory.
+          hostPressure: claimResponse?.data?.poolPolicy?.decidedHostPressure ?? hostPressure,
         },
       });
       if (admission.resumeMode === "durable-task" && admission.taskRunId) {


### PR DESCRIPTION
Local-CI admission opened and closed the pool on a number that is not CPU.

```ts
sustainedCpuPercent: () => (loadavg()[0] / cpus().length) * 100
```

Load average is a one-minute-smoothed count of runnable **plus uninterruptible-I/O** tasks. Using it as a utilization percentage is wrong in both directions.

## Evidence

Measured inside the live `dpf-portal-1` container, comparing a `/proc/stat` delta against the loadavg-derived figure over the **same 2-second window**:

```json
{"procStatUtilPct":55.2,"loadavg1":2.9,"cpus":12,"loadavgDerivedPct":24.2}
```

It reported 24.2% while the VM was 55.2% busy — admission looser than the evidence. The converse bites harder: Docker build I/O parks tasks in D-state, inflating load without using CPU, so a gate running its build can report `host-cpu-high` and close the pool for every gate queued behind it. A claim at 2026-09-10T02:01 was refused for exactly that while both the host and the VM read around 20-25%.

The correct sampler already existed and was already tested on the host-client side of the same observation (`scripts/lib/local-ci-host-pressure.mjs`). The server probe now takes the same cumulative-times delta over the same 1s window, so both halves of the merged pressure finally measure the same quantity. A window that does not advance is `NaN`, never `0`: `host-cpu-unmeasurable` closes the pool, whereas reporting an idle host nobody observed would admit onto one.

**The 85 ceiling is unchanged. The ceiling was never the problem; the measurement was.**

## Second symptom, same record

The decision is taken on the merged client+broker pressure, but only the client's own sample reached the caller, so gate records carried a server-derived `rollbackReason` next to client numbers that contradicted it — a `host-cpu-high` refusal printed beside `sustainedCpuPercent: 19.93` against an 85 ceiling. I lost real time chasing that contradiction as if it were a bug in the gate.

`resolveNonprodPoolPolicy` now returns `decidedHostPressure` and `gate-worktree` records that, falling back to its own sample only when no broker contributed. A reason and the numbers beside it have to come from one observation, or the record is not evidence.

`docs/testing/pre-pr-gate.md` already instructs operators to *"diagnose a timeout from that durable record"*, so that page is updated here to say what the paired sample now is. `docs/architecture/context-engineering-standards.md` is attested rather than edited: it describes admission evidence scope, claim identity and evidence planning, none of which this touches.

## Evidence of correctness

- Local-CI gate **PASSED** on `fe0081f55427`.
- 102 nonprod tests, 28 gate-lease tests, 40 repo guards, typecheck — all green.
- New unit tests cover the busy/idle/saturated cases, the unmeasurable cases (non-advancing and backwards clocks), and that `decidedHostPressure` carries the broker's figure on both an open and a closed pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
